### PR TITLE
Fix type on loop iterators in openmp for loops

### DIFF
--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -2168,14 +2168,14 @@ rvector_t QubitVector<data_t>::probabilities(const reg_t &qubits) const {
   {
     rvector_t probs_private(DIM, 0.);
     #pragma omp for
-      for (size_t k = 0; k < END; k++) {
+      for (int_t k = 0; k < END; k++) {
         auto idx = indexes(qubits, qubits_sorted, k);
-        for (size_t m = 0; m < DIM; ++m) {
+        for (int_t m = 0; m < DIM; ++m) {
           probs_private[m] += probability(idx[m]);
         }
       }
     #pragma omp critical
-    for (size_t m = 0; m < DIM; ++m) {
+    for (int_t m = 0; m < DIM; ++m) {
       probs[m] += probs_private[m];
     }
   }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now in the statevector simulator there were a few for loops that
were using size_t as the loop iterator type. However the type there
should int_t so it's signed. This commit just fixes this issue and
switches the type.

### Details and comments