### PR TITLE
[WIP] Add circuit equivalence checker

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -17,6 +17,7 @@ Qiskit Aer qasm simulator backend.
 import json
 import logging
 import datetime
+import os
 import time
 import uuid
 from numpy import ndarray
@@ -32,6 +33,10 @@ from ..aererror import AerError
 
 # Logger
 logger = logging.getLogger(__name__)
+
+# Location where we put external libraries that will be loaded at runtime
+# by the simulator extension
+LIBRARY_DIR = os.path.dirname(__file__)
 
 
 class AerJSONEncoder(json.JSONEncoder):
@@ -129,7 +134,7 @@ class AerBackend(BaseBackend):
             config["noise_model"] = noise_model
 
         # Add runtime config
-        config['library_dir'] = self.configuration().library_dir
+        config['library_dir'] = LIBRARY_DIR
         qobj.config = QasmQobjConfig.from_dict(config)
         # Get the JSON serialized string
         output = json.dumps(qobj, cls=AerJSONEncoder).encode('UTF-8')

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -14,7 +14,6 @@ Qiskit Aer qasm simulator backend.
 """
 
 import logging
-import os
 from math import log2
 from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
@@ -55,6 +54,9 @@ class QasmSimulator(AerBackend):
 
         * "zero_threshold" (double): Sets the threshold for truncating
             small values to zero in the result data (Default: 1e-10).
+
+        * "validation_threshold" (double): Sets the threshold for checking
+            if initial states are valid (Default: 1e-8).
 
         * "max_parallel_threads" (int): Sets the maximum number of CPU
             cores used by OpenMP for parallelization. If set to 0 the
@@ -165,10 +167,7 @@ class QasmSimulator(AerBackend):
             'name': 'TODO',
             'parameters': [],
             'qasm_def': 'TODO'
-        }],
-        # Location where we put external libraries that will be loaded at runtime
-        # by the simulator extension
-        'library_dir': os.path.dirname(__file__)
+        }]
     }
 
     def __init__(self, configuration=None, provider=None):

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -17,7 +17,6 @@ Qiskit Aer statevector simulator backend.
 """
 
 import logging
-import os
 from math import log2
 from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
@@ -42,6 +41,9 @@ class StatevectorSimulator(AerBackend):
 
         * "zero_threshold" (double): Sets the threshold for truncating
             small values to zero in the result data (Default: 1e-10).
+
+        * "validation_threshold" (double): Sets the threshold for checking
+            if the initial statevector is valid (Default: 1e-8).
 
         * "max_parallel_threads" (int): Sets the maximum number of CPU
             cores used by OpenMP for parallelization. If set to 0 the
@@ -92,10 +94,7 @@ class StatevectorSimulator(AerBackend):
                 'parameters': [],
                 'qasm_def': 'TODO'
             }
-        ],
-        # Location where we put external libraries that will be loaded at runtime
-        # by the simulator extension
-        'library_dir': os.path.dirname(__file__)
+        ]
     }
 
     def __init__(self, configuration=None, provider=None):

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -40,8 +40,16 @@ class UnitarySimulator(AerBackend):
         `backend_options` kwarg diction for `UnitarySimulator.run` or
         `qiskit.execute`
 
+        * "identity_checker" (bool): Set operation to identity checker
+            mode (Default: False)
+
         * "initial_unitary" (matrix_like): Sets a custom initial unitary
             matrix for the simulation instead of identity (Default: None).
