### PR TITLE
Add controlled-swap and update static indexing in qubitvector

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 -----
 - Improve efficiency of parallelization with max_memory_mb a new parameter of backend_opts (#61)
 - Add optimized mcx, mcy, mcz, mcu1, mcu2, mcu3, gates to QubitVector (#124)
+- Add optimized controlled-swap gate to QubitVector
 
 Changed
 -------

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -1461,7 +1461,7 @@ void QubitVector<data_t>::apply_mcswap(const reg_t &qubits) {
   // Calculate the swap positions for the last two qubits.
   // If N = 2 this is just a regular SWAP gate rather than a controlled-SWAP gate.
   const size_t N = qubits.size();
-  const size_t pos0 = BITS[N - 1];
+  const size_t pos0 = MASKS[N - 1];
   const size_t pos1 = pos0 + BITS[N - 2];
 
   switch (N) {

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -155,7 +155,7 @@ public:
   // Set all entries in the vector to 0.
   void zero();
 
-  // index0 returns only the integer representation of a number of bits set
+  // index0 returns the integer representation of a number of bits set
   // to zero inserted into an arbitrary bit string.
   // Eg: for qubits 0,2 in a state k = ba ( ba = 00 => k=0, etc).
   // indexes0([1], k) -> int(b0a)
@@ -164,13 +164,6 @@ public:
   // ==> output = 297 = 100101001 (with 0's put into places 1 and 4).
   template<typename list_t>
   uint_t index0(const list_t &qubits_sorted, const uint_t k) const;
-
-  // Return a vector of of 2^N in ints, where each int corresponds to an N qubit
-  // bitstring for M-N qubit bits in state k, and the specified N qubits in states
-  // [0, ..., 2^N - 1] qubits_sorted must be sorted lowest to highest. Eg. {0, 1}.
-  // qubits specifies the location of the qubits in the retured strings.
-  template<size_t N>
-  areg_t<1ULL << N> indexes(const areg_t<N> &qs, const areg_t<N> &qubits_sorted, const uint_t k) const;
 
   // Return a std::unique_ptr to an array of of 2^N in ints
   // each int corresponds to an N qubit bitstring for M-N qubit bits in state k,
@@ -192,6 +185,10 @@ public:
   // output[2]: 313 = 100111001 (with 1 put into place 1, and 0 put into place 4).
   // output[3]: 313 = 100111011 (with 1's put into places 1 and 4).
   indexes_t indexes(const reg_t &qubits, const reg_t &qubits_sorted, const uint_t k) const;
+
+  // As above but returns a fixed sized array of of 2^N in ints
+  template<size_t N>
+  areg_t<1ULL << N> indexes(const areg_t<N> &qs, const areg_t<N> &qubits_sorted, const uint_t k) const;
 
   // State initialization of a component
   // Initialize the specified qubits to a desired statevector
@@ -257,29 +254,33 @@ public:
   // Apply Specialized Gates
   //-----------------------------------------------------------------------
 
-  // Apply a single-qubit Pauli-X gate to the state vector
-  void apply_x(const uint_t qubit);
-
-  // Apply a single-qubit Pauli-Y gate to the state vector
-  void apply_y(const uint_t qubit);
-
-  // Apply a single-qubit Pauli-Z gate to the state vector
-  void apply_z(const uint_t qubit);
-
-  // Apply multi-controlled X-gate
+  // Apply a general N-qubit multi-controlled X-gate
+  // If N=1 this implements an optimized X gate
+  // If N=2 this implements an optimized CX gate
+  // If N=3 this implements an optimized Toffoli gate
   void apply_mcx(const reg_t &qubits);
 
-  // Apply multi-controlled Y-gate
+  // Apply a general multi-controlled Y-gate
+  // If N=1 this implements an optimized Y gate
+  // If N=2 this implements an optimized CY gate
+  // If N=3 this implements an optimized CCY gate
   void apply_mcy(const reg_t &qubits);
 
-  // Apply multi-controlled Z-gate
+  // Apply a general multi-controlled Z-gate
+  // If N=1 this implements an optimized Z gate
+  // If N=2 this implements an optimized CZ gate
+  // If N=3 this implements an optimized CCZ gate
   void apply_mcz(const reg_t &qubits);
   
-  // Apply multi-controlled single-qubit unitary gate
+  // Apply a general multi-controlled single-qubit unitary gate
+  // If N=1 this implements an optimized single-qubit gate
+  // If N=2 this implements an optimized CU gate
+  // If N=3 this implements an optimized CCU gate
   void apply_mcu(const reg_t &qubits, const cvector_t &mat);
 
-  // Apply a multi-controlled SWAP gate
-  // If qubits is length 2 this is a regular (non-controlled) swap gate.
+  // Apply a general multi-controlled SWAP gate
+  // If N=2 this implements an optimized SWAP  gate
+  // If N=3 this implements an optimized Fredkin gate
   void apply_mcswap(const reg_t &qubits);
 
   //-----------------------------------------------------------------------
@@ -414,114 +415,110 @@ protected:
   void check_checkpoint() const;
 
   //-----------------------------------------------------------------------
-  // State update with Lambda functions
+  // Statevector update with Lambda function
   //-----------------------------------------------------------------------
-  // These functions loop through the indexes of the qubitvector data and
-  // apply a lambda function to each entry.
-
   // Apply a lambda function to all entries of the statevector.
   // The function signature should be:
+  //
   // [&](const int_t k)->void
+  //
   // where k is the index of the vector
   template <typename Lambda>
   void apply_lambda(Lambda&& func);
 
+  //-----------------------------------------------------------------------
+  // Statevector block update with Lambda function
+  //-----------------------------------------------------------------------
+  // These functions loop through the indexes of the qubitvector data and
+  // apply a lambda function to each block specified by the qubits argument.
+  //
+  // NOTE: The lambda functions can use the dynamic or static indexes
+  // signature however if N is known at compile time the static case should
+  // be preferred as it is significantly faster.
+
   // Apply a N-qubit lambda function to all blocks of the statevector
-  // for the given qubits. The function signature should be:
-  // [&](const indexes_t &inds)->void
-  // where inds are the 2 ** N indexes for each N-qubit block returned by
-  // the dynamic_indexes function
+  // for the given qubits. The function signature should be either:
+  //
+  // (Static): [&](const areg_t<1ULL<<N> &inds)->void
+  // (Dynamic): [&](const indexes_t &inds)->void
+  //
+  // where `inds` are the 2 ** N indexes for each N-qubit block returned by
+  // the `indexes` function.
   template <typename Lambda, typename list_t>
   void apply_lambda(Lambda&& func, const list_t &qubits);
 
-  //-----------------------------------------------------------------------
-  // State matrix update with Lambda functions
-  //-----------------------------------------------------------------------
-  // These functions loop through the indexes of the qubitvector data and
-  // apply a lambda function taking a vector matrix argument to each entry.
-
-  // Apply a N-qubit matrix lambda function to all blocks of the statevector
-  // for the given qubits. The function signature should be:
-  // [&](const indexes_t &inds, const cvector_t &m)->void
-  // where inds are the 2 ** N indexes for each N-qubit block returned by
-  // the dynamic_indexes function and m is a vectorized complex matrix.
-  template <typename Lambda, typename list_t>
-  void apply_matrix_lambda(Lambda&& func,
-                           const list_t &qubits,
-                           const cvector_t &mat);
+  // Apply an N-qubit parameterized lambda function to all blocks of the
+  // statevector for the given qubits. The function signature should be:
+  //
+  // (Static): [&](const areg_t<1ULL<<N> &inds, const param_t &params)->void
+  // (Dynamic): [&](const indexes_t &inds, const param_t &params)->void
+  //
+  // where `inds` are the 2 ** N indexes for each N-qubit block returned by
+  // the `indexes` function and `param` is a templated parameter class.
+  // (typically a complex vector).
+  template <typename Lambda, typename list_t, typename param_t>
+  void apply_lambda(Lambda&& func, const list_t &qubits, const param_t &par);
 
   //-----------------------------------------------------------------------
-  // State reduction functions with Lambda functions
+  // State reduction with Lambda functions
   //-----------------------------------------------------------------------
-  // These functions loop through the indexes of the qubitvector data and
-  // apply a lambda function to each entry that appplies a reduction on
-  // two doubles (val_re, val_im) and returns the complex result
-  // complex_t(val_re, val_im)
-
   // Apply a complex reduction lambda function to all entries of the
   // statevector and return the complex result.
   // The function signature should be:
+  //
   // [&](const int_t k, double &val_re, double &val_im)->void
+  //
   // where k is the index of the vector, val_re and val_im are the doubles
   // to store the reduction.
   // Returns complex_t(val_re, val_im)
   template <typename Lambda>
   complex_t apply_reduction_lambda(Lambda&& func) const;
 
-  // Apply a 1-qubit complex reduction  lambda function to all blocks of the
-  // statevector for the given qubit. The function signature should be:
-  // [&](const int_t k1, const int_t k2, double &val_re, double &val_im)->void
-  // where (k1, k2) are the 0 and 1 indexes for each qubit block
-  // val_re and val_im are the doubles to store the reduction.
-  // Returns complex_t(val_re, val_im)
-  template <typename Lambda>
-  complex_t apply_reduction_lambda(Lambda&& func,
-                                   const uint_t qubit) const;
-
-  // Apply a N-qubit complex reduction lambda function to all blocks of the
-  // statevector for the given qubits. The function signature should be:
-  // [&](const indexes_t &inds, double &val_re, double &val_im)->void
-  // where inds are the 2 ** N indexes for each N-qubit block returned by
-  // the static_indexes function, val_re and val_im are the doubles to store
-  // the reduction.
-  // Returns complex_t(val_re, val_im)
-  template <typename Lambda>
-  complex_t apply_reduction_lambda(Lambda&& func,
-                                   const reg_t &qubits) const;
-
   //-----------------------------------------------------------------------
-  // State matrix reduction functions with Lambda functions
+  // Statevector block reduction with Lambda function
   //-----------------------------------------------------------------------
   // These functions loop through the indexes of the qubitvector data and
-  // apply a lambda function to each entry that also applies a reduction
-  // and also applies a matrix. Unlike apply_matrix_lambda these should not
-  // update the state.
+  // apply a reduction lambda function to each block specified by the qubits
+  // argument. The reduction lambda stores the reduction in two doubles
+  // (val_re, val_im) and returns the complex result complex_t(val_re, val_im)
+  //
+  // NOTE: The lambda functions can use the dynamic or static indexes
+  // signature however if N is known at compile time the static case should
+  // be preferred as it is significantly faster.
 
-  // Apply a 1-qubit complex matrix reduction lambda function to all blocks of the
-  // statevector for the given qubit. The function signature should be:
-  // [&](const int_t k1, const int_t k2, const cvector_t &m,
-  //     double &val_re, double &val_im)->void
-  // where (k1, k2) are the 0 and 1 indexes for each qubit block, m is a
-  // vectorized complex matrix, val_re and val_im are the doubles to store
-  // the reduction.
-  // Returns complex_t(val_re, val_im)
-  template <typename Lambda>
-  complex_t apply_matrix_reduction_lambda(Lambda&& func,
-                                          const uint_t qubit,
-                                          const cvector_t &mat) const;
+  // Apply a N-qubit complex matrix reduction lambda function to all blocks
+  // of the statevector for the given qubits.
+  // The lambda function signature should be:
+  //
+  // (Static): [&](const areg_t<1ULL<<N> &inds, const param_t &mat,
+  //               double &val_re, double &val_im)->void
+  // (Dynamic): [&](const indexes_t &inds, const param_t &mat,
+  //                double &val_re, double &val_im)->void
+  //
+  // where `inds` are the 2 ** N indexes for each N-qubit block returned by
+  // the `indexes` function, `val_re` and `val_im` are the doubles to
+  // store the reduction returned as complex_t(val_re, val_im).
+  template <typename Lambda, typename list_t>
+  complex_t apply_reduction_lambda(Lambda&& func,
+                                   const list_t &qubits) const;
 
-  // Apply a N-qubit complex matrix reduction lambda function to all blocks of the
-  // statevector for the given qubits. The function signature should be:
-  // [&](const indexes_t &inds, const cvector_t &m,
-  //     double &val_re, double &val_im)->void
-  // where inds are the 2 ** N indexes for each N-qubit block returned by
-  // the static_indexes function, m is a vectorized complex matrix,
-  // val_re and val_im are the doubles to store the reduction.
-  // Returns complex_t(val_re, val_im)
-  template <typename Lambda>
-  complex_t apply_matrix_reduction_lambda(Lambda&& func,
-                                          const reg_t &qubits,
-                                          const cvector_t &mat) const;
+  // Apply a N-qubit complex matrix reduction lambda function to all blocks
+  // of the statevector for the given qubits.
+  // The lambda function signature should be:
+  //
+  // (Static): [&](const areg_t<1ULL<<N> &inds, const param_t &parms,
+  //               double &val_re, double &val_im)->void
+  // (Dynamic): [&](const indexes_t &inds, const param_t &params,
+  //                double &val_re, double &val_im)->void
+  //
+  // where `inds` are the 2 ** N indexes for each N-qubit block returned by
+  // the `indexe`s function, `params` is a templated parameter class
+  // (typically a complex vector), `val_re` and `val_im` are the doubles to
+  // store the reduction returned as complex_t(val_re, val_im).
+  template <typename Lambda, typename list_t, typename param_t>
+  complex_t apply_reduction_lambda(Lambda&& func,
+                                   const list_t &qubits,
+                                   const param_t &params) const;
 
   //-----------------------------------------------------------------------
   // Optimized matrix multiplication
@@ -717,12 +714,12 @@ uint_t QubitVector<data_t>::index0(const list_t &qubits_sorted, const uint_t k) 
 template <typename data_t>
 template <size_t N>
 areg_t<1ULL << N> QubitVector<data_t>::indexes(const areg_t<N> &qs,
-                                       const areg_t<N> &qubits_sorted,
-                                       const uint_t k) const {
+                                               const areg_t<N> &qubits_sorted,
+                                               const uint_t k) const {
   areg_t<1ULL << N> ret;
   ret[0] = index0(qubits_sorted, k);
   for (size_t i = 0; i < N; i++) {
-    const auto n = 1ULL << i;
+    const auto n = BITS[i];
     const auto bit = BITS[qs[i]];
     for (size_t j = 0; j < n; j++)
       ret[n + j] = ret[j] | bit;
@@ -763,7 +760,7 @@ void QubitVector<data_t>::initialize_component(const reg_t &qubits, const cvecto
     }    // (where psi is is the post-reset state of the non-initialized qubits)
    };
   // Use the lambda function
-  apply_matrix_lambda(lambda, qubits, state);
+  apply_lambda(lambda, qubits, state);
 }
 
 //------------------------------------------------------------------------------
@@ -915,11 +912,11 @@ void QubitVector<data_t>::set_json_chop_threshold(double threshold) {
  *
  ******************************************************************************/
 
+
 //------------------------------------------------------------------------------
-// General lambda
+// State update
 //------------------------------------------------------------------------------
 
-// Static N-qubit
 template <typename data_t>
 template<typename Lambda>
 void QubitVector<data_t>::apply_lambda(Lambda&& func) {
@@ -933,11 +930,9 @@ void QubitVector<data_t>::apply_lambda(Lambda&& func) {
   }
 }
 
-// Dynamic N-qubit
 template <typename data_t>
 template<typename Lambda, typename list_t>
-void QubitVector<data_t>::apply_lambda(Lambda&& func,
-                                       const list_t &qubits) {
+void QubitVector<data_t>::apply_lambda(Lambda&& func, const list_t &qubits) {
 
   // Error checking
   #ifdef DEBUG
@@ -954,19 +949,17 @@ void QubitVector<data_t>::apply_lambda(Lambda&& func,
 #pragma omp for
     for (int_t k = 0; k < END; k++) {
       // store entries touched by U
-      auto inds = indexes(qubits, qubits_sorted, k);
+      const auto inds = indexes(qubits, qubits_sorted, k);
       std::forward<Lambda>(func)(inds);
     }
   }
 }
 
-//------------------------------------------------------------------------------
-// Matrix Lambda
-//------------------------------------------------------------------------------
-// Dynamic N-qubit
 template <typename data_t>
-template<typename Lambda, typename list_t>
-void QubitVector<data_t>::apply_matrix_lambda(Lambda&& func, const list_t &qubits, const cvector_t &mat) {
+template<typename Lambda, typename list_t, typename param_t>
+void QubitVector<data_t>::apply_lambda(Lambda&& func,
+                                       const list_t &qubits,
+                                       const param_t &params) {
 
   // Error checking
   #ifdef DEBUG
@@ -984,7 +977,7 @@ void QubitVector<data_t>::apply_matrix_lambda(Lambda&& func, const list_t &qubit
 #pragma omp for
     for (int_t k = 0; k < END; k++) {
       const auto inds = indexes(qubits, qubits_sorted, k);
-      std::forward<Lambda>(func)(inds, mat);
+      std::forward<Lambda>(func)(inds, params);
     }
   }
 }
@@ -1012,45 +1005,11 @@ complex_t QubitVector<data_t>::apply_reduction_lambda(Lambda &&func) const {
   return complex_t(val_re, val_im);
 }
 
-// Single-qubit
+
 template <typename data_t>
-template<typename Lambda>
-complex_t QubitVector<data_t>::apply_reduction_lambda(Lambda &&func,
-                                                      const uint_t qubit) const {
-
-  // Error handling
-  #ifdef DEBUG
-  check_qubit(qubit);
-  #endif
-
-  const int_t END1 = data_size_;       // end for k1 loop
-  const int_t END2 = BITS[qubit];      // end for k2 loop
-  const int_t STEP1 = BITS[qubit + 1]; // step for k1 loop
-
-  // Reduction variables
-  double val_re = 0.;
-  double val_im = 0.;
-#pragma omp parallel reduction(+:val_re, val_im) if (num_qubits_ > omp_threshold_ && omp_threads_ > 1)         \
-                                               num_threads(omp_threads_)
-  {
-#ifdef _WIN32
-  #pragma omp for
-#else
-  #pragma omp for collapse(2)
-#endif
-    for (int_t k1 = 0; k1 < END1; k1 += STEP1)
-      for (int_t k2 = 0; k2 < END2; k2++) {
-        std::forward<Lambda>(func)(k1, k2, val_re, val_im);
-      }
-  } // end omp parallel
-  return complex_t(val_re, val_im);
-}
-
-// Dynamic N-qubit
-template <typename data_t>
-template<typename Lambda>
+template<typename Lambda, typename list_t>
 complex_t QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
-                                                      const reg_t &qubits) const {
+                                                      const list_t &qubits) const {
 
   // Error checking
   #ifdef DEBUG
@@ -1078,50 +1037,12 @@ complex_t QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
   return complex_t(val_re, val_im);
 }
 
-//------------------------------------------------------------------------------
-// Matrix and Reduction Lambda
-//------------------------------------------------------------------------------
 
 template <typename data_t>
-template<typename Lambda>
-complex_t QubitVector<data_t>::apply_matrix_reduction_lambda(Lambda &&func,
-                                                             const uint_t qubit,
-                                                             const cvector_t &mat) const {
-
-  // Error handling
-  #ifdef DEBUG
-  check_qubit(qubit);
-  #endif
-
-  const int_t END1 = data_size_;       // end for k1 loop
-  const int_t END2 = BITS[qubit];      // end for k2 loop
-  const int_t STEP1 = BITS[qubit + 1]; // step for k1 loop
-
-  // Reduction variables
-  double val_re = 0.;
-  double val_im = 0.;
-#pragma omp parallel reduction(+:val_re, val_im) if (num_qubits_ > omp_threshold_ && omp_threads_ > 1)         \
-                                               num_threads(omp_threads_)
-  {
-#ifdef _WIN32
-  #pragma omp for
-#else
-  #pragma omp for collapse(2)
-#endif
-    for (int_t k1 = 0; k1 < END1; k1 += STEP1)
-      for (int_t k2 = 0; k2 < END2; k2++) {
-        std::forward<Lambda>(func)(k1, k2, mat, val_re, val_im);
-      }
-  } // end omp parallel
-  return complex_t(val_re, val_im);
-}
-
-
-template <typename data_t>
-template<typename Lambda>
-complex_t QubitVector<data_t>::apply_matrix_reduction_lambda(Lambda&& func,
-                                                             const reg_t &qubits,
-                                                             const cvector_t &mat) const {
+template<typename Lambda, typename list_t, typename param_t>
+complex_t QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
+                                                      const list_t &qubits,
+                                                      const param_t &params) const {
 
   const auto NUM_QUBITS = qubits.size();
   // Error checking
@@ -1143,7 +1064,7 @@ complex_t QubitVector<data_t>::apply_matrix_reduction_lambda(Lambda&& func,
 #pragma omp for
     for (int_t k = 0; k < END; k++) {
       const auto inds = indexes(qubits, qubits_sorted, k);
-      std::forward<Lambda>(func)(inds, mat, val_re, val_im);
+      std::forward<Lambda>(func)(inds, params, val_re, val_im);
     }
   } // end omp parallel
   return complex_t(val_re, val_im);
@@ -1165,15 +1086,12 @@ void QubitVector<data_t>::apply_matrix(const reg_t &qubits,
   check_vector(mat, 2 * N);
   #endif
 
-  // Optimized 1-qubit apply matrix.
-  if (N==1) {
-    apply_matrix(qubits[0], mat);
-    return;
-  }
-
   // Matrix-swap based optimized 2-6 qubit implementation
   if (gate_opt_ && N <= 6) {
     switch (N) {
+      case 1:
+        apply_matrix(qubits[0], mat);
+        return;
       case 2:
         apply_matrix2(qubits, mat);
         return;
@@ -1194,110 +1112,212 @@ void QubitVector<data_t>::apply_matrix(const reg_t &qubits,
     } // end switch
   }
   
-  // General implementation
-  const uint_t DIM = BITS[N];
-  // Lambda function for N-qubit matrix multiplication
-  auto lambda = [&](const indexes_t &inds, const cvector_t &_mat)->void {
-    auto cache = std::make_unique<complex_t[]>(DIM);
-    for (size_t i = 0; i < DIM; i++) {
-      const auto ii = inds[i];
-      cache[i] = data_[ii];
-      data_[ii] = 0.;
+  // Static array optimized lambda functions
+  switch (N) {
+    case 1:
+      apply_matrix(qubits[0], mat);
+      return;
+    case 2: {
+      // Lambda function for 2-qubit matrix multiplication
+      auto lambda = [&](const areg_t<4> &inds, const cvector_t &_mat)->void {
+        std::array<complex_t, 4> cache;
+        for (size_t i = 0; i < 4; i++) {
+          const auto ii = inds[i];
+          cache[i] = data_[ii];
+          data_[ii] = 0.;
+        }
+        // update state vector
+        for (size_t i = 0; i < 4; i++)
+          for (size_t j = 0; j < 4; j++)
+            data_[inds[i]] += _mat[i + 4 * j] * cache[j];
+      };
+      apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}), mat);
+      return;
     }
-    // update state vector
-    for (size_t i = 0; i < DIM; i++)
-      for (size_t j = 0; j < DIM; j++)
-        data_[inds[i]] += _mat[i + DIM * j] * cache[j];
-  };
-
-  // Use the lambda function
-  apply_matrix_lambda(lambda, qubits, mat);
+    case 3: {
+      // Lambda function for 3-qubit matrix multiplication
+      auto lambda = [&](const areg_t<8> &inds, const cvector_t &_mat)->void {
+        std::array<complex_t, 8> cache;
+        for (size_t i = 0; i < 8; i++) {
+          const auto ii = inds[i];
+          cache[i] = data_[ii];
+          data_[ii] = 0.;
+        }
+        // update state vector
+        for (size_t i = 0; i < 8; i++)
+          for (size_t j = 0; j < 8; j++)
+            data_[inds[i]] += _mat[i + 8 * j] * cache[j];
+      };
+      apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}), mat);
+      return;
+    }
+    case 4: {
+      // Lambda function for 4-qubit matrix multiplication
+      auto lambda = [&](const areg_t<16> &inds, const cvector_t &_mat)->void {
+        std::array<complex_t, 16> cache;
+        for (size_t i = 0; i < 16; i++) {
+          const auto ii = inds[i];
+          cache[i] = data_[ii];
+          data_[ii] = 0.;
+        }
+        // update state vector
+        for (size_t i = 0; i < 16; i++)
+          for (size_t j = 0; j < 16; j++)
+            data_[inds[i]] += _mat[i + 16 * j] * cache[j];
+      };
+      apply_lambda(lambda, areg_t<4>({{qubits[0], qubits[1], qubits[2], qubits[3]}}), mat);
+      return;
+    }
+    default: {
+      const uint_t DIM = BITS[N];
+      // Lambda function for N-qubit matrix multiplication
+      auto lambda = [&](const indexes_t &inds, const cvector_t &_mat)->void {
+        auto cache = std::make_unique<complex_t[]>(DIM);
+        for (size_t i = 0; i < DIM; i++) {
+          const auto ii = inds[i];
+          cache[i] = data_[ii];
+          data_[ii] = 0.;
+        }
+        // update state vector
+        for (size_t i = 0; i < DIM; i++)
+          for (size_t j = 0; j < DIM; j++)
+            data_[inds[i]] += _mat[i + DIM * j] * cache[j];
+      };
+      apply_lambda(lambda, qubits, mat);
+    }
+  } // end switch
 }
 
 template <typename data_t>
 void QubitVector<data_t>::apply_diagonal_matrix(const reg_t &qubits,
                                                 const cvector_t &diag) {
-
-  // Optimized 1-qubit apply matrix.                                                
-  if (qubits.size() == 1) {
-    apply_diagonal_matrix(qubits[0], diag);
-    return;
-  }
-
   const size_t N = qubits.size();
-  const uint_t DIM = BITS[N];
   // Error checking
   #ifdef DEBUG
   check_vector(diag, N);
   #endif
 
-  // Lambda function for N-qubit matrix multiplication
-  auto lambda = [&](const indexes_t &inds,
-                    const cvector_t &_mat)->void {
-    for (size_t i = 0; i < DIM; i++) {
-      data_[inds[i]] *= _mat[i];
+  switch (N) {
+    case 1:
+      apply_diagonal_matrix(qubits[0], diag);
+      return;
+    case 2: {
+      // Lambda function for 2-qubit diagional matrix multiplication
+      auto lambda = [&](const areg_t<4> &inds,
+                        const cvector_t &_mat)->void {
+        for (size_t i = 0; i < 4; i++) {
+          data_[inds[i]] *= _mat[i];
+        }
+      };
+      apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}), diag);
+      return;
     }
-  };
-
-  // Use the lambda function
-  apply_matrix_lambda(lambda, qubits, diag);
+    case 3: {
+      // Lambda function for 3-qubit diagional matrix multiplication
+      auto lambda = [&](const areg_t<8> &inds,
+                        const cvector_t &_mat)->void {
+        for (size_t i = 0; i < 8; i++) {
+          data_[inds[i]] *= _mat[i];
+        }
+      };
+      apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}), diag);
+      return;
+    }
+    case 4: {
+      // Lambda function for 4-qubit diagional matrix multiplication
+      auto lambda = [&](const areg_t<16> &inds,
+                        const cvector_t &_mat)->void {
+        for (size_t i = 0; i < 16; i++) {
+          data_[inds[i]] *= _mat[i];
+        }
+      };
+      apply_lambda(lambda, areg_t<4>({{qubits[0], qubits[1], qubits[2], qubits[3]}}), diag);
+      return;
+    }
+    default: {
+      const uint_t DIM = BITS[N];
+      // Lambda function for N-qubit diagional  matrix multiplication
+      auto lambda = [&](const indexes_t &inds,
+                        const cvector_t &_mat)->void {
+        for (size_t i = 0; i < DIM; i++) {
+          data_[inds[i]] *= _mat[i];
+        }
+      };
+      apply_lambda(lambda, qubits, diag);
+    }
+  } // end switch
 }
 
 template <typename data_t>
 void QubitVector<data_t>::apply_permutation_matrix(const reg_t& qubits,
                                                    const std::vector<std::pair<uint_t, uint_t>> &pairs) {
-  // Lambda function for permutation matrix
-  auto lambda = [&](const indexes_t &inds)->void {
-    for (const auto& p : pairs) {
-      std::swap(data_[inds[p.first]], data_[inds[p.second]]);
+  const size_t N = qubits.size();
+
+  // Error checking
+  #ifdef DEBUG
+  check_vector(diag, N);
+  #endif
+
+  switch (N) {
+    case 1: {
+      // Lambda function for permutation matrix
+      auto lambda = [&](const areg_t<2> &inds)->void {
+        for (const auto& p : pairs) {
+          std::swap(data_[inds[p.first]], data_[inds[p.second]]);
+        }
+      };
+      apply_lambda(lambda, areg_t<1>({{qubits[0]}}));
+      return;
     }
-  };
-  // Use the lambda function
-  apply_lambda(lambda, qubits);
+    case 2: {
+      // Lambda function for permutation matrix
+      auto lambda = [&](const areg_t<4> &inds)->void {
+        for (const auto& p : pairs) {
+          std::swap(data_[inds[p.first]], data_[inds[p.second]]);
+        }
+      };
+      apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}));
+      return;
+    }
+    case 3: {
+      // Lambda function for permutation matrix
+      auto lambda = [&](const areg_t<8> &inds)->void {
+        for (const auto& p : pairs) {
+          std::swap(data_[inds[p.first]], data_[inds[p.second]]);
+        }
+      };
+      apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}));
+      return;
+    }
+    case 4: {
+      // Lambda function for permutation matrix
+      auto lambda = [&](const areg_t<16> &inds)->void {
+        for (const auto& p : pairs) {
+          std::swap(data_[inds[p.first]], data_[inds[p.second]]);
+        }
+      };
+      apply_lambda(lambda, areg_t<4>({{qubits[0], qubits[1], qubits[2], qubits[3]}}));
+      return;
+    }
+    default: {
+      // Lambda function for permutation matrix
+      auto lambda = [&](const indexes_t &inds)->void {
+        for (const auto& p : pairs) {
+          std::swap(data_[inds[p.first]], data_[inds[p.second]]);
+        }
+      };
+      // Use the lambda function
+      apply_lambda(lambda, qubits);
+    }
+  } // end switch
 }
