### PR TITLE
Allow NoiseModel.as_dict() to return a serializable dict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,8 @@ Added
 
 Changed
 -------
-
+- Add an optional parameter to `NoiseModel.as_dict()` for returning dictionaries that can be
+  serialized using the standard `json` library directly.
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ Added
 Changed
 -------
 - Add an optional parameter to `NoiseModel.as_dict()` for returning dictionaries that can be
-  serialized using the standard `json` library directly.
+  serialized using the standard `json` library directly. (#165)
 
 Removed
 -------

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -9,7 +9,10 @@
 Noise model class for Qiskit Aer simulators.
 """
 
+import json
 import logging
+
+from qiskit.providers.aer.backends.aerbackend import AerJSONEncoder
 
 from .noiseerror import NoiseError
 from .errors.quantum_error import QuantumError
@@ -399,14 +402,17 @@ class NoiseModel:
         # Convert noise instructions to basis_gates string
         return list(self._basis_gates)
 
-    def as_dict(self):
+    def as_dict(self, serializable=False):
         """
         Return dictionary for noise model.
+
+        Args:
+            serializable (bool): if `True`, return a dict containing only types
+                that can be serializable by the stdlib `json` module.
 
         Returns:
             dict: a dictionary for a noise model.
         """
-
         error_list = []
 
         # Add default quantum errors
@@ -446,7 +452,11 @@ class NoiseModel:
             error_dict["gate_qubits"] = [self._str2qubits(qubits_str)]
             error_list.append(error_dict)
 
-        return {"errors": error_list, "x90_gates": self._x90_gates}
+        ret = {"errors": error_list, "x90_gates": self._x90_gates}
+        if serializable:
+            ret = json.loads(json.dumps(ret, cls=AerJSONEncoder))
+
+        return ret
 
     @staticmethod
     def from_dict(noise_dict):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR adds an optional parameter to `NoiseModel.as_dict()` for returning a "dict composed only of types that can be serialized directly using `json.dumps()` without the need for a custom encoder". It is mostly for the needs of `IBMQProvider` - since online simulators can also accept noise models, it allows the serialization to be contained within `Aer` without requiring extra imports or duplication in the other provider.

I went with an approach that hopefully minimizes the impact of this change - by default, the parameter is set to `False` for preserving current behaviour, and relies on the existing AerJSONEncoder` doing a dummy "dump -> load" cycle. 

### Details and comments