+
+        * "target_unitary" (matrix_like): Sets a custom target unitary
+            other than the identity for identity_checker mode. This sets
+            the inital state to target_unitary^dagger and then checks
+            that the output is the identity (Defualt: None).
 
         * "validation_threshold" (double): Sets the threshold for checking
             if initial unitary and target unitary are unitary matrices.

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -17,7 +17,6 @@ Qiskit Aer Unitary Simulator Backend.
 """
 
 import logging
-import os
 from math import log2, sqrt
 from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
@@ -43,6 +42,10 @@ class UnitarySimulator(AerBackend):
 
         * "initial_unitary" (matrix_like): Sets a custom initial unitary
             matrix for the simulation instead of identity (Default: None).
+
+        * "validation_threshold" (double): Sets the threshold for checking
+            if initial unitary and target unitary are unitary matrices.
+            (Default: 1e-8).
 
         * "zero_threshold" (double): Sets the threshold for truncating
             small values to zero in the result data (Default: 1e-10).
@@ -97,10 +100,7 @@ class UnitarySimulator(AerBackend):
                 'parameters': [],
                 'qasm_def': 'TODO'
             }
-        ],
-        # Location where we put external libraries that will be loaded at runtime
-        # by the simulator extension
-        'library_dir': os.path.dirname(__file__)
+        ]
     }
 
     def __init__(self, configuration=None, provider=None):

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -208,6 +208,9 @@ protected:
   // Controller config settings
   json_t config_;
 
+  // Validation threshold parameter
+  double validation_threshold_ = 1e-8;
+
   // Noise model
   Noise::NoiseModel noise_model_;
 
@@ -259,6 +262,9 @@ protected:
 void Controller::set_config(const json_t &config) {
   // Save config for passing to State and Data classes
   config_ = config;
+
+  // Get threhold parameter for general validation functions
+  JSON::get_value(validation_threshold_, "validation_threhsold", config);
 
   // Load noise model
   if (JSON::check_key("noise_model", config))

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -310,7 +310,7 @@ void QasmController::set_config(const json_t &config) {
     // Override simulator method to statevector
     simulation_method_ = Method::statevector;
     // Check initial state is normalized
-    if (!Utils::is_unit_vector(initial_statevector_, 1e-10)) {
+    if (!Utils::is_unit_vector(initial_statevector_, validation_threshold_)) {
       throw std::runtime_error("QasmController: initial_statevector is not a unit vector");
     }
   }

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -112,7 +112,7 @@ void StatevectorController::set_config(const json_t &config) {
   //Add custom initial state
   if (JSON::get_value(initial_state_, "initial_statevector", config)) {
     // Check initial state is normalized
-    if (!Utils::is_unit_vector(initial_state_, 1e-10))
+    if (!Utils::is_unit_vector(initial_state_, validation_threshold_))
       throw std::runtime_error("StatevectorController: initial_statevector is not a unit vector");
   }
 }

--- a/src/simulators/unitary/unitary_controller.hpp
+++ b/src/simulators/unitary/unitary_controller.hpp
@@ -104,7 +104,7 @@ void UnitaryController::set_config(const json_t &config) {
   //Add custom initial unitary
   if (JSON::get_value(initial_unitary_, "initial_unitary", config) ) {
     // Check initial state is unitary
-    if (!Utils::is_unitary(initial_unitary_, 1e-10))
+    if (!Utils::is_unitary(initial_unitary_, validation_threshold_))
       throw std::runtime_error("UnitaryController: initial_unitary is not unitary");
   }
 }

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -161,6 +161,9 @@ protected:
   // Threshold for chopping small values to zero in JSON
   double json_chop_threshold_ = 1e-10;
 
+  // Threshold for comparing state to identity matrix
+  double identity_threshold_ = 1e-8;
+
   // Table of allowed gate names to gate enum class members
   const static stringmap_t<Gates> gateset_;
 };
@@ -253,6 +256,10 @@ void State<data_t>::set_config(const json_t &config) {
   // Set threshold for truncating snapshots
   JSON::get_value(json_chop_threshold_, "zero_threshold", config);
   BaseState::qreg_.set_json_chop_threshold(json_chop_threshold_);
+
+  // Set threshold for general validation functions
+  JSON::get_value(identity_threshold_, "identity_checker_threshold", config);
+  BaseState::qreg_.set_check_identity_threshold(identity_threshold_);
 }
 
 

--- a/src/simulators/unitary/unitarymatrix.hpp
+++ b/src/simulators/unitary/unitarymatrix.hpp
@@ -63,6 +63,9 @@ public:
   // Returns a copy of the underlying data_t data as a complex vector
   AER::cmatrix_t matrix() const;
 
+  // Return the trace of the unitary
+  complex_t trace() const;
+
   // Return JSON serialization of UnitaryMatrix;
   json_t json() const;
 
@@ -74,6 +77,23 @@ public:
   // an exception is raised.
   void initialize_from_matrix(const AER::cmatrix_t &mat);
 
+  //-----------------------------------------------------------------------
+  // Identity checking
+  //-----------------------------------------------------------------------
+  
+  // Return pair (True, theta) if the current matrix is equal to
+  // exp(i * theta) * identity matrix. Otherwise return (False, 0).
+  // The phase is returned as a parameter between -Pi and Pi.
+  std::pair<bool, double> check_identity() const;
+
+  // Set the threshold for verify_identity
+  void set_check_identity_threshold(double threshold) {
+    identity_threshold_ = threshold;
+  }
+
+  // Get the threshold for verify_identity
+  double get_check_identity_threshold() {return identity_threshold_;}
+
 protected:
 
   //-----------------------------------------------------------------------
@@ -81,6 +101,14 @@ protected:
   //-----------------------------------------------------------------------
   size_t num_qubits_;
   size_t rows_;
+
+  //-----------------------------------------------------------------------
+  // Additional config settings
+  //-----------------------------------------------------------------------
+  
+  double identity_threshold_ = 1e-10; // Threshold for verifying if the
+                                      // internal matrix is identity up to
+                                      // global phase
 };
 
 /*******************************************************************************
@@ -158,8 +186,8 @@ UnitaryMatrix<data_t>::UnitaryMatrix(size_t num_qubits) {
 template <class data_t>
 AER::cmatrix_t UnitaryMatrix<data_t>::matrix() const {
 
-  AER::cmatrix_t ret(rows_, rows_);
   const int_t nrows = rows_;
+  AER::cmatrix_t ret(nrows, nrows);
 
   #pragma omp parallel if (BaseVector::num_qubits_ > BaseVector::omp_threshold_ && BaseVector::omp_threads_ > 1) num_threads(BaseVector::omp_threads_)
   {
@@ -222,6 +250,63 @@ void UnitaryMatrix<data_t>::set_num_qubits(size_t num_qubits) {
   rows_ = 1ULL << num_qubits;
   // Set the underlying vectorized matrix to be 2 * number of qubits
   BaseVector::set_num_qubits(2 * num_qubits);
+}
+
+template <class data_t>
+complex_t UnitaryMatrix<data_t>::trace() const {
+  const int_t NROWS = rows_;
+  const int_t DIAG = NROWS + 1;
+  double val_re = 0.;
+  double val_im = 0.;
+#pragma omp parallel reduction(+:val_re, val_im) if (BaseVector::num_qubits_ > BaseVector::omp_threshold_ && BaseVector::omp_threads_ > 1) BaseVector::num_threads(BaseVector::omp_threads_)
+  {
+#pragma omp for
+  for (int_t k = 0; k < NROWS; ++k) {
+    val_re += std::real(BaseVector::data_[k * DIAG]);
+    val_im += std::imag(BaseVector::data_[k * DIAG]);
+  }
+  }
+  return complex_t(val_re, val_im);
+}
+
+
+//------------------------------------------------------------------------------
+// Check Identity
+//------------------------------------------------------------------------------
+
+template <class data_t>
+std::pair<bool, double> UnitaryMatrix<data_t>::check_identity() const {
+  // To check if identity we first check we check that:
+  // 1. U(0, 0) = exp(i * theta)
+  // 2. U(i, i) = U(0, 0)
+  // 3. U(i, j) = 0 for j != i 
+  auto failed = std::make_pair(false, 0.0);
+
+  // Check condition 1.
+  const auto u00 = BaseVector::data_[0];
+  if (std::norm(std::abs(u00) - 1.0) > identity_threshold_) {
+    return failed;
+  }
+  const auto theta = std::arg(u00);
+
+  // Check conditions 2 and 3
+  double delta = 0.;
+  for (size_t i=0; i < rows_; i++) {
+    for (size_t j=0; j < rows_; j++) {
+      auto val = (i==j) ? std::norm(BaseVector::data_[i + rows_ * j] - u00)
+                        : std::norm(BaseVector::data_[i + rows_ * j]);
+      if (val > identity_threshold_) {
+        return failed; // fail fast if single entry differs
+      } else
+        delta += val; // accumulate difference
+    }
+  }
+  // Check small errors didn't accumulate
+  if (delta > identity_threshold_) {
+    return failed;
+  }
+  // Otherwise we pass
+  return std::make_pair(true, theta);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds an identity checker mode to the `UnitarySimulator` that can be used as a basis for a circuit equivalence checker.

This mode is activated by using `backend_options={"identity_checker": True}` for the `UnitarySimulator` and in this case instead of returning the final unitary matrix the result will say if the final unitary is `exp(i * theta) * U_target` where `U_target` is the identity matrix, or a custom target unitary matrix. If result is `True` it also returns the global phase `theta`. 

### Details and comments

To manually activate the identity checking mode one can do the following

```python
# Get ideal circuit
target_circuit = ... # Target quantum circuit
target_unitary = qiskit.execute(circuit_target, UnitarySimulator()).result().get_unitary(target_circuit)

# Check new circuit
test_circuit = ... # new quantum circuit
opts = {
    "identity_checker": True, 
    "target_unitary": target_unitary
}
job = qiskit.execute(test_circuit, UnitarySimulator(),
    backend_options=opts)
results = job.results()
print(results.data(0))
# prints 
{"identity": [True, 0.0]}  # output is [pass, global_phase]
```

A more efficient method is to compares $U_{target}^\dagger . U = id$ (`inverse(target_circuit).circuit` to the identity):

```python
target_circuit = ...
test_circuit = ... 
check_circuit = target_circuit.inverse() + test_circuit
opts =  {"identity_checker": True }
job = qiskit.execute(check_circuit, UnitaryVerifier(),
    backend_options=opts)
results = job.results()
print(results.data(check_circuit))
```

### TODO

Decide how to expose this functionality to the user for a circuit equivalence checker such as `check_equivalent(circuit1, circuit2)`