### PR TITLE
convert explicitly from json_t to std::string in CHSimulator::Runner

### DIFF
--- a/src/simulators/ch/ch_runner.hpp
+++ b/src/simulators/ch/ch_runner.hpp
@@ -612,7 +612,7 @@ std::vector<std::string> Runner::serialize_decomposition() const
   #pragma omp parallel for if(num_threads_ > 1 && num_states_ > omp_threshold_) num_threads(num_threads_)
   for(uint_t i=0; i<num_states_; i++)
   {
-    serialized_states[i] = serialize_state(i);
+    serialized_states[i] = serialize_state(i).dump();
   }
   return serialized_states;
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This resolve #91 .

### Details and comments
Explicitly convert from `json_t` to `std::string`.
```
    serialized_states[i] = serialize_state(i).dump();
```

