### PR TITLE
Fix non OpenMP build, add qobj method to AerJob

### DIFF
--- a/qiskit/providers/aer/aerjob.py
+++ b/qiskit/providers/aer/aerjob.py
@@ -9,7 +9,6 @@
 
 """This module implements the job class used for AerBackend objects."""
 
-import warnings
 from concurrent import futures
 import logging
 import sys
@@ -130,3 +129,11 @@ class AerJob(BaseJob):
     def backend(self):
         """Return the instance of the backend used for this job."""
         return self._backend
+
+    def qobj(self):
+        """Return the Qobj submitted for this job.
+
+        Returns:
+            Qobj: the Qobj submitted for this job.
+        """
+        return self._qobj

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -256,7 +256,7 @@ json_t Controller::execute(const json_t &qobj_js) {
   // Qobj was loaded successfully, now we proceed
   try {
     int num_circuits = qobj.circuits.size();
-
+    int num_threads_circuit = 1;
   // Check for OpenMP and number of available CPUs
   #ifdef _OPENMP
     int omp_nthreads = std::max(1, omp_get_max_threads());
@@ -267,7 +267,7 @@ json_t Controller::execute(const json_t &qobj_js) {
 
     // Calculate threads for parallel circuit execution
     // TODO: add memory checking for limiting thread number
-    int num_threads_circuit = (max_threads_circuit_ < 1) 
+    num_threads_circuit = (max_threads_circuit_ < 1) 
       ? std::min<int>({num_circuits, available_threads_ , max_threads_total_})
       : std::min<int>({num_circuits, available_threads_ , max_threads_total_, max_threads_circuit_});
     


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #16 and fixes #10

### Details and comments

* Adds `qobj` method to `AerJob` class that returns the submitted/run qobj.
* Fixes the missing definition for `num_threads_circuit` outside the `#ifdef _OPENMP` block so that single threaded execution works when building the simulators without OpenMP.