+
 
 /*******************************************************************************
  *
  * APPLY OPTIMIZED GATES
  *
  ******************************************************************************/
-
-//------------------------------------------------------------------------------
-// Single-qubit gates
-//------------------------------------------------------------------------------
-template <typename data_t>
-void QubitVector<data_t>::apply_x(const uint_t qubit) {
-  // Lambda function for optimized Pauli-X gate
-  auto lambda = [&](const areg_t<2> &inds)->void {
-    const auto i0 = inds[0];
-    const auto i1 = inds[1];
-    std::swap(data_[i0], data_[i1]);
-  };
-  apply_lambda(lambda, (areg_t<1>){qubit});
-}
-
-template <typename data_t>
-void QubitVector<data_t>::apply_y(const uint_t qubit) {
-  // Lambda function for optimized Pauli-Y gate
-  const complex_t I(0., 1.);
-  auto lambda = [&](const areg_t<2> &inds)->void {
-    const auto i0 = inds[0];
-    const auto i1 = inds[1];
-    const complex_t cache = data_[i0];
-    data_[i0] = -I * data_[i1]; // mat(0,1)
-    data_[i1] = I * cache;     // mat(1,0)
-  };
-  apply_lambda(lambda, (areg_t<1>){qubit});
-}
-
-template <typename data_t>
-void QubitVector<data_t>::apply_z(const uint_t qubit) {
-  // Lambda function for optimized Pauli-Z gate
-  auto lambda = [&](const areg_t<2> &inds)->void {
-    data_[inds[1]] *= complex_t(-1.0, 0.0);
-  };
-  apply_lambda(lambda, (areg_t<1>){qubit});
-}
 
 //------------------------------------------------------------------------------
 // Multi-controlled gates
