### PR TITLE
Remap noise model utility function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ The format is based on `Keep a Changelog`_.
 
 Added
 -----
+- add `remap_noise_model` function to noise.utils (#181)
+- Add `__eq__` method to NoiseModel, QuantumError, ReadoutError (#181)
 - Add support for labelled gates in noise models (#175).
 - Improve efficiency of parallelization with max_memory_mb a new parameter of backend_opts (#61)
 - Add optimized mcx, mcy, mcz, mcu1, mcu2, mcu3, gates to QubitVector (#124)

--- a/qiskit/providers/aer/noise/__init__.py
+++ b/qiskit/providers/aer/noise/__init__.py
@@ -71,10 +71,11 @@ canonical types of quantum errors:
 Noise Utilities
 --------------
 The `noise.utils` module contains utilities for noise models and errors including:
-    'approximate_quantum_error' for approximating a general quantum error via
-    a provided set of errors (e.g. approximating amplitude damping via reset errors)
-    'approximate_noise_model' for approximating all the errors in a nose model using
-    the same provided set of errors
+   `remap_noise_model` for remapping the qubits specified in a NoiseModel.
+   `approximate_quantum_error` for approximating a general quantum error via
+   a provided set of errors (e.g. approximating amplitude damping via reset errors).
+   `approximate_noise_model` for approximating all the errors in a nose model using
+   the same provided set of errors.
 """
 
 from .noise_model import NoiseModel

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -155,7 +155,7 @@ class QuantumError:
         # Rescale probabilities if their sum is ok to avoid
         # accumulation of rounding errors
         self._noise_probabilities = list(np.array(self._noise_probabilities) / total_probs)
-    
+
     def __repr__(self):
         """Display QuantumError."""
         return "QuantumError({})".format(
@@ -170,6 +170,12 @@ class QuantumError:
                 j, pair[0], pair[1])
         return output
 
+    def __eq__(self, other):
+        """Test if two QuantumErrors are equal as SuperOps"""
+        if not isinstance(other, QuantumError):
+            return False
+        return self.to_quantumchannel() == other.to_quantumchannel()
+
     def copy(self):
         """Make a copy of current QuantumError."""
         # pylint: disable=no-value-for-parameter
@@ -179,7 +185,7 @@ class QuantumError:
     @property
     def atol(self):
         """The absolute tolerence parameter for float comparisons."""
-        return QuantumError.ATOL
+        return self.ATOL
 
     @atol.setter
     def atol(self, atol):
@@ -200,7 +206,7 @@ class QuantumError:
     @rtol.setter
     def rtol(self, rtol):
         """Set the relative tolerence parameter for float comparisons."""
-        max_tol = QuantumError.MAX_TOL
+        max_tol = self.MAX_TOL
         if rtol < 0:
             raise NoiseError("Invalid rtol: must be non-negative.")
         if rtol > max_tol:

--- a/qiskit/providers/aer/noise/errors/readout_error.py
+++ b/qiskit/providers/aer/noise/errors/readout_error.py
@@ -76,6 +76,15 @@ class ReadoutError:
             output += "\n P(j|{0}) =  {1}".format(j, vec)
         return output
 
+    def __eq__(self, other):
+        """Test if two ReadoutErrors are equal."""
+        if not isinstance(other, ReadoutError):
+            return False
+        if self.number_of_qubits != other.number_of_qubits:
+            return False
+        return np.allclose(self._probabilities, other._probabilities,
+                           atol=self.atol, rtol=self.rtol)
+
     def copy(self):
         """Make a copy of current ReadoutError."""
         # pylint: disable=no-value-for-parameter
@@ -95,34 +104,34 @@ class ReadoutError:
     @property
     def atol(self):
         """The absolute tolerence parameter for float comparisons."""
-        return ReadoutError.ATOL
+        return self.ATOL
 
     @atol.setter
     def atol(self, atol):
         """Set the absolute tolerence parameter for float comparisons."""
-        max_tol = ReadoutError.MAX_TOL
+        max_tol = self.MAX_TOL
         if atol < 0:
             raise NoiseError("Invalid atol: must be non-negative.")
         if atol > max_tol:
             raise NoiseError(
                 "Invalid atol: must be less than {}.".format(max_tol))
-        ReadoutError.ATOL = atol
+        self.ATOL = atol
 
     @property
     def rtol(self):
         """The relative tolerence parameter for float comparisons."""
-        return ReadoutError.RTOL
+        return self.RTOL
 
     @rtol.setter
     def rtol(self, rtol):
         """Set the relative tolerence parameter for float comparisons."""
-        max_tol = ReadoutError.MAX_TOL
+        max_tol = self.MAX_TOL
         if rtol < 0:
             raise NoiseError("Invalid rtol: must be non-negative.")
         if rtol > max_tol:
             raise NoiseError(
                 "Invalid rtol: must be less than {}.".format(max_tol))
-        ReadoutError.RTOL = rtol
+        self.RTOL = rtol
 
     def ideal(self):
         """Return True if current error object is an identity"""

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -98,19 +98,102 @@ class NoiseModel:
         self._local_readout_errors = {}
         self._x90_gates = []
 
-    def reset(self):
-        """Reset the noise model."""
-        self.__init__()
+    @property
+    def basis_gates(self):
+        """Return basis_gates for compiling to the noise model."""
+        # Convert noise instructions to basis_gates string
+        return sorted(self._basis_gates)
 
     @property
     def noise_instructions(self):
         """Return the set of noisy instructions for this noise model."""
-        return self._noise_instructions
+        return sorted(self._noise_instructions)
 
     @property
     def noise_qubits(self):
         """Return the set of noisy qubits for this noise model."""
-        return self._noise_qubits
+        return sorted(self._noise_qubits)
+
+    def __repr__(self):
+        """Display noise model"""
+
+        # Get default errors
+        default_error_ops = []
+        for inst in self._default_quantum_errors:
+            default_error_ops.append('{}'.format(inst))
+        if self._default_readout_error is not None:
+            if 'measure' not in default_error_ops:
+                default_error_ops.append('measure')
+
+        # Get local errors
+        local_error_ops = []
+        for inst, dic in self._local_quantum_errors.items():
+            for q_str in dic.keys():
+                local_error_ops.append((inst, self._str2qubits(q_str)))
+        for q_str in self._local_readout_errors:
+            tmp = ('measure', self._str2qubits(q_str))
+            if tmp not in local_error_ops:
+                local_error_ops.append(tmp)
+
+        # Get nonlocal errors
+        nonlocal_error_ops = []
+        for inst, dic in self._nonlocal_quantum_errors.items():
+            for q_str, errors in dic.items():
+                for nq_str in errors:
+                    nonlocal_error_ops.append((inst, self._str2qubits(q_str),
+                                               self._str2qubits(nq_str)))
+
+        output = "NoiseModel:"
+        if default_error_ops == [] and local_error_ops == [] and nonlocal_error_ops == []:
+            output += " Ideal"
+        else:
+            output += "\n  Basis gates: {}".format(self.basis_gates)
+            if self._noise_instructions:
+                output += "\n  Instructions with noise: {}".format(
+                    list(self._noise_instructions))
+            if self._noise_qubits:
+                output += "\n  Qubits with noise: {}".format(
+                    list(self._noise_qubits))
+            if self._x90_gates:
+                output += "\n  X-90 based single qubit gates: {}".format(
+                    list(self._x90_gates))
+            if default_error_ops != []:
+                output += "\n  All-qubits errors: {}".format(default_error_ops)
+            if local_error_ops != []:
+                output += "\n  Specific qubit errors: {}".format(
+                    local_error_ops)
+            if nonlocal_error_ops != []:
+                output += "\n  Non-local specific qubit errors: {}".format(
+                    nonlocal_error_ops)
+        return output
+
+    def __eq__(self, other):
+        """Test if two noise models are equal."""
+        # This returns True if both noise models have:
+        # the same basis_gates
+        # the same noise_qubits
+        # the same noise_instructions
+        if (not isinstance(other, NoiseModel)
+                or self.basis_gates != other.basis_gates
+                or self.noise_qubits != other.noise_qubits
+                or self.noise_instructions != other.noise_instructions):
+            return False
+        # Check default readout errors is equal
+        if not self._readout_errors_equal(other):
+            return False
+        # Check quantum errors equal
+        if not self._all_qubit_quantum_errors_equal(other):
+            return False
+        if not self._local_quantum_errors_equal(other):
+            return False
+        if not self._nonlocal_quantum_errors_equal(other):
+            return False
+        # If we made it here they are equal
+        return True
+
+    def reset(self):
+        """Reset the noise model."""
+        self.__init__()
 
     def add_basis_gates(self, instructions, warnings=True):
         """Add additional gates to the noise model basis_gates.
@@ -129,7 +212,8 @@ class NoiseModel:
             # If the instruction is in the default basis gates for the
             # QasmSimulator we add it to the basis gates.
             if inst in self.QASMSIMULATOR_BASIS_GATES:
-                self._basis_gates.add(inst)
+                if inst not in ['measure', 'reset']:
+                    self._basis_gates.add(inst)
             elif warnings:
                 logger.warning(
                     "Warning: Adding a gate \"%s\" to basis_gates which is "
@@ -465,65 +549,6 @@ class NoiseModel:
                     "all-qubit readout error for these qubits.", qubits)
         self._noise_instructions.add("measure")
 
-    def __repr__(self):
-        """Display noise model"""
-
-        # Get default errors
-        default_error_ops = []
-        for inst in self._default_quantum_errors:
-            default_error_ops.append('{}'.format(inst))
-        if self._default_readout_error is not None:
-            if 'measure' not in default_error_ops:
-                default_error_ops.append('measure')
-
-        # Get local errors
-        local_error_ops = []
-        for inst, dic in self._local_quantum_errors.items():
-            for q_str in dic.keys():
-                local_error_ops.append((inst, self._str2qubits(q_str)))
-        for q_str in self._local_readout_errors:
-            tmp = ('measure', self._str2qubits(q_str))
-            if tmp not in local_error_ops:
-                local_error_ops.append(tmp)
-
-        # Get nonlocal errors
-        nonlocal_error_ops = []
-        for inst, dic in self._nonlocal_quantum_errors.items():
-            for q_str, errors in dic.items():
-                for nq_str in errors:
-                    nonlocal_error_ops.append((inst, self._str2qubits(q_str),
-                                               self._str2qubits(nq_str)))
-
-        output = "NoiseModel:"
-        if default_error_ops == [] and local_error_ops == [] and nonlocal_error_ops == []:
-            output += " Ideal"
-        else:
-            output += "\n  Basis gates: {}".format(self.basis_gates)
-            if self._noise_instructions:
-                output += "\n  Instructions with noise: {}".format(
-                    list(self._noise_instructions))
-            if self._noise_qubits:
-                output += "\n  Qubits with noise: {}".format(
-                    list(self._noise_qubits))
-            if self._x90_gates:
-                output += "\n  X-90 based single qubit gates: {}".format(
-                    list(self._x90_gates))
-            if default_error_ops != []:
-                output += "\n  All-qubits errors: {}".format(default_error_ops)
-            if local_error_ops != []:
-                output += "\n  Specific qubit errors: {}".format(
-                    local_error_ops)
-            if nonlocal_error_ops != []:
-                output += "\n  Non-local specific qubit errors: {}".format(
-                    nonlocal_error_ops)
-        return output
-
-    @property
-    def basis_gates(self):
-        """Return basis_gates for compiling to the noise model."""
-        # Convert noise instructions to basis_gates string
-        return list(self._basis_gates)
-
     def as_dict(self, serializable=False):
         """
         Return dictionary for noise model.
@@ -707,3 +732,67 @@ class NoiseModel:
         """Convert dicitonary keys to comma seperated print string."""
         tmp = "".join(["{}, ".format(self._str2qubits(key)) for key in keys])
         return tmp[:-2]
+
+    def _readout_errors_equal(self, other):
+        """Check two noise models have equal readout errors"""
+        # Check default readout error is equal
+        if self._default_readout_error != other._default_readout_error:
+            return False
+        # Check local readout errors are equal
+        if sorted(self._local_readout_errors.keys()) != sorted(
+                other._local_readout_errors.keys()):
+            return False
+        for key in self._local_readout_errors:
+            if self._local_readout_errors[key] != other._local_readout_errors[
+                    key]:
+                return False
+        return True
+
+    def _all_qubit_quantum_errors_equal(self, other):
+        """Check two noise models have equal local quantum errors"""
+        if sorted(self._default_quantum_errors.keys()) != sorted(
+                other._default_quantum_errors.keys()):
+            return False
+        for key in self._default_quantum_errors:
+            if self._default_quantum_errors[
+                    key] != other._default_quantum_errors[key]:
+                return False
+        return True
+
+    def _local_quantum_errors_equal(self, other):
+        """Check two noise models have equal local quantum errors"""
+        if sorted(self._local_quantum_errors.keys()) != sorted(
+                other._local_quantum_errors.keys()):
+            return False
+        for key in self._local_quantum_errors:
+            inner_dict1 = self._local_quantum_errors[key]
+            inner_dict2 = other._local_quantum_errors[key]
+            if sorted(inner_dict1.keys()) != sorted(inner_dict2.keys()):
+                return False
+            for inner_key in inner_dict1:
+                if inner_dict1[inner_key] != inner_dict2[inner_key]:
+                    return False
+            if self._local_quantum_errors[key] != other._local_quantum_errors[
+                    key]:
+                return False
+        return True
+
+    def _nonlocal_quantum_errors_equal(self, other):
+        """Check two noise models have equal non-local quantum errors"""
+        if sorted(self._nonlocal_quantum_errors.keys()) != sorted(
+                other._nonlocal_quantum_errors.keys()):
+            return False
+        for key in self._nonlocal_quantum_errors:
+            inner_dict1 = self._nonlocal_quantum_errors[key]
+            inner_dict2 = other._nonlocal_quantum_errors[key]
+            if sorted(inner_dict1.keys()) != sorted(inner_dict2.keys()):
+                return False
+            for inner_key in inner_dict1:
+                iinner_dict1 = inner_dict1[inner_key]
+                iinner_dict2 = inner_dict2[inner_key]
+                if sorted(iinner_dict1.keys()) != sorted(iinner_dict2.keys()):
+                    return False
+                for iinner_key in iinner_dict1:
+                    if iinner_dict1[iinner_key] != iinner_dict2[iinner_key]:
+                        return False
+        return True

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -9,7 +9,6 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-
 """
 Noise model class for Qiskit Aer simulators.
 """
@@ -34,7 +33,8 @@ class NoiseModel:
     # Get the default basis gates for the Qiskit Aer Qasm Simulator
     # this is used to decide what are instructions for a noise model
     # and what are labels for other named instructions
-    QASMSIMULATOR_BASIS_GATES = QasmSimulator.DEFAULT_CONFIGURATION['basis_gates']
+    QASMSIMULATOR_BASIS_GATES = QasmSimulator.DEFAULT_CONFIGURATION[
+        'basis_gates']
 
     # Checks for standard 1-3 qubit instructions
     _1qubit_instructions = set([
@@ -50,7 +50,7 @@ class NoiseModel:
         Args:
             basis_gates (list[str] or None): Specify an initial basis_gates
                 for the noise model. If None a default value of ['id', 'u3', 'cx']
-                is used [Default: None].
+                is used (Default: None).
 
         Additional Information
         ----------------------
@@ -61,23 +61,41 @@ class NoiseModel:
         be added to the NoiseModel basis_gates either using the init method, or
         the `add_basis_Gates` method.
         """
-        # Initialize empty quantum errors
         if basis_gates is None:
-            self._basis_gates = set(['id', 'u3', 'cx'])  # Store noise model basis gates
+            # Default basis gates is id, u3, cx so that all standard
+            # non-identity instructions can be unrolled to u3, cx,
+            # and identities won't be unrolled to u3.
+            self._basis_gates = set(['id', 'u3', 'cx'])
         else:
-            self._basis_gates = set(_instruction_names(basis_gates))
-        self._noise_instructions = set(
-        )  # Store gates with a noise model defined
-        # TODO: Code would be cleaner if these were replaced with classes
-        # Type: dict(str: list(QuantumError)
+            self._basis_gates = set(self._instruction_names(basis_gates))
+        # Store gates with a noise model defined
+        self._noise_instructions = set()
+        # Store qubits referenced in noise model.
+        # These include gate qubits in local quantum and readout errors,
+        # and both gate and noise qubits for non-local quantum errors.
+        self._noise_qubits = set()
+        # Default (all-qubit) quantum errors are stored as:
+        # dict(str: QuantumError)
+        # where they keys are the instruction str label
         self._default_quantum_errors = {}
-        # Type: dict(str: dict(str: list(QuantumError))
+        # Local quantum errors are stored as:
+        # dict(str: dict(str: QuantumError))
+        # where the outer keys are the instruction str label and the
+        # inner dict keys are the gate qubits
         self._local_quantum_errors = {}
-        # Type: dict(str: dict(str: list(pair(list(QuantumError), list(int)))))
+        # Non-local quantum errors are stored as:
+        # dict(str: dict(str: dict(str: QuantumError)))
+        # where the outer keys are the instruction str label, the middle dict
+        # keys are the gate qubits, and the inner most dict keys are
+        # the noise qubits.
         self._nonlocal_quantum_errors = {}
-        # Initialize empty readout errors
-        self._default_readout_error = None  # Type: ReadoutError
-        self._local_readout_errors = {}  # Type: dict(str: ReadoutError)
+        # Default (all-qubit) readout error is stored as a single
+        # ReadoutError object since there may only be one defined.
+        self._default_readout_error = None
+        # Local readout errors are stored as:
+        # dict(str: ReadoutError)
+        # where the dict keys are the gate qubits.
+        self._local_readout_errors = {}
         self._x90_gates = []
 
     def reset(self):
@@ -89,6 +107,11 @@ class NoiseModel:
         """Return the set of noisy instructions for this noise model."""
         return self._noise_instructions
 
+    @property
+    def noise_qubits(self):
+        """Return the set of noisy qubits for this noise model."""
+        return self._noise_qubits
+
     def add_basis_gates(self, instructions, warnings=True):
         """Add additional gates to the noise model basis_gates.
 
@@ -99,7 +122,7 @@ class NoiseModel:
             instructions (list[str] or
                           list[Instruction]): the instructions error applies to.
             warnings (bool): display warning if instruction is not in
-                             QasmSimulator basis_gates [Default: True].
+                             QasmSimulator basis_gates (Default: True).
         """
         names = self._instruction_names(instructions)
         for inst in names:
@@ -140,7 +163,7 @@ class NoiseModel:
                           Instruction or
                           list[Instruction]): the instructions error applies to.
             warnings (bool): Display warning if appending to an instruciton that
-                             already has an error [Default: True]
+                             already has an error (Default: True).
 
         Raises:
             NoiseError: if the input parameters are invalid.
@@ -164,14 +187,15 @@ class NoiseModel:
         for inst in instruction_names:
             self._check_number_of_qubits(error, inst)
             if inst in self._default_quantum_errors:
-                self._default_quantum_errors[inst].append(error)
+                new_error = self._default_quantum_errors[inst].compose(error)
+                self._default_quantum_errors[inst] = new_error
                 if warnings:
                     logger.warning(
                         "WARNING: all-qubit error already exists for "
                         "instruction \"%s\", "
-                        "appending additional error.", inst)
+                        "composing with additional error.", inst)
             else:
-                self._default_quantum_errors[inst] = [error]
+                self._default_quantum_errors[inst] = error
             # Check if a specific qubit error has been applied for this instruction
             if inst in self._local_quantum_errors:
                 local_qubits = self._keys2str(
@@ -180,7 +204,8 @@ class NoiseModel:
                     logger.warning(
                         "WARNING: all-qubit error for instruction "
                         "\"%s\" will not apply to qubits: "
-                        "%s as specific error already exists.", inst, local_qubits)
+                        "%s as specific error already exists.", inst,
+                        local_qubits)
             self._noise_instructions.add(inst)
             self.add_basis_gates(inst, warnings=False)
 
@@ -195,7 +220,7 @@ class NoiseModel:
                           list[Instruction]): the instructions error applies to.
             qubits (list[int]): qubits instruction error applies to.
             warnings (bool): Display warning if appending to an instruciton that
-                             already has an error [Default: True]
+                             already has an error (Default: True).
 
         Raises:
             NoiseError: if the input parameters are invalid.
@@ -216,6 +241,9 @@ class NoiseModel:
         # Check if error is ideal and if so don't add to the noise model
         if error.ideal():
             return
+        # Add noise qubits
+        for qubit in qubits:
+            self._noise_qubits.add(qubit)
         # Add instructions
         for inst in instruction_names:
             if not isinstance(inst, str):
@@ -234,20 +262,20 @@ class NoiseModel:
                                  " the error size ({})".format(
                                      len(qubits), error.number_of_qubits))
             if qubits_str in qubit_dict:
-                qubit_dict[qubits_str].append(error)
+                new_error = qubit_dict[qubits_str].compose(error)
+                qubit_dict[qubits_str] = new_error
                 if warnings:
                     logger.warning(
                         "WARNING: quantum error already exists for "
                         "instruction \"%s\" on qubits %s "
                         ", appending additional error.", inst, qubits)
             else:
-                qubit_dict[qubits_str] = [error]
+                qubit_dict[qubits_str] = error
             # Add updated dictionary
             self._local_quantum_errors[inst] = qubit_dict
 
             # Check if all-qubit error is already defined for this instruction
             if inst in self._default_quantum_errors:
-                self._default_quantum_errors[inst].append(error)
                 if warnings:
                     logger.warning(
                         "WARNING: Specific error for instruction \"%s\" "
@@ -256,8 +284,12 @@ class NoiseModel:
             self._noise_instructions.add(inst)
             self.add_basis_gates(inst, warnings=False)
 
-    def add_nonlocal_quantum_error(self, error, instructions, qubits,
-                                   noise_qubits, warnings=True):
+    def add_nonlocal_quantum_error(self,
+                                   error,
+                                   instructions,
+                                   qubits,
+                                   noise_qubits,
+                                   warnings=True):
         """
         Add a non-local quantum error to the noise model.
 
@@ -271,7 +303,7 @@ class NoiseModel:
                                       should be applied to if different
                                       to the instruction qubits.
             warnings (bool): Display warning if appending to an instruciton that
-                             already has an error [Default: True]
+                             already has an error (Default: True).
 
         Raises:
             NoiseError: if the input parameters are invalid.
@@ -293,25 +325,36 @@ class NoiseModel:
         # Check if error is ideal and if so don't add to the noise model
         if error.ideal():
             return
-
+        # Add noise qubits
+        for qubit in qubits:
+            self._noise_qubits.add(qubit)
+        for qubit in noise_qubits:
+            self._noise_qubits.add(qubit)
         # Add instructions
         for inst in instruction_names:
             if inst in self._nonlocal_quantum_errors:
-                qubit_dict = self._nonlocal_quantum_errors[inst]
+                gate_qubit_dict = self._nonlocal_quantum_errors[inst]
             else:
-                qubit_dict = {}
-            qubits_str = self._qubits2str(qubits)
-            if qubits_str in qubit_dict:
-                qubit_dict[qubits_str].append((error, noise_qubits))
+                gate_qubit_dict = {}
+            qs_str = self._qubits2str(qubits)
+            nqs_str = self._qubits2str(noise_qubits)
+            if qs_str in gate_qubit_dict:
+                noise_qubit_dict = gate_qubit_dict[nqs_str]
+                if nqs_str in noise_qubit_dict:
+                    new_error = noise_qubit_dict[nqs_str].compose(error)
+                    noise_qubit_dict[nqs_str] = new_error
+                else:
+                    noise_qubit_dict[nqs_str] = error
+                gate_qubit_dict[qs_str] = noise_qubit_dict
                 if warnings:
                     logger.warning(
-                        "WARNING: nonlocal error already exists for "
+                        "Warning: nonlocal error already exists for "
                         "instruction \"%s\" on qubits %s."
-                        "Appending additional error.", inst, qubits)
+                        "Composing additional error.", inst, qubits)
             else:
-                qubit_dict[qubits_str] = [(error, noise_qubits)]
+                gate_qubit_dict[qs_str] = {nqs_str: error}
             # Add updated dictionary
-            self._nonlocal_quantum_errors[inst] = qubit_dict
+            self._nonlocal_quantum_errors[inst] = gate_qubit_dict
             self._noise_instructions.add(inst)
             self.add_basis_gates(inst, warnings=False)
 
@@ -322,7 +365,7 @@ class NoiseModel:
         Args:
             error (ReadoutError): the quantum error object.
             warnings (bool): Display warning if appending to an instruciton that
-                             already has an error [Default: True]
+                             already has an error (Default: True)
 
         Raises:
             NoiseError: if the input parameters are invalid.
@@ -349,8 +392,9 @@ class NoiseModel:
             )
         if self._default_readout_error is not None:
             if warnings:
-                logger.warning("WARNING: all-qubit readout error already exists, "
-                               "overriding with new readout error.")
+                logger.warning(
+                    "WARNING: all-qubit readout error already exists, "
+                    "overriding with new readout error.")
         self._default_readout_error = error
 
         # Check if a specific qubit error has been applied for this instruction
@@ -393,6 +437,10 @@ class NoiseModel:
         if error.ideal():
             return
 
+        # Add noise qubits
+        for qubit in qubits:
+            self._noise_qubits.add(qubit)
+
         # Convert qubits list to hashable string
         qubits_str = self._qubits2str(qubits)
         # Check error matches qubit size
@@ -410,10 +458,11 @@ class NoiseModel:
 
         # Check if all-qubit readout error is already defined
         if self._default_readout_error is not None:
-            logger.warning(
-                "WARNING: Specific readout error on qubits "
-                "%s overrides previously defined "
-                "all-qubit readout error for these qubits.", qubits)
+            if warnings:
+                logger.warning(
+                    "WARNING: Specific readout error on qubits "
+                    "%s overrides previously defined "
+                    "all-qubit readout error for these qubits.", qubits)
         self._noise_instructions.add("measure")
 
     def __repr__(self):
@@ -441,9 +490,9 @@ class NoiseModel:
         nonlocal_error_ops = []
         for inst, dic in self._nonlocal_quantum_errors.items():
             for q_str, errors in dic.items():
-                for error in errors:
+                for nq_str in errors:
                     nonlocal_error_ops.append((inst, self._str2qubits(q_str),
-                                               error[1]))
+                                               self._str2qubits(nq_str)))
 
         output = "NoiseModel:"
         if default_error_ops == [] and local_error_ops == [] and nonlocal_error_ops == []:
@@ -453,6 +502,9 @@ class NoiseModel:
             if self._noise_instructions:
                 output += "\n  Instructions with noise: {}".format(
                     list(self._noise_instructions))
+            if self._noise_qubits:
+                output += "\n  Qubits with noise: {}".format(
+                    list(self._noise_qubits))
             if self._x90_gates:
                 output += "\n  X-90 based single qubit gates: {}".format(
                     list(self._x90_gates))
@@ -486,29 +538,29 @@ class NoiseModel:
         error_list = []
 
         # Add default quantum errors
-        for name, errors in self._default_quantum_errors.items():
-            for error in errors:
-                error_dict = error.as_dict()
-                error_dict["operations"] = [name]
-                error_list.append(error_dict)
+        for name, error in self._default_quantum_errors.items():
+            error_dict = error.as_dict()
+            error_dict["operations"] = [name]
+            error_list.append(error_dict)
 
         # Add specific qubit errors
         for name, qubit_dict in self._local_quantum_errors.items():
-            for qubits_str, errors in qubit_dict.items():
-                for error in errors:
-                    error_dict = error.as_dict()
-                    error_dict["operations"] = [name]
-                    error_dict["gate_qubits"] = [self._str2qubits(qubits_str)]
-                    error_list.append(error_dict)
+            for qubits_str, error in qubit_dict.items():
+                error_dict = error.as_dict()
+                error_dict["operations"] = [name]
+                error_dict["gate_qubits"] = [self._str2qubits(qubits_str)]
+                error_list.append(error_dict)
 
         # Add non-local errors
         for name, qubit_dict in self._nonlocal_quantum_errors.items():
-            for qubits_str, errors in qubit_dict.items():
-                for error, noise_qubits in errors:
+            for qubits_str, noise_qubit_dict in qubit_dict.items():
+                for noise_qubits_str, error in noise_qubit_dict.items():
                     error_dict = error.as_dict()
                     error_dict["operations"] = [name]
                     error_dict["gate_qubits"] = [self._str2qubits(qubits_str)]
-                    error_dict["noise_qubits"] = [list(noise_qubits)]
+                    error_dict["noise_qubits"] = [
+                        self._str2qubits(noise_qubits_str)
+                    ]
                     error_list.append(error_dict)
 
         # Add default readout error
@@ -532,6 +584,9 @@ class NoiseModel:
     def from_dict(noise_dict):
         """
         Load NoiseModel from a dictionary.
+
+        Args:
+            noise_dict (dict): A serialized noise model.
 
         Returns:
             NoiseModel: the noise model.
@@ -565,16 +620,22 @@ class NoiseModel:
                         if all_noise_qubits is not None:
                             for noise_qubits in all_noise_qubits:
                                 noise_model.add_nonlocal_quantum_error(
-                                    qerror, instruction_names, gate_qubits,
-                                    noise_qubits)
+                                    qerror,
+                                    instruction_names,
+                                    gate_qubits,
+                                    noise_qubits,
+                                    warnings=False)
                         # Add local quantum error
                         else:
                             noise_model.add_quantum_error(
-                                qerror, instruction_names, gate_qubits)
+                                qerror,
+                                instruction_names,
+                                gate_qubits,
+                                warnings=False)
                 else:
                     # Add all-qubit quantum error
                     noise_model.add_all_qubit_quantum_error(
-                        qerror, instruction_names)
+                        qerror, instruction_names, warnings=False)
 
             # Add ReadoutError
             elif error_type is 'roerror':
