### PR TITLE
add reset_error to noise module

### DIFF
--- a/qiskit/providers/aer/__init__.py
+++ b/qiskit/providers/aer/__init__.py
@@ -9,6 +9,7 @@
 
 from .aerprovider import AerProvider
 from .aerjob import AerJob
+from .aererror import AerError
 from .backends import *
 from . import noise
 from . import utils

--- a/qiskit/providers/aer/noise/__init__.py
+++ b/qiskit/providers/aer/noise/__init__.py
@@ -57,6 +57,7 @@ canonical types of quantum errors:
    Coherent unitary error
    Pauli error
    Depolarizing error
+   Reset error
    Thermal relaxation error
    Amplitude damping error
    Phase damping error

--- a/qiskit/providers/aer/noise/errors/__init__.py
+++ b/qiskit/providers/aer/noise/errors/__init__.py
@@ -7,11 +7,14 @@
 
 """Standard error module for Qiskit Aer."""
 
+from .quantum_error import QuantumError
+from .readout_error import ReadoutError
 from .standard_errors import kraus_error
 from .standard_errors import mixed_unitary_error
 from .standard_errors import coherent_unitary_error
 from .standard_errors import pauli_error
 from .standard_errors import depolarizing_error
+from .standard_errors import reset_error
 from .standard_errors import thermal_relaxation_error
 from .standard_errors import phase_amplitude_damping_error
 from .standard_errors import amplitude_damping_error

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -289,6 +289,26 @@ def depolarizing_error(prob, num_qubits, standard_gates=False):
     return pauli_error(zip(paulis, probs), standard_gates=standard_gates)
 
 
+def reset_error(prob0, prob1=0):
+    """Single qubit reset error channel.
+
+    The probability of no reset is given by 1 - prob0 - prob1
+
+    Args:
+        prob0 (double): reset probability to |0>
+        prob1 (double): reset probability to |1>
+
+    Returns:
+        QuantumError: the quantum error object.
+    """
+    noise_ops = [
+        ([{'name': 'id', 'qubits': [0]}], 1 - prob0 - prob1),
+        ([{'name': 'reset', 'qubits': [0]}], prob0),
+        ([{'name': 'reset', 'qubits': [0]}, {'name': 'x', 'qubits': [0]}], prob1),
+    ]
+    return QuantumError(noise_ops)
+
+
 def thermal_relaxation_error(t1, t2, time, excited_state_population=0):
     """
     Single-qubit thermal relaxation quantum error channel.
@@ -312,10 +332,10 @@ def thermal_relaxation_error(t1, t2, time, excited_state_population=0):
     """
     if excited_state_population < 0:
         raise NoiseError("Invalid excited state population " +
-                            "({} < 0).".format(excited_state_population))
+                         "({} < 0).".format(excited_state_population))
     if excited_state_population > 1:
         raise NoiseError("Invalid excited state population " +
-                            "({} > 1).".format(excited_state_population))
+                         "({} > 1).".format(excited_state_population))
     if time < 0:
         raise NoiseError("Invalid gate_time ({} < 0)".format(time))
     if t1 <= 0:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds `reset_error` function to the standard errors noise module.

### Details and comments

This allows a user to build a single-qubit reset error without having to deal with making a QobInstruction input.
