### PR TITLE
Add multiple exit codes for standalone simulator

### DIFF
--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -16,7 +16,22 @@
 
 /*******************************************************************************
  *
- * Main
+ * EXIT CODES:
+ * 
+ * 0: The Qobj was succesfully executed.
+ *    Returns full result JSON.
+ * 
+ * 1: Command line invalid or Qobj JSON cannot be loaded.
+ *    Returns JSON:
+ *    {"success": false, "status": "ERROR: Invalid input (error msg)"}
+ * 
+ * 2: Qobj failed to load or execute.
+ *    Returns JSON:
+ *    {"success": false, "status": "ERROR: Failed to execute qobj (error msg)"}
+ * 
+ * 3: At least one experiment in Qobj failed to execute successfully.
+ *    Returns parial result JSON with failed experiments returning:
+ *    "{"success": false, "status": "ERROR: error msg"}
  *
  ******************************************************************************/
 
@@ -69,7 +84,8 @@ int main(int argc, char **argv) {
     usage(std::string(argv[0]), out);
     return 1;
   }
-
+  
+  // Parse command line options
   for(auto pos = 1ul; pos < static_cast<unsigned int>(argc); ++pos){
     auto option = parse_cmd_options(std::string(argv[pos]));
     switch(option){
@@ -96,14 +112,30 @@ int main(int argc, char **argv) {
     AER::Simulator::QasmController sim;
     // Check for config
     sim.set_config(qobj["config"]);
-    out << sim.execute(qobj).dump(4) << std::endl;
+    auto result = sim.execute(qobj);
+    out << result.dump(4) << std::endl;
 
-    return 0;
+    // Check if execution was succesful.
+    bool success = false;
+    std::string status = "";
+    JSON::get_value(success, "success", result);
+    JSON::get_value(status, "status", result);
+    if (success) {
+      // The simulation was successfully executed
+      return 0;
+    }
+    if (status == "COMPLETED") {
+      // The simulation was was completed unsuccesfully.
+      // This means at least one of the experiments in the qobj failed.
+      return 3;
+    }
+    // If we got here we failed to execute the Qobj
+    return 2;
   } catch (std::exception &e) {
     std::stringstream msg;
     msg << "Failed to execute qobj (" << e.what() << ")";
     failed(msg.str(), out, indent);
-    return 1;
+    return 2;
   }
 
 } // end main


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds additional exit codes to standalone QasmSimulator. Closes #86 @sdague.

### Details and comments

 EXIT CODES: 
  * 0: The Qobj was succesfully executed. Returns full result JSON.
 * 1: Command line invalid or Qobj JSON cannot be loaded.  Returns JSON: `{"success": false, "status": "ERROR: Invalid input (error msg)"}`
 * 2: Qobj failed to load or execute. Returns JSON: `{"success": false, "status": "ERROR: Failed to execute qobj (error msg)"}`
 * 3: At least one experiment in Qobj failed to execute successfully. Returns parial result JSON with failed experiments returning: `{"success": false, "status": "ERROR: error msg"}`