### PR TITLE
Migrating `Qobj` to the new `QasmQobj`

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -18,7 +18,7 @@ from numpy import ndarray
 
 from qiskit.providers import BaseBackend
 from qiskit.providers.models import BackendStatus
-from qiskit.qobj import QobjConfig
+from qiskit.qobj import QasmQobjConfig
 from qiskit.result import Result
 from qiskit.util import local_hardware_info
 
@@ -124,7 +124,7 @@ class AerBackend(BaseBackend):
 
         # Add runtime config
         config['library_dir'] = self.configuration().library_dir
-        qobj.config = QobjConfig.from_dict(config)
+        qobj.config = QasmQobjConfig.from_dict(config)
         # Get the JSON serialized string
         output = json.dumps(qobj, cls=AerJSONEncoder).encode('UTF-8')
         # Revert original qobj

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -111,7 +111,7 @@ class QuantumError:
         """Print error information."""
         output = "QuantumError on {} qubits. Noise circuits:".format(self._number_of_qubits)
         for j, pair in enumerate(zip(self.probabilities, self.circuits)):
-            output += "\n  P({0}) = {1}, QobjInstructions = [{2}".format(j, pair[0], pair[1])
+            output += "\n  P({0}) = {1}, QasmQobjInstructions = [{2}".format(j, pair[0], pair[1])
         return output
 
     @property

--- a/qiskit/providers/aer/utils/qobj_utils.py
+++ b/qiskit/providers/aer/utils/qobj_utils.py
@@ -14,28 +14,28 @@ IS ADDED TO QISKIT TERRA. THEY WILL NOT BE SUPPORTED AFTER THAT.
 
 import copy
 import numpy as np
-from qiskit.qobj import QobjInstruction
+from qiskit.qobj import QasmQobjInstruction
 
 
 def append_instr(qobj, exp_index, instruction):
-    """Append a QobjInstruction to a QobjExperiment.
+    """Append a QasmQobjInstruction to a QobjExperiment.
 
     Args:
         qobj (Qobj): a Qobj object.
         exp_index (int): The index of the experiment in the qobj.
-        instruction (QobjInstruction): instruction to insert.
+        instruction (QasmQobjInstruction): instruction to insert.
     """
     qobj.experiments[exp_index].instructions.append(instruction)
     return qobj
 
 
 def insert_instr(qobj, exp_index, item, pos):
-    """Insert a QobjInstruction into a QobjExperiment.
+    """Insert a QasmQobjInstruction into a QobjExperiment.
 
     Args:
         qobj (Qobj): a Qobj object
         exp_index (int): The index of the experiment in the qobj.
-        instruction(QobjInstruction): instruction to insert.
+        instruction(QasmQobjInstruction): instruction to insert.
         pos (int): the position to insert the item.
     """
     qobj.experiments[exp_index].instructions.insert(pos, item)
@@ -43,7 +43,7 @@ def insert_instr(qobj, exp_index, item, pos):
 
 
 def get_instr_pos(qobj, exp_index, name):
-    """Return all locations of QobjInstruction in a Qobj experiment.
+    """Return all locations of QasmQobjInstruction in a Qobj experiment.
 
     The return list is sorted in reverse order so iterating over it
     to insert new items will work as expected.
@@ -51,10 +51,10 @@ def get_instr_pos(qobj, exp_index, name):
     Args:
         qobj (Qobj): a Qobj object
         exp_index (int): The index of the experiment in the qobj
-        name (str): QobjInstruction name to find
+        name (str): QasmQobjInstruction name to find
 
     Returns:
-        list[int]: A list of positions where the QobjInstruction is located.
+        list[int]: A list of positions where the QasmQobjInstruction is located.
     """
     # Check only the name string of the item
     positions = [i for i, val in enumerate(qobj.experiments[exp_index].instructions)
@@ -63,7 +63,7 @@ def get_instr_pos(qobj, exp_index, name):
 
 
 def unitary_instr(mat, qubits, label=None):
-    """Create a unitary gate QobjInstruction.
+    """Create a unitary gate QasmQobjInstruction.
 
     Args:
         mat (matrix_like): an n-qubit unitary matrix
@@ -71,7 +71,7 @@ def unitary_instr(mat, qubits, label=None):
         label (str): optional string label for the untiary matrix
 
     Returns:
-        QobjInstruction: The qobj item for the unitary instruction.
+        QasmQobjInstruction: The qobj item for the unitary instruction.
 
     Raises:
         ValueError: if the input matrix is not unitary
@@ -97,35 +97,35 @@ def unitary_instr(mat, qubits, label=None):
                    "params": np.array(mat, dtype=complex)}
     if label is not None:
         instruction["label"] = str(label)
-    return QobjInstruction(**instruction)
-
+    return QasmQobjInstruction(**instruction)
 
 def measure_instr(qubits, memory, registers=None):
+
     """Create a multi-qubit measure instruction"""
     if len(qubits) != len(memory):
         raise ValueError("Number of qubits does not match number of memory")
     if registers is None:
-        return QobjInstruction(name='measure', qubits=qubits, memory=memory)
+        return QasmQobjInstruction(name='measure', qubits=qubits, memory=memory)
     # Case where we also measure to registers
     if len(qubits) != len(registers):
         raise ValueError("Number of qubits does not match number of registers")
-    return QobjInstruction(name='measure', qubits=qubits, memory=memory,
+    return QasmQobjInstruction(name='measure', qubits=qubits, memory=memory,
                            register=registers)
 
 
 def reset_instr(qubits):
     """Create a multi-qubit reset instruction"""
-    return QobjInstruction(name='reset', qubits=qubits)
+    return QasmQobjInstruction(name='reset', qubits=qubits)
 
 
 def barrier_instr(num_qubits):
-    """Create a barrier QobjInstruction."""
-    return QobjInstruction(name='barrier', qubits=list(range(num_qubits)))
+    """Create a barrier QasmQobjInstruction."""
+    return QasmQobjInstruction(name='barrier', qubits=list(range(num_qubits)))
 
 
 def iden_instr(qubit):
-    """Create a barrier QobjInstruction."""
-    return QobjInstruction(name='id', qubits=[qubit])
+    """Create a barrier QasmQobjInstruction."""
+    return QasmQobjInstruction(name='id', qubits=[qubit])
 
 
 def snapshot_instr(snapshot_type, label, qubits=None, params=None):
@@ -139,7 +139,7 @@ def snapshot_instr(snapshot_type, label, qubits=None, params=None):
                          See additional information.
 
     Returns:
-        QobjInstruction: The qobj item for the snapshot instruction.
+        QasmQobjInstruction: The qobj item for the snapshot instruction.
 
 
     Additional Information:
@@ -178,7 +178,7 @@ def snapshot_instr(snapshot_type, label, qubits=None, params=None):
         snap["name"] = "expval_matrix"
         snap["params"] = [[1.0, qubits, params]]
     # TODO: implicit conversion for Pauli expval params
-    return QobjInstruction(**snap)
+    return QasmQobjInstruction(**snap)
 
 
 def insert_snapshots_after_barriers(qobj, snapshot):
@@ -189,7 +189,7 @@ def insert_snapshots_after_barriers(qobj, snapshot):
 
     Args:
         qobj (Qobj): a qobj to insert snapshots into
-        snapshot (QobjInstruction): a snapshot instruction.
+        snapshot (QasmQobjInstruction): a snapshot instruction.
 
     Additional Information:
     """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Rename `qiskit.qobj` Qobj classes to the new QasmQobj classes so  the Qobj validator god is happy again.


