### PR TITLE
use vector<string> in json deserialization for clifford

### DIFF
--- a/src/simulators/stabilizer/clifford.hpp
+++ b/src/simulators/stabilizer/clifford.hpp
@@ -360,8 +360,8 @@ void from_json(const json_t &js, Clifford &clif) {
   if (!has_keys)
     throw std::invalid_argument("Invalid Clifford JSON.");
 
-  const json_t& stab = js["stabilizers"];
-  const json_t& destab = js["destabilizers"];
+  const std::vector<std::string> stab = js["stabilizers"];
+  const std::vector<std::string> destab = js["destabilizers"];
   const auto nq = stab.size();
   if (nq != destab.size()) {
     throw std::invalid_argument("Invalid Clifford JSON: stabilizer and destabilizer lengths do not match.");


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A small change in deserialization from json in Clifford

### Details and comments

Copying a `std::string` object from a string array of `json_t` causes a compilation error in some compilers. This PR changes to extract a `std::string` object from `std::vector<std::string>` instead of a string array of `json_t`.


