### PR TITLE
Add coupling_map to backends

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -118,6 +118,12 @@ class QasmSimulator(AerBackend):
 
     MAX_QUBIT_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
 
+    CMAP = []
+    for i in range(MAX_QUBIT_MEMORY):
+        for j in range(MAX_QUBIT_MEMORY):
+            if i != j:
+                CMAP.append([i, j])
+
     DEFAULT_CONFIGURATION = {
         'backend_name': 'qasm_simulator',
         'backend_version': __version__,
@@ -130,8 +136,7 @@ class QasmSimulator(AerBackend):
         'memory': True,
         'max_shots': 100000,
         'description': 'A C++ simulator with realistic for qobj files',
-        'coupling_map': [[i, j] for i in range(MAX_QUBIT_MEMORY)
-                         for j in range(MAX_QUBIT_MEMORY) if i != j],
+        'coupling_map': CMAP,
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -118,12 +118,6 @@ class QasmSimulator(AerBackend):
 
     MAX_QUBIT_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
 
-    CMAP = []
-    for i in range(MAX_QUBIT_MEMORY):
-        for j in range(MAX_QUBIT_MEMORY):
-            if i != j:
-                CMAP.append([i, j])
-
     DEFAULT_CONFIGURATION = {
         'backend_name': 'qasm_simulator',
         'backend_version': __version__,
@@ -135,8 +129,8 @@ class QasmSimulator(AerBackend):
         'open_pulse': False,
         'memory': True,
         'max_shots': 100000,
-        'description': 'A C++ simulator with realistic for qobj files',
-        'coupling_map': CMAP,
+        'description': 'A C++ simulator with realistic noise for qobj files',
+        'coupling_map': None,
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -90,7 +90,7 @@ class QasmSimulator(AerBackend):
             cores. For systems with a small number of cores it enabling
             can reduce performance (Default: False).
 
-        * "ch_approximation_error" (double): Set the error in the 
+        * "ch_approximation_error" (double): Set the error in the
             approximation for the ch method. A smaller error needs more
             memory and computational time. (Default: 0.05)
 
@@ -130,6 +130,8 @@ class QasmSimulator(AerBackend):
         'memory': True,
         'max_shots': 100000,
         'description': 'A C++ simulator with realistic for qobj files',
+        'coupling_map': [[i, j] for i in range(MAX_QUBIT_MEMORY)
+                         for j in range(MAX_QUBIT_MEMORY) if i != j],
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],
@@ -217,13 +219,12 @@ class QasmSimulator(AerBackend):
                     else:
                         if n_qubits > 63:
                             raise AerError(err_string + ', and has too many ' +
-                                           'qubits to fall back to the ' + 
+                                           'qubits to fall back to the ' +
                                            'CH simulator.')
                         if not ch_supported:
                             raise AerError(err_string + ', and contains ' +
-                                           'instructions not supported by ' + 
+                                           'instructions not supported by ' +
                                            'the CH simulator.')
                         logger.info('The QasmSimulator will automatically '
                                     'switch to the CH backend, based on '
                                     'the memory requirements.')
-

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -68,12 +68,6 @@ class StatevectorSimulator(AerBackend):
 
     MAX_QUBIT_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
 
-    CMAP = []
-    for i in range(MAX_QUBIT_MEMORY):
-        for j in range(MAX_QUBIT_MEMORY):
-            if i != j:
-                CMAP.append([i, j])
-
     DEFAULT_CONFIGURATION = {
         'backend_name': 'statevector_simulator',
         'backend_version': __version__,
@@ -86,7 +80,7 @@ class StatevectorSimulator(AerBackend):
         'memory': True,
         'max_shots': 1,
         'description': 'A C++ statevector simulator for qobj files',
-        'coupling_map': CMAP,
+        'coupling_map': None,
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -68,6 +68,12 @@ class StatevectorSimulator(AerBackend):
 
     MAX_QUBIT_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
 
+    CMAP = []
+    for i in range(MAX_QUBIT_MEMORY):
+        for j in range(MAX_QUBIT_MEMORY):
+            if i != j:
+                CMAP.append([i, j])
+
     DEFAULT_CONFIGURATION = {
         'backend_name': 'statevector_simulator',
         'backend_version': __version__,
@@ -80,8 +86,7 @@ class StatevectorSimulator(AerBackend):
         'memory': True,
         'max_shots': 1,
         'description': 'A C++ statevector simulator for qobj files',
-        'coupling_map': [[i, j] for i in range(MAX_QUBIT_MEMORY)
-                         for j in range(MAX_QUBIT_MEMORY) if i != j],
+        'coupling_map': CMAP,
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -80,6 +80,8 @@ class StatevectorSimulator(AerBackend):
         'memory': True,
         'max_shots': 1,
         'description': 'A C++ statevector simulator for qobj files',
+        'coupling_map': [[i, j] for i in range(MAX_QUBIT_MEMORY)
+                         for j in range(MAX_QUBIT_MEMORY) if i != j],
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -62,6 +62,12 @@ class UnitarySimulator(AerBackend):
 
     MAX_QUBIT_MEMORY = int(log2(sqrt(local_hardware_info()['memory'] * (1024 ** 3) / 16)))
 
+    CMAP = []
+    for i in range(MAX_QUBIT_MEMORY):
+        for j in range(MAX_QUBIT_MEMORY):
+            if i != j:
+                CMAP.append([i, j])
+
     DEFAULT_CONFIGURATION = {
         'backend_name': 'unitary_simulator',
         'backend_version': __version__,
@@ -75,8 +81,7 @@ class UnitarySimulator(AerBackend):
         'max_shots': 1,
         'description': 'A Python simulator for computing the unitary' +
                        'matrix for experiments in qobj files',
-        'coupling_map': [[i, j] for i in range(MAX_QUBIT_MEMORY)
-                         for j in range(MAX_QUBIT_MEMORY) if i != j],
+        'coupling_map': CMAP,
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -60,12 +60,12 @@ class UnitarySimulator(AerBackend):
             (Default: 6).
     """
 
-    MAX_QUBITS_MEMORY = int(log2(sqrt(local_hardware_info()['memory'] * (1024 ** 3) / 16)))
+    MAX_QUBIT_MEMORY = int(log2(sqrt(local_hardware_info()['memory'] * (1024 ** 3) / 16)))
 
     DEFAULT_CONFIGURATION = {
         'backend_name': 'unitary_simulator',
         'backend_version': __version__,
-        'n_qubits': MAX_QUBITS_MEMORY,
+        'n_qubits': MAX_QUBIT_MEMORY,
         'url': 'https://github.com/Qiskit/qiskit-aer',
         'simulator': True,
         'local': True,
@@ -74,7 +74,9 @@ class UnitarySimulator(AerBackend):
         'memory': False,
         'max_shots': 1,
         'description': 'A Python simulator for computing the unitary' +
-                        'matrix for experiments in qobj files',
+                       'matrix for experiments in qobj files',
+        'coupling_map': [[i, j] for i in range(MAX_QUBIT_MEMORY)
+                         for j in range(MAX_QUBIT_MEMORY) if i != j],
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -62,12 +62,6 @@ class UnitarySimulator(AerBackend):
 
     MAX_QUBIT_MEMORY = int(log2(sqrt(local_hardware_info()['memory'] * (1024 ** 3) / 16)))
 
-    CMAP = []
-    for i in range(MAX_QUBIT_MEMORY):
-        for j in range(MAX_QUBIT_MEMORY):
-            if i != j:
-                CMAP.append([i, j])
-
     DEFAULT_CONFIGURATION = {
         'backend_name': 'unitary_simulator',
         'backend_version': __version__,
@@ -81,7 +75,7 @@ class UnitarySimulator(AerBackend):
         'max_shots': 1,
         'description': 'A Python simulator for computing the unitary' +
                        'matrix for experiments in qobj files',
-        'coupling_map': CMAP,
+        'coupling_map': None,
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'snapshot', 'unitary'],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
fixes #87 


### Details and comments
The specification says that all backends must have a `coupling_map`.  This PR makes Aer backends inline with the spec.
