### PR TITLE
Clean up backend options and fix test depreciation warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Added
 
 Changed
 -------
+- Depreciated "initial_statevector" backend option for QasmSimulator and StatevectorSimulator (#185)
+- Rename "chop_threshold" backend option to "zero_threshold" and change default value to 1e-10 (#185).
 - Add an optional parameter to `NoiseModel.as_dict()` for returning dictionaries that can be
   serialized using the standard `json` library directly. (#165)
 

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -30,6 +30,8 @@ class QasmSimulator(AerBackend):
         `backend_options` kwarg diction for `QasmSimulator.run` or
         `qiskit.execute`
 
+        Simulation method option
+        ------------------------
         * "method" (str): Set the simulation method. Allowed values are:
             * "statevector": Uses a dense statevector simulation.
             * "stabilizer": uses a Clifford stabilizer state simulator that
@@ -42,15 +44,11 @@ class QasmSimulator(AerBackend):
             available memory, uses the statevector method. Otherwise, uses
             the extended_stabilizer method (Default: "automatic").
 
-        * "max_memory_mb" (int): Set the amount of memory (in MB)
-        the simulator has access to (Default: Maximum available)
+        General options
+        ---------------
 
-        * "initial_statevector" (vector_like): Sets a custom initial
-            statevector for the simulation instead of the all zero
-            initial state (Default: None).
-
-        * "chop_threshold" (double): Sets the threshold for truncating small
-            values to zero in the Result data (Default: 1e-15)
+        * "zero_threshold" (double): Sets the threshold for truncating
+            small values to zero in the result data (Default: 1e-10).
 
         * "max_parallel_threads" (int): Sets the maximum number of CPU
             cores used by OpenMP for parallelization. If set to 0 the
@@ -70,47 +68,50 @@ class QasmSimulator(AerBackend):
             Note that this cannot be enabled at the same time as parallel
             experiment execution (Default: 1).
 
-        * "max_statevector_memory_mb" (int): Sets the maximum size of memory
+        * "max_memory_mb" (int): Sets the maximum size of memory
             to store a state vector. If a state vector needs more, an error
             is thrown. In general, a state vector of n-qubits uses 2^n complex
             values (16 Bytes). If set to 0, the maximum will be automatically
-            set to the system memory size (Default: 0).
+            set to half the system memory size (Default: 0).
 
+        "statevector" method options
+        ----------------------------
         * "statevector_parallel_threshold" (int): Sets the threshold that
             "n_qubits" must be greater than to enable OpenMP
             parallelization for matrix multiplication during execution of
             an experiment. If parallel circuit or shot execution is enabled
             this will only use unallocated CPU cores up to
             max_parallel_threads. Note that setting this too low can reduce
-            performance (Default: 12).
+            performance (Default: 14).
 
         * "statevector_sample_measure_opt" (int): Sets the threshold that
             the number of qubits must be greater than to enable a large
             qubit optimized implementation of measurement sampling. Note
             that setting this two low can reduce performance (Default: 10)
 
-        * "statevector_hpc_gate_opt" (bool): If set to True this enables
-            a different optimzied gate application routine that can
-            increase performance on systems with a large number of CPU
-            cores. For systems with a small number of cores it enabling
-            can reduce performance (Default: False).
+        "stabilizer" method options
+        ---------------------------
+        * "stabilizer_max_snapshot_probabilities" (int): (Default: 32)
 
-        * "extended_stabilizer_approximation_error" (double): Set the error
-            in the approximation for the extended_stabilizer method. A
-            smaller error needs more memory and computational time.
-            (Default: 0.05)
-
-        * "extended_stabilizer_disable_measurement_opt" (bool): Force the
-            simulator to re-run the monte-carlo step for every measurement.
-            Enabling this will improve the sampling accuracy if the output
-            distribution is strongly peaked, but requires more
-            computational time. (Default: True)
+        "extended_stabilizer" method options
+        ------------------------------------
+        * "extended_stabilizer_measure_sampling" (bool): Enable measure
+            sampling optimization on supported circuits. This prevents the
+            simulator from re-running the measure monte-carlo step for each
+            shot. Enabling measure sampling may reduce accuracy of the
+            measurement counts if the output distribution is strongly
+            peaked. (Default: False)
 
         * "extended_stabilizer_mixing_time" (int): Set how long the
             monte-carlo method runs before performing measurements. If the
             output distribution is strongly peaked, this can be decreased
             alongside setting extended_stabilizer_disable_measurement_opt
             to True. (Default: 5000)
+
+        * "extended_stabilizer_approximation_error" (double): Set the error
+            in the approximation for the extended_stabilizer method. A
+            smaller error needs more memory and computational time.
+            (Default: 0.05)
 
         * "extended_stabilizer_norm_estimation_samples" (int): Number of
             samples used to compute the correct normalisation for a

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -34,12 +34,8 @@ class StatevectorSimulator(AerBackend):
         `backend_options` kwarg diction for `StatevectorSimulator.run` or
         `qiskit.execute`
 
-        * "initial_statevector" (vector_like): Sets a custom initial
-            statevector for the simulation instead of the all zero
-            initial state (Default: None).
-
-        * "chop_threshold" (double): Sets the threshold for truncating small
-            values to zero in the Result data (Default: 1e-15)
+        * "zero_threshold" (double): Sets the threshold for truncating
+            small values to zero in the result data (Default: 1e-10).
 
         * "max_parallel_threads" (int): Sets the maximum number of CPU
             cores used by OpenMP for parallelization. If set to 0 the
@@ -51,19 +47,19 @@ class StatevectorSimulator(AerBackend):
             execution will be disabled. If set to 0 the maximum will be
             automatically set to max_parallel_threads (Default: 1).
 
+        * "max_memory_mb" (int): Sets the maximum size of memory
+            to store a state vector. If a state vector needs more, an error
+            is thrown. In general, a state vector of n-qubits uses 2^n complex
+            values (16 Bytes). If set to 0, the maximum will be automatically
+            set to half the system memory size (Default: 0).
+
         * "statevector_parallel_threshold" (int): Sets the threshold that
             "n_qubits" must be greater than to enable OpenMP
             parallelization for matrix multiplication during execution of
             an experiment. If parallel circuit or shot execution is enabled
             this will only use unallocated CPU cores up to
             max_parallel_threads. Note that setting this too low can reduce
-            performance (Default: 12).
-
-        * "statevector_hpc_gate_opt" (bool): If set to True this enables
-            a different optimzied gate application routine that can
-            increase performance on systems with a large number of CPU
-            cores. For systems with a small number of cores it enabling
-            can reduce performance (Default: False).
+            performance (Default: 14).
     """
 
     MAX_QUBIT_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -38,26 +38,32 @@ class UnitarySimulator(AerBackend):
         * "initial_unitary" (matrix_like): Sets a custom initial unitary
             matrix for the simulation instead of identity (Default: None).
 
-        * "chop_threshold" (double): Sets the threshold for truncating small
-            values to zero in the Result data (Default: 1e-15)
+        * "zero_threshold" (double): Sets the threshold for truncating
+            small values to zero in the result data (Default: 1e-10).
 
         * "max_parallel_threads" (int): Sets the maximum number of CPU
             cores used by OpenMP for parallelization. If set to 0 the
             maximum will be set to the number of CPU cores (Default: 0).
 
-         * "max_parallel_experiments" (int): Sets the maximum number of
+        * "max_parallel_experiments" (int): Sets the maximum number of
             qobj experiments that may be executed in parallel up to the
             max_parallel_threads value. If set to 1 parallel circuit
             execution will be disabled. If set to 0 the maximum will be
             automatically set to max_parallel_threads (Default: 1).
 
-        * "unitary_parallel_threshold" (int): Sets the threshold that
-            "n_qubits" must be greater than to enable OpenMP
+        * "max_memory_mb" (int): Sets the maximum size of memory
+            to store a state vector. If a state vector needs more, an error
+            is thrown. In general, a state vector of n-qubits uses 2^n complex
+            values (16 Bytes). If set to 0, the maximum will be automatically
+            set to half the system memory size (Default: 0).
+
+        * "statevector_parallel_threshold" (int): Sets the threshold that
+            2 * "n_qubits" must be greater than to enable OpenMP
             parallelization for matrix multiplication during execution of
-            an experiment. If parallel circuit execution is enabled this
-            will only use unallocated CPU cores up to max_parallel_threads.
-            Note that setting this too low can reduce performance
-            (Default: 6).
+            an experiment. If parallel circuit or shot execution is enabled
+            this will only use unallocated CPU cores up to
+            max_parallel_threads. Note that setting this too low can reduce
+            performance (Default: 14).
     """
 
     MAX_QUBIT_MEMORY = int(log2(sqrt(local_hardware_info()['memory'] * (1024 ** 3) / 16)))

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -223,20 +223,16 @@ void State::initialize_qreg(uint_t num_qubits, const chstate_t &state)
 void State::set_config(const json_t &config)
 {
   // Set the error upper bound in the stabilizer rank approximation
-  JSON::get_value(approximation_error_, "ch_approximation_error", config); // DEPRECIATED
   JSON::get_value(approximation_error_, "extended_stabilizer_approximation_error", config);
   // Set the number of samples used in the norm estimation routine
-  JSON::get_value(norm_estimation_samples_, "ch_norm_estimation_samples", config); // DEPRECIATED
   JSON::get_value(norm_estimation_samples_, "extended_stabilizer_norm_estimation_samples", config);
   // Set the number of steps used in the metropolis sampler before we
   // consider the distribution as approximating the output
-  JSON::get_value(metropolis_mixing_steps_, "ch_mixing_time", config); // DEPRECIATED
   JSON::get_value(metropolis_mixing_steps_, "extended_stabilizer_mixing_time", config);
   //Set the threshold of the decomposition before we use omp
-  JSON::get_value(omp_threshold_rank_, "ch_parallel_threshold", config); // DEPRECIATED
   JSON::get_value(omp_threshold_rank_, "extended_stabilizer_parallel_threshold", config);
   //Set the truncation threshold for the probabilities snapshot.
-  JSON::get_value(snapshot_chop_threshold_, "chop_threshold", config);
+  JSON::get_value(snapshot_chop_threshold_, "zero_threshold", config);
   //Set the number of samples for the probabilities snapshot
   JSON::get_value(probabilities_snapshot_samples_, "probabilities_snapshot_samples", config);
 }

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -29,8 +29,8 @@ namespace Simulator {
  * 
  * - "initial_statevector" (json complex vector): Use a custom initial
  *      statevector for the simulation [Default: null].
- * - "chop_threshold" (double): Threshold for truncating small values to
- *      zero in result data [Default: 1e-15]
+ * - "zero_threshold" (double): Threshold for truncating small values to
+ *      zero in result data [Default: 1e-10]
  * - "statevector_parallel_threshold" (int): Threshold that number of qubits
  *      must be greater than to enable OpenMP parallelization at State
  *      level [Default: 13]
@@ -222,8 +222,7 @@ protected:
   // TODO: initial stabilizer state
 
   // Controller-level parameter for CH method
-
-  bool extended_stabilizer_disable_measurement_opt_ = true;
+  bool extended_stabilizer_measure_sampling_ = false;
 };
 
 //=========================================================================
@@ -291,7 +290,8 @@ void QasmController::set_config(const json_t &config) {
       throw std::runtime_error("QasmController: initial_statevector is not a unit vector");
     }
   }
-  JSON::get_value(extended_stabilizer_disable_measurement_opt_, "disable_measurement_opt", config);
+  JSON::get_value(extended_stabilizer_measure_sampling_,
+                  "extended_stabilizer_measure_sampling", config);
 }
 
 void QasmController::clear_config() {
@@ -527,8 +527,8 @@ std::pair<bool, size_t>
 QasmController::check_measure_sampling_opt(const Circuit &circ) const {
   // Find first instance of a measurement and check there
   // are no reset or initialize operations before the measurement
-  if(simulation_method(circ) == Method::extended_stabilizer && extended_stabilizer_disable_measurement_opt_)
-  {
+  if(simulation_method(circ) == Method::extended_stabilizer
+     && !extended_stabilizer_measure_sampling_) {
     return std::make_pair(false, 0);
   }
   auto start = circ.ops.begin();

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -162,7 +162,7 @@ protected:
   size_t max_qubits_snapshot_probs_ = 32;
 
   // Threshold for chopping small values to zero in JSON
-  double json_chop_threshold_ = 1e-15;
+  double json_chop_threshold_ = 1e-10;
 
   // Table of allowed gate names to gate enum class members
   const static stringmap_t<Gates> gateset_;
@@ -244,10 +244,10 @@ size_t State::required_memory_mb(uint_t num_qubits,
 
 void State::set_config(const json_t &config) {
   // Set threshold for truncating snapshots
-  JSON::get_value(json_chop_threshold_, "chop_threshold", config);
+  JSON::get_value(json_chop_threshold_, "zero_threshold", config);
 
   // Load max snapshot qubit size and set hard limit of 64 qubits.
-  JSON::get_value(max_qubits_snapshot_probs_, "max_snapshot_probabilities", config);
+  JSON::get_value(max_qubits_snapshot_probs_, "stabilizer_max_snapshot_probabilities", config);
   max_qubits_snapshot_probs_ = std::max<uint_t>(max_qubits_snapshot_probs_, 64);
 }
 

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -397,7 +397,7 @@ protected:
   // Config settings
   //----------------------------------------------------------------------- 
   uint_t omp_threads_ = 1;     // Disable multithreading by default
-  uint_t omp_threshold_ = 13;  // Qubit threshold for multithreading when enabled
+  uint_t omp_threshold_ = 14;  // Qubit threshold for multithreading when enabled
   int sample_measure_index_size_ = 10; // Sample measure indexing qubit size
   double json_chop_threshold_ = 0;  // Threshold for choping small values
                                     // in JSON serialization

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -25,8 +25,8 @@ namespace Simulator {
  * 
  * - "initial_statevector" (json complex vector): Use a custom initial
  *      statevector for the simulation [Default: null].
- * - "chop_threshold" (double): Threshold for truncating small values to
- *      zero in result data [Default: 1e-15]
+ * - "zero_threshold" (double): Threshold for truncating small values to
+ *      zero in result data [Default: 1e-10]
  * - "statevector_parallel_threshold" (int): Threshold that number of qubits
  *      must be greater than to enable OpenMP parallelization at State
  *      level [Default: 13]

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -255,7 +255,7 @@ protected:
   int sample_measure_index_size_ = 10;
 
   // Threshold for chopping small values to zero in JSON
-  double json_chop_threshold_ = 1e-15;
+  double json_chop_threshold_ = 1e-10;
 
   // Table of allowed gate names to gate enum class members
   const static stringmap_t<Gates> gateset_;
@@ -382,7 +382,7 @@ template <class statevec_t>
 void State<statevec_t>::set_config(const json_t &config) {
 
   // Set threshold for truncating snapshots
-  JSON::get_value(json_chop_threshold_, "chop_threshold", config);
+  JSON::get_value(json_chop_threshold_, "zero_threshold", config);
   BaseState::qreg_.set_json_chop_threshold(json_chop_threshold_);
 
   // Set OMP threshold for state update functions

--- a/src/simulators/unitary/unitary_controller.hpp
+++ b/src/simulators/unitary/unitary_controller.hpp
@@ -26,8 +26,8 @@ namespace Simulator {
  * 
  * - "initial_unitary" (json complex matrix): Use a custom initial unitary
  *      matrix for the simulation [Default: null].
- * - "chop_threshold" (double): Threshold for truncating small values to
- *      zero in result data [Default: 1e-15]
+ * - "zero_threshold" (double): Threshold for truncating small values to
+ *      zero in result data [Default: 1e-10]
  * - "unitary_parallel_threshold" (int): Threshold that number of qubits
  *      must be greater than to enable OpenMP parallelization at State
  *      level [Default: 6]

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -152,7 +152,7 @@ protected:
   int omp_qubit_threshold_ = 6;
 
   // Threshold for chopping small values to zero in JSON
-  double json_chop_threshold_ = 1e-15;
+  double json_chop_threshold_ = 1e-10;
 
   // Table of allowed gate names to gate enum class members
   const static stringmap_t<Gates> gateset_;
@@ -244,7 +244,7 @@ void State<data_t>::set_config(const json_t &config) {
   JSON::get_value(omp_qubit_threshold_, "unitary_parallel_threshold", config);
 
   // Set threshold for truncating snapshots
-  JSON::get_value(json_chop_threshold_, "chop_threshold", config);
+  JSON::get_value(json_chop_threshold_, "zero_threshold", config);
   BaseState::qreg_.set_json_chop_threshold(json_chop_threshold_);
 }
 

--- a/test/benchmark/quantum_volume_benchmarks.py
+++ b/test/benchmark/quantum_volume_benchmarks.py
@@ -2,8 +2,8 @@
 # See "Writing benchmarks" in the asv docs for more information.
 """Quantum Voluming benchmark suite"""
 
-import qiskit as Terra
 from qiskit import QiskitError
+from qiskit.compiler import transpile, assemble
 from qiskit.providers.aer import QasmSimulator
 from .tools import quantum_volume_circuit, mixed_unitary_noise_model, \
                    reset_noise_model, kraus_noise_model, no_noise
@@ -42,9 +42,9 @@ class QuantumVolumeTimeSuite:
                 # We want always the same seed, as we want always the same circuits
                 # for the same value pairs of qubits,depth
                 circ = quantum_volume_circuit(num_qubits, depth, seed=1)
-                self.qv_circuits.append(
-                    Terra.compile(
-                        circ, self.backend, shots=1, basis_gates=['u3', 'cx']))
+                circ = transpile(circ, basis_gates=['u3', 'cx'])
+                qobj = assemble(circ, self.backend, shots=1)
+                self.qv_circuits.append(qobj)
         self.param_names = ["Quantum Volume", "Noise Model"]
         # This will run every benchmark for one of the combinations we have here:
         # bench(qv_circuits, None) => bench(qv_circuits, mixed()) =>

--- a/test/benchmark/simple_benchmarks.py
+++ b/test/benchmark/simple_benchmarks.py
@@ -36,7 +36,7 @@ class SimpleU3TimeSuite:
         self.circuits = []
         for i in 5, 10, 15:
             circuit = simple_u3_circuit(i)
-            self.circuits.append(Terra.compile(circuit, self.backend, shots=1))
+            self.circuits.append(Terra.assemble(circuit, self.backend, shots=1))
 
         self.param_names = [
             "Simple u3 circuits", "Noise Model"
@@ -71,7 +71,7 @@ class SimpleCxTimeSuite:
         ]
         for i in 5, 10, 15:
             circuit = simple_cnot_circuit(i)
-            self.circuits.append(Terra.compile(circuit, self.backend, shots=1))
+            self.circuits.append(Terra.assemble(circuit, self.backend, shots=1))
         self.params = (self.circuits, [
             no_noise(),
             mixed_unitary_noise_model(),

--- a/test/benchmarks/parallelization_test.py
+++ b/test/benchmarks/parallelization_test.py
@@ -1,6 +1,6 @@
 import sys
 import qiskit
-from qiskit import compile
+from qiskit.compiler import assemble
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
 from qiskit.providers.aer import QasmSimulator
 
@@ -21,18 +21,19 @@ shots = 1024
 
 simulator = QasmSimulator()
 
-parallel_shots_list = { 1, 5, 10, 20, 30, 40, 50, 60, 70, 80}
+parallel_shots_list = {1, 5, 10, 20, 30, 40, 50, 60, 70, 80}
 
 circuit = quantum_volume_circuit(qubit, depth, measure, seed)
-qobj = compile(circuit, simulator, shots=shots)
+qobj = assemble(circuit, simulator, shots=shots)
 
 for parallel_shots in parallel_shots_list:
-    backend_opts = { 
+    backend_opts = {
         'max_parallel_threads': 80,
         'max_parallel_shots': parallel_shots,
         'parallel_state_update': 80 / parallel_shots
-        }
-    
+    }
+
     result = simulator.run(qobj, backend_options=backend_opts).result()
-    
-    print (80, parallel_shots, 80 / parallel_shots, result.metadata['time_taken'])
+
+    print(80, parallel_shots, 80 / parallel_shots,
+          result.metadata['time_taken'])

--- a/test/terra/backends/qasm_simulator/qasm_algorithms.py
+++ b/test/terra/backends/qasm_simulator/qasm_algorithms.py
@@ -9,7 +9,7 @@ QasmSimulator Integration Tests
 """
 
 from test.terra.reference import ref_algorithms
-from qiskit import compile
+from qiskit import execute
 from qiskit.providers.aer import QasmSimulator
 
 
@@ -28,8 +28,8 @@ class QasmAlgorithmTests:
         circuits = ref_algorithms.grovers_circuit(
             final_measure=True, allow_sampling=True)
         targets = ref_algorithms.grovers_counts(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -38,8 +38,8 @@ class QasmAlgorithmTests:
         shots = 2000
         circuits = ref_algorithms.teleport_circuit()
         targets = ref_algorithms.teleport_counts(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -59,12 +59,13 @@ class QasmAlgorithmTestsWaltzBasis:
         circuits = ref_algorithms.grovers_circuit(
             final_measure=True, allow_sampling=True)
         targets = ref_algorithms.grovers_counts(shots)
-        qobj = compile(
+
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -73,12 +74,12 @@ class QasmAlgorithmTestsWaltzBasis:
         shots = 2000
         circuits = ref_algorithms.teleport_circuit()
         targets = ref_algorithms.teleport_counts(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -98,9 +99,9 @@ class QasmAlgorithmTestsMinimalBasis:
         circuits = ref_algorithms.grovers_circuit(
             final_measure=True, allow_sampling=True)
         targets = ref_algorithms.grovers_counts(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -109,8 +110,8 @@ class QasmAlgorithmTestsMinimalBasis:
         shots = 2000
         circuits = ref_algorithms.teleport_circuit()
         targets = ref_algorithms.teleport_counts(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_basics.py
+++ b/test/terra/backends/qasm_simulator/qasm_basics.py
@@ -8,8 +8,8 @@
 QasmSimulator Integration Tests
 """
 from test.terra.utils.mock import FakeFailureQasmSimulator, FakeSuccessQasmSimulator
-from qiskit.transpiler import transpile
-from qiskit import assemble, QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.compiler import transpile, assemble
 from qiskit.providers.aer import AerError
 
 

--- a/test/terra/backends/qasm_simulator/qasm_cliffords.py
+++ b/test/terra/backends/qasm_simulator/qasm_cliffords.py
@@ -10,7 +10,7 @@ QasmSimulator Integration Tests
 
 from test.terra.reference import ref_1q_clifford
 from test.terra.reference import ref_2q_clifford
-from qiskit import compile
+from qiskit import execute
 from qiskit.providers.aer import QasmSimulator
 
 
@@ -29,9 +29,8 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.h_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.h_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -41,9 +40,8 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.h_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -56,9 +54,8 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.x_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.x_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -71,9 +68,8 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.z_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.z_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -86,9 +82,8 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.y_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -101,9 +96,8 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.s_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.s_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -113,9 +107,12 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.s_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(
+            circuits,
+            self.SIMULATOR,
+            shots=shots,
+            basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -128,9 +125,12 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.sdg_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(
+            circuits,
+            self.SIMULATOR,
+            shots=shots,
+            basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -140,9 +140,8 @@ class QasmCliffordTests:
         circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.sdg_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -155,9 +154,8 @@ class QasmCliffordTests:
         circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.cx_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -167,9 +165,8 @@ class QasmCliffordTests:
         circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.cx_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -182,9 +179,8 @@ class QasmCliffordTests:
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.cz_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -194,9 +190,8 @@ class QasmCliffordTests:
         circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.cz_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -209,9 +204,8 @@ class QasmCliffordTests:
         circuits = ref_2q_clifford.swap_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.swap_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -221,9 +215,8 @@ class QasmCliffordTests:
         circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.swap_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -243,13 +236,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.h_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.h_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -259,13 +251,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.h_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -278,13 +269,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.x_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.x_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -298,13 +288,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.z_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.z_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -314,10 +303,9 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.z_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.z_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -330,9 +318,8 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.y_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -342,13 +329,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.y_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -361,13 +347,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.s_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.s_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -377,13 +362,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.s_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -396,13 +380,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.sdg_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -412,13 +395,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.sdg_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -431,13 +413,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.cx_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -447,13 +428,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.cx_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -466,13 +446,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.cz_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -482,13 +461,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.cz_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -501,13 +479,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_2q_clifford.swap_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.swap_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -517,13 +494,12 @@ class QasmCliffordTestsWaltzBasis:
         circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.swap_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits,
             self.SIMULATOR,
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -544,10 +520,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.h_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.h_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -557,10 +532,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.h_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -573,10 +547,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.x_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.x_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -590,10 +563,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.z_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.z_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -607,10 +579,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.y_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -624,10 +595,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.s_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.s_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -637,10 +607,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.s_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -653,10 +622,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.sdg_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -666,10 +634,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_1q_clifford.sdg_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -682,10 +649,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.cx_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -695,10 +661,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.cx_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -711,10 +676,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.cz_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -724,10 +688,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.cz_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -740,10 +703,9 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_2q_clifford.swap_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_2q_clifford.swap_gate_counts_deterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -753,9 +715,8 @@ class QasmCliffordTestsMinimalBasis:
         circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_2q_clifford.swap_gate_counts_nondeterministic(shots)
-        qobj = compile(
+        job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_conditional.py
+++ b/test/terra/backends/qasm_simulator/qasm_conditional.py
@@ -9,7 +9,7 @@ QasmSimulator Integration Tests
 """
 
 from test.terra.reference import ref_conditionals
-from qiskit import compile
+from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
 
 
@@ -28,7 +28,7 @@ class QasmConditionalTests:
         circuits = ref_conditionals.conditional_circuits_1bit(
             final_measure=True)
         targets = ref_conditionals.conditional_counts_1bit(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
@@ -40,7 +40,7 @@ class QasmConditionalTests:
         circuits = ref_conditionals.conditional_circuits_2bit(
             final_measure=True)
         targets = ref_conditionals.conditional_counts_2bit(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -4,13 +4,13 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
-
 """
 QasmSimulator Integration Tests
 """
 
 from test.benchmark.tools import quantum_volume_circuit
-from qiskit import compile, QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.compiler import assemble, transpile
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors import ReadoutError, depolarizing_error
@@ -24,12 +24,12 @@ class QasmFusionTests:
 
     SIMULATOR = QasmSimulator()
     BACKEND_OPTS = {'fusion_verbose': True}
-    
+
     def create_statevector_circuit(self):
         qr = QuantumRegister(10)
         cr = ClassicalRegister(10)
         circuit = QuantumCircuit(qr, cr)
-        circuit.u3(0.1,0.1,0.1,qr[0])
+        circuit.u3(0.1, 0.1, 0.1, qr[0])
         circuit.barrier(qr)
         circuit.x(qr[0])
         circuit.barrier(qr)
@@ -37,139 +37,213 @@ class QasmFusionTests:
         circuit.barrier(qr)
         circuit.x(qr[0])
         circuit.barrier(qr)
-        circuit.u3(0.1,0.1,0.1,qr[0])
+        circuit.u3(0.1, 0.1, 0.1, qr[0])
         circuit.barrier(qr)
         circuit.measure(qr, cr)
         return circuit
-    
+
     def noise_model(self):
         readout_error = [0.01, 0.1]
         depolarizing = {'u3': (1, 0.001), 'cx': (2, 0.02)}
         noise = NoiseModel()
-        readout = [[1.0 - readout_error[0], readout_error[0]], [readout_error[1], 1.0 - readout_error[1]]]
+        readout = [[1.0 - readout_error[0], readout_error[0]],
+                   [readout_error[1], 1.0 - readout_error[1]]]
         noise.add_all_qubit_readout_error(ReadoutError(readout))
         for gate, (num_qubits, gate_error) in depolarizing.items():
-            noise.add_all_qubit_quantum_error(depolarizing_error(gate_error, num_qubits), gate)
-            return noise    
-    
+            noise.add_all_qubit_quantum_error(
+                depolarizing_error(gate_error, num_qubits), gate)
+            return noise
+
     def check_mat_exist(self, result):
-        fusion_gates = result.as_dict()['results'][0]['metadata']['fusion_verbose']
+        fusion_gates = result.as_dict(
+        )['results'][0]['metadata']['fusion_verbose']
         for gate in fusion_gates:
-            print (gate)
-    
+            print(gate)
+
     def test_clifford_no_fusion(self):
         """Test Fusion with clifford simulator"""
         shots = 100
-        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj, backend_options={'fusion_verbose': True}).result()
+        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
+            final_measure=True)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(
+            qobj, backend_options={
+                'fusion_verbose': True
+            }).result()
         self.is_completed(result)
-        
-        self.assertTrue('results' in result.as_dict(), 
-                        msg="results must exist in result")
-        self.assertTrue('metadata' in result.as_dict()['results'][0], 
-                        msg="metadata must exist in results[0]")
-        self.assertTrue('fusion_verbose' not in result.as_dict()['results'][0]['metadata'], 
-                        msg="fusion must not work for clifford")
+
+        self.assertTrue(
+            'results' in result.as_dict(), msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result.as_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' not in result.as_dict()['results'][0]['metadata'],
+            msg="fusion must not work for clifford")
 
     def test_noise_fusion(self):
         """Test Fusion with noise model option"""
         circuit = self.create_statevector_circuit()
-        
+
         shots = 100
         noise_model = self.noise_model()
-        qobj = compile([circuit], self.SIMULATOR, shots=shots, seed=1, basis_gates=noise_model.basis_gates)
+        circuit = transpile([circuit],
+                            backend=self.SIMULATOR,
+                            basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed=1)
 
-        result = self.SIMULATOR.run(qobj, noise_model=noise_model, backend_options={'fusion_enable': True, 'fusion_verbose': True, 'fusion_threshold': 1}).result()
+        result = self.SIMULATOR.run(
+            qobj,
+            noise_model=noise_model,
+            backend_options={
+                'fusion_enable': True,
+                'fusion_verbose': True,
+                'fusion_threshold': 1
+            }).result()
         self.is_completed(result)
-        
-        self.assertTrue('results' in result.as_dict(), 
-                        msg="results must exist in result")
-        self.assertTrue('metadata' in result.as_dict()['results'][0], 
-                        msg="metadata must exist in results[0]")
-        self.assertTrue('fusion_verbose' in result.as_dict()['results'][0]['metadata'], 
-                        msg="verbose must work with noise")
-        
+
+        self.assertTrue(
+            'results' in result.as_dict(), msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result.as_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' in result.as_dict()['results'][0]['metadata'],
+            msg="verbose must work with noise")
+
     def test_fusion_verbose(self):
         """Test Fusion with verbose option"""
         circuit = self.create_statevector_circuit()
-        
+
         shots = 100
-        qobj = compile([circuit], self.SIMULATOR, shots=shots, seed=1)
-        
-        result_verbose = self.SIMULATOR.run(qobj, backend_options={'fusion_enable': True, 'fusion_verbose': True, 'fusion_threshold': 1}).result()
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed=1)
+
+        result_verbose = self.SIMULATOR.run(
+            qobj,
+            backend_options={
+                'fusion_enable': True,
+                'fusion_verbose': True,
+                'fusion_threshold': 1
+            }).result()
         self.is_completed(result_verbose)
-        self.assertTrue('results' in result_verbose.as_dict(), 
-                        msg="results must exist in result")
-        self.assertTrue('metadata' in result_verbose.as_dict()['results'][0], 
-                        msg="metadata must exist in results[0]")
-        self.assertTrue('fusion_verbose' in result_verbose.as_dict()['results'][0]['metadata'], 
-                        msg="fusion must work for satevector")
+        self.assertTrue(
+            'results' in result_verbose.as_dict(),
+            msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result_verbose.as_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' in result_verbose.as_dict()['results'][0]
+            ['metadata'],
+            msg="fusion must work for satevector")
 
-        result_nonverbose = self.SIMULATOR.run(qobj, backend_options={'fusion_enable': True, 'fusion_verbose': False, 'fusion_threshold': 1}).result()
+        result_nonverbose = self.SIMULATOR.run(
+            qobj,
+            backend_options={
+                'fusion_enable': True,
+                'fusion_verbose': False,
+                'fusion_threshold': 1
+            }).result()
         self.is_completed(result_nonverbose)
-        self.assertTrue('results' in result_nonverbose.as_dict(), 
-                        msg="results must exist in result")
-        self.assertTrue('metadata' in result_nonverbose.as_dict()['results'][0], 
-                        msg="metadata must exist in results[0]")
-        self.assertTrue('fusion_verbose' not in result_nonverbose.as_dict()['results'][0]['metadata'], 
-                        msg="verbose must not work if fusion_verbose is False")
+        self.assertTrue(
+            'results' in result_nonverbose.as_dict(),
+            msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result_nonverbose.as_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' not in result_nonverbose.as_dict()['results'][0]
+            ['metadata'],
+            msg="verbose must not work if fusion_verbose is False")
 
-        result_default = self.SIMULATOR.run(qobj, backend_options={'fusion_enable': True}).result()
+        result_default = self.SIMULATOR.run(
+            qobj, backend_options={
+                'fusion_enable': True
+            }).result()
         self.is_completed(result_default)
-        self.assertTrue('results' in result_default.as_dict(), 
-                        msg="results must exist in result")
-        self.assertTrue('metadata' in result_default.as_dict()['results'][0], 
-                        msg="metadata must exist in results[0]")
-        self.assertTrue('fusion_verbose' not in result_default.as_dict()['results'][0]['metadata'], 
-                        msg="verbose must not work if fusion_verbose is False")
-        
+        self.assertTrue(
+            'results' in result_default.as_dict(),
+            msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result_default.as_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' not in result_default.as_dict()['results'][0]
+            ['metadata'],
+            msg="verbose must not work if fusion_verbose is False")
+
     def test_control_fusion(self):
         """Test Fusion enable/disable option"""
         shots = 100
         circuit = self.create_statevector_circuit()
-        qobj = compile([circuit], self.SIMULATOR, shots=shots, seed=0)
-        
-        result_verbose = self.SIMULATOR.run(qobj, backend_options={'fusion_enable': True, 'fusion_verbose': True, 'fusion_threshold': 1}).result()
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed=0)
+
+        result_verbose = self.SIMULATOR.run(
+            qobj,
+            backend_options={
+                'fusion_enable': True,
+                'fusion_verbose': True,
+                'fusion_threshold': 1
+            }).result()
         self.is_completed(result_verbose)
-        self.assertTrue('results' in result_verbose.as_dict(), 
-                        msg="results must exist in result")
-        self.assertTrue('metadata' in result_verbose.as_dict()['results'][0], 
-                        msg="metadata must exist in results[0]")
-        self.assertTrue('fusion_verbose' in result_verbose.as_dict()['results'][0]['metadata'], 
-                        msg="fusion must work for satevector")
+        self.assertTrue(
+            'results' in result_verbose.as_dict(),
+            msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result_verbose.as_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' in result_verbose.as_dict()['results'][0]
+            ['metadata'],
+            msg="fusion must work for satevector")
 
-        result_disabled = self.SIMULATOR.run(qobj, backend_options={'fusion_enable': False, 'fusion_verbose': True, 'fusion_threshold': 1}).result()
+        result_disabled = self.SIMULATOR.run(
+            qobj,
+            backend_options={
+                'fusion_enable': False,
+                'fusion_verbose': True,
+                'fusion_threshold': 1
+            }).result()
         self.is_completed(result_disabled)
-        self.assertTrue('results' in result_disabled.as_dict(), 
-                        msg="results must exist in result")
-        self.assertTrue('metadata' in result_disabled.as_dict()['results'][0], 
-                        msg="metadata must exist in results[0]")
-        self.assertTrue('fusion_verbose' not in result_disabled.as_dict()['results'][0]['metadata'], 
-                        msg="fusion must not work with fusion_enable is False")
+        self.assertTrue(
+            'results' in result_disabled.as_dict(),
+            msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result_disabled.as_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' not in result_disabled.as_dict()['results'][0]
+            ['metadata'],
+            msg="fusion must not work with fusion_enable is False")
 
-        result_default = self.SIMULATOR.run(qobj, backend_options={'fusion_verbose': True}).result()
+        result_default = self.SIMULATOR.run(
+            qobj, backend_options={
+                'fusion_verbose': True
+            }).result()
         self.is_completed(result_default)
-        self.assertTrue('results' in result_default.as_dict(), 
-                        msg="results must exist in result")
-        self.assertTrue('metadata' in result_default.as_dict()['results'][0], 
-                        msg="metadata must exist in results[0]")
-        self.assertTrue('fusion_verbose' not in result_default.as_dict()['results'][0]['metadata'], 
-                        msg="fusion must not work by default for satevector")
-
+        self.assertTrue(
+            'results' in result_default.as_dict(),
+            msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result_default.as_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' not in result_default.as_dict()['results'][0]
+            ['metadata'],
+            msg="fusion must not work by default for satevector")
 
     def test_fusion_operations(self):
         """Test Fusion enable/disable option"""
         shots = 100
-        
+
         qr = QuantumRegister(10)
         cr = ClassicalRegister(10)
         circuit = QuantumCircuit(qr, cr)
-        
+
         for i in range(10):
             circuit.h(qr[i])
             circuit.barrier(qr)
-            
+
         circuit.x(qr[0])
         circuit.barrier(qr)
         circuit.x(qr[1])
@@ -180,11 +254,11 @@ class QasmFusionTests:
         circuit.barrier(qr)
         circuit.cx(qr[2], qr[3])
         circuit.barrier(qr)
-        circuit.u3(0.1,0.1,0.1,qr[3])
+        circuit.u3(0.1, 0.1, 0.1, qr[3])
         circuit.barrier(qr)
-        circuit.u3(0.1,0.1,0.1,qr[3])
+        circuit.u3(0.1, 0.1, 0.1, qr[3])
         circuit.barrier(qr)
-        
+
         circuit.x(qr[0])
         circuit.barrier(qr)
         circuit.x(qr[1])
@@ -195,11 +269,11 @@ class QasmFusionTests:
         circuit.barrier(qr)
         circuit.cx(qr[2], qr[3])
         circuit.barrier(qr)
-        circuit.u3(0.1,0.1,0.1,qr[3])
+        circuit.u3(0.1, 0.1, 0.1, qr[3])
         circuit.barrier(qr)
-        circuit.u3(0.1,0.1,0.1,qr[3])
+        circuit.u3(0.1, 0.1, 0.1, qr[3])
         circuit.barrier(qr)
-        
+
         circuit.x(qr[0])
         circuit.barrier(qr)
         circuit.x(qr[1])
@@ -210,20 +284,35 @@ class QasmFusionTests:
         circuit.barrier(qr)
         circuit.cx(qr[2], qr[3])
         circuit.barrier(qr)
-        circuit.u3(0.1,0.1,0.1,qr[3])
+        circuit.u3(0.1, 0.1, 0.1, qr[3])
         circuit.barrier(qr)
-        circuit.u3(0.1,0.1,0.1,qr[3])
+        circuit.u3(0.1, 0.1, 0.1, qr[3])
         circuit.barrier(qr)
-        
+
         circuit.measure(qr, cr)
 
-        qobj = compile([circuit], self.SIMULATOR, shots=shots, seed=1)
- 
-        result_fusion = self.SIMULATOR.run(qobj, backend_options={'fusion_enable': True, 'fusion_verbose': True, 'fusion_threshold': 1}).result()
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed=1)
+
+        result_fusion = self.SIMULATOR.run(
+            qobj,
+            backend_options={
+                'fusion_enable': True,
+                'fusion_verbose': True,
+                'fusion_threshold': 1
+            }).result()
         self.is_completed(result_fusion)
-        
-        result_nonfusion = self.SIMULATOR.run(qobj, backend_options={'fusion_enable': False, 'fusion_verbose': True, 'fusion_threshold': 1}).result()
+
+        result_nonfusion = self.SIMULATOR.run(
+            qobj,
+            backend_options={
+                'fusion_enable': False,
+                'fusion_verbose': True,
+                'fusion_threshold': 1
+            }).result()
         self.is_completed(result_nonfusion)
 
-        self.assertDictAlmostEqual(result_fusion.get_counts(circuit), result_nonfusion.get_counts(circuit), delta=0.0, msg="fusion x-x-x was failed")
-      
+        self.assertDictAlmostEqual(
+            result_fusion.get_counts(circuit),
+            result_nonfusion.get_counts(circuit),
+            delta=0.0,
+            msg="fusion x-x-x was failed")

--- a/test/terra/backends/qasm_simulator/qasm_initialize.py
+++ b/test/terra/backends/qasm_simulator/qasm_initialize.py
@@ -9,7 +9,7 @@ QasmSimulator Integration Tests
 """
 
 from test.terra.reference import ref_initialize
-from qiskit import compile
+from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
 
 
@@ -29,7 +29,7 @@ class QasmInitializeTests:
         shots = 2000
         circuits = ref_initialize.initialize_circuits_1(final_measure=True)
         targets = ref_initialize.initialize_counts_1(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
@@ -42,7 +42,7 @@ class QasmInitializeTests:
         shots = 2000
         circuits = ref_initialize.initialize_circuits_2(final_measure=True)
         targets = ref_initialize.initialize_counts_2(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
@@ -53,7 +53,7 @@ class QasmInitializeTests:
         shots = 2000
         circuits = ref_initialize.initialize_sampling_optimization()
         targets = ref_initialize.initialize_counts_sampling_optimization(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)

--- a/test/terra/backends/qasm_simulator/qasm_measure.py
+++ b/test/terra/backends/qasm_simulator/qasm_measure.py
@@ -9,7 +9,7 @@ QasmSimulator Integration Tests
 """
 
 from test.terra.reference import ref_measure
-from qiskit import compile
+from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
 
 
@@ -28,7 +28,7 @@ class QasmMeasureTests:
         circuits = ref_measure.measure_circuits_deterministic(
             allow_sampling=True)
         targets = ref_measure.measure_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
@@ -40,7 +40,7 @@ class QasmMeasureTests:
         circuits = ref_measure.measure_circuits_deterministic(
             allow_sampling=False)
         targets = ref_measure.measure_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
@@ -52,7 +52,7 @@ class QasmMeasureTests:
         circuits = ref_measure.measure_circuits_nondeterministic(
             allow_sampling=True)
         targets = ref_measure.measure_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
@@ -64,7 +64,7 @@ class QasmMeasureTests:
         circuits = ref_measure.measure_circuits_nondeterministic(
             allow_sampling=False)
         targets = ref_measure.measure_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)

--- a/test/terra/backends/qasm_simulator/qasm_method.py
+++ b/test/terra/backends/qasm_simulator/qasm_method.py
@@ -10,7 +10,7 @@ QasmSimulator Integration Tests
 
 from test.terra.reference import ref_2q_clifford
 from test.terra.reference import ref_non_clifford
-from qiskit import compile
+from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer import AerError
 from qiskit.providers.aer.noise import NoiseModel
@@ -34,7 +34,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -71,7 +71,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -101,7 +101,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -132,7 +132,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -162,7 +162,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -189,7 +189,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -225,7 +225,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -254,7 +254,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -283,7 +283,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(
@@ -313,7 +313,7 @@ class QasmMethodTests:
         shots = 100
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
         def get_result():
             return self.SIMULATOR.run(

--- a/test/terra/backends/qasm_simulator/qasm_noncliffords.py
+++ b/test/terra/backends/qasm_simulator/qasm_noncliffords.py
@@ -9,7 +9,7 @@ QasmSimulator Integration Tests
 """
 
 from test.terra.reference import ref_non_clifford
-from qiskit import compile
+from qiskit import execute
 from qiskit.providers.aer import QasmSimulator
 
 
@@ -28,8 +28,8 @@ class QasmNonCliffordTests:
         circuits = ref_non_clifford.t_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -39,8 +39,8 @@ class QasmNonCliffordTests:
         circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -53,8 +53,8 @@ class QasmNonCliffordTests:
         circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -64,8 +64,8 @@ class QasmNonCliffordTests:
         circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -78,8 +78,8 @@ class QasmNonCliffordTests:
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -89,8 +89,8 @@ class QasmNonCliffordTests:
         circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -110,12 +110,8 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.t_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
-        qobj = compile(
-            circuits,
-            self.SIMULATOR,
-            shots=shots,
-            basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -125,12 +121,8 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
-        qobj = compile(
-            circuits,
-            self.SIMULATOR,
-            shots=shots,
-            basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -143,12 +135,8 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
-        qobj = compile(
-            circuits,
-            self.SIMULATOR,
-            shots=shots,
-            basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -158,12 +146,8 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
-        qobj = compile(
-            circuits,
-            self.SIMULATOR,
-            shots=shots,
-            basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -176,12 +160,8 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
-        qobj = compile(
-            circuits,
-            self.SIMULATOR,
-            shots=shots,
-            basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -191,12 +171,8 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
-        qobj = compile(
-            circuits,
-            self.SIMULATOR,
-            shots=shots,
-            basis_gates=['u1', 'u2', 'u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -216,9 +192,8 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.t_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -228,9 +203,8 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -243,9 +217,8 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -255,9 +228,8 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -270,9 +242,8 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
@@ -282,8 +253,7 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-        result = self.SIMULATOR.run(qobj).result()
+        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_reset.py
+++ b/test/terra/backends/qasm_simulator/qasm_reset.py
@@ -9,7 +9,7 @@ QasmSimulator Integration Tests
 """
 
 from test.terra.reference import ref_reset
-from qiskit import compile
+from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
 
 
@@ -29,7 +29,7 @@ class QasmResetTests:
         shots = 100
         circuits = ref_reset.reset_circuits_deterministic(final_measure=True)
         targets = ref_reset.reset_counts_deterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
@@ -43,7 +43,7 @@ class QasmResetTests:
         circuits = ref_reset.reset_circuits_nondeterministic(
             final_measure=True)
         targets = ref_reset.reset_counts_nondeterministic(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
@@ -54,7 +54,7 @@ class QasmResetTests:
         shots = 2000
         circuits = ref_reset.reset_sampling_optimization()
         targets = ref_reset.reset_counts_sampling_optimization(shots)
-        qobj = compile(circuits, self.SIMULATOR, shots=shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)

--- a/test/terra/backends/qasm_simulator/qasm_thread_management.py
+++ b/test/terra/backends/qasm_simulator/qasm_thread_management.py
@@ -12,7 +12,7 @@ import multiprocessing
 import psutil
 
 from test.benchmark.tools import quantum_volume_circuit
-from qiskit import compile
+from qiskit import execute
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
@@ -36,13 +36,10 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = 100
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(
-            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-
         backend_opts = self.BACKEND_OPTS.copy()
-
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuit, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         if result.metadata['omp_enabled']:
             self.assertEqual(
                 result.metadata['parallel_experiments'],
@@ -64,13 +61,10 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = 100
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(
-            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
-
         backend_opts = self.BACKEND_OPTS.copy()
-
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuit, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         system_memory = int(psutil.virtual_memory().total / 1024 / 1024)
         self.assertGreaterEqual(
             result.metadata['max_memory_mb'],
@@ -86,14 +80,13 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = 100
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(
-            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_memory_mb'] = 128
 
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuit, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         self.assertEqual(
             result.metadata['max_memory_mb'],
             128,
@@ -107,15 +100,14 @@ class QasmThreadManagementTests:
         circuits = []
         for _ in range(experiments):
             circuits.append(quantum_volume_circuit(4, 1, measure=True, seed=0))
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_experiments'] = experiments
         backend_opts['max_memory_mb'] = 1024
 
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuits, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         if result.metadata['omp_enabled']:
             self.assertEqual(
                 result.metadata['parallel_experiments'],
@@ -142,15 +134,14 @@ class QasmThreadManagementTests:
             circuits.append(
                 quantum_volume_circuit(16, 1, measure=True,
                                        seed=0))  # 2 MB for each
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_experiments'] = experiments
         backend_opts['max_memory_mb'] = 1
 
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuits, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         if result.metadata['omp_enabled']:
             self.assertEqual(
                 result.metadata['parallel_experiments'],
@@ -179,15 +170,14 @@ class QasmThreadManagementTests:
             circuits.append(
                 quantum_volume_circuit(4, 1, measure=True,
                                        seed=0))  # 2 MB for each
-        qobj = compile(
-            circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_experiments'] = experiments
         backend_opts['max_memory_mb'] = 1024
 
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuits, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         if result.metadata['omp_enabled']:
             self.assertEqual(
                 result.metadata['parallel_experiments'],
@@ -204,15 +194,14 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = multiprocessing.cpu_count()
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(
-            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_shots'] = shots
         backend_opts['noise_model'] = self.dummy_noise_model()
 
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuit, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         if result.metadata['omp_enabled']:
             self.assertEqual(
                 result.metadata['parallel_experiments'],
@@ -234,14 +223,13 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = multiprocessing.cpu_count()
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(
-            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_shots'] = shots
 
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuit, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         if result.metadata['omp_enabled']:
             self.assertEqual(
                 result.metadata['parallel_experiments'],
@@ -265,15 +253,14 @@ class QasmThreadManagementTests:
         if shots == 0:
             return
         circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
-        qobj = compile(
-            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_shots'] = multiprocessing.cpu_count()
         backend_opts['noise_model'] = self.dummy_noise_model()
 
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuit, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         if result.metadata['omp_enabled']:
             self.assertEqual(
                 result.metadata['parallel_experiments'],
@@ -295,16 +282,15 @@ class QasmThreadManagementTests:
         # Test circuit
         shots = multiprocessing.cpu_count()
         circuit = quantum_volume_circuit(16, 1, measure=True, seed=0)
-        qobj = compile(
-            circuit, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
 
         backend_opts = self.BACKEND_OPTS.copy()
         backend_opts['max_parallel_shots'] = shots
         backend_opts['noise_model'] = self.dummy_noise_model()
         backend_opts['max_memory_mb'] = 1
 
-        result = self.SIMULATOR.run(
-            qobj, backend_options=backend_opts).result()
+        result = execute(
+            circuit, self.SIMULATOR, shots=shots,
+            backend_options=backend_opts).result()
         if result.metadata['omp_enabled']:
             self.assertEqual(
                 result.metadata['parallel_experiments'],

--- a/test/terra/backends/test_qasm_extended_stabilizer_simulator.py
+++ b/test/terra/backends/test_qasm_extended_stabilizer_simulator.py
@@ -4,7 +4,6 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
-
 """
 ExtendedStabilizer Integration Tests
 """
@@ -40,11 +39,8 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         circuits = ref_reset.reset_circuits_deterministic(final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_reset.reset_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj, backend_options={"method": "extended_stabilizer"})
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -54,14 +50,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         # For statevector output we can combine deterministic and non-deterministic
         # count output circuits
         shots = 2000
-        circuits = ref_reset.reset_circuits_nondeterministic(final_measure=True)
+        circuits = ref_reset.reset_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_reset.reset_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -72,14 +70,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_measure_deterministic_with_sampling(self):
         """Test ExtendedStabilizer measure with deterministic counts with sampling"""
         shots = 100
-        circuits = ref_measure.measure_circuits_deterministic(allow_sampling=True)
+        circuits = ref_measure.measure_circuits_deterministic(
+            allow_sampling=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_measure.measure_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -87,14 +87,12 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_measure_deterministic_without_sampling(self):
         """Test ExtendedStabilizer measure with deterministic counts without sampling"""
         shots = 100
-        circuits = ref_measure.measure_circuits_deterministic(allow_sampling=False)
+        circuits = ref_measure.measure_circuits_deterministic(
+            allow_sampling=False)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_measure.measure_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj, backend_options={"method": "extended_stabilizer"})
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -102,14 +100,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_measure_nondeterministic_with_sampling(self):
         """Test CHimulator measure with non-deterministic counts with sampling"""
         shots = 2000
-        circuits = ref_measure.measure_circuits_nondeterministic(allow_sampling=True)
+        circuits = ref_measure.measure_circuits_nondeterministic(
+            allow_sampling=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_measure.measure_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -117,14 +117,12 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_measure_nondeterministic_without_sampling(self):
         """Test CHimulator measure with non-deterministic counts without sampling"""
         shots = 2000
-        circuits = ref_measure.measure_circuits_nondeterministic(allow_sampling=False)
+        circuits = ref_measure.measure_circuits_nondeterministic(
+            allow_sampling=False)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_measure.measure_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj, backend_options={"method": "extended_stabilizer"})
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -135,15 +133,17 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_measure_deterministic_multi_qubit_with_sampling(self):
         """Test ExtendedStabilizer multi-qubit measure with deterministic counts with sampling"""
         shots = 100
-        qobj = ref_measure.measure_circuits_qobj_deterministic(allow_sampling=True)
+        qobj = ref_measure.measure_circuits_qobj_deterministic(
+            allow_sampling=True)
         qobj.config.shots = shots
         circuits = [experiment.header.name for experiment in qobj.experiments]
         targets = ref_measure.measure_counts_qobj_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -151,15 +151,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_measure_deterministic_multi_qubit_without_sampling(self):
         """Test ExtendedStabilizer multi-qubit measure with deterministic counts without sampling"""
         shots = 100
-        qobj = ref_measure.measure_circuits_qobj_deterministic(allow_sampling=False)
+        qobj = ref_measure.measure_circuits_qobj_deterministic(
+            allow_sampling=False)
         qobj.config.shots = shots
         circuits = [experiment.header.name for experiment in qobj.experiments]
         targets = ref_measure.measure_counts_qobj_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer"
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -167,15 +168,17 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_measure_nondeterministic_multi_qubit_with_sampling(self):
         """Test CHimulator reset with non-deterministic counts"""
         shots = 2000
-        qobj = ref_measure.measure_circuits_qobj_nondeterministic(allow_sampling=True)
+        qobj = ref_measure.measure_circuits_qobj_nondeterministic(
+            allow_sampling=True)
         qobj.config.shots = shots
         circuits = [experiment.header.name for experiment in qobj.experiments]
         targets = ref_measure.measure_counts_qobj_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -183,15 +186,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_measure_nondeterministic_multi_qubit_without_sampling(self):
         """Test CHimulator reset with non-deterministic counts"""
         shots = 2000
-        qobj = ref_measure.measure_circuits_qobj_nondeterministic(allow_sampling=False)
+        qobj = ref_measure.measure_circuits_qobj_nondeterministic(
+            allow_sampling=False)
         qobj.config.shots = shots
         circuits = [experiment.header.name for experiment in qobj.experiments]
         targets = ref_measure.measure_counts_qobj_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer"
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -202,14 +206,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_conditional_1bit(self):
         """Test conditional operations on 1-bit conditional register."""
         shots = 100
-        circuits = ref_conditionals.conditional_circuits_1bit(final_measure=True)
+        circuits = ref_conditionals.conditional_circuits_1bit(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_conditionals.conditional_counts_1bit(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -217,14 +223,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_conditional_2bit(self):
         """Test conditional operations on 2-bit conditional register."""
         shots = 100
-        circuits = ref_conditionals.conditional_circuits_2bit(final_measure=True)
+        circuits = ref_conditionals.conditional_circuits_2bit(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_conditionals.conditional_counts_2bit(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -235,14 +243,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_h_gate_deterministic_default_basis_gates(self):
         """Test h-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_1q_clifford.h_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_1q_clifford.h_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.h_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -250,14 +260,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_h_gate_nondeterministic_default_basis_gates(self):
         """Test h-gate circuits compiling to backend default basis_gates."""
         shots = 2000
-        circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(final_measure=True)
+        circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.h_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -268,14 +280,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_x_gate_deterministic_default_basis_gates(self):
         """Test x-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_1q_clifford.x_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_1q_clifford.x_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.x_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -286,14 +300,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_z_gate_deterministic_default_basis_gates(self):
         """Test z-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_1q_clifford.z_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_1q_clifford.z_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.z_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -304,14 +320,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_y_gate_deterministic_default_basis_gates(self):
         """Test y-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_1q_clifford.y_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_1q_clifford.y_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -322,14 +340,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_s_gate_deterministic_default_basis_gates(self):
         """Test s-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_1q_clifford.s_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_1q_clifford.s_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.s_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -337,14 +357,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_s_gate_nondeterministic_default_basis_gates(self):
         """Test s-gate circuits compiling to backend default basis_gates."""
         shots = 2000
-        circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(final_measure=True)
+        circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.s_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -355,14 +377,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_sdg_gate_deterministic_default_basis_gates(self):
         """Test sdg-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.sdg_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -370,14 +394,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_sdg_gate_nondeterministic_default_basis_gates(self):
         shots = 2000
         """Test sdg-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(final_measure=True)
+        circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.sdg_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -388,14 +414,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_cx_gate_deterministic_default_basis_gates(self):
         """Test cx-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.cx_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -403,14 +431,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_cx_gate_nondeterministic_default_basis_gates(self):
         """Test cx-gate circuits compiling to backend default basis_gates."""
         shots = 2000
-        circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(final_measure=True)
+        circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.cx_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -421,14 +451,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_cz_gate_deterministic_default_basis_gates(self):
         """Test cz-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_2q_clifford.cz_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.cz_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -436,14 +468,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_cz_gate_nondeterministic_default_basis_gates(self):
         """Test cz-gate circuits compiling to backend default basis_gates."""
         shots = 2000
-        circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(final_measure=True)
+        circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.cz_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -454,14 +488,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_swap_gate_deterministic_default_basis_gates(self):
         """Test swap-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_2q_clifford.swap_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_2q_clifford.swap_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.swap_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -469,14 +505,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_swap_gate_nondeterministic_default_basis_gates(self):
         """Test swap-gate circuits compiling to backend default basis_gates."""
         shots = 2000
-        circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(final_measure=True)
+        circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.swap_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_measure_sampling": True
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -487,32 +525,35 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_t_gate_deterministic_default_basis_gates(self):
         """Test t-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_non_clifford.t_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_non_clifford.t_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer"
+            })
         result = job.result()
         self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+        self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     def test_t_gate_nondeterministic_default_basis_gates(self):
         """Test t-gate circuits compiling to backend default basis_gates."""
-        shots = 2000
-        circuits = ref_non_clifford.t_gate_circuits_nondeterministic(final_measure=True)
+        shots = 500
+        circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      'extended_stabilizer_mixing_time': 50
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                'extended_stabilizer_mixing_time': 50
+            })
         result = job.result()
         self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+        self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     # ---------------------------------------------------------------------
     # Test tdg-gate
@@ -520,33 +561,36 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_tdg_gate_deterministic_default_basis_gates(self):
         """Test tdg-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_non_clifford.tdg_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer"
+            })
         result = job.result()
         self.is_completed(result)
 
-        self.compare_counts(result, circuits, targets, delta=0.05*shots)
+        self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     def test_tdg_gate_nondeterministic_default_basis_gates(self):
         """Test tdg-gate circuits compiling to backend default basis_gates."""
-        shots = 2000
-        circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(final_measure=True)
+        shots = 500
+        circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "extended_stabilizer_mixing_time": 50
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_mixing_time": 50
+            })
         result = job.result()
         self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+        self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     # ---------------------------------------------------------------------
     # Test ccx-gate
@@ -554,14 +598,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_ccx_gate_deterministic_default_basis_gates(self):
         """Test ccx-gate circuits compiling to backend default basis_gates."""
         shots = 100
-        circuits = ref_non_clifford.ccx_gate_circuits_deterministic(final_measure=True)
+        circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "extended_stabilizer_mixing_time": 100
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_mixing_time": 100
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -569,15 +615,16 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     def test_ccx_gate_nondeterministic_default_basis_gates(self):
         """Test ccx-gate circuits compiling to backend default basis_gates."""
         shots = 500
-        circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(final_measure=True)
+        circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
+            final_measure=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "extended_stabilizer_mixing_time": 100,
-                                      "disable_measurement_opt": True
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_mixing_time": 100
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.10 * shots)
@@ -587,34 +634,36 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
     # # ---------------------------------------------------------------------
     def test_grovers_default_basis_gates(self):
         """Test grovers circuits compiling to backend default basis_gates."""
-        shots = 2000
-        circuits = ref_algorithms.grovers_circuit(final_measure=True,
-                                                  allow_sampling=True)
+        shots = 500
+        circuits = ref_algorithms.grovers_circuit(
+            final_measure=True, allow_sampling=True)
         qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
         targets = ref_algorithms.grovers_counts(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "extended_stabilizer_mixing_time": 100,
-                                  })
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer",
+                "extended_stabilizer_mixing_time": 100,
+            })
+        result = job.result()
+        self.is_completed(result)
+        self.compare_counts(result, circuits, targets, delta=0.1 * shots)
+
+    def test_teleport_default_basis_gates(self):
+        """Test teleport circuits compiling to backend default basis_gates."""
+        shots = 1000
+        circuits = ref_algorithms.teleport_circuit()
+        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        targets = ref_algorithms.teleport_counts(shots)
+        job = QasmSimulator().run(
+            qobj,
+            backend_options={
+                "method": "extended_stabilizer"
+            })
         result = job.result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
-    def test_teleport_default_basis_gates(self):
-        """Test teleport circuits compiling to backend default basis_gates."""
-        shots = 2000
-        circuits = ref_algorithms.teleport_circuit()
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
-        targets = ref_algorithms.teleport_counts(shots)
-        job = QasmSimulator().run(qobj,
-                                  backend_options={
-                                      "method": "extended_stabilizer",
-                                      "disable_measurement_opt": False
-                                  })
-        result = job.result()
-        self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/backends/test_qasm_extended_stabilizer_simulator.py
+++ b/test/terra/backends/test_qasm_extended_stabilizer_simulator.py
@@ -19,7 +19,7 @@ from test.terra.reference import ref_2q_clifford
 from test.terra.reference import ref_non_clifford
 from test.terra.reference import ref_algorithms
 
-from qiskit import compile as qiskit_compile
+from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         # count output circuits
         shots = 100
         circuits = ref_reset.reset_circuits_deterministic(final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_reset.reset_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj, backend_options={"method": "extended_stabilizer"})
@@ -52,7 +52,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 2000
         circuits = ref_reset.reset_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_reset.reset_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -72,7 +72,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_measure.measure_circuits_deterministic(
             allow_sampling=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_measure.measure_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -89,7 +89,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_measure.measure_circuits_deterministic(
             allow_sampling=False)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_measure.measure_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj, backend_options={"method": "extended_stabilizer"})
@@ -102,7 +102,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 2000
         circuits = ref_measure.measure_circuits_nondeterministic(
             allow_sampling=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_measure.measure_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -119,7 +119,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 2000
         circuits = ref_measure.measure_circuits_nondeterministic(
             allow_sampling=False)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_measure.measure_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj, backend_options={"method": "extended_stabilizer"})
@@ -208,7 +208,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_conditionals.conditional_circuits_1bit(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_conditionals.conditional_counts_1bit(shots)
         job = QasmSimulator().run(
             qobj,
@@ -225,7 +225,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_conditionals.conditional_circuits_2bit(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_conditionals.conditional_counts_2bit(shots)
         job = QasmSimulator().run(
             qobj,
@@ -245,7 +245,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_1q_clifford.h_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.h_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -262,7 +262,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 2000
         circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.h_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -282,7 +282,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_1q_clifford.x_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.x_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -302,7 +302,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_1q_clifford.z_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.z_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -322,7 +322,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_1q_clifford.y_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -342,7 +342,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_1q_clifford.s_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.s_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -359,7 +359,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 2000
         circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.s_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -379,7 +379,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.sdg_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -396,7 +396,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         """Test sdg-gate circuits compiling to backend default basis_gates."""
         circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_1q_clifford.sdg_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -416,7 +416,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.cx_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -433,7 +433,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 2000
         circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.cx_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -453,7 +453,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.cz_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -470,7 +470,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 2000
         circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.cz_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -490,7 +490,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_2q_clifford.swap_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.swap_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -507,7 +507,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 2000
         circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_2q_clifford.swap_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -527,7 +527,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_non_clifford.t_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -543,7 +543,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 500
         circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -563,7 +563,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -580,7 +580,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 500
         circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -600,7 +600,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 100
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -617,7 +617,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 500
         circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
             final_measure=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(
             qobj,
@@ -637,7 +637,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         shots = 500
         circuits = ref_algorithms.grovers_circuit(
             final_measure=True, allow_sampling=True)
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_algorithms.grovers_counts(shots)
         job = QasmSimulator().run(
             qobj,
@@ -653,7 +653,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         """Test teleport circuits compiling to backend default basis_gates."""
         shots = 1000
         circuits = ref_algorithms.teleport_circuit()
-        qobj = qiskit_compile(circuits, QasmSimulator(), shots=shots)
+        qobj = assemble(circuits, QasmSimulator(), shots=shots)
         targets = ref_algorithms.teleport_counts(shots)
         job = QasmSimulator().run(
             qobj,

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -4,7 +4,6 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
-
 """
 NoiseModel class integration tests
 """
@@ -12,7 +11,7 @@ NoiseModel class integration tests
 import unittest
 from test.terra import common
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit import compile
+from qiskit.compiler import assemble, transpile
 from qiskit.providers.aer.backends import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.quantum_error import QuantumError
@@ -49,12 +48,14 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_readout_error([probs_given0, probs_given1], [0])
 
         shots = 2000
-        target = {'0x0': probs_given0[0] * shots / 2,
-                  '0x1': probs_given0[1] * shots / 2,
-                  '0x2': probs_given1[0] * shots / 2,
-                  '0x3': probs_given1[1] * shots / 2}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        target = {
+            '0x0': probs_given0[0] * shots / 2,
+            '0x1': probs_given0[1] * shots / 2,
+            '0x2': probs_given1[0] * shots / 2,
+            '0x3': probs_given1[1] * shots / 2
+        }
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -82,12 +83,14 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_readout_error([probs_given0, probs_given1], [1])
 
         shots = 2000
-        target = {'0x0': probs_given0[0] * shots / 2,
-                  '0x1': probs_given1[0] * shots / 2,
-                  '0x2': probs_given0[1] * shots / 2,
-                  '0x3': probs_given1[1] * shots / 2}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        target = {
+            '0x0': probs_given0[0] * shots / 2,
+            '0x1': probs_given1[0] * shots / 2,
+            '0x2': probs_given0[1] * shots / 2,
+            '0x3': probs_given1[1] * shots / 2
+        }
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -116,14 +119,20 @@ class TestNoise(common.QiskitAerTestCase):
 
         # Expected counts
         shots = 2000
-        p00 = 0.5 * (probs_given0[0] ** 2 + probs_given1[0] ** 2)
-        p01 = 0.5 * (probs_given0[0] * probs_given0[1] + probs_given1[0] * probs_given1[1])
-        p10 = 0.5 * (probs_given0[0] * probs_given0[1] + probs_given1[0] * probs_given1[1])
-        p11 = 0.5 * (probs_given0[1] ** 2 + probs_given1[1] ** 2)
-        target = target = {'0x0': p00 * shots, '0x1': p01 * shots,
-                           '0x2': p10 * shots, '0x3': p11 * shots}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        p00 = 0.5 * (probs_given0[0]**2 + probs_given1[0]**2)
+        p01 = 0.5 * (probs_given0[0] * probs_given0[1] +
+                     probs_given1[0] * probs_given1[1])
+        p10 = 0.5 * (probs_given0[0] * probs_given0[1] +
+                     probs_given1[0] * probs_given1[1])
+        p11 = 0.5 * (probs_given0[1]**2 + probs_given1[1]**2)
+        target = target = {
+            '0x0': p00 * shots,
+            '0x1': p01 * shots,
+            '0x2': p10 * shots,
+            '0x3': p11 * shots
+        }
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -137,7 +146,7 @@ class TestNoise(common.QiskitAerTestCase):
         circuit.h(qr)
         circuit.barrier(qr)
         # We will manually add a correlated measure operation to
-        # the compiled qobj
+        # the assembled qobj
         backend = QasmSimulator()
 
         # Correlated 2-qubit readout error
@@ -145,21 +154,35 @@ class TestNoise(common.QiskitAerTestCase):
         probs_given01 = [0, 0.6, 0.4, 0]
         probs_given10 = [0, 0, 1, 0]
         probs_given11 = [0.1, 0, 0, 0.9]
-        probs_noise = [probs_given00, probs_given01, probs_given10, probs_given11]
+        probs_noise = [
+            probs_given00, probs_given01, probs_given10, probs_given11
+        ]
         noise_model = NoiseModel()
         noise_model.add_readout_error(probs_noise, [0, 1])
 
         # Expected counts
         shots = 2000
         probs_ideal = [0.25, 0.25, 0.25, 0.25]
-        p00 = sum([ideal * noise[0] for ideal, noise in zip(probs_ideal, probs_noise)])
-        p01 = sum([ideal * noise[1] for ideal, noise in zip(probs_ideal, probs_noise)])
-        p10 = sum([ideal * noise[2] for ideal, noise in zip(probs_ideal, probs_noise)])
-        p11 = sum([ideal * noise[3] for ideal, noise in zip(probs_ideal, probs_noise)])
-        target = {'0x0': p00 * shots, '0x1': p01 * shots,
-                  '0x2': p10 * shots, '0x3': p11 * shots}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        p00 = sum([
+            ideal * noise[0] for ideal, noise in zip(probs_ideal, probs_noise)
+        ])
+        p01 = sum([
+            ideal * noise[1] for ideal, noise in zip(probs_ideal, probs_noise)
+        ])
+        p10 = sum([
+            ideal * noise[2] for ideal, noise in zip(probs_ideal, probs_noise)
+        ])
+        p11 = sum([
+            ideal * noise[3] for ideal, noise in zip(probs_ideal, probs_noise)
+        ])
+        target = {
+            '0x0': p00 * shots,
+            '0x1': p01 * shots,
+            '0x2': p10 * shots,
+            '0x3': p11 * shots
+        }
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         # Add measure to qobj
         item = measure_instr([0, 1], [0, 1])
         append_instr(qobj, 0, item)
@@ -178,8 +201,13 @@ class TestNoise(common.QiskitAerTestCase):
         circuit.x(qr)
         circuit.measure(qr, cr)
         backend = QasmSimulator()
-        noise_circs = [[{"name": "reset", "qubits": [0]}],
-                       [{"name": "id", "qubits": [0]}]]
+        noise_circs = [[{
+            "name": "reset",
+            "qubits": [0]
+        }], [{
+            "name": "id",
+            "qubits": [0]
+        }]]
 
         # 50% reset noise on qubit-0 "u3" only.
         noise_probs = [0.5, 0.5]
@@ -188,8 +216,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_quantum_error(error, "u3", [0])
         shots = 2000
         target = {'0x2': shots / 2, '0x3': shots / 2}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -204,8 +232,13 @@ class TestNoise(common.QiskitAerTestCase):
         circuit.x(qr)
         circuit.measure(qr, cr)
         backend = QasmSimulator()
-        noise_circs = [[{"name": "reset", "qubits": [0]}],
-                       [{"name": "id", "qubits": [0]}]]
+        noise_circs = [[{
+            "name": "reset",
+            "qubits": [0]
+        }], [{
+            "name": "id",
+            "qubits": [0]
+        }]]
 
         # 25% reset noise on qubit-1 "u3" only.
         noise_probs = [0.25, 0.75]
@@ -215,8 +248,8 @@ class TestNoise(common.QiskitAerTestCase):
         shots = 2000
         # target = {'01': shots / 4, '11': 3 * shots / 4}
         target = {'0x1': shots / 4, '0x3': 3 * shots / 4}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -231,8 +264,13 @@ class TestNoise(common.QiskitAerTestCase):
         circuit.x(qr)
         circuit.measure(qr, cr)
         backend = QasmSimulator()
-        noise_circs = [[{"name": "reset", "qubits": [0]}],
-                       [{"name": "id", "qubits": [0]}]]
+        noise_circs = [[{
+            "name": "reset",
+            "qubits": [0]
+        }], [{
+            "name": "id",
+            "qubits": [0]
+        }]]
 
         # 100% reset noise on all qubit "u3".
         noise_probs = [1, 0]
@@ -242,8 +280,8 @@ class TestNoise(common.QiskitAerTestCase):
         shots = 100
         # target = {'00': shots}
         target = {'0x0': shots}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0)
@@ -264,8 +302,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_all_qubit_quantum_error(error, 'id')
         # Execute
         target = {'0x3': shots}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0)
@@ -285,10 +323,14 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model = NoiseModel()
         noise_model.add_all_qubit_quantum_error(error, 'id')
         # Execute
-        target = {'0x0': 9 * shots / 16, '0x1': 3 * shots / 16,
-                  '0x2': 3 * shots / 16, '0x3': shots / 16}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        target = {
+            '0x0': 9 * shots / 16,
+            '0x1': 3 * shots / 16,
+            '0x2': 3 * shots / 16,
+            '0x3': shots / 16
+        }
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -309,8 +351,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_quantum_error(error, 'id', [1])
         # Execute
         target = {'0x2': shots}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0)
@@ -331,8 +373,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_quantum_error(error, 'id', [0])
         # Execute
         target = {'0x0': 3 * shots / 4, '0x1': shots / 4}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -355,8 +397,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_nonlocal_quantum_error(error, 'cx', [0, 1], [0, 1, 2])
         # Execute
         target = {'0x0': 3 * shots / 4, '0x4': shots / 4}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -374,10 +416,14 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model = NoiseModel()
         noise_model.add_all_qubit_quantum_error(error, 'measure')
         # Execute
-        target = {'0x0': 9 * shots / 16, '0x1': 3 * shots / 16,
-                  '0x2': 3 * shots / 16, '0x3': shots / 16}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        target = {
+            '0x0': 9 * shots / 16,
+            '0x1': 3 * shots / 16,
+            '0x2': 3 * shots / 16,
+            '0x3': shots / 16
+        }
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -396,8 +442,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_quantum_error(error, 'measure', [1])
         # Execute
         target = {'0x0': 3 * shots / 4, '0x2': shots / 4}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -419,8 +465,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_nonlocal_quantum_error(error, 'measure', [0], [1])
         # Execute
         target = {'0x0': 3 * shots / 4, '0x2': shots / 4}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -441,10 +487,14 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model = NoiseModel()
         noise_model.add_all_qubit_quantum_error(error, 'reset')
         # Execute
-        target = {'0x0': 9 * shots / 16, '0x1': 3 * shots / 16,
-                  '0x2': 3 * shots / 16, '0x3': shots / 16}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        target = {
+            '0x0': 9 * shots / 16,
+            '0x1': 3 * shots / 16,
+            '0x2': 3 * shots / 16,
+            '0x3': shots / 16
+        }
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -466,8 +516,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_quantum_error(error, 'reset', [1])
         # Execute
         target = {'0x0': 3 * shots / 4, '0x2': shots / 4}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -491,8 +541,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_nonlocal_quantum_error(error, 'reset', [0], [1])
         # Execute
         target = {'0x0': 3 * shots / 4, '0x2': shots / 4}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -517,8 +567,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_all_qubit_quantum_error(error, 'id')
         # Execute
         target = {'0x0': 3 * shots / 4, '0x1': shots / 4}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
@@ -539,8 +589,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_all_qubit_quantum_error(error, ['id', 'x'])
         # Execute
         target = {'0x0': shots}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0)
@@ -561,8 +611,8 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model.add_all_qubit_quantum_error(error, ['id', 'x'])
         # Execute
         target = {'0x1': shots}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0)
@@ -583,13 +633,18 @@ class TestNoise(common.QiskitAerTestCase):
         noise_model = NoiseModel()
         noise_model.add_all_qubit_quantum_error(error, ['id', 'x'])
         # Execute
-        target = {'0x0': 3 * shots / 16, '0x1': shots / 16,
-                  '0x2': 9 * shots / 16, '0x3': 3 * shots / 16}
-        qobj = compile([circuit], backend, shots=shots,
-                       basis_gates=noise_model.basis_gates)
+        target = {
+            '0x0': 3 * shots / 16,
+            '0x1': shots / 16,
+            '0x2': 9 * shots / 16,
+            '0x3': 3 * shots / 16
+        }
+        circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
+        qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
         self.is_completed(result)
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/reference/ref_measure.py
+++ b/test/terra/reference/ref_measure.py
@@ -14,8 +14,8 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 
 # The following is temporarily needed for qobj compiling
 # to test multi-qubit measurements which must be implemeted
-# direclty by qobj instructions until terra compiler supports them
-from qiskit import compile
+# direclty by qobj instructions until terra assembler supports them
+from qiskit.compiler import assemble
 from qiskit.providers.aer.backends import QasmSimulator
 from qiskit.providers.aer.utils.qobj_utils import insert_instr
 from qiskit.providers.aer.utils.qobj_utils import measure_instr
@@ -163,7 +163,7 @@ def _dummy_qobj():
     qr = QuantumRegister(1)
     circuit = QuantumCircuit(qr)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     # remove experiment
     qobj.experiments = []
     return qobj
@@ -181,7 +181,7 @@ def measure_circuits_qobj_deterministic(allow_sampling=True):
     circuit = QuantumCircuit(qr, cr)
     circuit.x(qr[1])
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     insert_instr(qobj, 0, measure_instr([0, 1], [0, 1]), -1)
     if not allow_sampling:
         insert_instr(qobj, 0, iden_instr(0), -1)
@@ -194,7 +194,7 @@ def measure_circuits_qobj_deterministic(allow_sampling=True):
     circuit.x(qr[0])
     circuit.x(qr[2])
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     insert_instr(qobj, 0, measure_instr([0, 1, 2], [0, 1, 2]), -1)
     if not allow_sampling:
         insert_instr(qobj, 0, iden_instr(0), -1)
@@ -207,7 +207,7 @@ def measure_circuits_qobj_deterministic(allow_sampling=True):
     circuit.x(qr[1])
     circuit.x(qr[3])
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     insert_instr(qobj, 0, measure_instr([0, 1, 2, 3], [0, 1, 2, 3]), -1)
     if not allow_sampling:
         insert_instr(qobj, 0, iden_instr(0), -1)
@@ -263,7 +263,7 @@ def measure_circuits_qobj_nondeterministic(allow_sampling=True):
     circuit.h(qr[0])
     circuit.h(qr[1])
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     insert_instr(qobj, 0, measure_instr([0, 1], [0, 1]), -1)
     if not allow_sampling:
         insert_instr(qobj, 0, iden_instr(0), -1)
@@ -276,7 +276,7 @@ def measure_circuits_qobj_nondeterministic(allow_sampling=True):
     circuit.h(qr[0])
     circuit.h(qr[1])
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     insert_instr(qobj, 0, measure_instr([0, 1, 2], [0, 1, 2]), -1)
     if not allow_sampling:
         insert_instr(qobj, 0, iden_instr(0), -1)

--- a/test/terra/reference/ref_unitary_gate.py
+++ b/test/terra/reference/ref_unitary_gate.py
@@ -11,8 +11,8 @@ Test circuits and reference outputs for measure instruction.
 
 
 import numpy as np
-from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, compile
-
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.compiler import assemble
 from qiskit.providers.aer.backends import QasmSimulator
 from qiskit.providers.aer.utils.qobj_utils import unitary_instr
 from qiskit.providers.aer.utils.qobj_utils import append_instr
@@ -30,7 +30,7 @@ def _dummy_qobj():
     qr = QuantumRegister(1)
     circuit = QuantumCircuit(qr)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     # remove experiment
     qobj.experiments = []
     return qobj
@@ -52,7 +52,7 @@ def unitary_gate_circuits_real_deterministic(final_measure=True):
     # CX01, |00> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(cx_mat, [0, 1]))
     if final_measure:
         append_instr(qobj, 0, measure_instr([0], [0]))
@@ -62,7 +62,7 @@ def unitary_gate_circuits_real_deterministic(final_measure=True):
     # CX10, |00> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(cx_mat, [1, 0]))
     if final_measure:
         append_instr(qobj, 0, measure_instr([0], [0]))
@@ -72,7 +72,7 @@ def unitary_gate_circuits_real_deterministic(final_measure=True):
     # CX01.(X^I), |10> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(x_mat, [1]))
     append_instr(qobj, 0, unitary_instr(cx_mat, [0, 1]))
     if final_measure:
@@ -83,7 +83,7 @@ def unitary_gate_circuits_real_deterministic(final_measure=True):
     # CX10.(I^X), |01> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(x_mat, [0]))
     append_instr(qobj, 0, unitary_instr(cx_mat, [1, 0]))
     if final_measure:
@@ -94,7 +94,7 @@ def unitary_gate_circuits_real_deterministic(final_measure=True):
     # CX01.(I^X), |11> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(x_mat, [0]))
     append_instr(qobj, 0, unitary_instr(cx_mat, [0, 1]))
     if final_measure:
@@ -105,7 +105,7 @@ def unitary_gate_circuits_real_deterministic(final_measure=True):
     # CX10.(X^I), |11> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(x_mat, [1]))
     append_instr(qobj, 0, unitary_instr(cx_mat, [1, 0]))
     if final_measure:
@@ -218,7 +218,7 @@ def unitary_gate_circuits_complex_deterministic(final_measure=True):
     # CX01, |00> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(cx_mat, [0, 1]))
     if final_measure:
         append_instr(qobj, 0, measure_instr([0], [0]))
@@ -228,7 +228,7 @@ def unitary_gate_circuits_complex_deterministic(final_measure=True):
     # CX10, |00> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(cx_mat, [1, 0]))
     if final_measure:
         append_instr(qobj, 0, measure_instr([0], [0]))
@@ -238,7 +238,7 @@ def unitary_gate_circuits_complex_deterministic(final_measure=True):
     # CX01.(Y^I), |10> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(y_mat, [1]))
     append_instr(qobj, 0, unitary_instr(cx_mat, [0, 1]))
     if final_measure:
@@ -249,7 +249,7 @@ def unitary_gate_circuits_complex_deterministic(final_measure=True):
     # CX10.(I^Y), |01> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(y_mat, [0]))
     append_instr(qobj, 0, unitary_instr(cx_mat, [1, 0]))
     if final_measure:
@@ -260,7 +260,7 @@ def unitary_gate_circuits_complex_deterministic(final_measure=True):
     # CX01.(I^Y), |11> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(y_mat, [0]))
     append_instr(qobj, 0, unitary_instr(cx_mat, [0, 1]))
     if final_measure:
@@ -271,7 +271,7 @@ def unitary_gate_circuits_complex_deterministic(final_measure=True):
     # CX10.(Y^I), |11> state
     circuit = QuantumCircuit(*regs)
     circuit.barrier(qr)
-    qobj = compile(circuit, QasmSimulator(), shots=1)
+    qobj = assemble(circuit, QasmSimulator(), shots=1)
     append_instr(qobj, 0, unitary_instr(y_mat, [1]))
     append_instr(qobj, 0, unitary_instr(cx_mat, [1, 0]))
     if final_measure:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Cleans up some backend options documentation and names
* Updates test to use execute or transpile/assemble instead of compile to remove depreciation warnings

### Details and comments

* Closes #157 by changing extended stabilizer measure sampling option to value `"extended_stabilizer_measure_sampling"` with default value of `False` instead of `True`.
* Renames `"chop_threshold"` option to `"zero_threshold"` and changes default value from 1e-15 to 1e-10.
* Renames "max_statevector_memory_mb" to "max_memory_mb" in options
* removes depreciated `"ch_..." option parsing for extended stabilizer simulator
* removes `"inital_statevector"` option from documentation since `initialize` circuit instruction should be used now instead.