@@ -584,10 +645,12 @@ class NoiseModel:
                 # Add local readout error
                 if all_gate_qubits is not None:
                     for gate_qubits in all_gate_qubits:
-                        noise_model.add_readout_error(roerror, gate_qubits)
+                        noise_model.add_readout_error(
+                            roerror, gate_qubits, warnings=False)
                 # Add all-qubit readout error
                 else:
-                    noise_model.add_all_qubit_readout_error(roerror)
+                    noise_model.add_all_qubit_readout_error(
+                        roerror, warnings=False)
             # Invalid error type
             else:
                 raise NoiseError("Invalid error type: {}".format(error_type))

--- a/qiskit/providers/aer/noise/utils/__init__.py
+++ b/qiskit/providers/aer/noise/utils/__init__.py
@@ -10,8 +10,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Noise utils for Qiskit Aer.
 """
+Noise utils for Qiskit Aer.
+"""
+
+from .noise_remapper import remap_noise_model
 from .noise_transformation import NoiseTransformer
 from .noise_transformation import approximate_quantum_error
 from .noise_transformation import approximate_noise_model

--- a/qiskit/providers/aer/noise/utils/noise_remapper.py
+++ b/qiskit/providers/aer/noise/utils/noise_remapper.py
@@ -1,0 +1,126 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM Corp. 2017 and later.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Remap qubits in a NoiseModel.
+"""
+
+import logging
+
+from ..noise_model import NoiseModel
+from ..noiseerror import NoiseError
+
+logger = logging.getLogger(__name__)
+
+
+def remap_noise_model(noise_model, remapping, discard_qubits=False, warnings=True):
+    """Remap qubits in a noise model.
+
+    This remaps the specified gate qubits for local quantum errors, the gate
+    and noise qubits for non-local quantum errors, and the gate qubits for
+    local ReadoutErrors. All-qubit quantum and readout errors are unaffected.
+
+    Args:
+        noise_model (NoiseModel): a noise model to remap qubits.
+        remapping (list): list or remappings of old qubit to new qubit.
+            See Additional Information.
+        discard_qubits (bool): if True discard qubits not in remapping keys,
+            if False an identity mapping wil be assumed for unnamed qubits
+            (default: False).
+        warnings (bool): display warnings if qubits being remapped are not
+            in the input noise model (Default: True).
+
+    Returns:
+        NoiseModel: a new noise model with the same errors but remapped
+        gate and noise qubits for local and non-local errors.
+
+    Raises:
+        NoiseError: if remapping has duplicate qubits in the remapped qubits.
+
+    Additional Information
+    ----------------------
+    The remapping map be specified as either a list of pairs:
+        [(old, new), ...]
+    Or a list of old qubits where the new qubit is inffered from the position:
+        [old0, old1, ...] -> [(old0, 0), (old1, 1), ...]
+    If `discard_qubits` is False, any qubits in the noise model not specified in
+    the list of old qubits will be added to the remapping as a trivial
+    mapping (qubit, qubit).
+    """
+    if not isinstance(noise_model, NoiseModel):
+        raise NoiseError("Input must be a NoiseModel.")
+
+    if warnings:
+        # Warning if remapped qubit isn't in noise model
+        for qubit in remapping:
+            if qubit not in noise_model.noise_qubits:
+                logger.warning('Warning: qubit %s is not in noise model', qubit)
+
+    # Convert remapping into a inverse mapping dict
+    inv_map = {}
+    for pos, item in enumerate(remapping):
+        if isinstance(item, (list, tuple)) and len(item) == 2:
+            inv_map[int(item[0])] = int(item[1])
+        elif isinstance(item, int):
+            inv_map[item] = pos
+    # Add noise model qubits not in mapping as identity mapping
+    if not discard_qubits:
+        for qubit in noise_model.noise_qubits:
+            if qubit not in inv_map:
+                inv_map[qubit] = qubit
+
+    print(inv_map)
+    # Check mapping doesn't have duplicate qubits in output
+    new_qubits = list(inv_map.values())
+    if len(set(new_qubits)) != len(new_qubits):
+        raise NoiseError('Duplicate qubits in remapping: {}'.format(inv_map))
+
+    # Convert noise model to dict
+    nm_dict = noise_model.as_dict()
+
+    # Indexes of errors to keep
+    new_errors = []
+    for error in nm_dict['errors']:
+        keep_error = True
+        gate_qubits = error.get('gate_qubits', [])
+        noise_qubits = error.get('noise_qubits', [])
+        for qubits in gate_qubits + noise_qubits:
+            for qubit in qubits:
+                if qubit not in inv_map:
+                    keep_error = False
+                    break
+
+        # If any qubits were not in the full_mapping we discard error
+        if keep_error:
+            new_gate_qubits = gate_qubits
+            for i, qubits in enumerate(gate_qubits):
+                for j, qubit in enumerate(qubits):
+                    new_gate_qubits[i][j] = inv_map[qubit]
+
+            # Otherwise we remap the noise and gate qubits
+            new_noise_qubits = noise_qubits
+            for i, qubits in enumerate(noise_qubits):
+                for j, qubit in enumerate(qubits):
+                    new_noise_qubits[i][j] = inv_map[qubit]
+            if new_gate_qubits:
+                error['gate_qubits'] = new_gate_qubits
+            if new_noise_qubits:
+                error['noise_qubits'] = new_noise_qubits
+            new_errors.append(error)
+
+    # Update errors and convert back to NoiseModel
+    nm_dict['errors'] = new_errors
+    new_noise_model = NoiseModel.from_dict(nm_dict)
+
+    # Update basis gates from original model
+    new_noise_model._basis_gates = noise_model._basis_gates
+    return new_noise_model

--- a/qiskit/providers/aer/noise/utils/noise_transformation.py
+++ b/qiskit/providers/aer/noise/utils/noise_transformation.py
@@ -9,24 +9,25 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-
 """
 Noise transformation module
 
