### PR TITLE
imporve u1 performance in statevector

### DIFF
--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -1210,6 +1210,11 @@ template <typename data_t>
 void QubitVector<data_t>::apply_diagonal_matrix(const reg_t &qubits,
                                                 const cvector_t &diag) {
 
+  if (qubits.size() == 1) {
+    apply_diagonal_matrix(qubits[0], diag);
+    return;
+  }
+
   const size_t N = qubits.size();
   const uint_t DIM = BITS[N];
   // Error checking


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR improves singel-qubit phase operation in statevector.

### Details and comments
`AER::Statevector::apply_gate_phase` calls `AER::Statevector::apply_matrix(reg_t, cvector_t)`, which calls `QV::QubitVector::apply_diagonal_matrix(reg_t, cvector_t)`.

However, `apply_diagonal_matrix(uint_t, cvector_t)` is much better than `apply_diagonal_matrix(reg_t, cvector_t)`.

This PR bridges the both.
