### PR TITLE
reduced_basic_noise_model

### DIFF
--- a/qiskit/providers/aer/noise/device/__init__.py
+++ b/qiskit/providers/aer/noise/device/__init__.py
@@ -7,7 +7,7 @@
 
 """Device noise models module Qiskit Aer."""
 
-from .models import basic_device_noise_model
+from .models import basic_device_noise_model, reduced_basic_noise_model
 from .models import basic_device_readout_errors
 from .models import basic_device_gate_errors
 from . import parameters

--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -450,9 +450,7 @@ def reduced_basic_noise_model(backend, mapping):
     """
     full_noise_model = basic_device_noise_model(backend.properties())
     noise_model = full_noise_model.as_dict()
-
     n_qubits = backend.configuration().n_qubits
-    coupling_map = backend.configuration().coupling_map
 
     inv_map = [None]*n_qubits
     for idx, val in enumerate(mapping):

--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -458,12 +458,6 @@ def reduced_basic_noise_model(backend, mapping):
     for idx, val in enumerate(mapping):
         inv_map[val] = idx
 
-    reduced_cmap = []
-
-    for edge in coupling_map:
-        if edge[0] in mapping and edge[1] in mapping:
-            reduced_cmap.append(edge)
-
     idx_to_keep = []
     for idx, err in enumerate(noise_model['errors']):
         gate_qubits = err['gate_qubits']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Converts the basic noise model for a full device and maps it to a reduced coupling_map that specifies a subgraph of the device.  This allows for doing noise simulations on sub-graphs of devices without needing to pad the size of a circuit to the full width of the device.

This is meant to be used in conjunction with https://github.com/Qiskit/qiskit-terra/pull/2225

### Details and comments


