### PR TITLE
use qiskit.util instead of qiskit._util

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -20,7 +20,7 @@ from qiskit.providers import BaseBackend
 from qiskit.providers.models import BackendStatus
 from qiskit.qobj import QobjConfig
 from qiskit.result import Result
-from qiskit._util import local_hardware_info
+from qiskit.util import local_hardware_info
 
 from ..aerjob import AerJob
 from ..aererror import AerError

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -12,7 +12,7 @@ Qiskit Aer qasm simulator backend.
 import logging
 import os
 from math import log2
-from qiskit._util import local_hardware_info
+from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
 from .aerbackend import AerBackend
 from .qasm_controller_wrapper import qasm_controller_execute

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -14,7 +14,7 @@ Qiskit Aer statevector simulator backend.
 import logging
 import os
 from math import log2
-from qiskit._util import local_hardware_info
+from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
 from .aerbackend import AerBackend
 from .statevector_controller_wrapper import statevector_controller_execute

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -14,7 +14,7 @@ Qiskit Aer Unitary Simulator Backend.
 import logging
 import os
 from math import log2, sqrt
-from qiskit._util import local_hardware_info
+from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
 
 from .aerbackend import AerBackend

--- a/test/terra/test_ch_simulator.py
+++ b/test/terra/test_ch_simulator.py
@@ -579,7 +579,7 @@ class TestCHSimulator(common.QiskitAerTestCase):
                                   })
         result = job.result()
         self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+        self.compare_counts(result, circuits, targets, delta=0.10 * shots)
 
     # # ---------------------------------------------------------------------
     # # Test algorithms


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`qiskit._util` was renamed with `qiskit.util`


### Details and comments
`qiskit._util` was renamed with `qiskit.util` in https://github.com/Qiskit/qiskit-terra/pull/2013.
`aerbackend.py` and `*_simulator.py` are using `qiskit._util`.