### PR TITLE
Fix segfault on Mac OS when running the standalone qasm_simulator.

### DIFF
--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -94,6 +94,8 @@ int main(int argc, char **argv) {
 
     // Initialize simulator
     AER::Simulator::QasmController sim;
+    // Check for config
+    sim.set_config(qobj["config"]);
     out << sim.execute(qobj).dump(4) << std::endl;
 
     return 0;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


