### PR TITLE
Add to_channel method to QuantumError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out/*
 *.so
 *.pyc
 *_skbuild*
+*_cmake_test_compile*
 *.whl
 *.egg*
 build/*

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -260,13 +260,11 @@ class QuantumError:
         }
         return error
 
-    def compose(self, other, inplace=False, front=False):
+    def compose(self, other, front=False):
         """Return the composition error channel self∘other.
 
         Args:
-            other (QuantumError): a quantum error channel
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (QuantumError): a quantum error channel.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -336,22 +334,13 @@ class QuantumError:
                 # Add circuit
                 combined_noise_circuits.append(combined_circuit)
         noise_ops = zip(combined_noise_circuits, combined_noise_probabilities)
-        # Initialize new list of noise ops
-        tmp = QuantumError(noise_ops)
-        if inplace:
-            self._number_of_qubits = tmp._number_of_qubits
-            self._noise_circuits = tmp._noise_circuits
-            self._noise_probabilities = tmp._noise_probabilities
-            return self
-        return tmp
+        return QuantumError(noise_ops)
 
-    def power(self, n, inplace=False):
+    def power(self, n):
         """Return the compose of a error channel with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             QuantumError: the n-times composition error channel.
@@ -361,28 +350,16 @@ class QuantumError:
         """
         if not isinstance(n, int) or n < 1:
             raise NoiseError("Can only power with positive integer powers.")
-        # Update inplace
-        if inplace:
-            if n == 1:
-                return self
-            # cache current state to apply n-times
-            cache = self.copy()
-            for _ in range(1, n):
-                self.compose(cache, inplace=True)
-            return self
-        # Return new object
         ret = self.copy()
         for _ in range(1, n):
             ret = ret.compose(self)
         return ret
 
-    def tensor(self, other, inplace=False):
+    def tensor(self, other):
         """Return the tensor product quantum error channel self ⊗ other.
 
         Args:
             other (QuantumError): a quantum error channel.
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             QuantumError: the tensor product error channel self ⊗ other.
@@ -390,15 +367,13 @@ class QuantumError:
         Raises:
             NoiseError: if other is not a QuantumError or QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=False)
+        return self._tensor_product(other, reverse=False)
 
-    def expand(self, other, inplace=False):
+    def expand(self, other):
         """Return the tensor product quantum error channel self ⊗ other.
 
         Args:
             other (QuantumError): a quantum error channel.
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             QuantumError: the tensor product error channel other ⊗ self.
@@ -406,7 +381,7 @@ class QuantumError:
         Raises:
             NoiseError: if other is not a QuantumError or QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=True)
+        return self._tensor_product(other, reverse=True)
 
     def kron(self, other):
         """Return the tensor product quantum error channel self ⊗ other.
@@ -425,13 +400,11 @@ class QuantumError:
             DeprecationWarning)
         return self.tensor(other)
 
-    def _tensor_product(self, other, inplace=False, reverse=False):
+    def _tensor_product(self, other, reverse=False):
         """Return the tensor product error channel.
 
         Args:
             other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [default: False]
             reverse (bool): If False return self ⊗ other, if True return
                             if True return (other ⊗ self) [Default: False
         Returns:
@@ -498,14 +471,7 @@ class QuantumError:
                 # Add circuit
                 combined_noise_circuits.append(combined_circuit)
         noise_ops = zip(combined_noise_circuits, combined_noise_probabilities)
-        # Initialize new list of noise ops
-        tmp = QuantumError(noise_ops)
-        if inplace:
-            self._number_of_qubits = tmp._number_of_qubits
-            self._noise_circuits = tmp._noise_circuits
-            self._noise_probabilities = tmp._noise_probabilities
-            return self
-        return tmp
+        return QuantumError(noise_ops)
 
     @staticmethod
     def _tensor_kraus(kraus1, kraus0):

--- a/qiskit/providers/aer/noise/errors/readout_error.py
+++ b/qiskit/providers/aer/noise/errors/readout_error.py
@@ -136,13 +136,11 @@ class ReadoutError:
         }
         return error
 
-    def compose(self, other, inplace=False, front=False):
+    def compose(self, other, front=False):
         """Return the composition readout error self∘other.
 
         Args:
-            other (ReadoutError): a readout error
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (ReadoutError): a readout error.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -162,18 +160,13 @@ class ReadoutError:
             probs = np.dot(self._probabilities, other._probabilities)
         else:
             probs = np.dot(other._probabilities, self._probabilities)
-        if inplace:
-            self._probabilities = probs
-            return self
         return ReadoutError(probs)
 
-    def power(self, n, inplace=False):
+    def power(self, n):
         """Return the compose of the readout error with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             ReadoutError: the n-times composition channel.
@@ -183,28 +176,16 @@ class ReadoutError:
         """
         if not isinstance(n, int) or n < 1:
             raise NoiseError("Can only power with positive integer powers.")
-        # Update inplace
-        if inplace:
-            if n == 1:
-                return self
-            # cache current state to apply n-times
-            cache = self.copy()
-            for _ in range(1, n):
-                self.compose(cache, inplace=True)
-            return self
-        # Return new object
         ret = self.copy()
         for _ in range(1, n):
             ret = ret.compose(self)
         return ret
 
-    def tensor(self, other, inplace=False):
+    def tensor(self, other):
         """Return the tensor product readout error self ⊗ other.
 
         Args:
             other (ReadoutError): a readout error.
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             ReadoutError: the tensor product readout error self ⊗ other.
@@ -212,15 +193,13 @@ class ReadoutError:
         Raises:
             NoiseError: if other is not a ReadoutError.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=False)
+        return self._tensor_product(other, reverse=False)
 
-    def expand(self, other, inplace=False):
+    def expand(self, other):
         """Return the tensor product readout error self ⊗ other.
 
         Args:
             other (ReadoutError): a readout error.
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             ReadoutError: the tensor product readout error other ⊗ self.
@@ -228,7 +207,7 @@ class ReadoutError:
         Raises:
             NoiseError: if other is not a ReadoutError.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=True)
+        return self._tensor_product(other, reverse=True)
 
     @staticmethod
     def _check_probabilities(probabilities, threshold):
@@ -255,13 +234,11 @@ class ReadoutError:
                     "Invalid probabilities: {} "
                     "contains a negative probability.".format(vec))
 
-    def _tensor_product(self, other, inplace=False, reverse=False):
+    def _tensor_product(self, other, reverse=False):
         """Return the tensor product readout error.
 
         Args:
             other (ReadoutError): a readout error.
-            inplace (bool): If True modify the current object inplace
-                            [default: False]
             reverse (bool): If False return self ⊗ other, if True return
                             if True return (other ⊗ self) [Default: False
         Returns:
@@ -273,8 +250,4 @@ class ReadoutError:
             probs = np.kron(other._probabilities, self._probabilities)
         else:
             probs = np.kron(self._probabilities, other._probabilities)
-        if inplace:
-            self._probabilities = probs
-            self._number_of_qubits = self.number_of_qubits * other.number_of_qubits
-            return self
         return ReadoutError(probs)

--- a/test/terra/test_quantum_error.py
+++ b/test/terra/test_quantum_error.py
@@ -4,7 +4,6 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
-
 """
 QuantumError class tests
 """
@@ -12,6 +11,9 @@ QuantumError class tests
 import unittest
 from test.terra.utils import common
 import numpy as np
+
+from qiskit.quantum_info.operators.channel.superop import SuperOp
+from qiskit.quantum_info.operators.channel.kraus import Kraus
 from qiskit.providers.aer.noise.noiseerror import NoiseError
 from qiskit.providers.aer.noise.errors.quantum_error import QuantumError
 from qiskit.providers.aer.noise.errors.errorutils import standard_gate_unitary
@@ -22,71 +24,101 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_standard_gate_unitary(self):
         """Test standard gates are correct"""
+
         def norm(a, b):
             return round(np.linalg.norm(a - b), 15)
 
-        self.assertEqual(norm(standard_gate_unitary('id'), np.eye(2)), 0,
-                         msg="identity matrix")
-        self.assertEqual(norm(standard_gate_unitary('x'),
-                              np.array([[0, 1], [1, 0]])), 0,
-                         msg="Pauli-X matrix")
-        self.assertEqual(norm(standard_gate_unitary('y'),
-                              np.array([[0, -1j], [1j, 0]])), 0,
-                         msg="Pauli-Y matrix")
-        self.assertEqual(norm(standard_gate_unitary('z'),
-                              np.diag([1, -1])), 0,
-                         msg="Pauli-Z matrix")
-        self.assertEqual(norm(standard_gate_unitary('h'),
-                              np.array([[1, 1], [1, -1]]) / np.sqrt(2)), 0,
-                         msg="Hadamard gate matrix")
-        self.assertEqual(norm(standard_gate_unitary('s'),
-                              np.diag([1, 1j])), 0,
-                         msg="Phase gate matrix")
-        self.assertEqual(norm(standard_gate_unitary('sdg'),
-                              np.diag([1, -1j])), 0,
-                         msg="Adjoint phase gate matrix")
-        self.assertEqual(norm(standard_gate_unitary('t'),
-                              np.diag([1, (1 + 1j) / np.sqrt(2)])), 0,
-                         msg="T gate matrix")
-        self.assertEqual(norm(standard_gate_unitary('tdg'),
-                              np.diag([1, (1 - 1j) / np.sqrt(2)])), 0,
-                         msg="Adjoint T gate matrix")
-        self.assertEqual(norm(standard_gate_unitary('cx'),
-                              np.array([[1, 0, 0, 0],
-                                        [0, 0, 0, 1],
-                                        [0, 0, 1, 0],
-                                        [0, 1, 0, 0]])), 0,
-                         msg="Controlled-NOT gate matrix")
-        self.assertEqual(norm(standard_gate_unitary('cz'),
-                              np.diag([1, 1, 1, -1])), 0,
-                         msg="Controlled-Z gate matrix")
-        self.assertEqual(norm(standard_gate_unitary('swap'),
-                              np.array([[1, 0, 0, 0],
-                                        [0, 0, 1, 0],
-                                        [0, 1, 0, 0],
-                                        [0, 0, 0, 1]])), 0,
-                         msg="SWAP matrix")
-        self.assertEqual(norm(standard_gate_unitary('ccx'),
-                              np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                                        [0, 1, 0, 0, 0, 0, 0, 0],
-                                        [0, 0, 1, 0, 0, 0, 0, 0],
-                                        [0, 0, 0, 0, 0, 0, 0, 1],
-                                        [0, 0, 0, 0, 1, 0, 0, 0],
-                                        [0, 0, 0, 0, 0, 1, 0, 0],
-                                        [0, 0, 0, 0, 0, 0, 1, 0],
-                                        [0, 0, 0, 1, 0, 0, 0, 0]])), 0,
-                         msg="Toffoli gate matrix")
+        self.assertEqual(
+            norm(standard_gate_unitary('id'), np.eye(2)),
+            0,
+            msg="identity matrix")
+        self.assertEqual(
+            norm(standard_gate_unitary('x'), np.array([[0, 1], [1, 0]])),
+            0,
+            msg="Pauli-X matrix")
+        self.assertEqual(
+            norm(standard_gate_unitary('y'), np.array([[0, -1j], [1j, 0]])),
+            0,
+            msg="Pauli-Y matrix")
+        self.assertEqual(
+            norm(standard_gate_unitary('z'), np.diag([1, -1])),
+            0,
+            msg="Pauli-Z matrix")
+        self.assertEqual(
+            norm(
+                standard_gate_unitary('h'),
+                np.array([[1, 1], [1, -1]]) / np.sqrt(2)),
+            0,
+            msg="Hadamard gate matrix")
+        self.assertEqual(
+            norm(standard_gate_unitary('s'), np.diag([1, 1j])),
+            0,
+            msg="Phase gate matrix")
+        self.assertEqual(
+            norm(standard_gate_unitary('sdg'), np.diag([1, -1j])),
+            0,
+            msg="Adjoint phase gate matrix")
+        self.assertEqual(
+            norm(
+                standard_gate_unitary('t'), np.diag([1,
+                                                     (1 + 1j) / np.sqrt(2)])),
+            0,
+            msg="T gate matrix")
+        self.assertEqual(
+            norm(
+                standard_gate_unitary('tdg'),
+                np.diag([1, (1 - 1j) / np.sqrt(2)])),
+            0,
+            msg="Adjoint T gate matrix")
+        self.assertEqual(
+            norm(
+                standard_gate_unitary('cx'),
+                np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0],
+                          [0, 1, 0, 0]])),
+            0,
+            msg="Controlled-NOT gate matrix")
+        self.assertEqual(
+            norm(standard_gate_unitary('cz'), np.diag([1, 1, 1, -1])),
+            0,
+            msg="Controlled-Z gate matrix")
+        self.assertEqual(
+            norm(
+                standard_gate_unitary('swap'),
+                np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0],
+                          [0, 0, 0, 1]])),
+            0,
+            msg="SWAP matrix")
+        self.assertEqual(
+            norm(
+                standard_gate_unitary('ccx'),
+                np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                          [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1],
+                          [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                          [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0, 0,
+                                                     0]])),
+            0,
+            msg="Toffoli gate matrix")
 
     def test_raise_probabilities_negative(self):
         """Test exception is raised for negative probabilities."""
-        noise_ops = [([{"name": "id", "qubits": [0]}], 1.1),
-                     ([{"name": "x", "qubits": [0]}], -0.1)]
+        noise_ops = [([{
+            "name": "id",
+            "qubits": [0]
+        }], 1.1), ([{
+            "name": "x",
+            "qubits": [0]
+        }], -0.1)]
         self.assertRaises(NoiseError, lambda: QuantumError(noise_ops))
 
     def test_raise_probabilities_normalized_qobj(self):
         """Test exception is raised for qobj probabilities greater than 1."""
-        noise_ops = [([{"name": "id", "qubits": [0]}], 0.9),
-                     ([{"name": "x", "qubits": [0]}], 0.2)]
+        noise_ops = [([{
+            "name": "id",
+            "qubits": [0]
+        }], 0.9), ([{
+            "name": "x",
+            "qubits": [0]
+        }], 0.2)]
         self.assertRaises(NoiseError, lambda: QuantumError(noise_ops))
 
     def test_raise_probabilities_normalized_unitary_kraus(self):
@@ -97,8 +129,10 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_raise_probabilities_normalized_nonunitary_kraus(self):
         """Test exception is raised for non-unitary kraus probs greater than 1."""
-        A0 = np.sqrt(0.9) * np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        A1 = np.sqrt(0.2) * np.array([[0, np.sqrt(0.3)], [0, 0]], dtype=complex)
+        A0 = np.sqrt(0.9) * np.array([[1, 0], [0, np.sqrt(1 - 0.3)]],
+                                     dtype=complex)
+        A1 = np.sqrt(0.2) * np.array([[0, np.sqrt(0.3)], [0, 0]],
+                                     dtype=complex)
         self.assertRaises(NoiseError, lambda: QuantumError([A0, A1]))
 
     def test_raise_non_cptp_kraus(self):
@@ -120,10 +154,13 @@ class TestQuantumError(common.QiskitAerTestCase):
         Ax = np.sqrt(0.25) * standard_gate_unitary('x')
         Ay = np.sqrt(0.25) * standard_gate_unitary('y')
         Az = np.sqrt(0.25) * standard_gate_unitary('z')
-        error_dict = QuantumError([Ai, Ax, Ay, Az], standard_gates=True).as_dict()
+        error_dict = QuantumError([Ai, Ax, Ay, Az],
+                                  standard_gates=True).as_dict()
         self.assertEqual(error_dict['type'], 'qerror')
-        self.assertAlmostEqual(np.linalg.norm(np.array(4 * [0.25]) -
-                                              np.array(error_dict['probabilities'])), 0.0)
+        self.assertAlmostEqual(
+            np.linalg.norm(
+                np.array(4 * [0.25]) - np.array(error_dict['probabilities'])),
+            0.0)
         for instr in error_dict['instructions']:
             self.assertEqual(len(instr), 1)
             self.assertIn(instr[0]['name'], ['x', 'y', 'z', 'id'])
@@ -138,8 +175,10 @@ class TestQuantumError(common.QiskitAerTestCase):
         error_dict = QuantumError([Ai, Ax, Ay, Az],
                                   standard_gates=False).as_dict()
         self.assertEqual(error_dict['type'], 'qerror')
-        self.assertAlmostEqual(np.linalg.norm(np.array(4 * [0.25]) -
-                                              np.array(error_dict['probabilities'])), 0.0)
+        self.assertAlmostEqual(
+            np.linalg.norm(
+                np.array(4 * [0.25]) - np.array(error_dict['probabilities'])),
+            0.0)
         for instr in error_dict['instructions']:
             self.assertEqual(len(instr), 1)
             self.assertIn(instr[0]['name'], ['unitary', 'id'])
@@ -153,8 +192,12 @@ class TestQuantumError(common.QiskitAerTestCase):
         B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
         error = QuantumError([B0, B1]).tensor(QuantumError([A0, A1]))
         kraus, p = error.error_term(0)
-        targets = [np.kron(B0, A0), np.kron(B0, A1),
-                   np.kron(B1, A0), np.kron(B1, A1)]
+        targets = [
+            np.kron(B0, A0),
+            np.kron(B0, A1),
+            np.kron(B1, A0),
+            np.kron(B1, A1)
+        ]
         self.assertEqual(p, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0, 1])
@@ -164,27 +207,33 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_tensor_both_unitary_instruction(self):
         """Test tensor of two unitary instruction errors."""
-        unitaries0 = [standard_gate_unitary('z'),
-                      standard_gate_unitary('s')]
+        unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
         probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'),
-                      standard_gate_unitary('y')]
+        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
         probs1 = [0.6, 0.4]
-        error0 = QuantumError([np.sqrt(probs0[0]) * unitaries0[0],
-                               np.sqrt(probs0[1]) * unitaries0[1]],
+        error0 = QuantumError([
+            np.sqrt(probs0[0]) * unitaries0[0],
+            np.sqrt(probs0[1]) * unitaries0[1]
+        ],
                               standard_gates=False)
-        error1 = QuantumError([np.sqrt(probs1[0]) * unitaries1[0],
-                               np.sqrt(probs1[1]) * unitaries1[1]],
+        error1 = QuantumError([
+            np.sqrt(probs1[0]) * unitaries1[0],
+            np.sqrt(probs1[1]) * unitaries1[1]
+        ],
                               standard_gates=False)
         error = error1.tensor(error0)
         # Kronecker product unitaries
-        target_unitaries = [np.kron(unitaries1[0], unitaries0[0]),
-                            np.kron(unitaries1[0], unitaries0[1]),
-                            np.kron(unitaries1[1], unitaries0[0]),
-                            np.kron(unitaries1[1], unitaries0[1])]
+        target_unitaries = [
+            np.kron(unitaries1[0], unitaries0[0]),
+            np.kron(unitaries1[0], unitaries0[1]),
+            np.kron(unitaries1[1], unitaries0[0]),
+            np.kron(unitaries1[1], unitaries0[1])
+        ]
         # Kronecker product probabilities
-        target_probs = [probs1[0] * probs0[0], probs1[0] * probs0[1],
-                        probs1[1] * probs0[0], probs1[1] * probs0[1]]
+        target_probs = [
+            probs1[0] * probs0[0], probs1[0] * probs0[1],
+            probs1[1] * probs0[0], probs1[1] * probs0[1]
+        ]
 
         for j in range(4):
             circ, p = error.error_term(j)
@@ -200,34 +249,59 @@ class TestQuantumError(common.QiskitAerTestCase):
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [], msg="Incorrect tensor probabilities")
-        self.assertEqual(target_unitaries, [], msg="Incorrect tensor unitaries")
+        self.assertEqual(
+            target_probs, [], msg="Incorrect tensor probabilities")
+        self.assertEqual(
+            target_unitaries, [], msg="Incorrect tensor unitaries")
 
     def test_tensor_both_unitary_standard_gates(self):
         """Test tensor of two unitary standard gate errors"""
-        unitaries0 = [standard_gate_unitary('id'),
-                      standard_gate_unitary('z')]
+        unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
         probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'),
-                      standard_gate_unitary('y')]
+        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
         probs1 = [0.6, 0.4]
-        error0 = QuantumError([np.sqrt(probs0[0]) * unitaries0[0],
-                               np.sqrt(probs0[1]) * unitaries0[1]],
+        error0 = QuantumError([
+            np.sqrt(probs0[0]) * unitaries0[0],
+            np.sqrt(probs0[1]) * unitaries0[1]
+        ],
                               standard_gates=True)
-        error1 = QuantumError([np.sqrt(probs1[0]) * unitaries1[0],
-                               np.sqrt(probs1[1]) * unitaries1[1]],
+        error1 = QuantumError([
+            np.sqrt(probs1[0]) * unitaries1[0],
+            np.sqrt(probs1[1]) * unitaries1[1]
+        ],
                               standard_gates=True)
         error = error1.tensor(error0)
         # Kronecker product probabilities
-        target_probs = [probs1[0] * probs0[0],
-                        probs1[0] * probs0[1],
-                        probs1[1] * probs0[0],
-                        probs1[1] * probs0[1]]
+        target_probs = [
+            probs1[0] * probs0[0], probs1[0] * probs0[1],
+            probs1[1] * probs0[0], probs1[1] * probs0[1]
+        ]
         # Target circuits
-        target_circs = [[{'name': 'id', 'qubits': [0]}, {'name': 'x', 'qubits': [1]}],
-                        [{'name': 'id', 'qubits': [0]}, {'name': 'y', 'qubits': [1]}],
-                        [{'name': 'z', 'qubits': [0]}, {'name': 'x', 'qubits': [1]}],
-                        [{'name': 'z', 'qubits': [0]}, {'name': 'y', 'qubits': [1]}]]
+        target_circs = [[{
+            'name': 'id',
+            'qubits': [0]
+        }, {
+            'name': 'x',
+            'qubits': [1]
+        }], [{
+            'name': 'id',
+            'qubits': [0]
+        }, {
+            'name': 'y',
+            'qubits': [1]
+        }], [{
+            'name': 'z',
+            'qubits': [0]
+        }, {
+            'name': 'x',
+            'qubits': [1]
+        }], [{
+            'name': 'z',
+            'qubits': [0]
+        }, {
+            'name': 'y',
+            'qubits': [1]
+        }]]
         for j in range(4):
             circ, p = error.error_term(j)
             # Remove prob from target if it is found
@@ -239,7 +313,8 @@ class TestQuantumError(common.QiskitAerTestCase):
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [], msg="Incorrect tensor probabilities")
+        self.assertEqual(
+            target_probs, [], msg="Incorrect tensor probabilities")
         self.assertEqual(target_circs, [], msg="Incorrect tensor circuits")
 
     def test_expand_both_kraus(self):
@@ -250,8 +325,12 @@ class TestQuantumError(common.QiskitAerTestCase):
         B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
         error = QuantumError([A0, A1]).expand(QuantumError([B0, B1]))
         kraus, p = error.error_term(0)
-        targets = [np.kron(B0, A0), np.kron(B1, A0),
-                   np.kron(B0, A1), np.kron(B1, A1)]
+        targets = [
+            np.kron(B0, A0),
+            np.kron(B1, A0),
+            np.kron(B0, A1),
+            np.kron(B1, A1)
+        ]
         self.assertEqual(p, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0, 1])
@@ -261,27 +340,33 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_expand_both_unitary_instruction(self):
         """Test expand of two unitary instruction errors."""
-        unitaries0 = [standard_gate_unitary('z'),
-                      standard_gate_unitary('s')]
+        unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
         probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'),
-                      standard_gate_unitary('y')]
+        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
         probs1 = [0.6, 0.4]
-        error0 = QuantumError([np.sqrt(probs0[0]) * unitaries0[0],
-                               np.sqrt(probs0[1]) * unitaries0[1]],
+        error0 = QuantumError([
+            np.sqrt(probs0[0]) * unitaries0[0],
+            np.sqrt(probs0[1]) * unitaries0[1]
+        ],
                               standard_gates=False)
-        error1 = QuantumError([np.sqrt(probs1[0]) * unitaries1[0],
-                               np.sqrt(probs1[1]) * unitaries1[1]],
+        error1 = QuantumError([
+            np.sqrt(probs1[0]) * unitaries1[0],
+            np.sqrt(probs1[1]) * unitaries1[1]
+        ],
                               standard_gates=False)
         error = error0.expand(error1)
         # Kronecker product unitaries
-        target_unitaries = [np.kron(unitaries1[0], unitaries0[0]),
-                            np.kron(unitaries1[0], unitaries0[1]),
-                            np.kron(unitaries1[1], unitaries0[0]),
-                            np.kron(unitaries1[1], unitaries0[1])]
+        target_unitaries = [
+            np.kron(unitaries1[0], unitaries0[0]),
+            np.kron(unitaries1[0], unitaries0[1]),
+            np.kron(unitaries1[1], unitaries0[0]),
+            np.kron(unitaries1[1], unitaries0[1])
+        ]
         # Kronecker product probabilities
-        target_probs = [probs1[0] * probs0[0], probs1[0] * probs0[1],
-                        probs1[1] * probs0[0], probs1[1] * probs0[1]]
+        target_probs = [
+            probs1[0] * probs0[0], probs1[0] * probs0[1],
+            probs1[1] * probs0[0], probs1[1] * probs0[1]
+        ]
 
         for j in range(4):
             circ, p = error.error_term(j)
@@ -297,34 +382,59 @@ class TestQuantumError(common.QiskitAerTestCase):
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [], msg="Incorrect expand probabilities")
-        self.assertEqual(target_unitaries, [], msg="Incorrect expand unitaries")
+        self.assertEqual(
+            target_probs, [], msg="Incorrect expand probabilities")
+        self.assertEqual(
+            target_unitaries, [], msg="Incorrect expand unitaries")
 
     def test_expand_both_unitary_standard_gates(self):
         """Test expand of two unitary standard gate errors"""
-        unitaries0 = [standard_gate_unitary('id'),
-                      standard_gate_unitary('z')]
+        unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
         probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'),
-                      standard_gate_unitary('y')]
+        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
         probs1 = [0.6, 0.4]
-        error0 = QuantumError([np.sqrt(probs0[0]) * unitaries0[0],
-                               np.sqrt(probs0[1]) * unitaries0[1]],
+        error0 = QuantumError([
+            np.sqrt(probs0[0]) * unitaries0[0],
+            np.sqrt(probs0[1]) * unitaries0[1]
+        ],
                               standard_gates=True)
-        error1 = QuantumError([np.sqrt(probs1[0]) * unitaries1[0],
-                               np.sqrt(probs1[1]) * unitaries1[1]],
+        error1 = QuantumError([
+            np.sqrt(probs1[0]) * unitaries1[0],
+            np.sqrt(probs1[1]) * unitaries1[1]
+        ],
                               standard_gates=True)
         error = error0.expand(error1)
         # Kronecker product probabilities
-        target_probs = [probs1[0] * probs0[0],
-                        probs1[0] * probs0[1],
-                        probs1[1] * probs0[0],
-                        probs1[1] * probs0[1]]
+        target_probs = [
+            probs1[0] * probs0[0], probs1[0] * probs0[1],
+            probs1[1] * probs0[0], probs1[1] * probs0[1]
+        ]
         # Target circuits
-        target_circs = [[{'name': 'id', 'qubits': [0]}, {'name': 'x', 'qubits': [1]}],
-                        [{'name': 'id', 'qubits': [0]}, {'name': 'y', 'qubits': [1]}],
-                        [{'name': 'z', 'qubits': [0]}, {'name': 'x', 'qubits': [1]}],
-                        [{'name': 'z', 'qubits': [0]}, {'name': 'y', 'qubits': [1]}]]
+        target_circs = [[{
+            'name': 'id',
+            'qubits': [0]
+        }, {
+            'name': 'x',
+            'qubits': [1]
+        }], [{
+            'name': 'id',
+            'qubits': [0]
+        }, {
+            'name': 'y',
+            'qubits': [1]
+        }], [{
+            'name': 'z',
+            'qubits': [0]
+        }, {
+            'name': 'x',
+            'qubits': [1]
+        }], [{
+            'name': 'z',
+            'qubits': [0]
+        }, {
+            'name': 'y',
+            'qubits': [1]
+        }]]
         for j in range(4):
             circ, p = error.error_term(j)
             # Remove prob from target if it is found
@@ -336,12 +446,14 @@ class TestQuantumError(common.QiskitAerTestCase):
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [], msg="Incorrect expand probabilities")
+        self.assertEqual(
+            target_probs, [], msg="Incorrect expand probabilities")
         self.assertEqual(target_circs, [], msg="Incorrect expand circuits")
 
     def test_raise_compose_different_dim(self):
         """Test composing incompatible errors raises exception"""
-        error0 = QuantumError([np.diag([1, 1, 1, -1])])  # 2-qubit coherent error
+        error0 = QuantumError([np.diag([1, 1, 1,
+                                        -1])])  # 2-qubit coherent error
         error1 = QuantumError([np.diag([1, -1])])  # 1-qubit coherent error
         self.assertRaises(NoiseError, lambda: error0.compose(error1))
         self.assertRaises(NoiseError, lambda: error1.compose(error0))
@@ -354,8 +466,12 @@ class TestQuantumError(common.QiskitAerTestCase):
         B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
         error = QuantumError([A0, A1]).compose(QuantumError([B0, B1]))
         kraus, p = error.error_term(0)
-        targets = [np.dot(B0, A0), np.dot(B0, A1),
-                   np.dot(B1, A0), np.dot(B1, A1)]
+        targets = [
+            np.dot(B0, A0),
+            np.dot(B0, A1),
+            np.dot(B1, A0),
+            np.dot(B1, A1)
+        ]
         self.assertEqual(p, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0])
@@ -365,29 +481,33 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_compose_both_unitary(self):
         """Test composition of two unitary errors."""
-        unitaries0 = [standard_gate_unitary('z'),
-                      standard_gate_unitary('s')]
+        unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
         probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'),
-                      standard_gate_unitary('y')]
+        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
         probs1 = [0.6, 0.4]
-        error0 = QuantumError([np.sqrt(probs0[0]) * unitaries0[0],
-                               np.sqrt(probs0[1]) * unitaries0[1]],
+        error0 = QuantumError([
+            np.sqrt(probs0[0]) * unitaries0[0],
+            np.sqrt(probs0[1]) * unitaries0[1]
+        ],
                               standard_gates=False)
-        error1 = QuantumError([np.sqrt(probs1[0]) * unitaries1[0],
-                               np.sqrt(probs1[1]) * unitaries1[1]],
+        error1 = QuantumError([
+            np.sqrt(probs1[0]) * unitaries1[0],
+            np.sqrt(probs1[1]) * unitaries1[1]
+        ],
                               standard_gates=False)
         error = error0.compose(error1)
         # Kronecker product unitaries
-        target_unitaries = [np.dot(unitaries1[0], unitaries0[0]),
-                            np.dot(unitaries1[0], unitaries0[1]),
-                            np.dot(unitaries1[1], unitaries0[0]),
-                            np.dot(unitaries1[1], unitaries0[1])]
+        target_unitaries = [
+            np.dot(unitaries1[0], unitaries0[0]),
+            np.dot(unitaries1[0], unitaries0[1]),
+            np.dot(unitaries1[1], unitaries0[0]),
+            np.dot(unitaries1[1], unitaries0[1])
+        ]
         # Kronecker product probabilities
-        target_probs = [probs1[0] * probs0[0],
-                        probs1[0] * probs0[1],
-                        probs1[1] * probs0[0],
-                        probs1[1] * probs0[1]]
+        target_probs = [
+            probs1[0] * probs0[0], probs1[0] * probs0[1],
+            probs1[1] * probs0[0], probs1[1] * probs0[1]
+        ]
 
         for j in range(4):
             circ, p = error.error_term(j)
@@ -403,34 +523,59 @@ class TestQuantumError(common.QiskitAerTestCase):
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [], msg="Incorrect compose probabilities")
-        self.assertEqual(target_unitaries, [], msg="Incorrect compose unitaries")
+        self.assertEqual(
+            target_probs, [], msg="Incorrect compose probabilities")
+        self.assertEqual(
+            target_unitaries, [], msg="Incorrect compose unitaries")
 
     def test_compose_both_qobj(self):
         """Test composition of two circuit errors"""
-        unitaries0 = [standard_gate_unitary('id'),
-                      standard_gate_unitary('z')]
+        unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
         probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'),
-                      standard_gate_unitary('y')]
+        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
         probs1 = [0.6, 0.4]
-        error0 = QuantumError([np.sqrt(probs0[0]) * unitaries0[0],
-                               np.sqrt(probs0[1]) * unitaries0[1]],
+        error0 = QuantumError([
+            np.sqrt(probs0[0]) * unitaries0[0],
+            np.sqrt(probs0[1]) * unitaries0[1]
+        ],
                               standard_gates=True)
-        error1 = QuantumError([np.sqrt(probs1[0]) * unitaries1[0],
-                               np.sqrt(probs1[1]) * unitaries1[1]],
+        error1 = QuantumError([
+            np.sqrt(probs1[0]) * unitaries1[0],
+            np.sqrt(probs1[1]) * unitaries1[1]
+        ],
                               standard_gates=True)
         error = error0.compose(error1)
         # Kronecker product probabilities
-        target_probs = [probs1[0] * probs0[0],
-                        probs1[0] * probs0[1],
-                        probs1[1] * probs0[0],
-                        probs1[1] * probs0[1]]
+        target_probs = [
+            probs1[0] * probs0[0], probs1[0] * probs0[1],
+            probs1[1] * probs0[0], probs1[1] * probs0[1]
+        ]
         # Target circuits
-        target_circs = [[{'name': 'id', 'qubits': [0]}, {'name': 'x', 'qubits': [0]}],
-                        [{'name': 'id', 'qubits': [0]}, {'name': 'y', 'qubits': [0]}],
-                        [{'name': 'z', 'qubits': [0]}, {'name': 'x', 'qubits': [0]}],
-                        [{'name': 'z', 'qubits': [0]}, {'name': 'y', 'qubits': [0]}]]
+        target_circs = [[{
+            'name': 'id',
+            'qubits': [0]
+        }, {
+            'name': 'x',
+            'qubits': [0]
+        }], [{
+            'name': 'id',
+            'qubits': [0]
+        }, {
+            'name': 'y',
+            'qubits': [0]
+        }], [{
+            'name': 'z',
+            'qubits': [0]
+        }, {
+            'name': 'x',
+            'qubits': [0]
+        }], [{
+            'name': 'z',
+            'qubits': [0]
+        }, {
+            'name': 'y',
+            'qubits': [0]
+        }]]
         for j in range(4):
             circ, p = error.error_term(j)
             # Remove prob from target if it is found
@@ -442,7 +587,8 @@ class TestQuantumError(common.QiskitAerTestCase):
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [], msg="Incorrect compose probabilities")
+        self.assertEqual(
+            target_probs, [], msg="Incorrect compose probabilities")
         self.assertEqual(target_circs, [], msg="Incorrect compose circuits")
 
     def test_compose_front_both_kraus(self):
@@ -451,10 +597,15 @@ class TestQuantumError(common.QiskitAerTestCase):
         A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
         B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
         B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
-        error = QuantumError([B0, B1]).compose(QuantumError([A0, A1]), front=True)
+        error = QuantumError([B0, B1]).compose(
+            QuantumError([A0, A1]), front=True)
         kraus, p = error.error_term(0)
-        targets = [np.dot(B0, A0), np.dot(B0, A1),
-                   np.dot(B1, A0), np.dot(B1, A1)]
+        targets = [
+            np.dot(B0, A0),
+            np.dot(B0, A1),
+            np.dot(B1, A0),
+            np.dot(B1, A1)
+        ]
         self.assertEqual(p, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0])
@@ -464,29 +615,33 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_compose_front_both_unitary(self):
         """Test front composition of two unitary errors."""
-        unitaries0 = [standard_gate_unitary('z'),
-                      standard_gate_unitary('s')]
+        unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
         probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'),
-                      standard_gate_unitary('y')]
+        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
         probs1 = [0.6, 0.4]
-        error0 = QuantumError([np.sqrt(probs0[0]) * unitaries0[0],
-                               np.sqrt(probs0[1]) * unitaries0[1]],
+        error0 = QuantumError([
+            np.sqrt(probs0[0]) * unitaries0[0],
+            np.sqrt(probs0[1]) * unitaries0[1]
+        ],
                               standard_gates=False)
-        error1 = QuantumError([np.sqrt(probs1[0]) * unitaries1[0],
-                               np.sqrt(probs1[1]) * unitaries1[1]],
+        error1 = QuantumError([
+            np.sqrt(probs1[0]) * unitaries1[0],
+            np.sqrt(probs1[1]) * unitaries1[1]
+        ],
                               standard_gates=False)
         error = error1.compose(error0, front=True)
         # Kronecker product unitaries
-        target_unitaries = [np.dot(unitaries1[0], unitaries0[0]),
-                            np.dot(unitaries1[0], unitaries0[1]),
-                            np.dot(unitaries1[1], unitaries0[0]),
-                            np.dot(unitaries1[1], unitaries0[1])]
+        target_unitaries = [
+            np.dot(unitaries1[0], unitaries0[0]),
+            np.dot(unitaries1[0], unitaries0[1]),
+            np.dot(unitaries1[1], unitaries0[0]),
+            np.dot(unitaries1[1], unitaries0[1])
+        ]
         # Kronecker product probabilities
-        target_probs = [probs1[0] * probs0[0],
-                        probs1[0] * probs0[1],
-                        probs1[1] * probs0[0],
-                        probs1[1] * probs0[1]]
+        target_probs = [
+            probs1[0] * probs0[0], probs1[0] * probs0[1],
+            probs1[1] * probs0[0], probs1[1] * probs0[1]
+        ]
 
         for j in range(4):
             circ, p = error.error_term(j)
@@ -502,34 +657,59 @@ class TestQuantumError(common.QiskitAerTestCase):
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [], msg="Incorrect compose probabilities")
-        self.assertEqual(target_unitaries, [], msg="Incorrect compose unitaries")
+        self.assertEqual(
+            target_probs, [], msg="Incorrect compose probabilities")
+        self.assertEqual(
+            target_unitaries, [], msg="Incorrect compose unitaries")
 
     def test_compose_front_both_qobj(self):
         """Test front composition of two circuit errors"""
-        unitaries0 = [standard_gate_unitary('id'),
-                      standard_gate_unitary('z')]
+        unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
         probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'),
-                      standard_gate_unitary('y')]
+        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
         probs1 = [0.6, 0.4]
-        error0 = QuantumError([np.sqrt(probs0[0]) * unitaries0[0],
-                               np.sqrt(probs0[1]) * unitaries0[1]],
+        error0 = QuantumError([
+            np.sqrt(probs0[0]) * unitaries0[0],
+            np.sqrt(probs0[1]) * unitaries0[1]
+        ],
                               standard_gates=True)
-        error1 = QuantumError([np.sqrt(probs1[0]) * unitaries1[0],
-                               np.sqrt(probs1[1]) * unitaries1[1]],
+        error1 = QuantumError([
+            np.sqrt(probs1[0]) * unitaries1[0],
+            np.sqrt(probs1[1]) * unitaries1[1]
+        ],
                               standard_gates=True)
         error = error1.compose(error0, front=True)
         # Kronecker product probabilities
-        target_probs = [probs1[0] * probs0[0],
-                        probs1[0] * probs0[1],
-                        probs1[1] * probs0[0],
-                        probs1[1] * probs0[1]]
+        target_probs = [
+            probs1[0] * probs0[0], probs1[0] * probs0[1],
+            probs1[1] * probs0[0], probs1[1] * probs0[1]
+        ]
         # Target circuits
-        target_circs = [[{'name': 'id', 'qubits': [0]}, {'name': 'x', 'qubits': [0]}],
-                        [{'name': 'id', 'qubits': [0]}, {'name': 'y', 'qubits': [0]}],
-                        [{'name': 'z', 'qubits': [0]}, {'name': 'x', 'qubits': [0]}],
-                        [{'name': 'z', 'qubits': [0]}, {'name': 'y', 'qubits': [0]}]]
+        target_circs = [[{
+            'name': 'id',
+            'qubits': [0]
+        }, {
+            'name': 'x',
+            'qubits': [0]
+        }], [{
+            'name': 'id',
+            'qubits': [0]
+        }, {
+            'name': 'y',
+            'qubits': [0]
+        }], [{
+            'name': 'z',
+            'qubits': [0]
+        }, {
+            'name': 'x',
+            'qubits': [0]
+        }], [{
+            'name': 'z',
+            'qubits': [0]
+        }, {
+            'name': 'y',
+            'qubits': [0]
+        }]]
         for j in range(4):
             circ, p = error.error_term(j)
             # Remove prob from target if it is found
@@ -541,8 +721,40 @@ class TestQuantumError(common.QiskitAerTestCase):
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [], msg="Incorrect compose probabilities")
+        self.assertEqual(
+            target_probs, [], msg="Incorrect compose probabilities")
         self.assertEqual(target_circs, [], msg="Incorrect compose circuits")
+
+    def test_to_channel_kraus(self):
+        """Test to_channel for Kraus inputs."""
+        A0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
+        A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
+        B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
+        B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
+        target = SuperOp(Kraus([A0, A1])).tensor(SuperOp(Kraus([B0, B1])))
+        error = QuantumError([A0, A1]).tensor(QuantumError([B0, B1]))
+        self.assertEqual(target, error.to_channel())
+
+    def test_to_channel_circuit(self):
+        """Test to_channel for circuit inputs."""
+        noise_ops = [([{
+            'name': 'reset',
+            'qubits': [0]
+        }], 0.2), ([{
+            'name': 'reset',
+            'qubits': [1]
+        }], 0.3), ([{
+            'name': 'id',
+            'qubits': [0]
+        }], 0.5)]
+        error = QuantumError(noise_ops)
+        reset = SuperOp(
+            np.array([[1, 0, 0, 1], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]))
+        iden = SuperOp(np.eye(4))
+        target = 0.2 * iden.tensor(reset) + 0.3 * reset.tensor(
+            iden) + 0.5 * iden.tensor(iden)
+        self.assertEqual(target, error.to_channel())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds `to_channel` method to `QuantumError` object that can convert quantum errors to `SuperOp` quantum channel objects.

* Fixes bug in `QuantumError.tensor` and `QuantumError.expand`

* Removes `inplace` kwargs from methods in `QuantumError` and `ReadoutError`

### Details and comments


