### PR TITLE
use ThreadPoolExecutor for all systems

### DIFF
--- a/qiskit/providers/aer/aerjob.py
+++ b/qiskit/providers/aer/aerjob.py
@@ -46,10 +46,7 @@ class AerJob(BaseJob):
         _executor (futures.Executor): executor to handle asynchronous jobs
     """
 
-    if sys.platform in ['darwin', 'win32']:
-        _executor = futures.ThreadPoolExecutor()
-    else:
-        _executor = futures.ProcessPoolExecutor()
+    _executor = futures.ThreadPoolExecutor()
 
     def __init__(self, backend, job_id, fn, qobj, *args):
         super().__init__(backend, job_id)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `AerJob` previously used `ProcessPoolExecutor` on linux and `ThreadPoolExecutor` on MacOS and Windows. Since we handle all parallelization in Aer on the C++ code side this changes the `AerJob` to use `ThreadPoolExecutor` on all OSes.

### Details and comments


