### PR TITLE
Adding -flat_namespace link flag to MacOS to avoid misbehavior in dy…

### DIFF
--- a/qiskit/providers/aer/backends/wrappers/CMakeLists.txt
+++ b/qiskit/providers/aer/backends/wrappers/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(qasm_controller_wrapper
 if(APPLE)
     message(STATUS "On Mac, we force linking with undefined symbols for Python library, they will be
         solved at runtime by the loader")
-    set_target_properties(qasm_controller_wrapper PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    set_target_properties(qasm_controller_wrapper PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -flat_namespace")
     unset(PYTHON_LIBRARIES)
 endif()
 
@@ -59,7 +59,11 @@ target_include_directories(statevector_controller_wrapper
 if(APPLE)
     message(STATUS "On Mac, we force linking with undefined symbols for Python library, they will be
         solved at runtime by the loader")
-    set_target_properties(statevector_controller_wrapper PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    # -flat_namespace linker flag is needed otherwise dynamic symbol resolution doesn't work as expected.
+    # Symbols with the same name exist in different .so, so the loader just takes the first one it finds,
+    # which is usually the one from the first .so loaded.
+    # See: Two-Leve namespace symbol resolution
+    set_target_properties(statevector_controller_wrapper PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -flat_namespace")
     unset(PYTHON_LIBRARIES)
 endif()
 
@@ -90,7 +94,7 @@ target_include_directories(unitary_controller_wrapper
 if(APPLE)
     message(STATUS "On Mac, we force linking with undefined symbols for Python library, they will be
         solved at runtime by the loader")
-    set_target_properties(unitary_controller_wrapper PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    set_target_properties(unitary_controller_wrapper PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -flat_namespace")
     unset(PYTHON_LIBRARIES)
 endif()
 

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -263,7 +263,7 @@ void Controller::set_config(const json_t &config) {
   // with preference given to parallel circuit execution
   if (max_parallel_experiments_ > 1)
     max_parallel_shots_ = 1;
- 
+
   if (JSON::check_key("max_memory_mb", config)) {
     JSON::get_value(max_memory_mb_, "max_memory_mb", config);
   } else {


### PR DESCRIPTION
…namic symbol resolution

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
gcc builds were failing on MacOS due to a problem with the dynamic symbol resolution.

### Details and comments
Symbols with the same name can exist in different .so. Python dynamic loads all the .so, so the loader needs to resolve all the symbols at runtime, and it just takes the first one it finds,
which is usually the one from the first .so loaded... causing misbehavior in different situations.
We have to link with the -flat_namespace linker flag otherwise dynamic symbol resolution doesn't work as expected.

See: Two-Leve namespace symbol resolution


