### PR TITLE
Disable unitary instruction tests until terra fix

### DIFF
--- a/test/terra/test_statevector_simulator.py
+++ b/test/terra/test_statevector_simulator.py
@@ -702,7 +702,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     # Test unitary gate qobj instruction
     # ---------------------------------------------------------------------
-    def test_unitary_gate_real(self):
+    def DISABLED_test_unitary_gate_real(self):
         """Test unitary qobj instruction with real matrices."""
         qobj = ref_unitary_gate.unitary_gate_circuits_real_deterministic(final_measure=False)
         circuits = [experiment.header.name for experiment in qobj.experiments]
@@ -712,7 +712,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         self.is_completed(result)
         self.compare_statevector(result, circuits, targets)
 
-    def test_unitary_gate_complex(self):
+    def DISABLED_test_unitary_gate_complex(self):
         """Test unitary qobj instruction with complex matrices."""
         qobj = ref_unitary_gate.unitary_gate_circuits_complex_deterministic(final_measure=False)
         circuits = [experiment.header.name for experiment in qobj.experiments]

--- a/test/terra/test_unitary_simulator.py
+++ b/test/terra/test_unitary_simulator.py
@@ -631,7 +631,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     # Test unitary gate qobj instruction
     # ---------------------------------------------------------------------
-    def test_unitary_gate_real(self):
+    def DISABLED_test_unitary_gate_real(self):
         """Test unitary qobj instruction with real matrices."""
         qobj = ref_unitary_gate.unitary_gate_circuits_real_deterministic(final_measure=False)
         circuits = [experiment.header.name for experiment in qobj.experiments]
@@ -641,7 +641,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         self.is_completed(result)
         self.compare_unitary(result, circuits, targets)
 
-    def test_unitary_gate_complex(self):
+    def DISABLED_test_unitary_gate_complex(self):
         """Test unitary qobj instruction with complex matrices."""
         qobj = ref_unitary_gate.unitary_gate_circuits_complex_deterministic(final_measure=False)
         circuits = [experiment.header.name for experiment in qobj.experiments]

--- a/test/terra/utils/qasm_simulator/qasm_extra.py
+++ b/test/terra/utils/qasm_simulator/qasm_extra.py
@@ -23,7 +23,7 @@ class QasmExtraTests(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     # Test unitary gate qobj instruction
     # ---------------------------------------------------------------------
-    def test_unitary_gate_real(self):
+    def DISABLED_test_unitary_gate_real(self):
         """Test unitary qobj instruction with real matrices."""
         shots = 100
         qobj = ref_unitary_gate.unitary_gate_circuits_real_deterministic(final_measure=True)
@@ -34,7 +34,7 @@ class QasmExtraTests(common.QiskitAerTestCase):
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
-    def test_unitary_gate_complex(self):
+    def DISABLED_test_unitary_gate_complex(self):
         """Test unitary qobj instruction with complex matrices."""
         shots = 100
         qobj = ref_unitary_gate.unitary_gate_circuits_complex_deterministic(final_measure=True)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Disable tests failing to Terra qobj changes until they can be fixed in Terra.

When updating these should be changed to use the new unitary circuit instruction being worked on in terra PR 1961

### Details and comments