@@ -1310,20 +1330,39 @@ void QubitVector<data_t>::apply_mcx(const reg_t &qubits) {
   const size_t pos0 = MASKS[N - 1];
   const size_t pos1 = MASKS[N];
 
-  if (N == 2) {
-    // Lambda function for multi-controlled X gate
-    auto lambda = [&](const areg_t<4> &inds)->void {
-      std::swap(data_[inds[pos0]], data_[inds[pos1]]);
-    };
-    apply_lambda(lambda, (areg_t<2>){qubits[0], qubits[1]});
-    return;
-  }
-
-  // Lambda function for multi-controlled X gate
-  auto lambda = [&](const indexes_t &inds)->void {
-    std::swap(data_[inds[pos0]], data_[inds[pos1]]);
-  };
-  apply_lambda(lambda, qubits);
+  switch (N) {
+    case 1: {
+      // Lambda function for X gate
+      auto lambda = [&](const areg_t<2> &inds)->void {
+        std::swap(data_[inds[pos0]], data_[inds[pos1]]);
+      };
+      apply_lambda(lambda, areg_t<1>({{qubits[0]}}));
+      return;
+    }
+    case 2: {
+      // Lambda function for CX gate
+      auto lambda = [&](const areg_t<4> &inds)->void {
+        std::swap(data_[inds[pos0]], data_[inds[pos1]]);
+      };
+      apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}));
+      return;
+    }
+    case 3: {
+      // Lambda function for Toffli gate
+      auto lambda = [&](const areg_t<8> &inds)->void {
+        std::swap(data_[inds[pos0]], data_[inds[pos1]]);
+      };
+      apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}));
+      return;
+    }
+    default: {
+      // Lambda function for general multi-controlled X gate
+      auto lambda = [&](const indexes_t &inds)->void {
+        std::swap(data_[inds[pos0]], data_[inds[pos1]]);
+      };
+      apply_lambda(lambda, qubits);
+    }
+  } // end switch
 }
 
 template <typename data_t>
