### PR TITLE
change format of unitary qobj params

### DIFF
--- a/qiskit/providers/aer/noise/errors/errorutils.py
+++ b/qiskit/providers/aer/noise/errors/errorutils.py
@@ -70,7 +70,7 @@ def standard_gate_instruction(instruction, ignore_phase=True):
         return [instruction]
 
     # Check single qubit gates
-    mat_dagger = np.conj(params)
+    mat_dagger = np.conj(params[0])
     if len(qubits) == 1:
         # Check clifford gates
         for j in range(24):
@@ -372,7 +372,7 @@ def standard_instruction_operator(instr):
 
     # Check if unitary instruction
     if name == 'unitary':
-        return Operator(params)
+        return Operator(params[0])
 
     # Otherwise return None if we cannot convert instruction
     return None
@@ -451,7 +451,7 @@ def make_unitary_instruction(mat, qubits, standard_gates=True):
         raise NoiseError("Input matrix is not unitary.")
     elif isinstance(qubits, int):
         qubits = [qubits]
-    instruction = {"name": "unitary", "qubits": qubits, "params": mat}
+    instruction = {"name": "unitary", "qubits": qubits, "params": [mat]}
     if standard_gates:
         return standard_gate_instruction(instruction)
     else:

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -546,7 +546,7 @@ class QuantumError:
             params = Kraus(SuperOp(op0).expand(op1)).data
         else:
             name = 'unitary'
-            params = op0.expand(op1).data
+            params = [op0.expand(op1).data]
         return {'name': name, 'qubits': qubits, 'params': params}
 
     @staticmethod
@@ -574,5 +574,5 @@ class QuantumError:
             params = Kraus(SuperOp(op0).compose(op1)).data
         else:
             name = 'unitary'
-            params = op0.compose(op1).data
+            params = [op0.compose(op1).data]
         return {'name': name, 'qubits': qubits0, 'params': params}

