### PR TITLE
Use cmake_args instead of cmd line call to build on OSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from skbuild import setup
 from setuptools import find_packages
 
@@ -11,6 +12,10 @@ VERSION_PATH = os.path.join(os.path.dirname(__file__),
 with open(VERSION_PATH, "r") as version_file:
     VERSION = version_file.read().strip()
 
+CMAKE_ARGS = []
+if sys.platform == 'darwin':
+    CMAKE_ARGS += ['-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9',
+                   '-DCMAKE_OSX_ARCHITECTURES:STRING=x86_64']
 
 def find_qiskit_aer_packages():
     location = 'qiskit/providers'
@@ -47,5 +52,6 @@ setup(
     ],
     install_requires=requirements,
     include_package_data=True,
-    keywords="qiskit aer simulator quantum addon backend"
+    keywords="qiskit aer simulator quantum addon backend",
+    cmake_args=CMAKE_ARGS
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is a simple update so that you no longer need to pass `--plat-name macosx-10.9-x86_64` with `python setup.py bdist_wheel` in order to build on OSX.

### Details and comments