@@ -1334,46 +1373,122 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
   const size_t pos1 = MASKS[N];
   const complex_t I(0., 1.);
 
-  if (N == 2) {
-    // Lambda function for multi-controlled Y gate
-    auto lambda = [&](const areg_t<4> &inds)->void {
-      const complex_t cache = data_[inds[pos0]];
-      data_[inds[pos0]] = -I * data_[inds[pos1]];
-      data_[inds[pos1]] = I * cache;
-    };
-    apply_lambda(lambda, (areg_t<2>){qubits[0], qubits[1]});
-    return;
-  }
-
-  // Lambda function for multi-controlled Y gate
-  auto lambda = [&](const indexes_t &inds)->void {
-    const complex_t cache = data_[inds[pos0]];
-    data_[inds[pos0]] = -I * data_[inds[pos1]];
-    data_[inds[pos1]] = I * cache;
-  };
-  apply_lambda(lambda, qubits);
+  switch (N) {
+    case 1: {
+      // Lambda function for Y gate
+      auto lambda = [&](const areg_t<2> &inds)->void {
+        const complex_t cache = data_[inds[pos0]];
+        data_[inds[pos0]] = -I * data_[inds[pos1]];
+        data_[inds[pos1]] = I * cache;
+      };
+      apply_lambda(lambda, areg_t<1>({{qubits[0]}}));
+      return;
+    }
+    case 2: {
+      // Lambda function for CY gate
+      auto lambda = [&](const areg_t<4> &inds)->void {
+        const complex_t cache = data_[inds[pos0]];
+        data_[inds[pos0]] = -I * data_[inds[pos1]];
+        data_[inds[pos1]] = I * cache;
+      };
+      apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}));
+      return;
+    }
+    case 3: {
+      // Lambda function for CCY gate
+      auto lambda = [&](const areg_t<8> &inds)->void {
+        const complex_t cache = data_[inds[pos0]];
+        data_[inds[pos0]] = -I * data_[inds[pos1]];
+        data_[inds[pos1]] = I * cache;
+      };
+      apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}));
+      return;
+    }
+    default: {
+      // Lambda function for general multi-controlled Y gate
+      auto lambda = [&](const indexes_t &inds)->void {
+        const complex_t cache = data_[inds[pos0]];
+        data_[inds[pos0]] = -I * data_[inds[pos1]];
+        data_[inds[pos1]] = I * cache;
+      };
+      apply_lambda(lambda, qubits);
+    }
+  } // end switch
 }
 
 template <typename data_t>
 void QubitVector<data_t>::apply_mcz(const reg_t &qubits) {
   const size_t N = qubits.size();
 
-  if (N == 2) {
-    // Lambda function for multi-controlled Z gate
-    auto lambda = [&](const areg_t<4> &inds)->void {
-      // Multiply last block index by -1
-      data_[inds[MASKS[qubits.size()]]] *= -1.;
-    };
-    apply_lambda(lambda, (areg_t<2>){qubits[0], qubits[1]});
-    return;
-  }
+  switch (N) {
+    case 1: {
+      // Lambda function for Z gate
+      auto lambda = [&](const areg_t<2> &inds)->void {
+        data_[inds[1]] *= -1.;
+      };
+      apply_lambda(lambda, areg_t<1>({{qubits[0]}}));
+      return;
+    }
+    case 2: {
+      // Lambda function for CZ gate
+      auto lambda = [&](const areg_t<4> &inds)->void {
+        data_[inds[3]] *= -1.;
+      };
+      apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}));
+      return;
+    }
+    case 3: {
+      // Lambda function for CCZ gate
+      auto lambda = [&](const areg_t<8> &inds)->void {
+         data_[inds[7]] *= -1.;
+      };
+      apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}));
+      return;
+    }
+    default: {
+      // Lambda function for general multi-controlled X gate
+      auto lambda = [&](const indexes_t &inds)->void {
+         data_[inds[MASKS[N]]] *= -1.;
+      };
+      apply_lambda(lambda, qubits);
+    }
+  } // end switch
+}
 
