### PR TITLE
add omp to probabilities in qubitvector

### DIFF
--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -2134,10 +2134,14 @@ rvector_t QubitVector<data_t>::probabilities(const reg_t &qubits) const {
     return probabilities();
 
   rvector_t probs(DIM, 0.);
-  for (size_t k = 0; k < END; k++) {
-    auto idx = indexes(qubits, qubits_sorted, k);
-    for (size_t m = 0; m < DIM; ++m) {
-      probs[m] += probability(idx[m]);
+#pragma omp parallel if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
+  {
+#pragma omp for
+    for (size_t k = 0; k < END; k++) {
+      auto idx = indexes(qubits, qubits_sorted, k);
+      for (size_t m = 0; m < DIM; ++m) {
+        probs[m] += probability(idx[m]);
+      }
     }
   }
   return probs;

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -2136,12 +2136,17 @@ rvector_t QubitVector<data_t>::probabilities(const reg_t &qubits) const {
   rvector_t probs(DIM, 0.);
 #pragma omp parallel if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
   {
+    rvector_t probs_private(DIM, 0.);
 #pragma omp for
     for (size_t k = 0; k < END; k++) {
       auto idx = indexes(qubits, qubits_sorted, k);
       for (size_t m = 0; m < DIM; ++m) {
-        probs[m] += probability(idx[m]);
+        probs_private[m] += probability(idx[m]);
       }
+    }
+#pragma omp critical
+    for (size_t m = 0; m < DIM; ++m) {
+      probs[m] += probs_private[m];
     }
   }
   return probs;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`QubitVector<data_t>::probabilities(const reg_t &qubits)` does not have an OMP directive.

### Details and comments
This PR adds `omp parallel` to a loop in `QubitVector<data_t>::probabilities(const reg_t &qubits)`.