### PR TITLE
Fix UnboundedLocalError in basic_device_noise_model

### DIFF
--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -152,6 +152,7 @@ def basic_device_gate_errors(properties, thermal_relaxation=True,
     """
     # Generate custom gate time dict
     custom_times = {}
+    relax_params = []
     if thermal_relaxation:
         # If including thermal relaxation errors load
         # T1, T2, and frequency values from properties


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I fixed UnboundedLocalError in basic_device_noise_model.

### Details and comments

In `noise.device.basic_device_noise_model`, if `thermal_relaxation=False`, an error　`UnboundLocalError: local variable 'relax_params' referenced before assignment` occurred at
[line 185](https://github.com/Qiskit/qiskit-aer/blob/master/qiskit/providers/aer/noise/device/models.py#L185). This is because `relax_params` is not declared. This is just a workaround and tests should be added later.