-  // Lambda function for multi-controlled Z gate
-  auto lambda = [&](const indexes_t &inds)->void {
-    // Multiply last block index by -1
-    data_[inds[MASKS[qubits.size()]]] *= -1.;
-  };
-  apply_lambda(lambda, qubits);
+
+template <typename data_t>
+void QubitVector<data_t>::apply_mcswap(const reg_t &qubits) {
+  // Calculate the swap positions for the last two qubits.
+  // If N = 2 this is just a regular SWAP gate rather than a controlled-SWAP gate.
+  const size_t N = qubits.size();
+  const size_t pos0 = BITS[N - 1];
+  const size_t pos1 = pos0 + BITS[N - 2];
+
+  switch (N) {
+    case 2: {
+      // Lambda function for SWAP gate
+      auto lambda = [&](const areg_t<4> &inds)->void {
+        std::swap(data_[inds[pos0]], data_[inds[pos1]]);
+      };
+      apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}));
+      return;
+    }
+    case 3: {
+      // Lambda function for C-SWAP gate
+      auto lambda = [&](const areg_t<8> &inds)->void {
+        std::swap(data_[inds[pos0]], data_[inds[pos1]]);
+      };
+      apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}));
+      return;
+    }
+    default: {
+      // Lambda function for general multi-controlled SWAP gate
+      auto lambda = [&](const indexes_t &inds)->void {
+        std::swap(data_[inds[pos0]], data_[inds[pos1]]);
+      };
+      apply_lambda(lambda, qubits);
+    }
+  } // end switch
 }
 
 template <typename data_t>
