### PR TITLE
Use sample measurement when shot is 1 and without noise

### DIFF
--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -495,7 +495,7 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
 
   // Check if measure sampler and optimization are valid
   auto check = check_measure_sampling_opt(opt_circ);
-  if (check.first == false || shots == 1) {
+  if (check.first == false) {
     // Perform standard execution if we cannot apply the
     // measurement sampling optimization
     while(shots-- > 0) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Update to use sample measurement function when shot is 1 and no noise. 
Simulation time changes from 25 sec to 5 sec for QV (25qubit/10depth/1shot).

### Summary

- remove `shots == 1` case in `run_circuit_without_noise ()`