-The goal of this module is to transform one 1-qubit noise channel (given by the QuantumError class)
-into another, built from specified "building blocks" (given as Kraus matrices) such that
-the new channel is as close as possible to the original one in the Hilber-Schmidt metric.
+The goal of this module is to transform one 1-qubit noise channel
+(given by the QuantumError class) into another, built from specified
+"building blocks" (given as Kraus matrices) such that the new channel is
+as close as possible to the original one in the Hilber-Schmidt metric.
 
-For a typical use case, consider a simulator for circuits built from the Clifford group.
-Computations on such circuits can be simulated at polynomial time and space, but not all
-noise channels can be used in such a simulation. To enable noisy Clifford simulation one can
-transform the given noise channel into the closest one, Hilbert-Schmidt wise, that
-can be used in a Clifford simulator.
+For a typical use case, consider a simulator for circuits built from the
+Clifford group. Computations on such circuits can be simulated at
+polynomial time and space, but not all noise channels can be used in such
+a simulation. To enable noisy Clifford simulation one can transform the
+given noise channel into the closest one, Hilbert-Schmidt wise, that can be
+used in a Clifford simulator.
 """
 
+import itertools
 import numpy
 import sympy
-import itertools
 
 from qiskit.providers.aer.noise.errors import QuantumError
 from qiskit.providers.aer.noise import NoiseModel
@@ -35,79 +36,108 @@ from qiskit.providers.aer.noise.errors.errorutils import single_qubit_clifford_i
 from qiskit.quantum_info.operators.channel import Kraus
 from qiskit.quantum_info.operators.channel import SuperOp
 
+
 def approximate_quantum_error(error, *,
-                              operator_string = None,
-                              operator_dict = None,
-                              operator_list = None):
+                              operator_string=None,
+                              operator_dict=None,
+                              operator_list=None):
     """Return an approximate QuantumError bases on the Hilbert-Schmidt metric.