@@ -1384,40 +1499,92 @@ void QubitVector<data_t>::apply_mcu(const reg_t &qubits,
   const size_t pos0 = MASKS[N - 1];
   const size_t pos1 = MASKS[N];
 
-  if (N == 2) {
-    // Lambda function for multi-controlled single-qubit gate
-    auto lambda = [&](const areg_t<4> &inds,
-                      const cvector_t &_mat)->void {
+  // Check if matrix is actually diagonal and if so use 
+  // diagonal matrix lambda function
+  // TODO: this should be changed to not check doubles with ==
+  if (mat[1] == 0.0 && mat[2] == 0.0) {
+    const cvector_t diag = {{mat[0], mat[3]}};
+    // Diagonal version
+    switch (N) {
+      case 1: {
+        // If N=1 this is just a single-qubit matrix
+        apply_diagonal_matrix(qubits[0], diag);
+        return;
+      }
+      case 2: {
+        // Lambda function for CU gate
+        auto lambda = [&](const areg_t<4> &inds,
+                          const cvector_t &_diag)->void {
+          data_[pos0] = _diag[0] * data_[pos0];
+          data_[pos1] = _diag[1] * data_[pos1];
+        };
+        apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}), diag);
+        return;
+      }
+      case 3: {
+        // Lambda function for CCU gate
+        auto lambda = [&](const areg_t<8> &inds,
+                          const cvector_t &_diag)->void {
+          data_[pos0] = _diag[0] * data_[pos0];
+          data_[pos1] = _diag[1] * data_[pos1];
+        };
+        apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}), diag);
+        return;
+      }
+      default: {
+        // Lambda function for general multi-controlled U gate
+        auto lambda = [&](const indexes_t &inds,
+                          const cvector_t &_diag)->void {
+          data_[pos0] = _diag[0] * data_[pos0];
+          data_[pos1] = _diag[1] * data_[pos1];
+        };
+        apply_lambda(lambda, qubits, diag);
+        return;
+      }
+    } // end switch
+  }
+
+  // Non-diagonal version
+  switch (N) {
+    case 1: {
+      // If N=1 this is just a single-qubit matrix
+      apply_matrix(qubits[0], mat);
+      return;
+    }
+    case 2: {
+      // Lambda function for CU gate
+      auto lambda = [&](const areg_t<4> &inds,
+                        const cvector_t &_mat)->void {
       const auto cache = data_[pos0];
       data_[pos0] = _mat[0] * data_[pos0] + _mat[2] * data_[pos1];
       data_[pos1] = _mat[1] * cache + _mat[3] * data_[pos1];
-    };
-    apply_matrix_lambda(lambda, (areg_t<2>){qubits[0], qubits[1]}, mat);
-    return;
-  }
-
-  // Lambda function for multi-controlled single-qubit gate
-  auto lambda = [&](const indexes_t &inds,
-                    const cvector_t &_mat)->void {
-    const auto cache = data_[pos0];
-    data_[pos0] = _mat[0] * data_[pos0] + _mat[2] * data_[pos1];
-    data_[pos1] = _mat[1] * cache + _mat[3] * data_[pos1];
-  };
-  apply_matrix_lambda(lambda, qubits, mat);
-}
-
-template <typename data_t>
-void QubitVector<data_t>::apply_mcswap(const reg_t &qubits) {
-  // Calculate the swap positions for the last two qubits.
-  // If N = 2 this is just a regular SWAP gate rather than a controlled-SWAP gate.
-  const size_t N = qubits.size();
-  const size_t pos0 = BITS[N - 1];
-  const size_t pos1 = pos0 + BITS[N - 2];
-  // Lambda function for multi-controlled single-qubit gate
-  auto lambda = [&](const indexes_t &inds)->void {
-     std::swap(data_[pos0], data_[pos1]);
-  };
-  apply_lambda(lambda, qubits);
+      };
+      apply_lambda(lambda, areg_t<2>({{qubits[0], qubits[1]}}), mat);
+      return;
+    }
+    case 3: {
+      // Lambda function for CCU gate
+      auto lambda = [&](const areg_t<8> &inds,
+                        const cvector_t &_mat)->void {
+      const auto cache = data_[pos0];
+      data_[pos0] = _mat[0] * data_[pos0] + _mat[2] * data_[pos1];
+      data_[pos1] = _mat[1] * cache + _mat[3] * data_[pos1];
+      };
+      apply_lambda(lambda, areg_t<3>({{qubits[0], qubits[1], qubits[2]}}), mat);
+      return;
+    }
+    default: {
+      // Lambda function for general multi-controlled U gate
+      auto lambda = [&](const indexes_t &inds,
+                        const cvector_t &_mat)->void {
+      const auto cache = data_[pos0];
+      data_[pos0] = _mat[0] * data_[pos0] + _mat[2] * data_[pos1];
+      data_[pos1] = _mat[1] * cache + _mat[3] * data_[pos1];
+      };
+      apply_lambda(lambda, qubits, mat);
+      return;
+    }
+  } // end switch
 }
 
 //------------------------------------------------------------------------------
@@ -1445,7 +1612,7 @@ void QubitVector<data_t>::apply_matrix(const uint_t qubit,
     data_[pos0] = _mat[0] * data_[pos0] + _mat[2] * data_[pos1];
     data_[pos1] = _mat[1] * cache + _mat[3] * data_[pos1];
   };
-  apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, mat);
+  apply_lambda(lambda, areg_t<1>({{qubit}}), mat);
 }
 
 template <typename data_t>
@@ -1464,8 +1631,10 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
         data_[k].imag(data_[k].real() * -1.);
         data_[k].real(cache);
       };
-      apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
-    } else if (diag[1] == complex_t(0., 1.)) {
+      apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
+      return;
+    }
+    if (diag[1] == complex_t(0., 1.)) {
       // [[1, 0], [0, i]]
       auto lambda = [&](const areg_t<2> &inds,
                         const cvector_t &_mat)->void {
@@ -1474,23 +1643,26 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
         data_[k].imag(data_[k].real());
         data_[k].real(cache * -1.);
       };
-      apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
-    } else if (diag[0] == 0.0) {
+      apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
+      return;
+    } 
+    if (diag[0] == 0.0) {
       // [[1, 0], [0, 0]]
       auto lambda = [&](const areg_t<2> &inds,
                         const cvector_t &_mat)->void {
         data_[inds[1]] = 0.0;
       };
-      apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
-    } else {
-      // general [[1, 0], [0, z]]
-      auto lambda = [&](const areg_t<2> &inds,
-                        const cvector_t &_mat)->void {
-        const auto k = inds[1];
-        data_[k] *= _mat[1];
-      };
-      apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
-    }
+      apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
+      return;
+    } 
+    // general [[1, 0], [0, z]]
+    auto lambda = [&](const areg_t<2> &inds,
+                      const cvector_t &_mat)->void {
+      const auto k = inds[1];
+      data_[k] *= _mat[1];
+    };
+    apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
+    return;
   } else if (diag[1] == 1.0) {
     // [[z, 0], [0, 1]] matrix
     if (diag[0] == complex_t(0., -1.)) {
@@ -1502,8 +1674,10 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
         data_[k].imag(data_[k].real() * -1.);
         data_[k].real(cache);
       };
-      apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
-    } else if (diag[0] == complex_t(0., 1.)) {
+      apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
+      return;
+    } 
+    if (diag[0] == complex_t(0., 1.)) {
       // [[i, 0], [0, 1]]
       auto lambda = [&](const areg_t<2> &inds,
                         const cvector_t &_mat)->void {
@@ -1512,23 +1686,26 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
         data_[k].imag(data_[k].real());
         data_[k].real(cache * -1.);
       };
-      apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
-    } else if (diag[0] == 0.0) {
+      apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
+      return;
+    } 
+    if (diag[0] == 0.0) {
       // [[0, 0], [0, 1]]
       auto lambda = [&](const areg_t<2> &inds,
                         const cvector_t &_mat)->void {
         data_[inds[0]] = 0.0;
       };
-      apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
-    } else {
-      // general [[z, 0], [0, 1]]
-      auto lambda = [&](const areg_t<2> &inds,
-                        const cvector_t &_mat)->void {
-        const auto k = inds[0];
-        data_[k] *= _mat[0];
-      };
-      apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
-    }
+      apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
+      return;
+    } 
+    // general [[z, 0], [0, 1]]
+    auto lambda = [&](const areg_t<2> &inds,
+                      const cvector_t &_mat)->void {
+      const auto k = inds[0];
+      data_[k] *= _mat[0];
+    };
+    apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
+    return;
   } else {
     // Lambda function for diagonal matrix multiplication
     auto lambda = [&](const areg_t<2> &inds,
@@ -1538,7 +1715,7 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
       data_[k0] *= _mat[0];
       data_[k1] *= _mat[1];
     };
-    apply_matrix_lambda(lambda, (areg_t<1>) {qubit}, diag);
+    apply_lambda(lambda, areg_t<1>({{qubit}}), diag);
   }
 }
 
@@ -2014,7 +2191,7 @@ double QubitVector<data_t>::norm(const reg_t &qubits, const cvector_t &mat) cons
     }
   };
   // Use the lambda function
-  return std::real(apply_matrix_reduction_lambda(lambda, qubits, mat));
+  return std::real(apply_reduction_lambda(lambda, qubits, mat));
 }
 
 template <typename data_t>
