### PR TITLE
allow various qubit vector classes in qasm controller

### DIFF
--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -298,7 +298,7 @@ OutputData QasmController::run_circuit(const Circuit &circ,
   switch (simulation_method(circ)) {
     case Method::statevector:
       // Statevector simulation
-      return run_circuit_helper<Statevector::State<QV::QubitVector<complex_t*>>>(
+      return run_circuit_helper<Statevector::State<>>(
                                                       circ,
                                                       shots,
                                                       rng_seed,
@@ -337,7 +337,7 @@ QasmController::Method QasmController::simulation_method(const Circuit &circ) co
     // Default method is statevector, unless the memory requirements are too large
     else
     {
-      Statevector::State<QV::QubitVector<complex_t*>> sv_state;
+      Statevector::State<> sv_state;
       if(!(validate_memory_requirements(sv_state, circ, false)))
       {
         if(validate_state(CH::State(), circ, noise_model_, false))

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -247,7 +247,8 @@ OutputData QasmController::run_circuit(const Circuit &circ,
   switch (simulation_method(circ)) {
     case Method::statevector:
       // Statevector simulation
-      return run_circuit_helper<Statevector::State<QV::QubitVector<complex_t*>>>(circ,
+      return run_circuit_helper<Statevector::State<QV::QubitVector<complex_t*>>>(
+                                                      circ,
                                                       shots,
                                                       rng_seed,
                                                       initial_statevector_); // allow custom initial state

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -337,7 +337,7 @@ QasmController::Method QasmController::simulation_method(const Circuit &circ) co
     // Default method is statevector, unless the memory requirements are too large
     else
     {
-      Statevector::State<> sv_state;
+      Statevector::State<QV::QubitVector<complex_t*>> sv_state;
       if(!(validate_memory_requirements(sv_state, circ, false)))
       {
         if(validate_state(CH::State(), circ, noise_model_, false))

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -73,7 +73,7 @@ public:
   // Clear the current config
   void virtual clear_config() override;
 
-private:
+protected:
   //-----------------------------------------------------------------------
   // Simulation types
   //-----------------------------------------------------------------------
@@ -247,7 +247,7 @@ OutputData QasmController::run_circuit(const Circuit &circ,
   switch (simulation_method(circ)) {
     case Method::statevector:
       // Statevector simulation
-      return run_circuit_helper<Statevector::State<>>(circ,
+      return run_circuit_helper<Statevector::State<QV::QubitVector<complex_t*>>>(circ,
                                                       shots,
                                                       rng_seed,
                                                       initial_statevector_); // allow custom initial state

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -119,7 +119,7 @@ OutputData StatevectorController::run_circuit(const Circuit &circ,
                                               uint_t shots,
                                               uint_t rng_seed) const {
   // Initialize  state
-  Statevector::State<QV::QubitVector<complex_t*>> state;
+  Statevector::State<> state;
 
   // Validate circuit and throw exception if invalid operations exist
   validate_state(state, circ, noise_model_, true);

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -119,7 +119,7 @@ OutputData StatevectorController::run_circuit(const Circuit &circ,
                                               uint_t shots,
                                               uint_t rng_seed) const {
   // Initialize  state
-  Statevector::State<> state;
+  Statevector::State<QV::QubitVector<complex_t*>> state;
 
   // Validate circuit and throw exception if invalid operations exist
   validate_state(state, circ, noise_model_, true);

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -40,7 +40,7 @@ enum class Snapshots {
 // QubitVector State subclass
 //=========================================================================
 
-template <class statevec_t>
+template <class statevec_t = QV::QubitVector<complex_t*>>
 class State : public Base::State<statevec_t> {
 public:
   using BaseState = Base::State<statevec_t>;

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -40,10 +40,10 @@ enum class Snapshots {
 // QubitVector State subclass
 //=========================================================================
 
-template <class data_t = complex_t*>
-class State : public Base::State<QV::QubitVector<data_t>> {
+template <class statevec_t>
+class State : public Base::State<statevec_t> {
 public:
-  using BaseState = Base::State<QV::QubitVector<data_t>>;
+  using BaseState = Base::State<statevec_t>;
 
   State() = default;
   virtual ~State() = default;
@@ -95,7 +95,7 @@ public:
 
   // Initializes to a specific n-qubit state
   virtual void initialize_qreg(uint_t num_qubits,
-                               const QV::QubitVector<data_t> &state) override;
+                               const statevec_t &state) override;
 
   // Returns the required memory for storing an n-qubit state in megabytes.
   // For this state the memory is indepdentent of the number of ops
@@ -308,7 +308,7 @@ void State<statevec_t>::initialize_qreg(uint_t num_qubits) {
 
 template <class statevec_t>
 void State<statevec_t>::initialize_qreg(uint_t num_qubits,
-                                   const QV::QubitVector<statevec_t> &state) {
+                                   const statevec_t &state) {
   // Check dimension of state
   if (state.num_qubits() != num_qubits) {
     throw std::invalid_argument("QubitVector::State::initialize: initial state does not match qubit number");


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Current `AER::Simulator::QasmController` cannot change its `statevec_t` class in `AER::Statevector::State` because `AER::Statevector::State` explicitly specifies `QV::QubitVector` as `statevec_t` in its class definition.
This PR changes`AER::Statevector::State` not to specify `statevec_t` and `AER::Simulator::QasmController` specifies `QV::QubitVector` in `run_circuit()`.

### Details and comments
Originally, `AER::Statevector::State` explicitly specifies `QV::QubitVector` as `statevec_t` in its class definition.
```
template <class data_t = complex_t*>
class State : public Base::State<QV::QubitVector<data_t>> {
public:
  using BaseState = Base::State<QV::QubitVector<data_t>>;

```
This PR changes`AER::Statevector::State` not to specify `statevec_t`.
```
template <class statevec_t>
class State : public Base::State<statevec_t> {
public:
  using BaseState = Base::State<statevec_t>;

```