+
+    Currently this is only implemented for 1-qubit QuantumErrors.
 
     Args:
         error (QuantumError): the error to be approximated.
-        operator_string (string): a name for a premade set of building blocks for the output channel
-        operator_dict (dict): a dictionary whose values are the building blocks for the output channel
-        operator_list (dict): list of building blocks for the output channel
-
-    Additional Information:
-        The operator input precedence is as follows: list < dict < string
-        if a string is given, dict is overwritten; if a dict is given, list is overwritten
-        possible values for string are 'pauli', 'reset', 'clifford'; see NoiseTransformer.named_operators
+        operator_string (string or None): a name for a premade set of
+            building blocks for the output channel (Default: None).
+        operator_dict (dict or None): a dictionary whose values are the
+            building blocks for the output channel (Default: None).
+        operator_list (dict or None): list of building blocks for the
+            output channel (Default: None).
 
     Returns:
         QuantumError: the approximate quantum error.
+
+    Raises:
+        NoiseError: if number of qubits is not supported or approximation
+        failsed.
+
+    Additional Information
+    ----------------------
+    The operator input precedence is as follows: list < dict < string
+    if a string is given, dict is overwritten; if a dict is given, list is
+    overwritten possible values for string are 'pauli', 'reset', 'clifford'
+    For further information see `NoiseTransformer.named_operators`.
     """
 
     if not isinstance(error, QuantumError):
         error = QuantumError(error)
     if error.number_of_qubits > 1:
-        raise NoiseError("Only 1-qubit noises can be converted, {}-qubit noise found in model".format(
-            error.number_of_qubits))
+        raise NoiseError("Only 1-qubit noises can be converted, {}-qubit "
+                         "noise found in model".format(error.number_of_qubits))
 
     error_kraus_operators = Kraus(error.to_quantumchannel()).data
     transformer = NoiseTransformer()
     if operator_string is not None:
         operator_string = operator_string.lower()
         if operator_string not in transformer.named_operators.keys():
-            raise RuntimeError("No information about noise type {}".format(operator_string))
+            raise RuntimeError(
+                "No information about noise type {}".format(operator_string))
         operator_dict = transformer.named_operators[operator_string]
     if operator_dict is not None:
         names, operator_list = zip(*operator_dict.items())
     if operator_list is not None:
-        op_matrix_list = [transformer.operator_matrix(operator) for operator in operator_list]
-        probabilities = transformer.transform_by_operator_list(op_matrix_list, error_kraus_operators)
+        op_matrix_list = [
+            transformer.operator_matrix(operator) for operator in operator_list
+        ]
+        probabilities = transformer.transform_by_operator_list(
+            op_matrix_list, error_kraus_operators)
         identity_prob = 1 - sum(probabilities)
         if identity_prob < 0 or identity_prob > 1:
-            raise RuntimeError("Approximated channel operators probabilities sum to {}".format(1-identity_prob))
-        quantum_error_spec = [([{'name': 'id', 'qubits':[0]}],identity_prob)]
-        op_circuit_list = [transformer.operator_circuit(operator) for operator in operator_list]
+            raise RuntimeError(
+                "Approximated channel operators probabilities sum to {}".
+                format(1 - identity_prob))
+        quantum_error_spec = [([{'name': 'id', 'qubits': [0]}], identity_prob)]
+        op_circuit_list = [
+            transformer.operator_circuit(operator)
+            for operator in operator_list
+        ]
         for (operator, probability) in zip(op_circuit_list, probabilities):
             quantum_error_spec.append((operator, probability))
         return QuantumError(quantum_error_spec)
 
-    raise Exception("Quantum error approximation failed - no approximating operators detected")
+    raise NoiseError(
+        "Quantum error approximation failed - no approximating operators detected"
+    )
 
 
 def approximate_noise_model(model, *,
-                              operator_string = None,
-                              operator_dict = None,
-                              operator_list = None):
+                            operator_string=None,
+                            operator_dict=None,
+                            operator_list=None):
     """Return an approximate noise model.
 
     Args:
         model (NoiseModel): the noise model to be approximated.
