### PR TITLE
Validate n_qubits before execution

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -136,8 +136,8 @@ class QasmSimulator(AerBackend):
         for experiment in qobj.experiments:
             name = experiment.header.name
             if experiment.config.memory_slots == 0:
-                logger.warning('No classical registers in circuit "%s", '
-                               'counts will be empty.', name)
+                logger.warning('No classical registers in circuit "%s": '
+                               'result data will not contain counts.', name)
             elif 'measure' not in [op.name for op in experiment.instructions]:
-                logger.warning('No measurements in circuit "%s", '
-                               'classical register will remain all zeros.', name)
+                logger.warning('No measurements in circuit "%s": '
+                               'count data will return all zeros.', name)

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -9,12 +9,16 @@
 Qiskit Aer qasm simulator backend.
 """
 
+import logging
 from math import log2
 from qiskit._util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
 from .aerbackend import AerBackend
 from qasm_controller_wrapper import qasm_controller_execute
+from ..aererror import AerError
 from ..version import __version__
+
+logger = logging.getLogger(__name__)
 
 
 class QasmSimulator(AerBackend):
@@ -77,7 +81,7 @@ class QasmSimulator(AerBackend):
         'backend_name': 'qasm_simulator',
         'backend_version': __version__,
         'n_qubits': MAX_QUBIT_MEMORY,
-        'url': 'TODO',
+        'url': 'https://github.com/Qiskit/qiskit-aer',
         'simulator': True,
         'local': True,
         'conditional': True,
@@ -117,5 +121,23 @@ class QasmSimulator(AerBackend):
                          provider=provider)
 
     def _validate(self, qobj):
-        # TODO
-        return
+        """Semantic validations of the qobj which cannot be done via schemas.
+
+        1. Check number of qubits will fit in local memory.
+        2. warn if no classical registers or measurements in circuit.
+        """
+        n_qubits = qobj.config.n_qubits
+        max_qubits = self.configuration().n_qubits
+        if n_qubits > max_qubits:
+            raise AerError('Number of qubits ({}) '.format(n_qubits) +
+                           'is greater than maximum ({}) '.format(max_qubits) +
+                           'for "{}" '.format(self.name()) +
+                           'with {} GB system memory.'.format(int(local_hardware_info()['memory'])))
+        for experiment in qobj.experiments:
+            name = experiment.header.name
+            if experiment.config.memory_slots == 0:
+                logger.warning('No classical registers in circuit "%s", '
+                               'counts will be empty.', name)
+            elif 'measure' not in [op.name for op in experiment.instructions]:
+                logger.warning('No measurements in circuit "%s", '
+                               'classical register will remain all zeros.', name)

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -106,26 +106,30 @@ class UnitarySimulator(AerBackend):
     def _validate(self, qobj):
         """Semantic validations of the qobj which cannot be done via schemas.
         Some of these may later move to backend schemas.
-
-        1. No shots
+        1. Set shots=1
         2. No measurements or reset
+        3. Check number of qubits will fit in local memory.
         """
+        n_qubits = qobj.config.n_qubits
+        max_qubits = self.configuration().n_qubits
+        if n_qubits > max_qubits:
+            raise AerError('Number of qubits ({}) '.format(n_qubits) +
+                           'is greater than maximum ({}) '.format(max_qubits) +
+                           'for "{}" '.format(self.name()) +
+                           'with {} GB system memory.'.format(int(local_hardware_info()['memory'])))
         if qobj.config.shots != 1:
-            logger.info("UnitarySimulator only supports 1 shot. "
-                        "Setting shots=1.")
+            logger.info('"%s" only supports 1 shot. Setting shots=1.',
+                        self.name())
             qobj.config.shots = 1
         for experiment in qobj.experiments:
-            # Check for measure or reset operations
-            for pos, instr in reversed(list(enumerate(experiment.instructions))):
-                if instr.name == "measure":
-                    raise AerError("UnitarySimulator: circuit contains measure.")
-                if instr.name == "reset":
-                    raise AerError("UnitarySimulator: circuit contains reset.")
-            # Set shots to 1
+            name = experiment.header.name
             if getattr(experiment.config, 'shots', 1) != 1:
-                logger.info("UnitarySimulator only supports 1 shot. "
-                            "Setting shots=1 for circuit %s.", experiment.header.name)
+                logger.info('"%s" only supports 1 shot. '
+                            'Setting shots=1 for circuit "%s".',
+                            self.name(), name)
                 experiment.config.shots = 1
-            # Set memory slots to 0
-            if getattr(experiment.config, 'memory_slots', 0) != 0:
-                experiment.config.memory_slots = 0
+            for operation in experiment.instructions:
+                if operation.name in ['measure', 'reset']:
+                    raise AerError('Unsupported "%s" instruction "%s" ' +
+                                   'in circuit "%s" ', self.name(),
+                                   operation.name, name)

--- a/src/framework/data.hpp
+++ b/src/framework/data.hpp
@@ -309,7 +309,9 @@ json_t OutputData::json() const {
       tmp["snapshots"][pair.first] = pair.second.json();
     }
   }
-  // return json
+  // Check if data is null (empty) and if so return an empty JSON object
+  if (tmp.is_null())
+    return json_t::object();
   return tmp;
 }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Checks if the maximum number of qubits in a qobj fits in available system memory for a given Aer backend. If not it raises an exception before execution.

### Details and comments

* Backend validation checks number of qubits can fit in available memory before execution.  This Fixes #6 which was causing a broken process pool when the simulator attempted to run a simulation that was too large for available memory.
* Adds missing 'url' to Aer backend configuration
* Adds warnings for QasmSimulator if circuit contains no classical registers, or no measurements (same as BasicAer).
* Changes simulator to return `"data": {}` instead of `"data": null` as required by schema if simulator produces no result data. 

**Note:** We should also add memory checks on the C++ side, since these will be needed by the QasmSimulator in the future.