### PR TITLE
optimize compose and tensor of QuantumError

### DIFF
--- a/qiskit/providers/aer/noise/errors/errorutils.py
+++ b/qiskit/providers/aer/noise/errors/errorutils.py
@@ -324,39 +324,6 @@ def standard_gate_unitary(name):
     return None
 
 
-def standard_instruction_operator(name, params=None):
-    """Return the Operator for a standard gate."""
-    mat = standard_gate_unitary(name)
-    if isinstance(mat, np.ndarray):
-        return Operator(mat)
-    # Check if standard parameterized waltz gates
-    if name is 'u1':
-        lam = params[0]
-        mat = np.diag([1, np.exp(1j * lam)])
-        return Operator(mat)
-    if name is 'u2':
-        phi = params[0]
-        lam = params[1]
-        mat = np.array([[1, -np.exp(1j * lam)],
-                        [np.exp(1j * phi),
-                         np.exp(1j * (phi + lam))]]) / np.sqrt(2)
-        return Operator(mat)
-    if name is 'u3':
-        theta = params[0]
-        phi = params[1]
-        lam = params[2]
-        mat = np.array(
-            [[np.cos(theta / 2), -np.exp(1j * lam) * np.sin(theta / 2)],
-             [
-                 np.exp(1j * phi) * np.sin(theta / 2),
-                 np.exp(1j * (phi + lam)) * np.cos(theta / 2)
-             ]])
-        return Operator(mat)
-    if name is 'unitary':
-        return Operator(params)
-    raise NoiseError('Cannot convert instruction to Operator')
-
-
 def reset_superop(num_qubits):
     """Return a N-qubit reset SuperOp."""
     reset = SuperOp(
@@ -367,6 +334,73 @@ def reset_superop(num_qubits):
     for _ in range(num_qubits - 1):
         reset_n.tensor(reset)
     return reset_n
+
+
+def standard_instruction_operator(instr):
+    """Return the Operator for a standard gate instruction."""
+    # Convert to dict (for QobjInstruction types)
+    if hasattr(instr, 'as_dict'):
+        instr = instr.as_dict()
+    # Get name and parameters
+    name = instr.get('name', "")
+    params = instr.get('params', [])
+    # Check if standard unitary gate name
+    mat = standard_gate_unitary(name)
+    if isinstance(mat, np.ndarray):
+        return Operator(mat)
+
+    # Check if standard parameterized waltz gates
+    if name == 'u1':
+        lam = params[0]
+        mat = np.diag([1, np.exp(1j * lam)])
+        return Operator(mat)
+    if name == 'u2':
+        phi = params[0]
+        lam = params[1]
+        mat = np.array([[1, -np.exp(1j * lam)],
+                        [np.exp(1j * phi),
+                         np.exp(1j * (phi + lam))]]) / np.sqrt(2)
+        return Operator(mat)
+    if name == 'u3':
+        theta = params[0]
+        phi = params[1]
+        lam = params[2]
+        mat = np.array(
+            [[np.cos(theta / 2), -np.exp(1j * lam) * np.sin(theta / 2)],
+             [np.exp(1j * phi) * np.sin(theta / 2), np.exp(1j * (phi + lam)) * np.cos(theta / 2)]])
+        return Operator(mat)
+
+    # Check if unitary instruction
+    if name == 'unitary':
+        return Operator(params)
+
+    # Otherwise return None if we cannot convert instruction
+    return None
+
+
+def standard_instruction_channel(instr):
+    """Return the SuperOp channel for a standard instruction."""
+    # Check if standard operator
+    oper = standard_instruction_operator(instr)
+    if oper is not None:
+        return SuperOp(oper)
+
+    # Convert to dict (for QobjInstruction types)
+    if hasattr(instr, 'as_dict'):
+        instr = instr.as_dict()
+    # Get name and parameters
+    name = instr.get('name', "")
+
+    # Check if reset instruction
+    if name == 'reset':
+        # params should be the number of qubits being reset
+        num_qubits = len(instr['qubits'])
+        return reset_superop(num_qubits)
+    # Check if Kraus instruction
+    if name == 'kraus':
+        params = instr['params']
+        return SuperOp(Kraus(params))
+    return None
 
 
 def circuit2superop(circuit, min_qubits=1):
@@ -387,28 +421,13 @@ def circuit2superop(circuit, min_qubits=1):
     superop = SuperOp(np.eye(4**num_qubits))
     # compose each circuit element with the superoperator
     for instr in circuit:
-        name = None
-        qubits = None
-        params = None
-        if isinstance(instr, dict):
-            # Parse from plain dictionary qobj instruction
-            name = instr['name']
-            qubits = instr.get('qubits')
-            params = instr.get('params')
+        instr_op = standard_instruction_channel(instr)
+        if instr_op is None:
+            raise NoiseError('Cannot convert instruction {} to SuperOp'.format(instr))
+        if hasattr(instr, 'qubits'):
+            qubits = instr.qubits
         else:
-            # Parse from QasmQobjInstruction
-            if hasattr(instr, 'name'):
-                name = instr.name
-            if hasattr(instr, 'qubits'):
-                qubits = instr.qubits
-            if hasattr(instr, 'params'):
-                params = instr.params
-        if name is 'reset':
-            instr_op = reset_superop(len(qubits))
-        elif name is 'kraus':
-            instr_op = Kraus(params)
-        else:
-            instr_op = SuperOp(standard_instruction_operator(name, params))
+            qubits = instr['qubits']
         superop = superop.compose(instr_op, qubits=qubits)
     return superop
 

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -190,20 +190,15 @@ class TestQuantumError(common.QiskitAerTestCase):
         A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
         B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
         B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
-        error = QuantumError([B0, B1]).tensor(QuantumError([A0, A1]))
+        # Use quantum channels for reference
+        target = SuperOp(Kraus([A0, A1]).tensor(Kraus([B0, B1])))
+        error = QuantumError([A0, A1]).tensor(QuantumError([B0, B1]))
         kraus, p = error.error_term(0)
-        targets = [
-            np.kron(B0, A0),
-            np.kron(B0, A1),
-            np.kron(B1, A0),
-            np.kron(B1, A1)
-        ]
         self.assertEqual(p, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0, 1])
