### PR TITLE
adds kraus to QasmSimulator basis_gates

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -141,7 +141,8 @@ class QasmSimulator(AerBackend):
         'coupling_map': None,
         'basis_gates': [
             'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
-            't', 'tdg', 'ccx', 'swap', 'snapshot', 'unitary', 'reset', 'initialize'
+            't', 'tdg', 'ccx', 'swap', 'snapshot', 'unitary', 'reset',
+            'initialize', 'kraus'
         ],
         'gates': [{
             'name': 'TODO',

--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -306,7 +306,7 @@ def _device_thermal_relaxation_error(qubits,
     # for any multi qubit gates
     first = True
     error = None
-    for qubit in reversed(qubits):
+    for qubit in qubits:
         t1, t2, freq = relax_params[qubit]
         population = _excited_population(freq, temperature)
         if first:
@@ -314,7 +314,7 @@ def _device_thermal_relaxation_error(qubits,
             first = False
         else:
             single = thermal_relaxation_error(t1, t2, gate_time, population)
-            error = error.kron(single)
+            error = error.expand(single)
     return error
 
 

--- a/test/benchmark/tools.py
+++ b/test/benchmark/tools.py
@@ -37,7 +37,7 @@ def reset_noise_model():
     noise_model = NoiseModel()
     error1 = thermal_relaxation_error(50, 50, 0.1)
     noise_model.add_all_qubit_quantum_error(error1, ['u1', 'u2', 'u3'])
-    error2 = error1.kron(error1)
+    error2 = error1.tensor(error1)
     noise_model.add_all_qubit_quantum_error(error2, ['cx'])
     return noise_model
 
@@ -47,7 +47,7 @@ def kraus_noise_model():
     noise_model = NoiseModel()
     error1 = amplitude_damping_error(0.1)
     noise_model.add_all_qubit_quantum_error(error1, ['u1', 'u2', 'u3'])
-    error2 = error1.kron(error1)
+    error2 = error1.tensor(error1)
     noise_model.add_all_qubit_quantum_error(error2, ['cx'])
     return noise_model
 


### PR DESCRIPTION
Add kraus instruction to QasmSimulator basis gates since it is already supported and will be added to Terra soon.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds `kraus` to the `QasmSimulator` basis gates, so that a valid kasm QasmQobjInstruction can be directly simulated from qobj circuit.

### Details and comments

The `kraus` qobj format is `{"name": "kraus", "qubits": [q0, q1, ...], "params": [K0, K1, ...]}` where `Kj` are the serialized Kraus matrices of the correct dimension for the number of qubits specified.


### Example

```python
import numpy as np
from qiskit import *
from qiskit.providers.aer import QasmSimulator
from qiskit.qobj import QasmQobjInstruction

# Bitflip kraus
p = 0.25
kraus = [np.sqrt(p) * np.array([[0, 1], [1, 0]]),
         np.sqrt(1-p) * np.eye(2)]
kraus_instr = QasmQobjInstruction(name='kraus',
                                  qubits=[0],
                                  params=kraus)

# Empty circuit
qr = QuantumRegister(1)
cr = ClassicalRegister(1)
circ = QuantumCircuit(qr, cr)
circ.barrier(qr)
circ.measure(qr, cr)

# edit qobj
qobj = assemble_circuits(circ)
qobj.experiments[0].instructions.insert(0, kraus_instr)
qobj.config.shots = 10000

# Simulate
result = QasmSimulator().run(qobj).result()
print(result.get_counts(0))
{'0': 7461, '1': 2539}
```