--- a/qiskit/providers/aer/utils/qobj_utils.py
+++ b/qiskit/providers/aer/utils/qobj_utils.py
@@ -168,7 +168,7 @@ def snapshot_instr(snapshot_type, label, qubits=None, params=None):
         Matrix expectation value params:
             TODO
     """
-    snap = {"name": "snapshot", "type": snapshot_type, "label": str(label)}
+    snap = {"name": "snapshot", "snapshot_type": snapshot_type, "label": str(label)}
     if qubits is not None:
         snap["qubits"] = list(qubits)
     if params is not None:

--- a/qiskit/providers/aer/utils/qobj_utils.py
+++ b/qiskit/providers/aer/utils/qobj_utils.py
@@ -94,10 +94,11 @@ def unitary_instr(mat, qubits, label=None):
     if array.shape not in [(dim, dim), (1, dim)]:
         raise ValueError("Invalid")
     instruction = {"name": "unitary", "qubits": list(qubits),
-                   "params": np.array(mat, dtype=complex)}
+                   "params": [np.array(mat, dtype=complex)]}
     if label is not None:
         instruction["label"] = str(label)
     return QasmQobjInstruction(**instruction)
+
 
 def measure_instr(qubits, memory, registers=None):
 

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -358,10 +358,10 @@ inline void check_duplicate_qubits(const Op &op) {
 // Generator functions
 //------------------------------------------------------------------------------
 
-inline Op make_mat(const reg_t &qubits, const cmatrix_t &mat, std::string label = "") {
+inline Op make_unitary(const reg_t &qubits, const cmatrix_t &mat, std::string label = "") {
   Op op;
   op.type = OpType::matrix;
-  op.name = "mat";
+  op.name = "unitary";
   op.qubits = qubits;
   op.mats = {mat};
   if (label != "")
@@ -663,17 +663,20 @@ Op json_to_op_roerror(const json_t &js) {
 Op json_to_op_unitary(const json_t &js) {
   Op op;
   op.type = OpType::matrix;
-  op.name = "mat";
+  op.name = "unitary";
   JSON::get_value(op.qubits, "qubits", js);
-  cmatrix_t mat;
-  JSON::get_value(mat, "params", js);
+  JSON::get_value(op.mats, "params", js);
   // Validation
   check_empty_qubits(op);
   check_duplicate_qubits(op);
-  if (!Utils::is_unitary(mat, 1e-10)) {
-    throw std::invalid_argument("\"mat\" matrix is not unitary.");
+  if (op.mats.size() != 1) {
+    throw std::invalid_argument("\"unitary\" params must be a single matrix.");
   }
-  op.mats.push_back(mat);
+  for (const auto mat : op.mats) {
+    if (!Utils::is_unitary(mat, 1e-7)) {
+      throw std::invalid_argument("\"unitary\" matrix is not unitary.");
+    }
+  }
   // Check for a label
   std::string label;
   JSON::get_value(label, "label", js);
@@ -710,7 +713,8 @@ Op json_to_op_noise_switch(const json_t &js) {
 
 Op json_to_op_snapshot(const json_t &js) {
   std::string type;
-  JSON::get_value(type, "type", js);
+  JSON::get_value(type, "type", js); // LEGACY: TO REMOVE
+  JSON::get_value(type, "snapshot_type", js);
   if (type == "expectation_value_pauli" ||
       type == "expectation_value_pauli_with_variance")
     return json_to_op_snapshot_pauli(js);

--- a/src/noise/noise_model.hpp
+++ b/src/noise/noise_model.hpp
@@ -547,7 +547,7 @@ NoiseModel::NoiseOps NoiseModel::sample_noise_x90_u3(uint_t qubit,
                                                        complex_t lambda,
                                                        RngEngine &rng) const {
   NoiseOps ret;
-  const auto x90 = Operations::make_mat({qubit}, Utils::Matrix::X90, "x90");
+  const auto x90 = Operations::make_unitary({qubit}, Utils::Matrix::X90, "x90");
   if (std::abs(lambda) > u1_threshold_
       && std::abs(lambda - 2 * M_PI) > u1_threshold_
       && std::abs(lambda + 2 * M_PI) > u1_threshold_)
@@ -571,7 +571,7 @@ NoiseModel::NoiseOps NoiseModel::sample_noise_x90_u2(uint_t qubit,
                                                        complex_t lambda,
                                                        RngEngine &rng) const {
   NoiseOps ret;
-  const auto x90 = Operations::make_mat({qubit}, Utils::Matrix::X90, "x90");
+  const auto x90 = Operations::make_unitary({qubit}, Utils::Matrix::X90, "x90");
   if (std::abs(lambda - 0.5 * M_PI) > u1_threshold_)
     ret.push_back(Operations::make_u1(qubit, lambda - 0.5 * M_PI)); // add 1st U1
   auto sample = sample_noise_helper(x90, rng); // sample noise for 1st X90

--- a/src/noise/quantum_error.hpp
+++ b/src/noise/quantum_error.hpp
@@ -226,7 +226,7 @@ void QuantumError::set_from_kraus(const std::vector<cmatrix_t> &mats) {
   reg_t error_qubits(num_qubits);
   std::iota(error_qubits.begin(), error_qubits.end(), 0);
   for (size_t j=1; j < probs.size(); j++) {
-    auto op = Operations::make_mat(error_qubits, unitaries[j - 1]);
+    auto op = Operations::make_unitary(error_qubits, unitaries[j - 1]);
     circuits.push_back({op});
   }
 

--- a/test/terra/backends/qasm_simulator/qasm_extra.py
+++ b/test/terra/backends/qasm_simulator/qasm_extra.py
@@ -21,7 +21,7 @@ class QasmExtraTests:
     # ---------------------------------------------------------------------
     # Test unitary gate qobj instruction
     # ---------------------------------------------------------------------
-    def DISABLED_test_unitary_gate_real(self):
+    def test_unitary_gate_real(self):
         """Test unitary qobj instruction with real matrices."""
         shots = 100
         qobj = ref_unitary_gate.unitary_gate_circuits_real_deterministic(
@@ -34,7 +34,7 @@ class QasmExtraTests:
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
-    def DISABLED_test_unitary_gate_complex(self):
+    def test_unitary_gate_complex(self):
         """Test unitary qobj instruction with complex matrices."""
         shots = 100
         qobj = ref_unitary_gate.unitary_gate_circuits_complex_deterministic(

--- a/test/terra/backends/qasm_simulator/qasm_thread_management.py
+++ b/test/terra/backends/qasm_simulator/qasm_thread_management.py
@@ -36,7 +36,8 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = 100
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(circuit, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
 
@@ -63,7 +64,8 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = 100
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(circuit, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
 
@@ -84,7 +86,8 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = 100
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(circuit, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_memory_mb'] = 128
@@ -104,7 +107,8 @@ class QasmThreadManagementTests:
         circuits = []
         for _ in range(experiments):
             circuits.append(quantum_volume_circuit(4, 1, measure=True, seed=0))
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_experiments'] = experiments
@@ -138,7 +142,8 @@ class QasmThreadManagementTests:
             circuits.append(
                 quantum_volume_circuit(16, 1, measure=True,
                                        seed=0))  # 2 MB for each
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_experiments'] = experiments
@@ -174,7 +179,8 @@ class QasmThreadManagementTests:
             circuits.append(
                 quantum_volume_circuit(4, 1, measure=True,
                                        seed=0))  # 2 MB for each
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_experiments'] = experiments
@@ -198,7 +204,8 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = multiprocessing.cpu_count()
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(circuit, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_shots'] = shots
@@ -227,7 +234,8 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = multiprocessing.cpu_count()
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(circuit, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_shots'] = shots
@@ -257,7 +265,8 @@ class QasmThreadManagementTests:
         if shots == 0:
             return
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(circuit, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_shots'] = multiprocessing.cpu_count()
@@ -286,7 +295,8 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = multiprocessing.cpu_count()
         circuit = quantum_volume_circuit(16, 1, measure=True, seed=0)
-        qobj = compile(circuit, self.SIMULATOR, shots=shots)
+        qobj = compile(
+            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_shots'] = shots

--- a/test/terra/backends/test_statevector_simulator.py
+++ b/test/terra/backends/test_statevector_simulator.py
@@ -258,9 +258,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         self.compare_statevector(result, circuits, targets)
 
     def test_y_gate_deterministic_minimal_basis_gates(self):
-        """Test y-gate gate circuits compiling to U,CX
-        DISABLED until transpiler bug is fixed.
-        """
+        """Test y-gate gate circuits compiling to u3, cx."""
         circuits = ref_1q_clifford.y_gate_circuits_deterministic(final_measure=False)
         targets = ref_1q_clifford.y_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1, basis_gates=['u3', 'cx'])
@@ -727,7 +725,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     # Test unitary gate qobj instruction
     # ---------------------------------------------------------------------
-    def DISABLED_test_unitary_gate_real(self):
+    def test_unitary_gate_real(self):
         """Test unitary qobj instruction with real matrices."""
         qobj = ref_unitary_gate.unitary_gate_circuits_real_deterministic(final_measure=False)
         circuits = [experiment.header.name for experiment in qobj.experiments]
@@ -737,7 +735,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         self.is_completed(result)
         self.compare_statevector(result, circuits, targets)
 
-    def DISABLED_test_unitary_gate_complex(self):
+    def test_unitary_gate_complex(self):
         """Test unitary qobj instruction with complex matrices."""
         qobj = ref_unitary_gate.unitary_gate_circuits_complex_deterministic(final_measure=False)
         circuits = [experiment.header.name for experiment in qobj.experiments]

--- a/test/terra/backends/test_unitary_simulator.py
+++ b/test/terra/backends/test_unitary_simulator.py
@@ -153,7 +153,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         self.compare_unitary(result, circuits, targets)
 
     def test_y_gate_deterministic_waltz_basis_gates(self):
-        """Test y-gate gate circuits compiling to u1,u2,u3,cx"""
+        """Test y-gate gate circuits compiling to u1,u2,u3,cx."""
         circuits = ref_1q_clifford.y_gate_circuits_deterministic(final_measure=False)
         targets = ref_1q_clifford.y_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
@@ -162,9 +162,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         self.compare_unitary(result, circuits, targets)
 
     def test_y_gate_deterministic_minimal_basis_gates(self):
-        """Test y-gate gate circuits compiling to U,CX
-        DISABLED until transpiler bug is fixed.
-        """
+        """Test y-gate gate circuits compiling to u3, cx."""
         circuits = ref_1q_clifford.y_gate_circuits_deterministic(final_measure=False)
         targets = ref_1q_clifford.y_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
@@ -631,7 +629,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     # Test unitary gate qobj instruction
     # ---------------------------------------------------------------------
-    def DISABLED_test_unitary_gate_real(self):
+    def test_unitary_gate_real(self):
         """Test unitary qobj instruction with real matrices."""
         qobj = ref_unitary_gate.unitary_gate_circuits_real_deterministic(final_measure=False)
         circuits = [experiment.header.name for experiment in qobj.experiments]
@@ -641,7 +639,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         self.is_completed(result)
         self.compare_unitary(result, circuits, targets)
 
-    def DISABLED_test_unitary_gate_complex(self):
+    def test_unitary_gate_complex(self):
         """Test unitary qobj instruction with complex matrices."""
         qobj = ref_unitary_gate.unitary_gate_circuits_complex_deterministic(final_measure=False)
         circuits = [experiment.header.name for experiment in qobj.experiments]

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -232,7 +232,7 @@ class TestQuantumError(common.QiskitAerTestCase):
 
         for j in range(4):
             circ, p = error.error_term(j)
-            unitary = circ[0]['params']
+            unitary = circ[0]['params'][0]
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0, 1])
             # Remove prob from target if it is found
@@ -354,7 +354,7 @@ class TestQuantumError(common.QiskitAerTestCase):
 
         for j in range(4):
             circ, p = error.error_term(j)
-            unitary = circ[0]['params']
+            unitary = circ[0]['params'][0]
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0, 1])
             # Remove prob from target if it is found
@@ -484,7 +484,7 @@ class TestQuantumError(common.QiskitAerTestCase):
 
         for j in range(4):
             circ, p = error.error_term(j)
-            unitary = circ[0]['params']
+            unitary = circ[0]['params'][0]
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0])
             # Remove prob from target if it is found
@@ -606,7 +606,7 @@ class TestQuantumError(common.QiskitAerTestCase):
 
         for j in range(4):
             circ, p = error.error_term(j)
-            unitary = circ[0]['params']
+            unitary = circ[0]['params'][0]
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0])
             # Remove prob from target if it is found

--- a/test/terra/noise/test_standard_errors.py
+++ b/test/terra/noise/test_standard_errors.py
@@ -66,7 +66,8 @@ class TestNoise(common.QiskitAerTestCase):
         unitaries = [np.eye(2), np.diag([1, -1])]
         probs = [0.7, 0.3]
         error = mixed_unitary_error([(unitaries[0], probs[0]),
-                                     (unitaries[1], probs[1])])
+                                     (unitaries[1], probs[1])],
+                                    standard_gates=True)
         (op0, p0) = error.error_term(0)
         (op1, p1) = error.error_term(1)
         self.assertEqual(op0[0], {"name": "z", "qubits": [0]})
@@ -103,7 +104,7 @@ class TestNoise(common.QiskitAerTestCase):
             self.assertEqual(circ[0]['qubits'], [0])
             self.remove_if_found(p, target_probs)
             if name == "unitary":
-                self.remove_if_found(circ[0]['params'], target_unitaries)
+                self.remove_if_found(circ[0]['params'][0], target_unitaries)
             else:
                 target_identity_count += 1
         self.assertEqual(target_probs, [], msg="Incorrect probabilities")
@@ -147,7 +148,7 @@ class TestNoise(common.QiskitAerTestCase):
             self.assertEqual(circ[0]['qubits'], [0])
             self.remove_if_found(p, target_probs)
             if name == "unitary":
-                self.remove_if_found(circ[0]['params'], target_unitaries)
+                self.remove_if_found(circ[0]['params'][0], target_unitaries)
             else:
                 target_identity_count += 1
         self.assertEqual(target_probs, [], msg="Incorrect probabilities")
@@ -190,7 +191,7 @@ class TestNoise(common.QiskitAerTestCase):
             self.assertIn(name, 'unitary')
             self.assertEqual(circ[0]['qubits'], [0, 1])
             self.remove_if_found(p, target_probs)
-            self.remove_if_found(circ[0]['params'], target_unitaries)
+            self.remove_if_found(circ[0]['params'][0], target_unitaries)
         self.assertEqual(target_probs, [], msg="Incorrect probabilities")
         self.assertEqual(target_unitaries, [], msg="Incorrect unitaries")
 
@@ -210,7 +211,7 @@ class TestNoise(common.QiskitAerTestCase):
             self.assertIn(name, 'unitary')
             self.assertEqual(circ[0]['qubits'], [1])
             self.remove_if_found(p, target_probs)
-            self.remove_if_found(circ[0]['params'], target_unitaries)
+            self.remove_if_found(circ[0]['params'][0], target_unitaries)
         self.assertEqual(target_probs, [], msg="Incorrect probabilities")
         self.assertEqual(target_unitaries, [], msg="Incorrect unitaries")
 
@@ -267,7 +268,7 @@ class TestNoise(common.QiskitAerTestCase):
             self.assertIn(name, 'unitary')
             self.assertEqual(circ[0]['qubits'], [0, 1])
             self.remove_if_found(p, target_probs)
-            self.remove_if_found(circ[0]['params'], target_unitaries)
+            self.remove_if_found(circ[0]['params'][0], target_unitaries)
         self.assertEqual(target_probs, [], msg="Incorrect probabilities")
         self.assertEqual(target_unitaries, [], msg="Incorrect unitaries")
 
@@ -329,7 +330,7 @@ class TestNoise(common.QiskitAerTestCase):
             self.assertEqual(circ[0]['qubits'], [0])
             if name == "unitary":
                 self.assertAlmostEqual(p, p_depol / 4, msg="Incorrect Pauli probability")
-                self.remove_if_found(circ[0]['params'], target_unitaries)
+                self.remove_if_found(circ[0]['params'][0], target_unitaries)
             else:
                 self.assertAlmostEqual(p, 1 - p_depol + p_depol / 4,
                                        msg="Incorrect identity probability")
@@ -372,7 +373,7 @@ class TestNoise(common.QiskitAerTestCase):
             self.assertIn(name, ('unitary', "id"))
             if name == "unitary":
                 self.assertAlmostEqual(p, p_depol / 16)
-                op = circ[0]['params']
+                op = circ[0]['params'][0]
                 qubits = circ[0]['qubits']
                 if len(op) == 2:
                     self.assertIn(qubits, [[0], [1]])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Changes snapshot instructions to pass in `"type"` as `"snapshot_type"`, but for now maintains backwards compatibility with instructions that still use `"type"`. This backwards compatibility will be removed in Aer 0.3.
* Changes the unitary qobj instruction format to pass in the matrix as `"param": [mat]` rather than `"params": mat` (which unfortunately was baked into a lot of noise module files and could do with some proper refactoring in the future!).

Should be merged in sync with Terra PR [2164](https://github.com/Qiskit/qiskit-terra/pull/2164)

### Details and comments

