### PR TITLE
fix unordered_set enum class for gcc5

### DIFF
--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -79,9 +79,18 @@ struct Op {
 
 // This class is used to store type information about a set of operations.
 class OpSet {
+private:
+  // Hash function so that we can use an enum class as a std::unordered_set
+  // key on older C++11 compilers like GCC 5.
+  struct EnumClassHash {
+    template <typename T> size_t operator()(T t) const {
+      return static_cast<size_t>(t);
+    }
+  };
+
 public:
   // Alias for set of OpTypes
-  using optypeset_t = std::unordered_set<Operations::OpType>;
+  using optypeset_t = std::unordered_set<Operations::OpType, EnumClassHash>;
 
   // Public data members
   optypeset_t optypes;     // A set of op types

--- a/src/simulators/ch/ch_state.hpp
+++ b/src/simulators/ch/ch_state.hpp
@@ -41,9 +41,8 @@ public:
 
   virtual std::string name() const override {return "ch";}
 
-  inline virtual std::unordered_set<Operations::OpType> allowed_ops() const override
-  {
-    return std::unordered_set<Operations::OpType>({
+  inline virtual Operations::OpSet::optypeset_t allowed_ops() const override {
+    return Operations::OpSet::optypeset_t({
       Operations::OpType::gate,
       Operations::OpType::measure,
       Operations::OpType::reset,

--- a/test/terra/test_ch_simulator.py
+++ b/test/terra/test_ch_simulator.py
@@ -536,7 +536,7 @@ class TestCHSimulator(common.QiskitAerTestCase):
                                   })
         result = job.result()
         self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0.05*shots)
+        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_ccx_gate_nondeterministic_default_basis_gates(self):
         """Test ccx-gate circuits compiling to backend default basis_gates."""
@@ -547,7 +547,7 @@ class TestCHSimulator(common.QiskitAerTestCase):
         job = QasmSimulator().run(qobj,
                                   backend_options={
                                       "method": "ch",
-                                      "ch_mixing_time": 50,
+                                      "ch_mixing_time": 100,
                                       "disable_measurement_opt": True
                                   })
         result = job.result()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a GCC-5 bug where `std::unordered_set` doesn't work with `enum class` objects unless an explicit hash table is provided.

### Details and comments


