### PR TITLE
Fix compiler warnings

### DIFF
--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -25,21 +25,21 @@ enum class CmdArguments {
   INPUT_DATA
 };
 
-CmdArguments parse_cmd_options(const std::string& argv){
+inline CmdArguments parse_cmd_options(const std::string& argv){
   if(argv == "-v" || argv == "--version"){
        return CmdArguments::SHOW_VERSION;
   }
   return CmdArguments::INPUT_DATA;
 }
 
-void show_version(){
+inline void show_version(){
   std::cout << "Qiskit Aer: "
   << MAJOR_VERSION << "."
   << MINOR_VERSION << "."
   << PATCH_VERSION << "\n";
 }
 
-void failed(const std::string &msg, std::ostream &o = std::cout,
+inline void failed(const std::string &msg, std::ostream &o = std::cout,
             int indent = -1){
   json_t ret;
   ret["success"] = false;
@@ -47,7 +47,7 @@ void failed(const std::string &msg, std::ostream &o = std::cout,
   o << ret.dump(indent) << std::endl;
 }
 
-void usage(const std::string& command, std::ostream &out){
+inline void usage(const std::string& command, std::ostream &out){
   failed("Invalid command line", out);
   // Print usage message
   std::cerr << "\n\n";

--- a/src/base/state.hpp
+++ b/src/base/state.hpp
@@ -59,7 +59,7 @@ public:
   // - `OpType::kraus` if general Kraus noise channels are supported
   // For the case of gates the specific allowed gates are checked
   // with the `allowed_gates` function.
-  virtual std::unordered_set<Operations::OpType> allowed_ops() const = 0;
+  virtual Operations::OpSet::optypeset_t allowed_ops() const = 0;
 
   // Return the set of qobj gate instruction names supported by the state class
   // For example this could include {"u1", "u2", "u3", "U", "cx", "CX"}

--- a/src/misc/clang_omp_symbols.hpp
+++ b/src/misc/clang_omp_symbols.hpp
@@ -37,20 +37,20 @@ extern "C" {
 
     using __kmpc_barrier_t = void(*)(id*, int);
     __kmpc_barrier_t _hook__kmpc_barrier;
-    void __kmpc_barrier(id* pId, int gtid){
+    inline void __kmpc_barrier(id* pId, int gtid){
         _hook__kmpc_barrier(pId, gtid);
     }
 
     using __kmpc_for_static_fini_t =  void(*)(kmp_Ident *, int32_t);
     __kmpc_for_static_fini_t _hook__kmpc_for_static_fini;
-    void __kmpc_for_static_fini(kmp_Ident *loc, int32_t global_tid){
+    inline void __kmpc_for_static_fini(kmp_Ident *loc, int32_t global_tid){
         _hook__kmpc_for_static_fini(loc, global_tid);
     }
 
     using __kmpc_for_static_init_4_t = void(*)(kmp_Ident *, int32_t, int32_t, int32_t *,
                                      int32_t *, int32_t *, int32_t *, int32_t, int32_t);
     __kmpc_for_static_init_4_t _hook__kmpc_for_static_init_4;
-    void __kmpc_for_static_init_4(kmp_Ident *loc, int32_t global_tid,
+    inline void __kmpc_for_static_init_4(kmp_Ident *loc, int32_t global_tid,
                                      int32_t sched, int32_t *plastiter,
                                      int32_t *plower, int32_t *pupper,
                                      int32_t *pstride, int32_t incr,
@@ -62,7 +62,7 @@ extern "C" {
     using __kmpc_for_static_init_8_t = void(*)(kmp_Ident *, int32_t, int32_t, int32_t *,
                                      int64_t *, int64_t *, int64_t *, int64_t, int64_t);
     __kmpc_for_static_init_8_t _hook__kmpc_for_static_init_8;
-    void __kmpc_for_static_init_8(kmp_Ident *loc, int32_t global_tid,
+    inline void __kmpc_for_static_init_8(kmp_Ident *loc, int32_t global_tid,
                                      int32_t sched, int32_t *plastiter,
                                      int64_t *plower, int64_t *pupper,
                                      int64_t *pstride, int64_t incr,
@@ -74,7 +74,7 @@ extern "C" {
     using __kmpc_for_static_init_8u_t = void(*)(kmp_Ident *, int32_t, int32_t, int32_t *, uint64_t *, uint64_t *,
                                       int64_t *, int64_t, int64_t);
     __kmpc_for_static_init_8u_t _hook__kmpc_for_static_init_8u;
-    void __kmpc_for_static_init_8u(kmp_Ident *loc, int32_t global_tid,
+    inline void __kmpc_for_static_init_8u(kmp_Ident *loc, int32_t global_tid,
                                       int32_t sched, int32_t *plastiter1,
                                       uint64_t *plower, uint64_t *pupper,
                                       int64_t *pstride, int64_t incr,
@@ -249,7 +249,7 @@ extern "C" {
 namespace AER {
 namespace Hacks {
 
-void populate_hooks(void * handle){
+inline void populate_hooks(void * handle){
     _hook__kmpc_barrier = reinterpret_cast<decltype(&__kmpc_barrier)>(dlsym(handle, "__kmpc_barrier"));
     _hook__kmpc_for_static_fini = reinterpret_cast<decltype(&__kmpc_for_static_fini)>(dlsym(handle, "__kmpc_for_static_fini"));
     _hook__kmpc_end_reduce_nowait = reinterpret_cast<decltype(&__kmpc_end_reduce_nowait)>(dlsym(handle, "__kmpc_end_reduce_nowait"));

--- a/src/misc/gcc_omp_symbols.hpp
+++ b/src/misc/gcc_omp_symbols.hpp
@@ -10,47 +10,47 @@ extern "C" {
 
     using GOMP_atomic_start_t = void(*)();
     GOMP_atomic_start_t _hook_GOMP_atomic_start;
-    void GOMP_atomic_start (void){
+    inline void GOMP_atomic_start (void){
         _hook_GOMP_atomic_start();
     }
 
     using GOMP_atomic_end_t = void(*)();
     GOMP_atomic_end_t _hook_GOMP_atomic_end;
-    void GOMP_atomic_end (void){
+    inline void GOMP_atomic_end (void){
         _hook_GOMP_atomic_end();
     }
 
     using GOMP_barrier_t = void(*)();
     GOMP_barrier_t _hook_GOMP_barrier;
-    void GOMP_barrier(void){
+    inline void GOMP_barrier(void){
         _hook_GOMP_barrier();
     }
 
     using GOMP_parallel_t = void(*)(void (*)(void *), void *, unsigned, unsigned);
     GOMP_parallel_t _hook_GOMP_parallel;
-    void GOMP_parallel(void (*fn) (void *), void *data, unsigned num_threads, unsigned flags){
+    inline void GOMP_parallel(void (*fn) (void *), void *data, unsigned num_threads, unsigned flags){
         _hook_GOMP_parallel(fn, data, num_threads, flags);
     }
 
     #define __KAI_KMPC_CONVENTION
     using omp_get_max_threads_t = int(*)(void);
     omp_get_max_threads_t _hook_omp_get_max_threads;
-    int __KAI_KMPC_CONVENTION omp_get_max_threads(void) {
+    inline int __KAI_KMPC_CONVENTION omp_get_max_threads(void) {
         return _hook_omp_get_max_threads();
     }
     using omp_set_nested_t = void(*)(int);
     omp_set_nested_t _hook_omp_set_nested;
-    void __KAI_KMPC_CONVENTION omp_set_nested(int foo){
+    inline void __KAI_KMPC_CONVENTION omp_set_nested(int foo){
         _hook_omp_set_nested(foo);
     }
     using omp_get_num_threads_t = int(*)(void);
     omp_get_num_threads_t _hook_omp_get_num_threads;
-    int __KAI_KMPC_CONVENTION omp_get_num_threads(void) {
+    inline int __KAI_KMPC_CONVENTION omp_get_num_threads(void) {
         return _hook_omp_get_num_threads();
     }
     using omp_get_thread_num_t = int(*)(void);
     omp_get_thread_num_t _hook_omp_get_thread_num;
-    int __KAI_KMPC_CONVENTION omp_get_thread_num(void) {
+    inline int __KAI_KMPC_CONVENTION omp_get_thread_num(void) {
         return _hook_omp_get_thread_num();
     }
 }
@@ -58,7 +58,7 @@ extern "C" {
 namespace AER {
 namespace Hacks {
 
-    void populate_hooks(void * handle){
+    inline void populate_hooks(void * handle){
         _hook_GOMP_atomic_end = reinterpret_cast<decltype(&GOMP_atomic_end)>(dlsym(handle, "GOMP_atomic_end"));
         _hook_GOMP_atomic_start = reinterpret_cast<decltype(&GOMP_atomic_start)>(dlsym(handle, "GOMP_atomic_start"));
         _hook_GOMP_barrier = reinterpret_cast<decltype(&GOMP_barrier)>(dlsym(handle, "GOMP_barrier"));

--- a/src/simulators/stabilizer/binary_vector.hpp
+++ b/src/simulators/stabilizer/binary_vector.hpp
@@ -79,13 +79,13 @@ private:
  *
  ******************************************************************************/
 
-bool operator==(const BinaryVector &lhs, const BinaryVector &rhs) {
+inline bool operator==(const BinaryVector &lhs, const BinaryVector &rhs) {
   return lhs.isSame(rhs, true);
 }
 
 
-int64_t gauss_eliminate(std::vector<BinaryVector> &M,
-                        const int64_t start_col = 0)
+inline int64_t gauss_eliminate(std::vector<BinaryVector> &M,
+                               const int64_t start_col = 0)
 // returns the rank of M.
 // M[] has length nrows.
 // each M[i] must have the same length ncols.
@@ -114,9 +114,9 @@ int64_t gauss_eliminate(std::vector<BinaryVector> &M,
 }
 
 
-std::vector<uint64_t> string_to_bignum(std::string val,
-                                            uint64_t blockSize,
-                                            uint64_t base) {
+inline std::vector<uint64_t> string_to_bignum(std::string val,
+                                              uint64_t blockSize,
+                                              uint64_t base) {
   std::vector<uint64_t> ret;
   if (blockSize * log2(base) > 64) {
     throw std::runtime_error(
@@ -134,7 +134,7 @@ std::vector<uint64_t> string_to_bignum(std::string val,
 }
 
 
-std::vector<uint64_t> string_to_bignum(std::string val) {
+inline std::vector<uint64_t> string_to_bignum(std::string val) {
   std::string type = val.substr(0, 2);
   if (type == "0b" || type == "0B")
     // Binary string
@@ -241,19 +241,19 @@ bool BinaryVector::isSame(const BinaryVector &rhs, bool pad) const {
   if (!pad)
     return isSame(rhs);
 
-  const auto sz0 = m_data.size();
-  const auto sz1 = rhs.m_data.size();
-  const auto sz = (sz0 > sz1) ? sz1 : sz0;
+  const size_t sz0 = m_data.size();
+  const size_t sz1 = rhs.m_data.size();
+  const size_t sz = (sz0 > sz1) ? sz1 : sz0;
 
   // Check vectors agree on overlap
-  for (auto q = 0; q < sz; q++)
+  for (size_t q = 0; q < sz; q++)
     if (m_data[q] != rhs.m_data[q])
       return false;
   // Check padding of larger vector is trivial
-  for (auto q = sz; q < sz0; q++)
+  for (size_t q = sz; q < sz0; q++)
     if (m_data[q] != 0)
       return false;
-  for (auto q = sz; q < sz1; q++)
+  for (size_t q = sz; q < sz1; q++)
     if (rhs.m_data[q] != 0)
       return false;
 

--- a/src/simulators/stabilizer/clifford.hpp
+++ b/src/simulators/stabilizer/clifford.hpp
@@ -185,14 +185,14 @@ Clifford::Clifford(uint64_t nq) : num_qubits_(nq) {
   // initial state = all zeros
   // add destabilizers
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < nq; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(nq); i++) {
     Pauli::Pauli P(nq);
     P.X.setValue(1, i);
     table_.push_back(P);
   }
   // add stabilizers
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < nq; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(nq); i++) {
     Pauli::Pauli P(nq);
     P.Z.setValue(1, i);
     table_.push_back(P);
@@ -207,7 +207,7 @@ Clifford::Clifford(uint64_t nq) : num_qubits_(nq) {
 
 void Clifford::append_cx(const uint64_t qcon, const uint64_t qtar) {
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < 2 * num_qubits_; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++) {
     phases_[i] ^= (table_[i].X[qcon] && table_[i].Z[qtar] &&
                   (table_[i].X[qtar] ^ table_[i].Z[qcon] ^ 1));
     table_[i].X.setValue(table_[i].X[qtar] ^ table_[i].X[qcon], qtar);
@@ -217,7 +217,7 @@ void Clifford::append_cx(const uint64_t qcon, const uint64_t qtar) {
 
 void Clifford::append_h(const uint64_t qubit) {
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < 2 * num_qubits_; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++) {
     phases_[i] ^= (table_[i].X[qubit] && table_[i].Z[qubit]);
     // exchange X and Z
     bool b = table_[i].X[qubit];
@@ -228,7 +228,7 @@ void Clifford::append_h(const uint64_t qubit) {
 
 void Clifford::append_s(const uint64_t qubit) {
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < 2 * num_qubits_; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++) {
     phases_[i] ^= (table_[i].X[qubit] && table_[i].Z[qubit]);
     table_[i].Z.setValue(table_[i].Z[qubit] ^ table_[i].X[qubit], qubit);
   }
@@ -236,19 +236,19 @@ void Clifford::append_s(const uint64_t qubit) {
 
 void Clifford::append_x(const uint64_t qubit) {
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < 2 * num_qubits_; i++)
+  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++)
     phases_[i] ^= table_[i].Z[qubit];
 }
 
 void Clifford::append_y(const uint64_t qubit) {
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < 2 * num_qubits_; i++)
+  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++)
     phases_[i] ^= (table_[i].Z[qubit] ^ table_[i].X[qubit]);
 }
 
 void Clifford::append_z(const uint64_t qubit) {
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < 2 * num_qubits_; i++)
+  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++)
     phases_[i] ^= table_[i].X[qubit];
 }
 
@@ -351,11 +351,11 @@ json_t Clifford::json() const {
   return js;
 }
 
-void to_json(json_t &js, const Clifford &clif) {
+inline void to_json(json_t &js, const Clifford &clif) {
   js = clif.json();
 }
 
-void from_json(const json_t &js, Clifford &clif) {
+inline void from_json(const json_t &js, Clifford &clif) {
   bool has_keys = JSON::check_keys({"stabilizers", "destabilizers"}, js);
   if (!has_keys)
     throw std::invalid_argument("Invalid Clifford JSON.");

--- a/src/simulators/stabilizer/pauli.hpp
+++ b/src/simulators/stabilizer/pauli.hpp
@@ -89,7 +89,7 @@ std::string Pauli::str() const {
       label.push_back('Z');
   }
   return label;
-};
+}
 
 int8_t Pauli::phase_exponent(const Pauli& pauli1, const Pauli& pauli2) {
   int8_t exponent = 0;

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -49,8 +49,8 @@ public:
   virtual std::string name() const override {return "stabilizer";}
 
   // Return the set of qobj instruction types supported by the State
-  virtual std::unordered_set<Operations::OpType> allowed_ops() const override {
-    return std::unordered_set<Operations::OpType>({
+  virtual Operations::OpSet::optypeset_t allowed_ops() const override {
+    return Operations::OpSet::optypeset_t({
       Operations::OpType::gate,
       Operations::OpType::measure,
       Operations::OpType::reset,

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -56,8 +56,8 @@ public:
   virtual std::string name() const override {return "statevector";}
 
   // Return the set of qobj instruction types supported by the State
-  virtual std::unordered_set<Operations::OpType> allowed_ops() const override {
-    return std::unordered_set<Operations::OpType>({
+  virtual Operations::OpSet::optypeset_t allowed_ops() const override {
+    return Operations::OpSet::optypeset_t({
       Operations::OpType::gate,
       Operations::OpType::measure,
       Operations::OpType::reset,

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -49,8 +49,8 @@ public:
   virtual std::string name() const override {return "unitary";}
 
   // Return the set of qobj instruction types supported by the State
-  virtual std::unordered_set<Operations::OpType> allowed_ops() const override {
-    return std::unordered_set<Operations::OpType>({
+  virtual Operations::OpSet::optypeset_t allowed_ops() const override {
+    return Operations::OpSet::optypeset_t({
       Operations::OpType::gate,
       Operations::OpType::barrier,
       Operations::OpType::matrix,

--- a/src/simulators/unitary/unitarymatrix.hpp
+++ b/src/simulators/unitary/unitarymatrix.hpp
@@ -188,7 +188,8 @@ void UnitaryMatrix<data_t>::initialize() {
 template <class data_t>
 void UnitaryMatrix<data_t>::initialize_from_matrix(const AER::cmatrix_t &mat) {
   const int_t nrows = rows_;    // end for k loop
-  if (nrows != mat.GetRows() || nrows != mat.GetColumns()) {
+  if (nrows != static_cast<int_t>(mat.GetRows()) ||
+      nrows != static_cast<int_t>(mat.GetColumns())) {
     throw std::runtime_error(
       "UnitaryMatrix::initialize input matrix is incorrect shape (" +
       std::to_string(nrows) + "," + std::to_string(nrows) + ")!=(" +


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Fixes some pedantic compiler warnings for missing declarations and comparisons of signed to unsigned intergers.

* Changes State::allowed_ops to use the previously defined type alias

### Details and comments


