### PR TITLE
fix compiler warnings

### DIFF
--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -215,10 +215,10 @@ protected:
   void clear_parallelization();
 
   // Set parallelization for experiments
-  virtual void set_parallelization(const std::vector<Circuit>& circuits);
+  virtual void set_parallelization_experiments(const std::vector<Circuit>& circuits);
 
   // Set parallelization for a circuit
-  virtual void set_parallelization(const Circuit& circuit);
+  virtual void set_parallelization_circuit(const Circuit& circuit);
 
   // Return an estimate of the required memory for a circuit.
   virtual size_t required_memory_mb(const Circuit& circuit) const = 0;
@@ -300,7 +300,7 @@ void Controller::clear_parallelization() {
   parallel_state_update_ = 1;
 }
 
-void Controller::set_parallelization(const std::vector<Circuit>& circuits) {
+void Controller::set_parallelization_experiments(const std::vector<Circuit>& circuits) {
 
   if (max_parallel_experiments_ <= 0)
     return;
@@ -330,12 +330,12 @@ void Controller::set_parallelization(const std::vector<Circuit>& circuits) {
   }
 }
 
-void Controller::set_parallelization(const Circuit& circ) {
+void Controller::set_parallelization_circuit(const Circuit& circ) {
 
   if (max_parallel_threads_ < max_parallel_shots_)
     max_parallel_shots_ = max_parallel_threads_;
 
-  auto circ_memory_mb = required_memory_mb(circ);
+  int circ_memory_mb = required_memory_mb(circ);
 
   if (max_memory_mb_ < circ_memory_mb)
     throw std::runtime_error("a circuit requires more memory than max_memory_mb.");
@@ -418,7 +418,7 @@ bool Controller::validate_memory_requirements(state_t &state,
   if (max_memory_mb_ == 0)
     return true;
 
-  auto required_mb = state.required_memory_mb(circ.num_qubits, circ.ops);
+  int required_mb = state.required_memory_mb(circ.num_qubits, circ.ops);
   if(max_memory_mb_ < required_mb) {
     if(throw_except) {
       std::string name = "";
@@ -501,7 +501,7 @@ json_t Controller::execute(const json_t &qobj_js) {
     #endif
 
     // set parallelization for experiments
-    set_parallelization(qobj.circuits);
+    set_parallelization_experiments(qobj.circuits);
 
   #ifdef _OPENMP
     result["metadata"]["omp_enabled"] = true;
@@ -569,7 +569,7 @@ json_t Controller::execute_circuit(Circuit &circ) {
   try {
     // set parallelization for this circuit
     if (parallel_experiments_ == 1)
-      set_parallelization(circ);
+      set_parallelization_circuit(circ);
     // Single shot thread execution
     if (parallel_shots_ <= 1) {
       result["data"] = run_circuit(circ, circ.shots, circ.seed);
@@ -592,7 +592,7 @@ json_t Controller::execute_circuit(Circuit &circ) {
       for (int i = 0; i < parallel_shots_; i++) {
         try {
           data[i] = run_circuit(circ, subshots[i], circ.seed + i);
-        } catch (std::runtime_error error) {
+        } catch (std::runtime_error &error) {
           error_msgs[i] = error.what();
         }
       }

--- a/src/framework/circuitopt.hpp
+++ b/src/framework/circuitopt.hpp
@@ -23,6 +23,10 @@ namespace AER {
 
 class CircuitOptimization {
 public:
+
+  CircuitOptimization() = default;
+  virtual ~CircuitOptimization() = default;
+
   virtual void optimize_circuit(Circuit& circ,
                                 const Operations::OpSet &opset,
                                 OutputData &data) const = 0;

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -32,7 +32,7 @@ enum class OpType {
   matrix, matrix_sequence, kraus, roerror, noise_switch, initialize
 };
 
-std::ostream& operator<<(std::ostream& stream, const OpType& type) {
+inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
   switch (type) {
   case OpType::gate:
     stream << "gate";
@@ -120,7 +120,7 @@ struct Op {
                                                         // M x 1 column-matrices
 };
 
-std::ostream& operator<<(std::ostream& s, const Op& op) {
+inline std::ostream& operator<<(std::ostream& s, const Op& op) {
   s << op.name << "[";
   bool first = true;
   for (size_t qubit: op.qubits) {
@@ -205,7 +205,7 @@ public:
   stringset_t invalid_snapshots(const stringset_t &allowed_snapshots) const;
 };
 
-std::ostream& operator<<(std::ostream& s, const OpSet& opset) {
+inline std::ostream& operator<<(std::ostream& s, const OpSet& opset) {
   s << "optypes={";
   bool first = true;
   for (OpType optype: opset.optypes) {

--- a/src/noise/abstract_error.hpp
+++ b/src/noise/abstract_error.hpp
@@ -22,6 +22,10 @@ namespace Noise {
 class AbstractError {
 public:
 
+  // Constructors
+  AbstractError() = default;
+  virtual ~AbstractError() = default;
+
   // Alias for return type
   using NoiseOps = std::vector<Operations::Op>;
 

--- a/src/simulators/extended_stabilizer/chlib/chstabilizer.hpp
+++ b/src/simulators/extended_stabilizer/chlib/chstabilizer.hpp
@@ -993,8 +993,9 @@ double NormEstimate(std::vector<StabilizerState>& states, const std::vector< std
     for (size_t i=0; i<L; i++)
     {
       double re_eta =0., im_eta = 0.;
+      const int_t END = states.size();
       #pragma omp parallel for reduction(+:re_eta) reduction(+:im_eta)
-      for (int_t j=0; j<states.size(); j++)
+      for (int_t j=0; j<END; j++)
       {
           if(states[j].ScalarPart().eps != 0)
           {

--- a/src/simulators/qasm/basic_optimization.hpp
+++ b/src/simulators/qasm/basic_optimization.hpp
@@ -190,7 +190,6 @@ void Fusion::optimize_circuit(Circuit& circ,
   optimized_ops.clear();
   oplist_t buffer;
 
-  int idx = 0;
   for (const op_t op: circ.ops) {
     if (can_ignore(op))
       continue;
@@ -213,7 +212,9 @@ void Fusion::optimize_circuit(Circuit& circ,
     ret = true;
   }
 
-  circ.ops = optimized_ops;
+  if (ret) {
+    circ.ops = optimized_ops;
+  }
 
   if (verbose_) {
     data.add_additional_data("metadata",
@@ -266,7 +267,7 @@ oplist_t Fusion::aggregate(const oplist_t& original) const {
 
   int applied_total = 0;
   // calculate the minimal path to each operation in the circuit
-  for (int i = 0; i < original.size(); ++i) {
+  for (size_t i = 0; i < original.size(); ++i) {
     bool applied = false;
 
     // first, fusion from i-th to i-th

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -145,7 +145,7 @@ protected:
                         const Initstate_t &initial_state) const;
 
   // Set parallelization for qasm simulator
-  virtual void set_parallelization(const Circuit& circ) override;
+  virtual void set_parallelization_circuit(const Circuit& circ) override;
 
   //----------------------------------------------------------------
   // Run circuit helpers
@@ -397,7 +397,7 @@ size_t QasmController::required_memory_mb(const Circuit& circ) const {
   }
 }
 
-void QasmController::set_parallelization(const Circuit& circ) {
+void QasmController::set_parallelization_circuit(const Circuit& circ) {
 
   if (max_parallel_threads_ < max_parallel_shots_)
     max_parallel_shots_ = max_parallel_threads_;
@@ -411,7 +411,7 @@ void QasmController::set_parallelization(const Circuit& circ) {
       }
     }
     default: {
-      Base::Controller::set_parallelization(circ);
+      Base::Controller::set_parallelization_circuit(circ);
     }
   }
 }

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -1211,7 +1211,7 @@ void QubitVector<data_t>::apply_matrix_sequence(const std::vector<reg_t> &regs,
 
   for (size_t m = 1; m < sorted_mats.size(); m++) {
 
-    cvector_t u_tmp(U.size(), (0., 0.));
+    cvector_t u_tmp(U.size(), 0.);
     const cvector_t& u = sorted_mats[m];
 
     for (size_t i = 0; i < dim; ++i)
@@ -1825,7 +1825,7 @@ cvector_t QubitVector<data_t>::expand_matrix(const reg_t& src_qubits, const reg_
   const auto src_dim = BITS[src_qubits.size()];
 
   // generate a matrix for op
-  cvector_t u(dst_vmat_size, (.0, .0));
+  cvector_t u(dst_vmat_size, .0);
   std::vector<bool> filled(dst_dim, false);
 
   if (src_qubits.size() == 1) { //1-qubit operation
@@ -2146,8 +2146,8 @@ rvector_t QubitVector<data_t>::probabilities(const reg_t &qubits) const {
   if (N == 1)
     return probabilities(qubits[0]);
 
-  const uint_t DIM = BITS[N];
-  const uint_t END = BITS[num_qubits_ - N];
+  const int_t DIM = BITS[N];
+  const int_t END = BITS[num_qubits_ - N];
 
   // Error checking
   #ifdef DEBUG


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bunch of GCC-8 compiler warnings when building

### Details and comments

* Adds check for return in Fusion circuit optimisation (@hhorii can you confirm this is intended behaviour?)
* Adds virtual destructors to AbstractError and CircuitOptimization
* fixes hidden virtual set_parallelization functions by giving the circuit and experiment functions different names.
* adds inline to ostream functions to avoid warnings
* fixes some int comparison warnings in for loops