### PR TITLE
Improve error reporting if scikit-build is not preinstalled in the system at install time.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,6 @@
 include qiskit/providers/aer/VERSION.txt
+recursive-include src *
+recursive-include contrib *
+include CMakeLists.txt
+include cmake/*.cmake
+

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,15 @@
 import os
-from skbuild import setup
+try:
+    from skbuild import setup
+    dummy_install = False
+except:
+    print(""" WARNING
+              =======
+              scikit-build package is needed to build Aer sources.
+              Please, install scikit-build and reinstall Aer:
+              pip install -I qiskit-aer """)
+    from setuptools import setup
+    dummy_install = True
 from setuptools import find_packages
 
 requirements = [
@@ -26,7 +36,7 @@ def find_qiskit_aer_packages():
 setup(
     name='qiskit-aer',
     version=VERSION,
-    packages=find_qiskit_aer_packages(),
+    packages=find_qiskit_aer_packages() if not dummy_install else [],
     cmake_source_dir='.',
     description="Qiskit Aer - High performance simulators for Qiskit",
     author="AER Development Team",


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Better error checking at install time.


### Details and comments
If the user doesn't have scikit-build installed, it will show a message encouraging them to install it.


