### PR TITLE
Add support for optimized multi-controlled gates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ The format is based on `Keep a Changelog`_.
 Added
 -----
 - Improve efficiency of parallelization with max_memory_mb a new parameter of backend_opts (#61)
+- Add optimized mcx, mcy, mcz, mcu1, mcu2, mcu3, gates to QubitVector (#124)
 
 Changed
 -------

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -1311,7 +1311,7 @@ void QubitVector<data_t>::apply_mcx(const reg_t &qubits) {
   const size_t pos0 = MASKS[N - 1];
   const size_t pos1 = MASKS[N];
   // Lambda function for multi-controlled X gate
-  auto lambda = [&](indexes_t inds)->void {
+  auto lambda = [&](const indexes_t &inds)->void {
     std::swap(data_[inds[pos0]], data_[inds[pos1]]);
   };
   apply_lambda(lambda, qubits);
@@ -1325,7 +1325,7 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
   const size_t pos1 = MASKS[N];
   const complex_t I(0., 1.);
   // Lambda function for multi-controlled Y gate
-  auto lambda = [&](indexes_t inds)->void {
+  auto lambda = [&](const indexes_t &inds)->void {
     const complex_t cache = data_[inds[pos0]];
     data_[inds[pos0]] = -I * data_[inds[pos1]];
     data_[inds[pos1]] = I * cache;
@@ -1336,7 +1336,7 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
 template <typename data_t>
 void QubitVector<data_t>::apply_mcz(const reg_t &qubits) {
   // Lambda function for multi-controlled Z gate
-  auto lambda = [&](indexes_t inds)->void {
+  auto lambda = [&](const indexes_t &inds)->void {
     // Multiply last block index by -1
     data_[inds[MASKS[qubits.size()]]] *= -1.;
   };

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -222,15 +222,6 @@ public:
   // Apply Specialized Gates
   //-----------------------------------------------------------------------
 
-  // Apply a 2-qubit Controlled-NOT gate to the state vector
-  void apply_cnot(const uint_t qctrl, const uint_t qtrgt);
-
-  // Apply a 2-qubit Controlled-Z gate to the state vector
-  void apply_cz(const uint_t q0, const uint_t q1);
-
-  // Apply a 2-qubit SWAP gate to the state vector
-  void apply_swap(const uint_t q0, const uint_t q1);
-
   // Apply a single-qubit Pauli-X gate to the state vector
   void apply_x(const uint_t qubit);
 
@@ -240,8 +231,8 @@ public:
   // Apply a single-qubit Pauli-Z gate to the state vector
   void apply_z(const uint_t qubit);
 
-  // Apply a 3-qubit toffoli gate
-  void apply_toffoli(const uint_t qctrl0, const uint_t qctrl1, const uint_t qtrgt);
+  // Apply a 2-qubit SWAP gate to the state vector
+  void apply_swap(const uint_t q0, const uint_t q1);
 
   // Apply multi-controlled X-gate
   void apply_mcx(const reg_t &qubits);
@@ -1349,19 +1340,8 @@ void QubitVector<data_t>::apply_mcz(const reg_t &qubits) {
 }
 
 //------------------------------------------------------------------------------
-// Two-qubit gates
+// Swap gates
 //------------------------------------------------------------------------------
-
-template <typename data_t>
-void QubitVector<data_t>::apply_cnot(const uint_t qubit_ctrl, const uint_t qubit_trgt) {
-  // Lambda function for CNOT gate
-  auto lambda = [&](const indexes_t &inds)->void {
-    std::swap(data_[inds[1]], data_[inds[3]]);
-  };
-  // Use the lambda function
-  const reg_t qubits = {qubit_ctrl, qubit_trgt};
-  apply_lambda(lambda, qubits);
-}
 
 template <typename data_t>
 void QubitVector<data_t>::apply_swap(const uint_t qubit0, const uint_t qubit1) {
@@ -1371,34 +1351,6 @@ void QubitVector<data_t>::apply_swap(const uint_t qubit0, const uint_t qubit1) {
   };
   // Use the lambda function
   const reg_t qubits = {qubit0, qubit1};
-  apply_lambda(lambda, qubits);
-}
-
-template <typename data_t>
-void QubitVector<data_t>::apply_cz(const uint_t qubit_ctrl, const uint_t qubit_trgt) {
-
-  // Lambda function for CZ gate
-  auto lambda = [&](const indexes_t &inds)->void {
-    data_[inds[3]] *= -1.;
-  };
-  // Use the lambda function
-  const reg_t qubits = {qubit_ctrl, qubit_trgt};
-  apply_lambda(lambda, qubits);
-}
-
-//------------------------------------------------------------------------------
-// Three-qubit gates
-//------------------------------------------------------------------------------
-template <typename data_t>
-void QubitVector<data_t>::apply_toffoli(const uint_t qubit_ctrl0,
-                                const uint_t qubit_ctrl1,
-                                const uint_t qubit_trgt) {
-  // Lambda function for Toffoli gate
-  auto lambda = [&](const indexes_t &inds)->void {
-      std::swap(data_[inds[3]], data_[inds[7]]);
-  };
-  // Use the lambda function
-  const reg_t qubits = {qubit_ctrl0, qubit_ctrl1, qubit_trgt};
   apply_lambda(lambda, qubits);
 }
 

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -1310,7 +1310,7 @@ void QubitVector<data_t>::apply_mcx(const reg_t &qubits) {
   const size_t N = qubits.size();
   const size_t pos0 = MASKS[N - 1];
   const size_t pos1 = MASKS[N];
-  // Lambda function for CNOT gate
+  // Lambda function for multi-controlled X gate
   auto lambda = [&](indexes_t inds)->void {
     std::swap(data_[inds[pos0]], data_[inds[pos1]]);
   };
@@ -1324,7 +1324,7 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
   const size_t pos0 = MASKS[N - 1];
   const size_t pos1 = MASKS[N];
   const complex_t I(0., 1.);
-  // Lambda function for CNOT gate
+  // Lambda function for multi-controlled Y gate
   auto lambda = [&](indexes_t inds)->void {
     const complex_t cache = data_[inds[pos0]];
     data_[inds[pos0]] = -I * data_[inds[pos1]];
@@ -1335,9 +1335,10 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
 
 template <typename data_t>
 void QubitVector<data_t>::apply_mcz(const reg_t &qubits) {
-  // Multiply last block index by -1
+  // Lambda function for multi-controlled Z gate
   auto lambda = [&](indexes_t inds)->void {
-     data_[inds[MASKS[qubits.size()]]] *= -1.;
+    // Multiply last block index by -1
+    data_[inds[MASKS[qubits.size()]]] *= -1.;
   };
   apply_lambda(lambda, qubits);
 }
@@ -1349,7 +1350,7 @@ void QubitVector<data_t>::apply_mcu(const reg_t &qubits,
   const size_t N = qubits.size();
   const size_t pos0 = MASKS[N - 1];
   const size_t pos1 = MASKS[N];
-  // Lambda function for CNOT gate
+  // Lambda function for multi-controlled single-qubit gate
   auto lambda = [&](const indexes_t &inds,
                     const cvector_t &_mat)->void {
     const auto cache = data_[pos0];

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -25,7 +25,7 @@ namespace Statevector {
 enum class Gates {
   u1, u2, u3, id, x, y, z, h, s, sdg, t, tdg, // single qubit
   cx, cy, cz, swap, // two qubit
-  ccx, mcx, mcy, mcz // multi-qubit controlled
+  ccx, mcx, mcy, mcz, mcu1, mcu2, mcu3 // multi-qubit controlled
 };
 
 // Allowed snapshots enum class
@@ -74,7 +74,7 @@ public:
   virtual stringset_t allowed_gates() const override {
     return {"u1", "u2", "u3", "cx", "cz", "cy", "swap",
             "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx",
-            "mcx", "mcz", "mcy"};
+            "mcx", "mcz", "mcy", "mcu1", "mcu2", "mcu3"};
   }
 
   // Return the set of qobj snapshot types supported by the State
@@ -219,11 +219,22 @@ protected:
   //-----------------------------------------------------------------------
 
   // Apply a waltz gate specified by parameters u3(theta, phi, lambda)
-  void apply_gate_u3(const uint_t qubit, const double theta, const double phi,
+  void apply_gate_u3(const uint_t qubit,
+                     const double theta,
+                     const double phi,
                      const double lambda);
 
   // Optimize phase gate with diagonal [1, phase]
   void apply_gate_phase(const uint_t qubit, const complex_t phase);
+
+  //-----------------------------------------------------------------------
+  // Multi-controlled u3
+  //-----------------------------------------------------------------------
+  
+  void apply_gate_mcu3(const reg_t& qubits,
+                       const double theta,
+                       const double phi,
+                       const double lambda);
 
   //-----------------------------------------------------------------------
   // Config Settings
@@ -276,7 +287,10 @@ const stringmap_t<Gates> State<statevec_t>::gateset_({
   {"ccx", Gates::ccx},   // Controlled-CX gate (Toffoli)
   {"mcx", Gates::mcx},   // Multi-controlled-X gate
   {"mcy", Gates::mcy},   // Multi-controlled-Y gate
-  {"mcz", Gates::mcz}    // Multi-controlled-Z gate
+  {"mcz", Gates::mcz},   // Multi-controlled-Z gate
+  {"mcu1", Gates::mcu1}, // Multi-controlled-u1
+  {"mcu2", Gates::mcu2}, // Multi-controlled-u2
+  {"mcu3", Gates::mcu3}  // Multi-controlled-u3
 
 });
 
@@ -666,6 +680,22 @@ void State<statevec_t>::apply_gate(const Operations::Op &op) {
     case Gates::swap: {
       BaseState::qreg_.apply_swap(op.qubits[0], op.qubits[1]);
     } break;
+    case Gates::mcu3:
+      apply_gate_mcu3(op.qubits,
+                      std::real(op.params[0]),
+                      std::real(op.params[1]),
+                      std::real(op.params[2]));
+      break;
+    case Gates::mcu2:
+      apply_gate_mcu3(op.qubits,
+                      M_PI / 2.,
+                      std::real(op.params[0]),
+                      std::real(op.params[1]));
+      break;
+    case Gates::mcu1:
+      apply_gate_mcu3(op.qubits, 0., 0., std::real(op.params[0]));
+      break;
+
     default:
       // We shouldn't reach here unless there is a bug in gateset
       throw std::invalid_argument("QubitVector::State::invalid gate instruction \'" +
@@ -692,8 +722,20 @@ void State<statevec_t>::apply_matrix(const reg_t &qubits, const cvector_t &vmat)
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_gate_u3(uint_t qubit, double theta, double phi, double lambda) {
+void State<statevec_t>::apply_gate_u3(uint_t qubit,
+                                      double theta,
+                                      double phi,
+                                      double lambda) {
   apply_matrix(reg_t({qubit}), Utils::Matrix::U3(theta, phi, lambda));
+}
+
+template <class statevec_t>
+void State<statevec_t>::apply_gate_mcu3(const reg_t& qubits,
+                                        double theta,
+                                        double phi,
+                                        double lambda) {
+  const auto u3 = Utils::Matrix::U3(theta, phi, lambda);
+  BaseState::qreg_.apply_mcu(qubits, Utils::vectorize_matrix(u3));
 }
 
 template <class statevec_t>

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -24,8 +24,8 @@ namespace QubitUnitary {
 // Allowed gates enum class
 enum class Gates {
   u1, u2, u3, id, x, y, z, h, s, sdg, t, tdg, // single qubit
-  cx, cz, swap, // two qubit
-  ccx // three qubit
+  cx, cy, cz, swap, // two qubit
+  ccx, mcx, mcy, mcz // multi-qubit controlled
 };
 
 
@@ -60,8 +60,9 @@ public:
 
   // Return the set of qobj gate instruction names supported by the State
   virtual stringset_t allowed_gates() const override {
-    return {"U", "CX", "u1", "u2", "u3", "cx", "cz", "swap",
-            "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx"};
+    return {"u1", "u2", "u3", "cx", "cz", "cy", "swap",
+            "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx",
+            "mcx", "mcz", "mcy"};
   }
 
   // Return the set of qobj snapshot types supported by the State
@@ -169,14 +170,16 @@ const stringmap_t<Gates> State<data_t>::gateset_({
   {"u1", Gates::u1},  // zero-X90 pulse waltz gate
   {"u2", Gates::u2},  // single-X90 pulse waltz gate
   {"u3", Gates::u3},  // two X90 pulse waltz gate
-  {"U", Gates::u3},   // two X90 pulse waltz gate
   // Two-qubit gates
-  {"CX", Gates::cx},  // Controlled-X gate (CNOT)
   {"cx", Gates::cx},  // Controlled-X gate (CNOT)
+  {"cy", Gates::cy},  // Controlled-Z gate
   {"cz", Gates::cz},  // Controlled-Z gate
   {"swap", Gates::swap}, // SWAP gate
   // Three-qubit gates
-  {"ccx", Gates::ccx}  // Controlled-CX gate (Toffoli)
+  {"ccx", Gates::ccx},   // Controlled-CX gate (Toffoli)
+  {"mcx", Gates::mcx},   // Multi-controlled-X gate
+  {"mcy", Gates::mcy},   // Multi-controlled-Y gate
+  {"mcz", Gates::mcz}    // Multi-controlled-Z gate
 });
 
 //============================================================================
@@ -305,10 +308,17 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
       apply_gate_phase(op.qubits[0], std::exp(complex_t(0., 1.) * op.params[0]));
       break;
     case Gates::cx:
-      BaseState::qreg_.apply_cnot(op.qubits[0], op.qubits[1]);
+    case Gates::ccx:
+    case Gates::mcx:
+      BaseState::qreg_.apply_mcx(op.qubits);
+      break;
+    case Gates::cy:
+    case Gates::mcy:
+      BaseState::qreg_.apply_mcy(op.qubits);
       break;
     case Gates::cz:
-      BaseState::qreg_.apply_cz(op.qubits[0], op.qubits[1]);
+    case Gates::mcz:
+      BaseState::qreg_.apply_mcz(op.qubits);
       break;
     case Gates::id:
       break;
@@ -340,9 +350,6 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
     } break;
     case Gates::swap: {
       BaseState::qreg_.apply_swap(op.qubits[0], op.qubits[1]);
-    } break;
-    case Gates::ccx: {
-      BaseState::qreg_.apply_toffoli(op.qubits[0], op.qubits[1], op.qubits[2]);
     } break;
     default:
       // We shouldn't reach here unless there is a bug in gateset


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds support for multi-controller x,y,z,u1,u2,u3 gates to the statevector QasmSimulator, StatevectorSimulator and UnitarySimulator.

These gates have an optimized implementation making them faster to execute than the gate being unrolled into a basis of `cx` and single qubit gates.

Closes #127 

### Details and comments

These gates are passed in as (N+1)-qubit qobj instructions such as:

```python
{"name": "mcx", "qubits": [c0, c1,...,cn, target]}
```
where the first `N` qubits are the controls, and the last qubit is the target.

For the controlled `u1,u2,u3` gates the instruction includes the same parameters as for the single qubit gates. Eg:

```python
{"name": "mcu3", "qubits": [c0, c1,...,cn, target], "params": [theta, phi, lam]}
```
TODO:
- [ ] Add tests
- [x] Update Changelog