-        operator_string (string): a name for a premade set of building blocks for the output channel
-        operator_dict (dict): a dictionary whose values are the building blocks for the output channel
-        operator_list (dict): list of building blocks for the output channel
-
-    Additional Information:
-        The operator input precedence is as follows: list < dict < string
-        if a string is given, dict is overwritten; if a dict is given, list is overwritten
-        possible values for string are 'pauli', 'reset', 'clifford'; see NoiseTransformer.named_operators
+        operator_string (string or None): a name for a premade set of
+            building blocks for the output channel (Default: None).
+        operator_dict (dict or None): a dictionary whose values are the
+            building blocks for the output channel (Default: None).
+        operator_list (dict or None): list of building blocks for the
+            output channel (Default: None).
 
     Returns:
         NoiseModel: the approximate noise model.
 
     Raises:
-        NoiseError: if the QuantumError cannot be approximated.
+        NoiseError: if number of qubits is not supported or approximation
+        failsed.
+
+    Additional Information
+    ----------------------
+    The operator input precedence is as follows: list < dict < string
+    if a string is given, dict is overwritten; if a dict is given, list is
+    overwritten possible values for string are 'pauli', 'reset', 'clifford'
+    For further information see `NoiseTransformer.named_operators`.
     """
 
     #We need to iterate over all the errors in the noise model.
@@ -115,83 +145,106 @@ def approximate_noise_model(model, *,
 
     error_list = []
     # Add default quantum errors
-    for operation, errors in model._default_quantum_errors.items():
-        for error in errors:
-            error = approximate_quantum_error(error, operator_string=operator_string, operator_dict=operator_dict, operator_list=operator_list)
-            error_dict = error.as_dict()
-            error_dict["operations"] = [operation]
-            error_list.append(error_dict)
+    for operation, error in model._default_quantum_errors.items():
+        error = approximate_quantum_error(
+            error,
+            operator_string=operator_string,
+            operator_dict=operator_dict,
+            operator_list=operator_list)
+        error_dict = error.as_dict()
+        error_dict["operations"] = [operation]
+        error_list.append(error_dict)
 
     # Add specific qubit errors
     for operation, qubit_dict in model._local_quantum_errors.items():
-        for qubits_str, errors in qubit_dict.items():
-            for error in errors:
-                error = approximate_quantum_error(error, operator_string=operator_string, operator_dict=operator_dict,
-                                                  operator_list=operator_list)
-                error_dict = error.as_dict()
-                error_dict["operations"] = [operation]
-                error_dict["gate_qubits"] = [model._str2qubits(qubits_str)]
-                error_list.append(error_dict)
+        for qubits_str, error in qubit_dict.items():
+            error = approximate_quantum_error(
+                error,
+                operator_string=operator_string,
+                operator_dict=operator_dict,
+                operator_list=operator_list)
+            error_dict = error.as_dict()
+            error_dict["operations"] = [operation]
+            error_dict["gate_qubits"] = [model._str2qubits(qubits_str)]
+            error_list.append(error_dict)
 
     # Add non-local errors
     for operation, qubit_dict in model._nonlocal_quantum_errors.items():
-        for qubits_str, errors in qubit_dict.items():
-            for error, noise_qubits in errors:
-                error = approximate_quantum_error(error, operator_string=operator_string, operator_dict=operator_dict,
-                                                  operator_list=operator_list)
+        for qubits_str, noise_dict in qubit_dict.items():
+            for noise_str, error in noise_dict.items():
+                error = approximate_quantum_error(
+                    error,
+                    operator_string=operator_string,
+                    operator_dict=operator_dict,
+                    operator_list=operator_list)
                 error_dict = error.as_dict()
                 error_dict["operations"] = [operation]
                 error_dict["gate_qubits"] = [model._str2qubits(qubits_str)]
-                error_dict["noise_qubits"] = [list(noise_qubits)]
+                error_dict["noise_qubits"] = [model._str2qubits(noise_str)]
                 error_list.append(error_dict)
 
     # Add default readout error
     if model._default_readout_error is not None:
-        error = approximate_quantum_error(model._default_readout_error, operator_string=operator_string, operator_dict=operator_dict,
-                                          operator_list=operator_list)
+        error = approximate_quantum_error(
+            model._default_readout_error,
+            operator_string=operator_string,
+            operator_dict=operator_dict,
+            operator_list=operator_list)
         error_dict = error.as_dict()
         error_list.append(error_dict)
 
     # Add local readout error
     for qubits_str, error in model._local_readout_errors.items():
-        error = approximate_quantum_error(error, operator_string=operator_string, operator_dict=operator_dict,
-                                          operator_list=operator_list)
+        error = approximate_quantum_error(
+            error,
+            operator_string=operator_string,
+            operator_dict=operator_dict,
+            operator_list=operator_list)
         error_dict = error.as_dict()
         error_dict["gate_qubits"] = [model._str2qubits(qubits_str)]
         error_list.append(error_dict)
 
-    approx_noise_model = NoiseModel.from_dict({"errors": error_list, "x90_gates": model._x90_gates})
+    approx_noise_model = NoiseModel.from_dict({
+        "errors": error_list,
+        "x90_gates": model._x90_gates
+    })
+    # Update basis gates
+    approx_noise_model._basis_gates = model._basis_gates
     return approx_noise_model
 
+
 class NoiseTransformer:
-    """Transforms one quantum noise channel to another based on a specified criteria.
-    """
+    """Transforms one quantum channel to another based on a specified criteria."""
 
     def __init__(self):
         self.named_operators = {
-            'pauli': {'X': [{'name': 'x', 'qubits': [0]}],
-                      'Y': [{'name': 'y', 'qubits': [0]}],
-                      'Z': [{'name': 'z', 'qubits': [0]}]
-                      },
-            'reset': {
-                'p': [{'name': 'reset','qubits': [0]}], #reset to |0>
-                'q': [{'name': 'reset', 'qubits': [0]}, {'name': 'x','qubits': [0]}] #reset to |1>
+            'pauli': {
+                'X': [{'name': 'x', 'qubits': [0]}],
+                'Y': [{'name': 'y', 'qubits': [0]}],
+                'Z': [{'name': 'z', 'qubits': [0]}]
             },
-            'clifford': dict([(j, single_qubit_clifford_instructions(j)) for j in range(1,24)])
+            'reset': {
+                'p': [{'name': 'reset', 'qubits': [0]}],  # reset to |0>
+                'q': [{'name': 'reset', 'qubits': [0]},
+                      {'name': 'x', 'qubits': [0]}]  # reset to |1>
+            },
+            'clifford': dict([(j, single_qubit_clifford_instructions(j))
+                              for j in range(1, 24)])
         }
-
         self.fidelity_data = None
         self.use_honesty_constraint = True
         self.noise_kraus_operators = None
         self.transform_channel_operators = None
 
     def operator_matrix(self, operator):
-        """
-            Converts an operator representation to Kraus matrix representation
+        """Converts an operator representation to Kraus matrix representation
+
         Args:
-            operator: operator representation. Can be a noise circuit or a matrix or a list of matrices
-        Output:
-            The operator, converted to Kraus representation
+            operator (operator): operator representation. Can be a noise
+                circuit or a matrix or a list of matrices.
+
+        Returns:
+            Kraus: the operator, converted to Kraus representation.
         """
         if isinstance(operator, list) and isinstance(operator[0], dict):
             operator_error = QuantumError([(operator, 1)])
@@ -200,17 +253,18 @@ class NoiseTransformer:
         return operator
 
     def operator_circuit(self, operator):
+        """Converts an operator representation to noise circuit
+        Args:
+            operator (operator): operator representation. Can be a noise
+                circuit or a matrix or a list of matrices.
+        Output:
+            List: The operator, converted to noise circuit representation.
         """
-            Converts an operator representation to noise circuit
-               Args:
-                   operator: operator representation. Can be a noise circuit or a matrix or a list of matrices
-               Output:
-                   The operator, converted to noise circuit representation
-               """
         if isinstance(operator, numpy.ndarray):
             return [{'name': 'unitary', 'qubits': [0], 'params': [operator]}]
 
-        if isinstance(operator, list) and isinstance(operator[0], numpy.ndarray):
+        if isinstance(operator, list) and isinstance(operator[0],
+                                                     numpy.ndarray):
             if len(operator) == 1:
                 return [{'name': 'unitary', 'qubits': [0], 'params': operator}]
             else:
@@ -218,18 +272,16 @@ class NoiseTransformer:
 
         return operator
 
-
-
     # transformation interface methods
-    def transform_by_operator_list(self, transform_channel_operators, noise_kraus_operators):
+    def transform_by_operator_list(self, transform_channel_operators,
+                                   noise_kraus_operators):
         """
         Args:
-                noise_kraus_operators: a list of matrices (Kraus operators) for the input channel
-                transform_channel_operators: a list of matrices or tuples of matrices
-                representing Kraus operators that can construct the output channel
-                e.g. [X,Y,Z] represent the Pauli channel
-                and [(|0><0|, |0><1|), |1><0|, |1><1|)] represents the relaxation channel
-
+            noise_kraus_operators: a list of matrices (Kraus operators) for the input channel
+            transform_channel_operators: a list of matrices or tuples of matrices
+            representing Kraus operators that can construct the output channel
+            e.g. [X,Y,Z] represent the Pauli channel
+            and [(|0><0|, |0><1|), |1><0|, |1><1|)] represents the relaxation channel
 
         Output:
             A list of amplitudes that define the output channel.
@@ -252,15 +304,19 @@ class NoiseTransformer:
         """
         self.noise_kraus_operators = noise_kraus_operators
         self.transform_channel_operators = transform_channel_operators
-        full_transform_channel_operators = self.prepare_channel_operator_list(self.transform_channel_operators)
-        channel_matrices, const_channel_matrix = self.generate_channel_matrices(full_transform_channel_operators)
+        full_transform_channel_operators = self.prepare_channel_operator_list(
+            self.transform_channel_operators)
+        channel_matrices, const_channel_matrix = self.generate_channel_matrices(
+            full_transform_channel_operators)
         self.prepare_honesty_constraint(full_transform_channel_operators)
-        probabilities = self.transform_by_given_channel(channel_matrices, const_channel_matrix)
+        probabilities = self.transform_by_given_channel(
+            channel_matrices, const_channel_matrix)
         return probabilities
 
-    # convert to sympy matrices and verify that each singleton is in a tuple; also add identity matrix
     @staticmethod
     def prepare_channel_operator_list(ops_list):
+        # convert to sympy matrices and verify that each singleton is
+        # in a tuple; also add identity matrix
         result = [[sympy.eye(2)]]
         for ops in ops_list:
             if not isinstance(ops, tuple) and not isinstance(ops, list):
@@ -272,17 +328,20 @@ class NoiseTransformer:
         if not self.use_honesty_constraint:
             return
         goal = self.fidelity(self.noise_kraus_operators)
-        coefficients = [self.fidelity(ops) for ops in transform_channel_operators_list]
+        coefficients = [
+            self.fidelity(ops) for ops in transform_channel_operators_list
+        ]
         self.fidelity_data = {
             'goal': goal,
-            'coefficients': coefficients[1:]  # coefficients[0] corresponds to I
+            'coefficients':
+            coefficients[1:]  # coefficients[0] corresponds to I
         }
 
     # methods relevant to the transformation to quadratic programming instance
 
     @staticmethod
     def fidelity(channel):
-        return sum([numpy.abs(numpy.trace(E)) ** 2 for E in channel])
+        return sum([numpy.abs(numpy.trace(E))**2 for E in channel])
 
     def generate_channel_matrices(self, transform_channel_operators_list):
         """