-        for op in kraus[0]['params']:
-            self.remove_if_found(op, targets)
-        self.assertEqual(targets, [], msg="Incorrect tensor kraus")
+        error_superop = SuperOp(Kraus(kraus[0]['params']))
+        self.assertEqual(target, error_superop, msg="Incorrect tensor kraus")
 
     def test_tensor_both_unitary_instruction(self):
         """Test tensor of two unitary instruction errors."""
@@ -278,15 +273,9 @@ class TestQuantumError(common.QiskitAerTestCase):
         ]
         # Target circuits
         target_circs = [[{
-            'name': 'id',
-            'qubits': [0]
-        }, {
             'name': 'x',
             'qubits': [1]
         }], [{
-            'name': 'id',
-            'qubits': [0]
-        }, {
             'name': 'y',
             'qubits': [1]
         }], [{
@@ -323,20 +312,15 @@ class TestQuantumError(common.QiskitAerTestCase):
         A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
         B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
         B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
+        # Use quantum channels for reference
+        target = SuperOp(Kraus([A0, A1]).expand(Kraus([B0, B1])))
         error = QuantumError([A0, A1]).expand(QuantumError([B0, B1]))
         kraus, p = error.error_term(0)
-        targets = [
-            np.kron(B0, A0),
-            np.kron(B1, A0),
-            np.kron(B0, A1),
-            np.kron(B1, A1)
-        ]
         self.assertEqual(p, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0, 1])
-        for op in kraus[0]['params']:
-            self.remove_if_found(op, targets)
-        self.assertEqual(targets, [], msg="Incorrect expand kraus")
+        error_superop = SuperOp(Kraus(kraus[0]['params']))
+        self.assertEqual(target, error_superop, msg="Incorrect expand kraus")
 
     def test_expand_both_unitary_instruction(self):
         """Test expand of two unitary instruction errors."""
@@ -411,15 +395,9 @@ class TestQuantumError(common.QiskitAerTestCase):
         ]
         # Target circuits
         target_circs = [[{
-            'name': 'id',
-            'qubits': [0]
-        }, {
             'name': 'x',
             'qubits': [1]
         }], [{
-            'name': 'id',
-            'qubits': [0]
-        }, {
             'name': 'y',
             'qubits': [1]
         }], [{
@@ -464,20 +442,15 @@ class TestQuantumError(common.QiskitAerTestCase):
         A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
         B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
         B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
+        # Use quantum channels for reference
+        target = SuperOp(Kraus([A0, A1]).compose(Kraus([B0, B1])))
         error = QuantumError([A0, A1]).compose(QuantumError([B0, B1]))
         kraus, p = error.error_term(0)
-        targets = [
-            np.dot(B0, A0),
-            np.dot(B0, A1),
-            np.dot(B1, A0),
-            np.dot(B1, A1)
-        ]
         self.assertEqual(p, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0])
-        for op in kraus[0]['params']:
-            self.remove_if_found(op, targets)
-        self.assertEqual(targets, [], msg="Incorrect compose kraus")
+        error_superop = SuperOp(Kraus(kraus[0]['params']))
+        self.assertEqual(target, error_superop, msg="Incorrect compose kraus")
 
     def test_compose_both_unitary(self):
         """Test composition of two unitary errors."""
@@ -552,15 +525,9 @@ class TestQuantumError(common.QiskitAerTestCase):
         ]
         # Target circuits
         target_circs = [[{
-            'name': 'id',
-            'qubits': [0]
-        }, {
             'name': 'x',
             'qubits': [0]
         }], [{
-            'name': 'id',
-            'qubits': [0]
-        }, {
             'name': 'y',
             'qubits': [0]
         }], [{
@@ -597,21 +564,15 @@ class TestQuantumError(common.QiskitAerTestCase):
         A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
         B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
         B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
-        error = QuantumError([B0, B1]).compose(
-            QuantumError([A0, A1]), front=True)
+        # Use quantum channels for reference
+        target = SuperOp(Kraus([A0, A1]).compose(Kraus([B0, B1]), front=True))
+        error = QuantumError([A0, A1]).compose(QuantumError([B0, B1]), front=True)
         kraus, p = error.error_term(0)
-        targets = [
-            np.dot(B0, A0),
-            np.dot(B0, A1),
-            np.dot(B1, A0),
-            np.dot(B1, A1)
-        ]
         self.assertEqual(p, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0])
-        for op in kraus[0]['params']:
-            self.remove_if_found(op, targets)
-        self.assertEqual(targets, [], msg="Incorrect compose kraus")
+        error_superop = SuperOp(Kraus(kraus[0]['params']))
+        self.assertEqual(target, error_superop, msg="Incorrect front compose kraus")
 
     def test_compose_front_both_unitary(self):
         """Test front composition of two unitary errors."""
@@ -686,15 +647,9 @@ class TestQuantumError(common.QiskitAerTestCase):
         ]
         # Target circuits
         target_circs = [[{
-            'name': 'id',
-            'qubits': [0]
-        }, {
             'name': 'x',
             'qubits': [0]
-        }], [{
-            'name': 'id',
-            'qubits': [0]
-        }, {
+        }], [ {
             'name': 'y',
             'qubits': [0]
         }], [{


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changes `expand` `tensor` and `compose` of `QuantumError` to combine operations if they contain kraus or unitary qobj instructions. This reduces the number of operations in the composite error objects which should help slightly improve noisy simulation by reducing the number of operations to be executed.

### Details and comments

Previously when combining errors the instructions were appended with minimal reduction.

Eg:
```python
error1 = noise.errors.amplitude_damping_error(0.2)
error2 = noise.errors.pauli_error([('X', 0.5), ('I', 0.5)])
error = error1.compose(error2)
print(error._noise_probabilities)
print(error._noise_circuits)
# returns
[0.5, 0.5]
[[{'name': 'kraus',
   'qubits': [0],
   'params': [array([[0.       +0.j, 0.4472136+0.j],
           [0.       +0.j, 0.       +0.j]]),
    array([[1.        +0.j, 0.        +0.j],
           [0.        +0.j, 0.89442719+0.j]])]},
  {'name': 'x', 'qubits': [0]}],
 [{'name': 'kraus',
   'qubits': [0],
   'params': [array([[0.       +0.j, 0.4472136+0.j],
           [0.       +0.j, 0.       +0.j]]),
    array([[1.        +0.j, 0.        +0.j],
           [0.        +0.j, 0.89442719+0.j]])]},
  {'name': 'id', 'qubits': [0]}]]
```

After this fix the above example would return
```
[1.0]
[[{'name': 'kraus', 'qubits': [0], 'params': [array([[0.       +0.j, 0.       +0.j],
       [0.       +0.j, 0.4472136+0.j]]), array([[0.        +0.j, 0.89442719+0.j],
       [1.        +0.j, 0.        +0.j]])], 'param': [array([[ 0.        +0.j,  0.16245985+0.j],
       [-0.16245985+0.j,  0.        +0.j]]), array([[ 0.16245985+0.j,  0.        +0.j],
       [ 0.        +0.j, -0.16245985+0.j]]), array([[-0.68819096-0.j,  0.        +0.j],
       [ 0.        +0.j, -0.68819096+0.j]]), array([[0.        +0.j, 0.68819096+0.j],
       [0.68819096+0.j, 0.        +0.j]])]}]]
```