@@ -2029,8 +2206,10 @@ double QubitVector<data_t>::norm_diagonal(const reg_t &qubits, const cvector_t &
   #endif
 
   // Lambda function for N-qubit matrix norm
-  auto lambda = [&](const indexes_t &inds, const cvector_t &_mat,
-                    double &val_re, double &val_im)->void {
+  auto lambda = [&](const indexes_t &inds,
+                    const cvector_t &_mat,
+                    double &val_re,
+                    double &val_im)->void {
     (void)val_im; // unused
     for (size_t i = 0; i < DIM; i++) {
       const auto vi = _mat[i] * data_[inds[i]];
@@ -2038,7 +2217,7 @@ double QubitVector<data_t>::norm_diagonal(const reg_t &qubits, const cvector_t &
     }
   };
   // Use the lambda function
-  return std::real(apply_matrix_reduction_lambda(lambda, qubits, mat));
+  return std::real(apply_reduction_lambda(lambda, qubits, mat));
 }
 
 //------------------------------------------------------------------------------
@@ -2051,17 +2230,16 @@ double QubitVector<data_t>::norm(const uint_t qubit, const cvector_t &mat) const
   check_vector(mat, 2);
   #endif
   // Lambda function for norm reduction to real value.
-  auto lambda = [&](const int_t k1, const int_t k2,const cvector_t &_mat,
-                    double &val_re, double &val_im)->void {
-    (void)val_im; // unused;
-    const auto k = k1 | k2;
-    const auto cache0 = data_[k];
-    const auto cache1 = data_[k | BITS[qubit]];
-    const auto v0 = _mat[0] * cache0 + _mat[2] * cache1;
-    const auto v1 = _mat[1] * cache0 + _mat[3] * cache1;
+  auto lambda = [&](const areg_t<2> &inds,
+                    const cvector_t &_mat,
+                    double &val_re,
+                    double &val_im)->void {
+    (void)val_im; // unused
+    const auto v0 = _mat[0] * data_[inds[0]] + _mat[2] * data_[inds[1]];
+    const auto v1 = _mat[1] * data_[inds[0]] + _mat[3] * data_[inds[1]];
     val_re += std::real(v0 * std::conj(v0)) + std::real(v1 * std::conj(v1));
   };
-  return std::real(apply_matrix_reduction_lambda(lambda, qubit, mat));
+  return std::real(apply_reduction_lambda(lambda, areg_t<1>({{qubit}}), mat));
 }
 
 template <typename data_t>
@@ -2071,15 +2249,16 @@ double QubitVector<data_t>::norm_diagonal(const uint_t qubit, const cvector_t &m
   check_vector(mat, 1);
   #endif
   // Lambda function for norm reduction to real value.
-  auto lambda = [&](const int_t k1, const int_t k2,const cvector_t &_mat,
-                    double &val_re, double &val_im)->void {
-    (void)val_im; // unused;
-    const auto k = k1 | k2;
-    const auto v0 = _mat[0] * data_[k];
-    const auto v1 = _mat[1] * data_[k | BITS[qubit]];
+  auto lambda = [&](const areg_t<2> &inds,
+                    const cvector_t &_mat,
+                    double &val_re,
+                    double &val_im)->void {
+    (void)val_im; // unused
+    const auto v0 = _mat[0] * data_[inds[0]];
+    const auto v1 = _mat[1] * data_[inds[1]];
     val_re += std::real(v0 * std::conj(v0)) + std::real(v1 * std::conj(v1));
   };
-  return std::real(apply_matrix_reduction_lambda(lambda, qubit, mat));
+  return std::real(apply_reduction_lambda(lambda, areg_t<1>({{qubit}}), mat));
 }
 
 
@@ -2171,13 +2350,13 @@ rvector_t QubitVector<data_t>::probabilities(const uint_t qubit) const {
 
   // Lambda function for single qubit probs as reduction
   // p(0) stored as real part p(1) as imag part
-  auto lambda = [&](const int_t k1, const int_t k2,
-                    double &val_p0, double &val_p1)->void {
-    const auto k = k1 | k2;
-    val_p0 += probability(k);
-    val_p1 += probability(k | BITS[qubit]);
+  auto lambda = [&](const areg_t<2> &inds,
+                    double &val_p0,
+                    double &val_p1)->void {
+    val_p0 += probability(inds[0]);
+    val_p1 += probability(inds[1]);
   };
-  auto p0p1 = apply_reduction_lambda(lambda, qubit);
+  auto p0p1 = apply_reduction_lambda(lambda, areg_t<1>({{qubit}}));
   return rvector_t({std::real(p0p1), std::imag(p0p1)});
 }
 

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -266,9 +266,6 @@ public:
   // Apply a single-qubit Pauli-Z gate to the state vector
   void apply_z(const uint_t qubit);
 
-  // Apply a 2-qubit SWAP gate to the state vector
-  void apply_swap(const uint_t q0, const uint_t q1);
-
   // Apply multi-controlled X-gate
   void apply_mcx(const reg_t &qubits);
 
@@ -280,6 +277,10 @@ public:
   
   // Apply multi-controlled single-qubit unitary gate
   void apply_mcu(const reg_t &qubits, const cvector_t &mat);
+
+  // Apply a multi-controlled SWAP gate
+  // If qubits is length 2 this is a regular (non-controlled) swap gate.
+  void apply_mcswap(const reg_t &qubits);
 
   //-----------------------------------------------------------------------
   // Z-measurement outcome probabilities
@@ -1405,18 +1406,17 @@ void QubitVector<data_t>::apply_mcu(const reg_t &qubits,
   apply_matrix_lambda(lambda, qubits, mat);
 }
 
-//------------------------------------------------------------------------------
-// Swap gates
-//------------------------------------------------------------------------------
-
 template <typename data_t>
-void QubitVector<data_t>::apply_swap(const uint_t qubit0, const uint_t qubit1) {
-  // Lambda function for SWAP gate
+void QubitVector<data_t>::apply_mcswap(const reg_t &qubits) {
+  // Calculate the swap positions for the last two qubits.
+  // If N = 2 this is just a regular SWAP gate rather than a controlled-SWAP gate.
+  const size_t N = qubits.size();
+  const size_t pos0 = BITS[N - 1];
+  const size_t pos1 = pos0 + BITS[N - 2];
+  // Lambda function for multi-controlled single-qubit gate
   auto lambda = [&](const indexes_t &inds)->void {
-    std::swap(data_[inds[1]], data_[inds[2]]);
+     std::swap(data_[pos0], data_[pos1]);
   };
-  // Use the lambda function
-  const reg_t qubits = {qubit0, qubit1};
   apply_lambda(lambda, qubits);
 }
 

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -24,8 +24,7 @@ namespace QubitUnitary {
 // Allowed gates enum class
 enum class Gates {
   u1, u2, u3, id, x, y, z, h, s, sdg, t, tdg, // single qubit
-  cx, cy, cz, swap, // two qubit
-  ccx, mcx, mcy, mcz, mcu1, mcu2, mcu3 // multi-qubit controlled
+  mcx, mcy, mcz, mcu1, mcu2, mcu3, mcswap // multi-qubit controlled
 };
 
 
@@ -62,7 +61,7 @@ public:
   virtual stringset_t allowed_gates() const override {
     return {"u1", "u2", "u3", "cx", "cz", "cy", "swap",
             "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx",
-            "mcx", "mcz", "mcy", "mcu1", "mcu2", "mcu3"};
+            "mcx", "mcz", "mcy", "mcu1", "mcu2", "mcu3", "mcswap"};
   }
 
   // Return the set of qobj snapshot types supported by the State
@@ -182,18 +181,19 @@ const stringmap_t<Gates> State<data_t>::gateset_({
   {"u2", Gates::u2},  // single-X90 pulse waltz gate
   {"u3", Gates::u3},  // two X90 pulse waltz gate
   // Two-qubit gates
-  {"cx", Gates::cx},  // Controlled-X gate (CNOT)
-  {"cy", Gates::cy},  // Controlled-Z gate
-  {"cz", Gates::cz},  // Controlled-Z gate
-  {"swap", Gates::swap}, // SWAP gate
+  {"cx", Gates::mcx},  // Controlled-X gate (CNOT)
+  {"cy", Gates::mcy},  // Controlled-Z gate
+  {"cz", Gates::mcz},  // Controlled-Z gate
+  {"swap", Gates::mcswap}, // SWAP gate
   // Three-qubit gates
-  {"ccx", Gates::ccx},   // Controlled-CX gate (Toffoli)
+  {"ccx", Gates::mcx},   // Controlled-CX gate (Toffoli)
   {"mcx", Gates::mcx},   // Multi-controlled-X gate
   {"mcy", Gates::mcy},   // Multi-controlled-Y gate
   {"mcz", Gates::mcz},    // Multi-controlled-Z gate
   {"mcu1", Gates::mcu1}, // Multi-controlled-u1
   {"mcu2", Gates::mcu2}, // Multi-controlled-u2
-  {"mcu3", Gates::mcu3}  // Multi-controlled-u3
+  {"mcu3", Gates::mcu3},  // Multi-controlled-u3
+  {"mcswap", Gates::mcswap} // Multi-controlled-SWAP gate
 });
 
 //============================================================================
@@ -321,16 +321,12 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
     case Gates::u1:
       apply_gate_phase(op.qubits[0], std::exp(complex_t(0., 1.) * op.params[0]));
       break;
-    case Gates::cx:
-    case Gates::ccx:
     case Gates::mcx:
       BaseState::qreg_.apply_mcx(op.qubits);
       break;
-    case Gates::cy:
     case Gates::mcy:
       BaseState::qreg_.apply_mcy(op.qubits);
       break;
-    case Gates::cz:
     case Gates::mcz:
       BaseState::qreg_.apply_mcz(op.qubits);
       break;
@@ -362,9 +358,9 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
       const double isqrt2{1. / std::sqrt(2)};
       apply_gate_phase(op.qubits[0], complex_t(isqrt2, -isqrt2));
     } break;
-    case Gates::swap: {
-      BaseState::qreg_.apply_swap(op.qubits[0], op.qubits[1]);
-    } break;
+    case Gates::mcswap:
+      BaseState::qreg_.apply_mcswap(op.qubits);
+      break;
     case Gates::mcu3:
       apply_gate_mcu3(op.qubits,
                       std::real(op.params[0]),

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -23,8 +23,9 @@ namespace QubitUnitary {
 
 // Allowed gates enum class
 enum class Gates {
-  u1, u2, u3, id, x, y, z, h, s, sdg, t, tdg, // single qubit
-  mcx, mcy, mcz, mcu1, mcu2, mcu3, mcswap // multi-qubit controlled
+  id, h, s, sdg, t, tdg, // single qubit
+  // multi-qubit controlled (including single-qubit non-controlled)
+  mcx, mcy, mcz, mcu1, mcu2, mcu3, mcswap
 };
 
 
@@ -128,11 +129,6 @@ protected:
   // 1-Qubit Gates
   //-----------------------------------------------------------------------
 
-  void apply_gate_u3(const uint_t qubit,
-                     const double theta,
-                     const double phi,
-                     const double lambda);
-
   // Optimize phase gate with diagonal [1, phase]
   void apply_gate_phase(const uint_t qubit, const complex_t phase);
 
@@ -140,6 +136,9 @@ protected:
   // Multi-controlled u3
   //-----------------------------------------------------------------------
   
+  // Apply N-qubit multi-controlled single qubit waltz gate specified by
+  // parameters u3(theta, phi, lambda)
+  // NOTE: if N=1 this is just a regular u3 gate.
   void apply_gate_mcu3(const reg_t& qubits,
                        const double theta,
                        const double phi,
@@ -168,18 +167,18 @@ template <class data_t>
 const stringmap_t<Gates> State<data_t>::gateset_({
   // Single qubit gates
   {"id", Gates::id},   // Pauli-Identity gate
-  {"x", Gates::x},    // Pauli-X gate
-  {"y", Gates::y},    // Pauli-Y gate
-  {"z", Gates::z},    // Pauli-Z gate
+  {"x", Gates::mcx},    // Pauli-X gate
+  {"y", Gates::mcy},    // Pauli-Y gate
+  {"z", Gates::mcz},    // Pauli-Z gate
   {"s", Gates::s},    // Phase gate (aka sqrt(Z) gate)
   {"sdg", Gates::sdg}, // Conjugate-transpose of Phase gate
   {"h", Gates::h},    // Hadamard gate (X + Z / sqrt(2))
   {"t", Gates::t},    // T-gate (sqrt(S))
   {"tdg", Gates::tdg}, // Conjguate-transpose of T gate
   // Waltz Gates
-  {"u1", Gates::u1},  // zero-X90 pulse waltz gate
-  {"u2", Gates::u2},  // single-X90 pulse waltz gate
-  {"u3", Gates::u3},  // two X90 pulse waltz gate
+  {"u1", Gates::mcu1},  // zero-X90 pulse waltz gate
+  {"u2", Gates::mcu2},  // single-X90 pulse waltz gate
+  {"u3", Gates::mcu3},  // two X90 pulse waltz gate
   // Two-qubit gates
   {"cx", Gates::mcx},  // Controlled-X gate (CNOT)
   {"cy", Gates::mcy},  // Controlled-Z gate
@@ -306,43 +305,22 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
                                 op.name + "\'.");
   Gates g = it -> second;
   switch (g) {
-    case Gates::u3:
-      apply_gate_u3(op.qubits[0],
-                    std::real(op.params[0]),
-                    std::real(op.params[1]),
-                    std::real(op.params[2]));
-      break;
-    case Gates::u2:
-      apply_gate_u3(op.qubits[0],
-                    M_PI / 2.,
-                    std::real(op.params[0]),
-                    std::real(op.params[1]));
-      break;
-    case Gates::u1:
-      apply_gate_phase(op.qubits[0], std::exp(complex_t(0., 1.) * op.params[0]));
-      break;
     case Gates::mcx:
+      // Includes X, CX, CCX, etc
       BaseState::qreg_.apply_mcx(op.qubits);
       break;
     case Gates::mcy:
+      // Includes Y, CY, CCY, etc
       BaseState::qreg_.apply_mcy(op.qubits);
       break;
     case Gates::mcz:
+      // Includes Z, CZ, CCZ, etc
       BaseState::qreg_.apply_mcz(op.qubits);
       break;
     case Gates::id:
       break;
-    case Gates::x:
-      BaseState::qreg_.apply_x(op.qubits[0]);
-      break;
-    case Gates::y:
-      BaseState::qreg_.apply_y(op.qubits[0]);
-      break;
-    case Gates::z:
-      BaseState::qreg_.apply_z(op.qubits[0]);
-      break;
     case Gates::h:
-      apply_gate_u3(op.qubits[0], M_PI / 2., 0., M_PI);
+      apply_gate_mcu3(op.qubits, M_PI / 2., 0., M_PI);
       break;
     case Gates::s:
       apply_gate_phase(op.qubits[0], complex_t(0., 1.));
@@ -359,21 +337,25 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
       apply_gate_phase(op.qubits[0], complex_t(isqrt2, -isqrt2));
     } break;
     case Gates::mcswap:
+      // Includes SWAP, CSWAP, etc
       BaseState::qreg_.apply_mcswap(op.qubits);
       break;
     case Gates::mcu3:
+      // Includes u3, cu3, etc
       apply_gate_mcu3(op.qubits,
                       std::real(op.params[0]),
                       std::real(op.params[1]),
                       std::real(op.params[2]));
       break;
     case Gates::mcu2:
+      // Includes u2, cu2, etc
       apply_gate_mcu3(op.qubits,
                       M_PI / 2.,
                       std::real(op.params[0]),
                       std::real(op.params[1]));
       break;
     case Gates::mcu1:
+      // Includes u1, cu1, etc
       apply_gate_mcu3(op.qubits, 0., 0., std::real(op.params[0]));
       break;
     default:
@@ -398,12 +380,6 @@ void State<data_t>::apply_matrix(const reg_t &qubits, const cvector_t &vmat) {
   } else {
     BaseState::qreg_.apply_matrix(qubits, vmat);
   }
-}
-
-
-template <class data_t>
-void State<data_t>::apply_gate_u3(uint_t qubit, double theta, double phi, double lambda) {
-  apply_matrix(reg_t({qubit}), Utils::Matrix::U3(theta, phi, lambda));
 }
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* add controlled swap gate (Closes #128)
* remove apply_x/y/z and add them as N=1 case of apply_mcx/y/z
* add N=1-4 cases of static indexing to apply_matrix and apply_diagonal_matrix
* rename apply_matrix_lambda to apply_lambda and template parameter and make the type of the last param (previously matrix) a template parameter.
* rename apply_matrix_reduction_lambda to apply_reduction_lambda and make the type of the last param (previously matrix) a template parameter.
* remove single-qubit apply_reduction_lambda

### Details and comments