@@ -311,47 +370,59 @@ class NoiseTransformer:
             we find it easier to work with this representation of C when performing the combinatorial optimization
         """
 
-        symbols_string = " ".join(["x{}".format(i) for i in range(len(transform_channel_operators_list))])
+        symbols_string = " ".join([
+            "x{}".format(i)
+            for i in range(len(transform_channel_operators_list))
+        ])
         symbols = sympy.symbols(symbols_string, real=True, positive=True)
-        exp = symbols[1] # exp will contain the symbolic expression "x1 +...+ xn"
+        exp = symbols[
+            1]  # exp will contain the symbolic expression "x1 +...+ xn"
         for i in range(2, len(symbols)):
             exp = symbols[i] + exp
         # symbolic_operators_list is a list of lists; we flatten it the next line
-        symbolic_operators_list = [[sympy.sqrt(symbols[i]) * op for op in ops]
-                                   for (i, ops) in enumerate(transform_channel_operators_list)]
-        symbolic_operators = [op for ops in symbolic_operators_list for op in ops]
-        # channel_matrix_representation() peforms the required linear algebra to find the representing matrices.
-        operators_channel = self.channel_matrix_representation(symbolic_operators).subs(symbols[0], 1 - exp)
-        return self.generate_channel_quadratic_programming_matrices(operators_channel, symbols[1:])
+        symbolic_operators_list = [[
+            sympy.sqrt(symbols[i]) * op for op in ops
+        ] for (i, ops) in enumerate(transform_channel_operators_list)]
+        symbolic_operators = [
+            op for ops in symbolic_operators_list for op in ops
+        ]
+        # channel_matrix_representation() peforms the required linear
+        # algebra to find the representing matrices.
+        operators_channel = self.channel_matrix_representation(
+            symbolic_operators).subs(symbols[0], 1 - exp)
+        return self.generate_channel_quadratic_programming_matrices(
+            operators_channel, symbols[1:])
 
     @staticmethod
     def compute_channel_operation(rho, operators):
-        """
-        Given a quantum state's density function rho, the effect of the channel on this state is
-        rho -> \sum_{i=1}^n E_i * rho * E_i^\dagger
-        """
-
-        return sum([E * rho * E.H for E in operators], sympy.zeros(operators[0].rows))
+        # Given a quantum state's density function rho, the effect of the
+        # channel on this state is
+        # rho -> \sum_{i=1}^n E_i * rho * E_i^\dagger
+        return sum([E * rho * E.H for E in operators],
+                   sympy.zeros(operators[0].rows))
 
     @staticmethod
     def flatten_matrix(m):
         return [element for element in m]
 
     def channel_matrix_representation(self, operators):
-        """
-        We convert the operators to a matrix by applying the channel to the four basis elements of
-        the 2x2 matrix space representing density operators; this is standard linear algebra
-        """
+        # We convert the operators to a matrix by applying the channel to
+        # the four basis elements of the 2x2 matrix space representing
+        # density operators; this is standard linear algebra
         standard_base = [
             sympy.Matrix([[1, 0], [0, 0]]),
             sympy.Matrix([[0, 1], [0, 0]]),
             sympy.Matrix([[0, 0], [1, 0]]),
             sympy.Matrix([[0, 0], [0, 1]])
         ]
-        return (sympy.Matrix([self.flatten_matrix(self.compute_channel_operation(rho, operators))
-                              for rho in standard_base]))
+        return (sympy.Matrix([
+            self.flatten_matrix(
+                self.compute_channel_operation(rho, operators))
+            for rho in standard_base
+        ]))
 
-    def generate_channel_quadratic_programming_matrices(self, channel, symbols):
+    def generate_channel_quadratic_programming_matrices(
+            self, channel, symbols):
         """
         Args:
              channel: a 4x4 symbolic matrix
@@ -361,55 +432,65 @@ class NoiseTransformer:
             A list of 4x4 complex matrices ([D1, D2, ..., Dn], E) such that:
             channel == x1*D1 + ... + xn*Dn + E
         """
-        return (
-            [self.get_matrix_from_channel(channel, symbol) for symbol in symbols],
-            self.get_const_matrix_from_channel(channel, symbols)
-        )
+        return ([
+            self.get_matrix_from_channel(channel, symbol) for symbol in symbols
+        ], self.get_const_matrix_from_channel(channel, symbols))
 
     @staticmethod
     def get_matrix_from_channel(channel, symbol):
-        """
-        Args:
-            channel: a 4x4 symbolic matrix.
-            Each entry is assumed to be a polynomial of the form a1x1 + ... + anxn + c
-            symbol: a symbol xi
+        """Extract the numeric parameter matrix.
 
-        Output:
-            A 4x4 numerical matrix where for each entry,
-            if a1x1 + ... + anxn + c was the corresponding entry in the input channel
-            then the corresponding entry in the output matrix is ai.
+        Args:
+            channel (matrix): a 4x4 symbolic matrix.
+            symbol (list): a symbol xi
+
+        Returns
+            matrix: a 4x4 numeric matrix.
+
+        Additional Information
+        ----------------------
+        Each entry of the 4x4 symbolic input channel matrix is assumed to
+        be a polynomial of the form a1x1 + ... + anxn + c. The corresponding
+        entry in the output numeric matrix is ai.
         """
         n = channel.rows
         M = numpy.zeros((n, n), dtype=numpy.complex_)
         for (i, j) in itertools.product(range(n), range(n)):
-            M[i, j] = numpy.complex(sympy.Poly(channel[i, j], symbol).coeff_monomial(symbol))
+            M[i, j] = numpy.complex(
+                sympy.Poly(channel[i, j], symbol).coeff_monomial(symbol))
         return M
 
     @staticmethod
     def get_const_matrix_from_channel(channel, symbols):
-        """
-                Args:
-                    channel: a 4x4 symbolic matrix.
-                    Each entry is assumed to be a polynomial of the form a1x1 + ... + anxn + c
-                    symbols: The full list [x1, ..., xn] of symbols used in the matrix
+        """Extract the numeric constant matrix.
 
-                Output:
-                    A 4x4 numerical matrix where for each entry,
-                    if a1x1 + ... + anxn + c was the corresponding entry in the input channel
-                    then the corresponding entry in the output matrix is c.
-                """
+        Args:
+            channel (matrix): a 4x4 symbolic matrix.
+            symbols (list): The full list [x1, ..., xn] of symbols
+                used in the matrix.
+
+        Returns
+            matrix: a 4x4 numeric matrix.
+
+        Additional Information
+        ----------------------
+        Each entry of the 4x4 symbolic input channel matrix is assumed to
+        be a polynomial of the form a1x1 + ... + anxn + c. The corresponding
+        entry in the output numeric matrix is c.
+        """
         n = channel.rows
         M = numpy.zeros((n, n), dtype=numpy.complex_)
         for (i, j) in itertools.product(range(n), range(n)):
-            M[i, j] = numpy.complex(sympy.Poly(channel[i, j], symbols).coeff_monomial(1))
+            M[i, j] = numpy.complex(
+                sympy.Poly(channel[i, j], symbols).coeff_monomial(1))
         return M
 
-    def transform_by_given_channel(self, channel_matrices, const_channel_matrix):
-        """
-        This method creates the quadratic programming instance for minimizing the Hilbert-Schmidt
-        norm of the matrix (A-B) obtained as the difference of the input noise channel and the
-        output channel we wish to determine.
-        """
+    def transform_by_given_channel(self, channel_matrices,
+                                   const_channel_matrix):
+        # This method creates the quadratic programming instance for
+        # minimizing the Hilbert-Schmidt norm of the matrix (A-B) obtained
+        # as the difference of the input noise channel and the output
+        # channel we wish to determine.
         target_channel = SuperOp(Kraus(self.noise_kraus_operators))
         target_channel_matrix = target_channel._data.T
 
@@ -441,7 +522,8 @@ class NoiseTransformer:
         try:
             import cvxopt
         except ImportError:
-            raise ImportError("The CVXOPT library is required to use this module")
+            raise ImportError(
+                "The CVXOPT library is required to use this module")
         P = cvxopt.matrix(numpy.array(P).astype(float))
         q = cvxopt.matrix(numpy.array(q).astype(float)).T
         n = len(q)
@@ -449,7 +531,8 @@ class NoiseTransformer:
         #   1) sum of probs is less then 1
         #   2) All probs bigger than 0
         #   3) Honesty (measured using fidelity, if given)
-        G_data = [[1] * n] + [([-1 if i == k else 0 for i in range(n)]) for k in range(n)]
+        G_data = [[1] * n] + [([-1 if i == k else 0 for i in range(n)])
+                              for k in range(n)]
         h_data = [1] + [0] * n
         if self.fidelity_data is not None:
             G_data.append(self.fidelity_data['coefficients'])

