### PR TITLE
Add OSX and python 37 and 35 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,17 +41,17 @@ install_osx: &stage_osx
     - brew install libomp
     - brew install openblas
     - |
-    if [ ${TRAVIS_OS_NAME} = "osx" ]; then
-      if [[ ! -d ~/python-interpreters/$PYTHON_VERSION ]]; then
-        git clone git://github.com/pyenv/pyenv.git
-        cd pyenv/plugins/python-build
-        ./install.sh
-        cd ../../..
-        python-build $PYTHON_VERSION ~/python-interpreters/$PYTHON_VERSION
+      if [ ${TRAVIS_OS_NAME} = "osx" ]; then
+        if [[ ! -d ~/python-interpreters/$PYTHON_VERSION ]]; then
+          git clone git://github.com/pyenv/pyenv.git
+          cd pyenv/plugins/python-build
+          ./install.sh
+          cd ../../..
+          python-build $PYTHON_VERSION ~/python-interpreters/$PYTHON_VERSION
+        fi
+        virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
+        source venv/bin/activate
       fi
-      virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
-      source venv/bin/activate
-    fi
 
   install:
     # Installing qiskit-terra master branch...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,99 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 language: python
-python:
-  - "3.6"
-os: linux
-dist: trusty
 
-before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get -y update
-  - sudo apt-get -y install g++-7
-  - sudo apt-get -y install cmake
-  - sudo apt-get -y install libopenblas-dev
+install_linux: &stage_linux
+  os: linux
+  dist: trusty
+  before_install:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get -y update
+    - sudo apt-get -y install g++-7
+    - sudo apt-get -y install cmake
+    - sudo apt-get -y install libopenblas-dev
+  install:
+    # Installing qiskit-terra master branch...
+    - git clone https://github.com/Qiskit/qiskit-terra.git
+    - cd qiskit-terra
+    - pip install -r requirements.txt
+    - pip install -r requirements-dev.txt
+    - python ./setup.py install
+    - cd ..
+    # Installing qiskit-aer...
+    - pip install -r requirements-dev.txt
+    - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j2
+    - pip install dist/qiskit_aer*whl
 
-install:
-  # Installing qiskit-terra master branch...
-  - git clone https://github.com/Qiskit/qiskit-terra.git
-  - cd qiskit-terra
-  - pip install -r requirements.txt
-  - pip install -r requirements-dev.txt
-  - python ./setup.py install
-  - cd ..
-  # Installing qiskit-aer...
-  - pip install -r requirements-dev.txt
+install_osx: &stage_osx
+  os: osx
+  osx_image: xcode9.2
+  language: generic
+  cache:
+    pip: true
+    directories:
+      - ~/python-interpreters/
+  before_install:
+    # Travis does not provide support for Python 3 under osx - it needs to be
+    # installed manually.
+    - brew install libomp
+    - brew install openblas
+    - |
+    if [ ${TRAVIS_OS_NAME} = "osx" ]; then
+      if [[ ! -d ~/python-interpreters/$PYTHON_VERSION ]]; then
+        git clone git://github.com/pyenv/pyenv.git
+        cd pyenv/plugins/python-build
+        ./install.sh
+        cd ../../..
+        python-build $PYTHON_VERSION ~/python-interpreters/$PYTHON_VERSION
+      fi
+      virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
+      source venv/bin/activate
+    fi
+
+  install:
+    # Installing qiskit-terra master branch...
+    - git clone https://github.com/Qiskit/qiskit-terra.git
+    - cd qiskit-terra
+    - pip install -r requirements.txt
+    - pip install -r requirements-dev.txt
+    - python ./setup.py install
+    - cd ..
+    # Installing qiskit-aer...
+    - pip install -r requirements-dev.txt
+    - python setup.py bdist_wheel --plat-name macosx-10.9-x86_64 -- -DSTATIC_LINKING=False -- -j2
+    - pip install dist/qiskit_aer*whl
 
 script:
-  - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
-  - pip install dist/qiskit_aer*whl
   - mv qiskit qiskit.disable
   - python -m unittest discover -s test -v
+
+matrix:
+  fast_finish: true
+  include:
+    - python: "3.5"
+      <<: *stage_linux
+      name: "Python 3.5 Tests"
+    - python: "3.6"
+      <<: *stage_linux
+      name: "Python 3.6 Tests"
+    - os: linux
+      <<: *stage_linux
+      dist: xenial
+      python: "3.7"
+      sudo: true
+      name: "Python 3.7 Tests"
+    # OSX, Python 3.5.6 (via pyenv)
+    - name: "Python 3.5 Tests on OSX"
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.5.6
+    # OSX, Python 3.6.5 (via pyenv)
+    - name: "Python 3.6 Tests on OSX"
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.6.5
+    # OSX, Python 3.7.2 (via pyenv)
+    - name: "Python 3.7 Tests on OSX"
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.7.2

--- a/test/terra/utils/ref_qvolume.py
+++ b/test/terra/utils/ref_qvolume.py
@@ -20,7 +20,8 @@ def quantum_volume(qubit, final_measure=True, depth=10, seed=0):
     width = qubit
     
     np.random.seed(seed)
-    circuit = QuantumCircuit(qreg, name=f"Qvolume: {width} by {depth}, seed: {seed}")
+    name = "Qvolume: %s by %s, seed: %s" %(width, depth, seed)
+    circuit = QuantumCircuit(qreg, name=name)
     
     for _ in range(depth):
         # Generate uniformly random permutation Pj of [0...n-1]
@@ -45,7 +46,7 @@ def quantum_volume(qubit, final_measure=True, depth=10, seed=0):
                 elif name == "id":
                     pass  # do nothing
                 else:
-                    raise Exception(f"Unexpected gate name: {name}")
+                    raise Exception("Unexpected gate name: %s" % name)
     
     circuit.barrier(qreg)
     


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We support running aer on windows, osx, and linux but we only
currently test running things on linux and only under python36. This
commit adds the travis config for running tests under osx too so we can
verify that it works as expected. It also adds the missing python versions
so we verify aer works in all support environments on linux and osx.

### Details and comments


