### PR TITLE
Fix MacOS unresolved symbols at runtime with GCC

### DIFF
--- a/src/misc/clang_omp_symbols.hpp
+++ b/src/misc/clang_omp_symbols.hpp
@@ -37,20 +37,20 @@ extern "C" {
 
     using __kmpc_barrier_t = void(*)(id*, int);
     __kmpc_barrier_t _hook__kmpc_barrier;
-    inline void __kmpc_barrier(id* pId, int gtid){
+    void __kmpc_barrier(id* pId, int gtid){
         _hook__kmpc_barrier(pId, gtid);
     }
 
     using __kmpc_for_static_fini_t =  void(*)(kmp_Ident *, int32_t);
     __kmpc_for_static_fini_t _hook__kmpc_for_static_fini;
-    inline void __kmpc_for_static_fini(kmp_Ident *loc, int32_t global_tid){
+    void __kmpc_for_static_fini(kmp_Ident *loc, int32_t global_tid){
         _hook__kmpc_for_static_fini(loc, global_tid);
     }
 
     using __kmpc_for_static_init_4_t = void(*)(kmp_Ident *, int32_t, int32_t, int32_t *,
                                      int32_t *, int32_t *, int32_t *, int32_t, int32_t);
     __kmpc_for_static_init_4_t _hook__kmpc_for_static_init_4;
-    inline void __kmpc_for_static_init_4(kmp_Ident *loc, int32_t global_tid,
+    void __kmpc_for_static_init_4(kmp_Ident *loc, int32_t global_tid,
                                      int32_t sched, int32_t *plastiter,
                                      int32_t *plower, int32_t *pupper,
                                      int32_t *pstride, int32_t incr,
@@ -62,7 +62,7 @@ extern "C" {
     using __kmpc_for_static_init_8_t = void(*)(kmp_Ident *, int32_t, int32_t, int32_t *,
                                      int64_t *, int64_t *, int64_t *, int64_t, int64_t);
     __kmpc_for_static_init_8_t _hook__kmpc_for_static_init_8;
-    inline void __kmpc_for_static_init_8(kmp_Ident *loc, int32_t global_tid,
+    void __kmpc_for_static_init_8(kmp_Ident *loc, int32_t global_tid,
                                      int32_t sched, int32_t *plastiter,
                                      int64_t *plower, int64_t *pupper,
                                      int64_t *pstride, int64_t incr,
@@ -74,7 +74,7 @@ extern "C" {
     using __kmpc_for_static_init_8u_t = void(*)(kmp_Ident *, int32_t, int32_t, int32_t *, uint64_t *, uint64_t *,
                                       int64_t *, int64_t, int64_t);
     __kmpc_for_static_init_8u_t _hook__kmpc_for_static_init_8u;
-    inline void __kmpc_for_static_init_8u(kmp_Ident *loc, int32_t global_tid,
+    void __kmpc_for_static_init_8u(kmp_Ident *loc, int32_t global_tid,
                                       int32_t sched, int32_t *plastiter1,
                                       uint64_t *plower, uint64_t *pupper,
                                       int64_t *pstride, int64_t incr,
@@ -249,7 +249,7 @@ extern "C" {
 namespace AER {
 namespace Hacks {
 
-inline void populate_hooks(void * handle){
+void populate_hooks(void * handle){
     _hook__kmpc_barrier = reinterpret_cast<decltype(&__kmpc_barrier)>(dlsym(handle, "__kmpc_barrier"));
     _hook__kmpc_for_static_fini = reinterpret_cast<decltype(&__kmpc_for_static_fini)>(dlsym(handle, "__kmpc_for_static_fini"));
     _hook__kmpc_end_reduce_nowait = reinterpret_cast<decltype(&__kmpc_end_reduce_nowait)>(dlsym(handle, "__kmpc_end_reduce_nowait"));

--- a/src/misc/gcc_omp_symbols.hpp
+++ b/src/misc/gcc_omp_symbols.hpp
@@ -10,47 +10,47 @@ extern "C" {
 
     using GOMP_atomic_start_t = void(*)();
     GOMP_atomic_start_t _hook_GOMP_atomic_start;
-    inline void GOMP_atomic_start (void){
+    void GOMP_atomic_start (void){
         _hook_GOMP_atomic_start();
     }
 
     using GOMP_atomic_end_t = void(*)();
     GOMP_atomic_end_t _hook_GOMP_atomic_end;
-    inline void GOMP_atomic_end (void){
+    void GOMP_atomic_end (void){
         _hook_GOMP_atomic_end();
     }
 
     using GOMP_barrier_t = void(*)();
     GOMP_barrier_t _hook_GOMP_barrier;
-    inline void GOMP_barrier(void){
+    void GOMP_barrier(void){
         _hook_GOMP_barrier();
     }
 
     using GOMP_parallel_t = void(*)(void (*)(void *), void *, unsigned, unsigned);
     GOMP_parallel_t _hook_GOMP_parallel;
-    inline void GOMP_parallel(void (*fn) (void *), void *data, unsigned num_threads, unsigned flags){
+    void GOMP_parallel(void (*fn) (void *), void *data, unsigned num_threads, unsigned flags){
         _hook_GOMP_parallel(fn, data, num_threads, flags);
     }
 
     #define __KAI_KMPC_CONVENTION
     using omp_get_max_threads_t = int(*)(void);
     omp_get_max_threads_t _hook_omp_get_max_threads;
-    inline int __KAI_KMPC_CONVENTION omp_get_max_threads(void) {
+    int __KAI_KMPC_CONVENTION omp_get_max_threads(void) {
         return _hook_omp_get_max_threads();
     }
     using omp_set_nested_t = void(*)(int);
     omp_set_nested_t _hook_omp_set_nested;
-    inline void __KAI_KMPC_CONVENTION omp_set_nested(int foo){
+    void __KAI_KMPC_CONVENTION omp_set_nested(int foo){
         _hook_omp_set_nested(foo);
     }
     using omp_get_num_threads_t = int(*)(void);
     omp_get_num_threads_t _hook_omp_get_num_threads;
-    inline int __KAI_KMPC_CONVENTION omp_get_num_threads(void) {
+    int __KAI_KMPC_CONVENTION omp_get_num_threads(void) {
         return _hook_omp_get_num_threads();
     }
     using omp_get_thread_num_t = int(*)(void);
     omp_get_thread_num_t _hook_omp_get_thread_num;
-    inline int __KAI_KMPC_CONVENTION omp_get_thread_num(void) {
+    int __KAI_KMPC_CONVENTION omp_get_thread_num(void) {
         return _hook_omp_get_thread_num();
     }
 }
@@ -58,7 +58,7 @@ extern "C" {
 namespace AER {
 namespace Hacks {
 
-    inline void populate_hooks(void * handle){
+    void populate_hooks(void * handle){
         _hook_GOMP_atomic_end = reinterpret_cast<decltype(&GOMP_atomic_end)>(dlsym(handle, "GOMP_atomic_end"));
         _hook_GOMP_atomic_start = reinterpret_cast<decltype(&GOMP_atomic_start)>(dlsym(handle, "GOMP_atomic_start"));
         _hook_GOMP_barrier = reinterpret_cast<decltype(&GOMP_barrier)>(dlsym(handle, "GOMP_barrier"));


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
We changed some functions behavior by adding `inline` in order to avoid warnings message, but this had side effects and the MacOS builds with GCC where failing at runtime with `unresolved symbols`.
I have modified the clang related files as well for consistency, even though building with clang seemed to work fine (maybe this side effect was not happening due to the way the compiler treats symbols or inlines).