--- a/test/terra/noise/test_noise_remapper.py
+++ b/test/terra/noise/test_noise_remapper.py
@@ -1,0 +1,133 @@
+"""
+NoiseModel class integration tests
+"""
+
+import unittest
+from test.terra import common
+from qiskit.providers.aer.noise import NoiseModel
+from qiskit.providers.aer.noise.noiseerror import NoiseError
+from qiskit.providers.aer.noise.errors import depolarizing_error
+from qiskit.providers.aer.noise.utils import remap_noise_model
+
+
+class TestNoiseRemapper(common.QiskitAerTestCase):
+    """Testing remap_noise_model function"""
+
+    def test_raises_duplicate_qubits(self):
+        """Test duplicate qubits raises exception"""
+        model = NoiseModel()
+        self.assertRaises(NoiseError, remap_noise_model, model, [[0, 1], [2, 1]], warnings=False)
+        model = NoiseModel()
+        error = depolarizing_error(0.5, 1)
+        model.add_quantum_error(error, ['u3'], [2], False)
+        self.assertRaises(NoiseError, remap_noise_model, model, [[3, 2]], warnings=False)
+
+    def test_remap_all_qubit_quantum_errors(self):
+        """Test remapper doesn't effect all-qubit quantum errors."""
+        model = NoiseModel()
+        error1 = depolarizing_error(0.5, 1)
+        error2 = depolarizing_error(0.5, 2)
+        model.add_all_qubit_quantum_error(error1, ['u3'], False)
+        model.add_all_qubit_quantum_error(error2, ['cx'], False)
+
+        remapped_model = remap_noise_model(model, [[0, 1], [1, 0]], warnings=False)
+        self.assertEqual(model, remapped_model)
+
+    def test_remap_quantum_errors(self):
+        """Test remapping of quantum errors."""
+        model = NoiseModel()
+        error1 = depolarizing_error(0.5, 1)
+        error2 = depolarizing_error(0.5, 2)
+        model.add_quantum_error(error1, ['u3'], [0], False)
+        model.add_quantum_error(error2, ['cx'], [1, 2], False)
+
+        remapped_model = remap_noise_model(model, [[0, 1], [1, 2], [2, 0]], warnings=False)
+        target = NoiseModel()
+        target.add_quantum_error(error1, ['u3'], [1], False)
+        target.add_quantum_error(error2, ['cx'], [2, 0], False)
+        self.assertEqual(remapped_model, target)
+
+    def test_remap_nonlocal_quantum_errors(self):
+        """Test remapping of non-local quantum errors."""
+        model = NoiseModel()
+        error1 = depolarizing_error(0.5, 1)
+        error2 = depolarizing_error(0.5, 2)
+        model.add_nonlocal_quantum_error(error1, ['u3'], [0], [1], False)
+        model.add_nonlocal_quantum_error(error2, ['cx'], [1, 2], [3, 0], False)
+
+        remapped_model = remap_noise_model(model, [[0, 1], [1, 2], [2, 0]], warnings=False)
+        target = NoiseModel()
+        target.add_nonlocal_quantum_error(error1, ['u3'], [1], [2], False)
+        target.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
+        self.assertEqual(remapped_model, target)
+
+    def test_remap_all_qubit_readout_errors(self):
+        """Test remapping of all-qubit readout errors."""
+        model = NoiseModel()
+        error1 = [[0.9, 0.1], [0.5, 0.5]]
+        model.add_all_qubit_readout_error(error1, False)
+
+        remapped_model = remap_noise_model(model, [[0, 1], [1, 2], [2, 0]], warnings=False)
+        self.assertEqual(remapped_model, model)
+
+    def test_remap_readout_errors(self):
+        """Test remapping of readout errors."""
+        model = NoiseModel()
+        error1 = [[0.9, 0.1], [0.5, 0.5]]
+        error2 = [[0.8, 0.2, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0.1, 0.9]]
+        model.add_readout_error(error1, [1], False)
+        model.add_readout_error(error2, [0, 2], False)
+
+        remapped_model = remap_noise_model(model, [[0, 1], [1, 2], [2, 0]], warnings=False)
+        target = NoiseModel()
+        target.add_readout_error(error1, [2], False)
+        target.add_readout_error(error2, [1, 0], False)
+        self.assertEqual(remapped_model, target)
+
+    def test_reduce_noise_model(self):
+        """Test reduction mapping of noise model."""
+        error1 = depolarizing_error(0.5, 1)
+        error2 = depolarizing_error(0.5, 2)
+        roerror1 = [[0.9, 0.1], [0.5, 0.5]]
+        roerror2 = [[0.8, 0.2, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0.1, 0.9]]
+
+        model = NoiseModel()
+        model.add_all_qubit_quantum_error(error1, ['u3'], False)
+        model.add_quantum_error(error1, ['u3'], [1], False)
+        model.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
+        model.add_all_qubit_readout_error(roerror1, False)
+        model.add_readout_error(roerror2, [0, 2], False)
+
+        remapped_model = remap_noise_model(model, [0, 1, 2], discard_qubits=True, warnings=False)
+        target = NoiseModel()
+        target.add_all_qubit_quantum_error(error1, ['u3'], False)
+        target.add_quantum_error(error1, ['u3'], [1], False)
+        target.add_all_qubit_readout_error(roerror1, False)
+        target.add_readout_error(roerror2, [0, 2], False)
+        self.assertEqual(remapped_model, target)
+
+    def test_reduce_remapped_noise_model(self):
+        """Test reduction and remapping of noise model."""
+        error1 = depolarizing_error(0.5, 1)
+        error2 = depolarizing_error(0.5, 2)
+        roerror1 = [[0.9, 0.1], [0.5, 0.5]]
+        roerror2 = [[0.8, 0.2, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0.1, 0.9]]
+
+        model = NoiseModel()
+        model.add_all_qubit_quantum_error(error1, ['u3'], False)
+        model.add_quantum_error(error1, ['u3'], [1], False)
+        model.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
+        model.add_all_qubit_readout_error(roerror1, False)
+        model.add_readout_error(roerror2, [0, 2], False)
+
+        remapped_model = remap_noise_model(model, [2, 0, 1], discard_qubits=True, warnings=False)
+        target = NoiseModel()
+        target.add_all_qubit_quantum_error(error1, ['u3'], False)
+        target.add_quantum_error(error1, ['u3'], [2], False)
+        target.add_all_qubit_readout_error(roerror1, False)
+        target.add_readout_error(roerror2, [1, 0], False)
+        self.assertEqual(remapped_model, target)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/terra/noise/test_noise_transformation.py
+++ b/test/terra/noise/test_noise_transformation.py
@@ -30,64 +30,101 @@ try:
 except ImportError:
     has_cvxopt = False
 
+
 @unittest.skipUnless(has_cvxopt, "Needs cvxopt to test")
 class TestNoiseTransformer(unittest.TestCase):
     def setUp(self):
-        self.ops = {'X': standard_gate_unitary('x'),
-                    'Y': standard_gate_unitary('y'),
-                    'Z': standard_gate_unitary('z'),
-                    'H': standard_gate_unitary('h'),
-                    'S': standard_gate_unitary('s')
-                    }
+        self.ops = {
+            'X': standard_gate_unitary('x'),
+            'Y': standard_gate_unitary('y'),
+            'Z': standard_gate_unitary('z'),
+            'H': standard_gate_unitary('h'),
+            'S': standard_gate_unitary('s')
+        }
         self.n = NoiseTransformer()
 
-
-    def assertNoiseModelsAlmostEqual(self, lhs, rhs, places = 3):
-        self.assertNoiseDictsAlmostEqual(lhs._nonlocal_quantum_errors, rhs._nonlocal_quantum_errors, places=places)
-        self.assertNoiseDictsAlmostEqual(lhs._local_quantum_errors, rhs._local_quantum_errors, places=places)
-        self.assertNoiseDictsAlmostEqual(lhs._default_quantum_errors, rhs._default_quantum_errors, places=places)
-        self.assertNoiseDictsAlmostEqual(lhs._local_readout_errors, rhs._local_readout_errors, places=places)
+    def assertNoiseModelsAlmostEqual(self, lhs, rhs, places=3):
+        self.assertNoiseDictsAlmostEqual(
+            lhs._nonlocal_quantum_errors,
+            rhs._nonlocal_quantum_errors,
+            places=places)
+        self.assertNoiseDictsAlmostEqual(
+            lhs._local_quantum_errors,
+            rhs._local_quantum_errors,
+            places=places)
+        self.assertNoiseDictsAlmostEqual(
+            lhs._default_quantum_errors,
+            rhs._default_quantum_errors,
+            places=places)
+        self.assertNoiseDictsAlmostEqual(
+            lhs._local_readout_errors,
+            rhs._local_readout_errors,
+            places=places)
         if lhs._default_readout_error is not None:
             self.assertTrue(rhs._default_readout_error is not None)
-            self.assertErrorsAlmostEqual(lhs._default_readout_error, rhs._default_readout_error, places=places)
+            self.assertErrorsAlmostEqual(
+                lhs._default_readout_error,
+                rhs._default_readout_error,
+                places=places)
         else:
             self.assertTrue(rhs._default_readout_error is None)
 
     def assertNoiseDictsAlmostEqual(self, lhs, rhs, places=3):
         keys = set(lhs.keys()).union(set(rhs.keys()))
         for key in keys:
-            self.assertTrue(key in lhs.keys(), msg="Key {} is missing from lhs".format(key))
-            self.assertTrue(key in rhs.keys(), msg="Key {} is missing from rhs".format(key))
-            for (lhs_error, rhs_error) in zip (lhs[key], rhs[key]):
-                self.assertErrorsAlmostEqual(lhs_error, rhs_error, places=places)
+            self.assertTrue(
+                key in lhs.keys(),
+                msg="Key {} is missing from lhs".format(key))
+            self.assertTrue(
+                key in rhs.keys(),
+                msg="Key {} is missing from rhs".format(key))
+            if isinstance(lhs[key], dict):
+                self.assertNoiseDictsAlmostEqual(lhs[key], rhs[key], places=places)
+            else:
+                self.assertErrorsAlmostEqual(lhs[key], rhs[key], places=places)
 
-    def assertErrorsAlmostEqual(self, lhs, rhs, places = 3):
-        self.assertMatricesAlmostEqual(lhs.to_quantumchannel()._data, rhs.to_quantumchannel()._data, places)
+    def assertErrorsAlmostEqual(self, lhs, rhs, places=3):
+        self.assertMatricesAlmostEqual(lhs.to_quantumchannel()._data,
+                                       rhs.to_quantumchannel()._data, places)
 
-    def assertDictAlmostEqual(self, lhs, rhs, places = None):
+    def assertDictAlmostEqual(self, lhs, rhs, places=None):
         keys = set(lhs.keys()).union(set(rhs.keys()))
         for key in keys:
-            self.assertAlmostEqual(lhs.get(key), rhs.get(key), msg = "Not almost equal for key {}: {} !~ {}".format(key, lhs.get(key), rhs.get(key)), places = places)
+            self.assertAlmostEqual(
+                lhs.get(key),
+                rhs.get(key),
+                msg="Not almost equal for key {}: {} !~ {}".format(
+                    key, lhs.get(key), rhs.get(key)),
+                places=places)
 
-    def assertListAlmostEqual(self, lhs, rhs, places = None):
-        self.assertEqual(len(lhs), len(rhs), msg = "List lengths differ: {} != {}".format(len(lhs), len(rhs)))
+    def assertListAlmostEqual(self, lhs, rhs, places=None):
+        self.assertEqual(
+            len(lhs),
+            len(rhs),
+            msg="List lengths differ: {} != {}".format(len(lhs), len(rhs)))
         for i in range(len(lhs)):
