### PR TITLE
Reduce unnecessary loop for shot-level parallelization

### DIFF
--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -588,13 +588,12 @@ json_t Controller::execute_circuit(Circuit &circ) {
       // Vector to store parallel thread output data
       std::vector<OutputData> data(parallel_shots_);
       std::vector<std::string> error_msgs(parallel_shots_);
-      for (int i = 0; i < parallel_shots_; ++i)
       #pragma omp parallel for if (parallel_shots_ > 1) num_threads(parallel_shots_)
-      for (int j = 0; j < parallel_shots_; j++) {
+      for (int i = 0; i < parallel_shots_; i++) {
         try {
-          data[j] = run_circuit(circ, subshots[j], circ.seed + j);
+          data[i] = run_circuit(circ, subshots[i], circ.seed + i);
         } catch (std::runtime_error error) {
-          error_msgs[j] = error.what();
+          error_msgs[i] = error.what();
         }
       }
 

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -630,7 +630,7 @@ void QubitVector<data_t>::check_checkpoint() const {
 //------------------------------------------------------------------------------
 
 template <typename data_t>
-QubitVector<data_t>::QubitVector(size_t num_qubits) : num_qubits_(0), data_(0), checkpoint_(0){
+QubitVector<data_t>::QubitVector(size_t num_qubits) : num_qubits_(0), data_(nullptr), checkpoint_(0){
   set_num_qubits(num_qubits);
 }
 
@@ -772,20 +772,27 @@ void QubitVector<data_t>::zero() {
 
 template <typename data_t>
 void QubitVector<data_t>::set_num_qubits(size_t num_qubits) {
+
+  size_t prev_num_qubits = num_qubits_;
   num_qubits_ = num_qubits;
   data_size_ = BITS[num_qubits];
-
-  // Free any currently assigned memory
-  if (data_)
-    free(data_);
 
   if (checkpoint_) {
     free(checkpoint_);
     checkpoint_ = nullptr;
   }
 
+  // Free any currently assigned memory
+  if (data_) {
+    if (prev_num_qubits != num_qubits_) {
+      free(data_);
+      data_ = nullptr;
+    }
+  }
+
   // Allocate memory for new vector
-  data_ = reinterpret_cast<complex_t*>(malloc(sizeof(complex_t) * data_size_));
+  if (data_ == nullptr)
+    data_ = reinterpret_cast<complex_t*>(malloc(sizeof(complex_t) * data_size_));
 }
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix a bug in controller to parallelize shots.

### Details and comments
The first loop in `json_t Controller::execute_circuit(Circuit &circ)` is not necessary.
```
      for (int i = 0; i < parallel_shots_; ++i)
      #pragma omp parallel for if (parallel_shots_ > 1) num_threads(parallel_shots_)
      for (int j = 0; j < parallel_shots_; j++) {
        try {
          data[j] = run_circuit(circ, subshots[j], circ.seed + j);
        } catch (std::runtime_error error) {
          error_msgs[j] = error.what();
        }
      }
```