-            if isinstance(lhs[i], numpy.ndarray) and isinstance(rhs[i], numpy.ndarray):
-                self.assertMatricesAlmostEqual(lhs[i], rhs[i], places = places)
+            if isinstance(lhs[i], numpy.ndarray) and isinstance(
+                    rhs[i], numpy.ndarray):
+                self.assertMatricesAlmostEqual(lhs[i], rhs[i], places=places)
             else:
-                self.assertAlmostEqual(lhs[i], rhs[i], places = places)
+                self.assertAlmostEqual(lhs[i], rhs[i], places=places)
 
-    def assertMatricesAlmostEqual(self, lhs, rhs, places = None):
-        self.assertEqual(lhs.shape, rhs.shape, "Marix shapes differ: {} vs {}".format(lhs, rhs))
+    def assertMatricesAlmostEqual(self, lhs, rhs, places=None):
+        self.assertEqual(lhs.shape, rhs.shape,
+                         "Marix shapes differ: {} vs {}".format(lhs, rhs))
         n, m = lhs.shape
         for x in range(n):
             for y in range(m):
-                self.assertAlmostEqual(lhs[x,y], rhs[x,y], places = places, msg="Matrices {} and {} differ on ({}, {})".format(lhs, rhs, x, y))
-
+                self.assertAlmostEqual(
+                    lhs[x, y],
+                    rhs[x, y],
+                    places=places,
+                    msg="Matrices {} and {} differ on ({}, {})".format(
+                        lhs, rhs, x, y))
 
     def test_transformation_by_pauli(self):
         n = NoiseTransformer()
-        #polarization in the XY plane; we represent via Kraus operators
+        # polarization in the XY plane; we represent via Kraus operators
         X = self.ops['X']
         Y = self.ops['Y']
         Z = self.ops['Z']
@@ -95,17 +132,24 @@ class TestNoiseTransformer(unittest.TestCase):
         theta = numpy.pi / 5
         E0 = numpy.sqrt(1 - p) * numpy.array(numpy.eye(2))
         E1 = numpy.sqrt(p) * (numpy.cos(theta) * X + numpy.sin(theta) * Y)
-        results = approximate_quantum_error((E0, E1), operator_dict={"X": X, "Y": Y, "Z": Z})
-        expected_results = pauli_error([('X', p*numpy.cos(theta)*numpy.cos(theta)),
-                                        ('Y', p*numpy.sin(theta)*numpy.sin(theta)),
-                                        ('Z', 0),
-                                        ('I', 1-p)])
+        results = approximate_quantum_error((E0, E1),
+                                            operator_dict={
+                                                "X": X,
+                                                "Y": Y,
+                                                "Z": Z})
+        expected_results = pauli_error(
+            [('X', p * numpy.cos(theta) * numpy.cos(theta)),
+             ('Y', p * numpy.sin(theta) * numpy.sin(theta)), ('Z', 0),
+             ('I', 1 - p)])
         self.assertErrorsAlmostEqual(expected_results, results)
 
-
-        #now try again without fidelity; should be the same
+        # now try again without fidelity; should be the same
         n.use_honesty_constraint = False
-        results = approximate_quantum_error((E0, E1), operator_dict={"X": X, "Y": Y, "Z": Z})
+        results = approximate_quantum_error((E0, E1),
+                                            operator_dict={
+                                                "X": X,
+                                                "Y": Y,
+                                                "Z": Z})
         self.assertErrorsAlmostEqual(expected_results, results)
 
     def test_reset(self):
@@ -114,7 +158,7 @@ class TestNoiseTransformer(unittest.TestCase):
         error = amplitude_damping_error(gamma)
         p = (gamma - numpy.sqrt(1 - gamma) + 1) / 2
         q = 0
-        expected_results = reset_error(p,q)
+        expected_results = reset_error(p, q)
         results = approximate_quantum_error(error, operator_string="reset")
         self.assertErrorsAlmostEqual(results, expected_results)
 
@@ -127,10 +171,17 @@ class TestNoiseTransformer(unittest.TestCase):
         E0 = numpy.sqrt(1 - p) * numpy.array(numpy.eye(2))
         E1 = numpy.sqrt(p) * (numpy.cos(theta) * X + numpy.sin(theta) * Y)
 
-        results_dict = approximate_quantum_error((E0, E1), operator_dict={"X": X, "Y": Y, "Z": Z})
-        results_string = approximate_quantum_error((E0, E1), operator_string='pauli')
-        results_list = approximate_quantum_error((E0, E1), operator_list=[X, Y, Z])
-        results_tuple = approximate_quantum_error((E0, E1), operator_list=(X, Y, Z))
+        results_dict = approximate_quantum_error((E0, E1),
+                                                 operator_dict={
+                                                     "X": X,
+                                                     "Y": Y,
+                                                     "Z": Z})
+        results_string = approximate_quantum_error((E0, E1),
+                                                   operator_string='pauli')
+        results_list = approximate_quantum_error((E0, E1),
+                                                 operator_list=[X, Y, Z])
+        results_tuple = approximate_quantum_error((E0, E1),
+                                                  operator_list=(X, Y, Z))
 
         self.assertErrorsAlmostEqual(results_dict, results_string)
         self.assertErrorsAlmostEqual(results_string, results_list)
@@ -140,7 +191,10 @@ class TestNoiseTransformer(unittest.TestCase):
         n = NoiseTransformer()
         expected_fidelity = {'X': 0, 'Y': 0, 'Z': 0, 'H': 0, 'S': 2}
         for key in expected_fidelity:
-            self.assertAlmostEqual(expected_fidelity[key], n.fidelity([self.ops[key]]), msg = "Wrong fidelity for {}".format(key))
+            self.assertAlmostEqual(
+                expected_fidelity[key],
+                n.fidelity([self.ops[key]]),
+                msg="Wrong fidelity for {}".format(key))
 
     def test_approx_noise_model(self):
         noise_model = NoiseModel()
@@ -148,7 +202,7 @@ class TestNoiseTransformer(unittest.TestCase):
         p = 0.4
         q = 0.33
         ad_error = amplitude_damping_error(gamma)
-        r_error = reset_error(p,q) #should be approximated as-is
+        r_error = reset_error(p, q)  # should be approximated as-is
         noise_model.add_all_qubit_quantum_error(ad_error, 'iden x y s')
         noise_model.add_all_qubit_quantum_error(r_error, 'iden z h')
 
@@ -158,7 +212,8 @@ class TestNoiseTransformer(unittest.TestCase):
         gamma_p = (gamma - numpy.sqrt(1 - gamma) + 1) / 2
         gamma_q = 0
         ad_error_approx = reset_error(gamma_p, gamma_q)
-        expected_result.add_all_qubit_quantum_error(ad_error_approx, 'iden x y s')
+        expected_result.add_all_qubit_quantum_error(ad_error_approx,
+                                                    'iden x y s')
         expected_result.add_all_qubit_quantum_error(r_error, 'iden z h')
 
         self.assertNoiseModelsAlmostEqual(expected_result, result)
@@ -167,7 +222,8 @@ class TestNoiseTransformer(unittest.TestCase):
         x_p = 0.17
         y_p = 0.13
         z_p = 0.34
-        error = pauli_error([('X', x_p), ('Y', y_p), ('Z', z_p), ('I', 1 - (x_p + y_p + z_p))])
+        error = pauli_error([('X', x_p), ('Y', y_p), ('Z', z_p),
+                             ('I', 1 - (x_p + y_p + z_p))])
         results = approximate_quantum_error(error, operator_string="clifford")
         self.assertErrorsAlmostEqual(error, results)
 
@@ -182,17 +238,22 @@ class TestNoiseTransformer(unittest.TestCase):
         gamma = 0.23
         error = amplitude_damping_error(gamma)
         # kraus error is legit, transform_channel_operators are not
-        with self.assertRaisesRegex(TypeError, "takes 1 positional argument but 2 were given"):
+        with self.assertRaisesRegex(
+                TypeError, "takes 1 positional argument but 2 were given"):
             approximate_quantum_error(error, 7)
-        with self.assertRaisesRegex(RuntimeError, "No information about noise type seven"):
+        with self.assertRaisesRegex(RuntimeError,
+                                    "No information about noise type seven"):
             approximate_quantum_error(error, operator_string="seven")
 
-        #let's pretend cvxopt does not exist; the script should raise ImportError with proper message
+        # let's pretend cvxopt does not exist; the script should raise ImportError with proper message
         import unittest.mock
         import sys
         with unittest.mock.patch.dict(sys.modules, {'cvxopt': None}):
-            with self.assertRaisesRegex(ImportError, "The CVXOPT library is required to use this module"):
+            with self.assertRaisesRegex(
+                    ImportError,
+                    "The CVXOPT library is required to use this module"):
                 approximate_quantum_error(error, operator_string="reset")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -711,6 +711,16 @@ class TestQuantumError(common.QiskitAerTestCase):
             iden) + 0.5 * iden.tensor(iden)
         self.assertEqual(target, error.to_quantumchannel())
 
+    def test_equal(self):
+        """Test two quantum errors are equal"""
+        Ai = np.sqrt(0.25) * standard_gate_unitary('id')
+        Ax = np.sqrt(0.25) * standard_gate_unitary('x')
+        Ay = np.sqrt(0.25) * standard_gate_unitary('y')
+        Az = np.sqrt(0.25) * standard_gate_unitary('z')
+        error1 = QuantumError([Ai, Ax, Ay, Az], standard_gates=True)
+        error2 = QuantumError([Ai, Ax, Ay, Az], standard_gates=False)
+        self.assertEqual(error1, error2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/noise/test_readout_error.py
+++ b/test/terra/noise/test_readout_error.py
@@ -170,6 +170,12 @@ class TestReadoutError(common.QiskitAerTestCase):
         self.assertEqual(error.probabilities.tolist(), probs)
         self.assertEqual(error.as_dict(), error_dict)
 
+    def test_equal(self):
+        """Test two readout errors are equal"""
+        error1 = ReadoutError([[0.9, 0.1], [0.5, 0.5]])
+        error2 = ReadoutError(np.array([[0.9, 0.1], [0.5, 0.5]]))
+        self.assertEqual(error1, error2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds a qubit reampper utility function for NoiseModels: `remap_noise_model` (generalizes @nonhermitian function in #181)
* Adds `__eq__` method to `NoiseModel`, `QuantumError`, `ReadoutError`
* Cleans up how errors are stored inside noise model so that errors are composed into a single error rather than stored as a list. This should help with simulation efficiency.
* Adds additional noise model tests

### Details and comments

