### PR TITLE
Improve qubit truncation circuit optimization

### DIFF
--- a/src/base/circuitopt.hpp
+++ b/src/base/circuitopt.hpp
@@ -24,7 +24,9 @@
 #include <string>
 #include <vector>
 
-#include "framework/operations.hpp"
+#include "framework/circuit.hpp"
+#include "framework/data.hpp"
+
 
 namespace AER {
 

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -37,7 +37,7 @@
 #include "framework/data.hpp"
 #include "framework/rng.hpp"
 #include "framework/creg.hpp"
-#include "framework/circuitopt.hpp"
+#include "transpile/circuitopt.hpp"
 #include "noise/noise_model.hpp"
 
 #ifdef _OPENMP
@@ -143,9 +143,9 @@ public:
 
   // Add circuit optimization
   template <typename Type>
-  inline auto add_circuit_optimization(Type&& opt)-> typename std::enable_if_t<std::is_base_of<CircuitOptimization, std::remove_const_t<std::remove_reference_t<Type>>>::value >
+  inline auto add_circuit_optimization(Type&& opt)-> typename std::enable_if_t<std::is_base_of<Transpile::CircuitOptimization, std::remove_const_t<std::remove_reference_t<Type>>>::value >
   {
-      optimizations_.push_back(std::make_shared<std::remove_const_t<std::remove_reference_t<Type> > >(std::forward<Type>(opt)));
+      optimizations_.push_back(std::make_shared<std::remove_const_t<std::remove_reference_t<Type>>>(std::forward<Type>(opt)));
   }
 
 protected:
@@ -212,7 +212,7 @@ protected:
   Noise::NoiseModel noise_model_;
 
   // Circuit optimization
-  std::vector<std::shared_ptr<CircuitOptimization>> optimizations_;
+  std::vector<std::shared_ptr<Transpile::CircuitOptimization>> optimizations_;
 
   //-----------------------------------------------------------------------
   // Parallelization Config
@@ -281,7 +281,7 @@ void Controller::set_config(const json_t &config) {
     max_memory_mb_ = system_memory_mb / 2;
   }
 
-  for (std::shared_ptr<CircuitOptimization> opt: optimizations_)
+  for (std::shared_ptr<Transpile::CircuitOptimization> opt: optimizations_)
     opt->set_config(config_);
 
   std::string path;
@@ -453,7 +453,7 @@ Circuit Controller::optimize_circuit(const Circuit &input_circ,
   allowed_opset.gates = state.allowed_gates();
   allowed_opset.snapshots = state.allowed_snapshots();
 
-  for (std::shared_ptr<CircuitOptimization> opt: optimizations_)
+  for (std::shared_ptr<Transpile::CircuitOptimization> opt: optimizations_)
     opt->optimize_circuit(working_circ, allowed_opset, data);
 
   return working_circ;

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -16,10 +16,12 @@
 #define _aer_qasm_controller_hpp_
 
 #include "base/controller.hpp"
+#include "transpile/basic_opts.hpp"
+#include "transpile/fusion.hpp"
+#include "transpile/truncate_qubits.hpp"
 #include "simulators/extended_stabilizer/extended_stabilizer_state.hpp"
 #include "simulators/statevector/statevector_state.hpp"
 #include "simulators/stabilizer/stabilizer_state.hpp"
-#include "simulators/qasm/basic_optimization.hpp"
 
 
 namespace AER {
@@ -240,9 +242,9 @@ protected:
 // Constructor
 //-------------------------------------------------------------------------
 QasmController::QasmController() {
-  add_circuit_optimization(ReduceNop());
-  add_circuit_optimization(Fusion());
-  add_circuit_optimization(TruncateQubits());
+  add_circuit_optimization(Transpile::ReduceNop());
+  add_circuit_optimization(Transpile::Fusion());
+  add_circuit_optimization(Transpile::TruncateQubits());
 }
 
 //-------------------------------------------------------------------------

--- a/src/transpile/basic_opts.hpp
+++ b/src/transpile/basic_opts.hpp
@@ -1,0 +1,73 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_transpile_basic_opt_hpp_
+#define _aer_transpile_basic_opt_hpp_
+
+#include "transpile/circuitopt.hpp"
+
+namespace AER {
+namespace Transpile {
+
+using uint_t = uint_t;
+using op_t = Operations::Op;
+using optype_t = Operations::OpType;
+using oplist_t = std::vector<op_t>;
+using opset_t = Operations::OpSet;
+using reg_t = std::vector<uint_t>;
+
+class ReduceNop : public CircuitOptimization {
+public:
+  void optimize_circuit(Circuit& circ,
+                        const opset_t &opset,
+                        OutputData &data) const override;
+};
+
+void ReduceNop::optimize_circuit(Circuit& circ,
+                                 const opset_t &allowed_opset,
+                                 OutputData &data) const {
+
+  oplist_t::iterator it = circ.ops.begin();
+  while (it != circ.ops.end()) {
+    if (it->type == optype_t::barrier)
+      it = circ.ops.erase(it);
+    else
+      ++it;
+  }
+}
+
+class Debug : public CircuitOptimization {
+public:
+  void optimize_circuit(Circuit& circ,
+                        const opset_t &opset,
+                        OutputData &data) const override;
+};
+
+void Debug::optimize_circuit(Circuit& circ,
+                             const opset_t &allowed_opset,
+                             OutputData &data) const {
+
+  oplist_t::iterator it = circ.ops.begin();
+  while (it != circ.ops.end()) {
+    std::clog << it->name << std::endl;
+    ++it;
+  }
+}
+
+
+//-------------------------------------------------------------------------
+} // end namespace Transpile
+} // end namespace AER
+//-------------------------------------------------------------------------
+#endif

--- a/src/transpile/circuitopt.hpp
+++ b/src/transpile/circuitopt.hpp
@@ -1,0 +1,56 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_circuit_optimization_hpp_
+#define _aer_circuit_optimization_hpp_
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "framework/operations.hpp"
+
+namespace AER {
+namespace Transpile {
+
+class CircuitOptimization {
+public:
+
+  CircuitOptimization() = default;
+  virtual ~CircuitOptimization() = default;
+
+  virtual void optimize_circuit(Circuit& circ,
+                                const Operations::OpSet &opset,
+                                OutputData &data) const = 0;
+
+  virtual void set_config(const json_t &config);
+
+protected:
+  json_t config_;
+};
+
+void CircuitOptimization::set_config(const json_t& config) {
+  config_ = config;
+}
+
+//-------------------------------------------------------------------------
+} // end namespace Transpile
+} // end namespace AER
+//-------------------------------------------------------------------------
+#endif

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -12,12 +12,13 @@
  * that they have been altered from the originals.
  */
 
-#ifndef _aer_basic_opt_hpp_
-#define _aer_basic_opt_hpp_
+#ifndef _aer_transpile_fusion_hpp_
+#define _aer_transpile_fusion_hpp_
 
-#include "framework/circuitopt.hpp"
+#include "transpile/circuitopt.hpp"
 
 namespace AER {
+namespace Transpile {
 
 using uint_t = uint_t;
 using op_t = Operations::Op;
@@ -25,44 +26,6 @@ using optype_t = Operations::OpType;
 using oplist_t = std::vector<op_t>;
 using opset_t = Operations::OpSet;
 using reg_t = std::vector<uint_t>;
-
-class ReduceNop : public CircuitOptimization {
-public:
-  void optimize_circuit(Circuit& circ,
-                        const opset_t &opset,
-                        OutputData &data) const override;
-};
-
-void ReduceNop::optimize_circuit(Circuit& circ,
-                                 const opset_t &allowed_opset,
-                                 OutputData &data) const {
-
-  oplist_t::iterator it = circ.ops.begin();
-  while (it != circ.ops.end()) {
-    if (it->type == optype_t::barrier)
-      it = circ.ops.erase(it);
-    else
-      ++it;
-  }
-}
-
-class Debug : public CircuitOptimization {
-public:
-  void optimize_circuit(Circuit& circ,
-                        const opset_t &opset,
-                        OutputData &data) const override;
-};
-
-void Debug::optimize_circuit(Circuit& circ,
-                             const opset_t &allowed_opset,
-                             OutputData &data) const {
-
-  oplist_t::iterator it = circ.ops.begin();
-  while (it != circ.ops.end()) {
-    std::clog << it->name << std::endl;
-    ++it;
-  }
-}
 
 class Fusion : public CircuitOptimization {
 public:
@@ -473,124 +436,8 @@ cmatrix_t Fusion::matrix(const op_t& op) const {
   }
 }
 
-class TruncateQubits : public CircuitOptimization {
-public:
-
-  void set_config(const json_t &config) override;
-
-  // truncate unnecessary qubits
-  void optimize_circuit(Circuit& circ,
-                        const opset_t &opset,
-                        OutputData &data) const override;
-
-private:
-  // check this optimization can be applied
-  bool can_apply(const Circuit& circ) const;
-
-  // check this optimization can be applied
-  bool can_apply(const op_t& op) const;
-
-  // generate a new mapping. a value of reg_t is original and its index is the new mapping
-  reg_t generate_mapping(const Circuit& circ) const;
-
-  // remap qubits in an operation
-  op_t remap_qubits(const op_t op, const reg_t new_mapping)const;
-
-  // show debug info
-  bool verbose_ = false;
-
-  // disabled in config
-  bool active_ = true;
-};
-
-void TruncateQubits::set_config(const json_t &config) {
-
-  CircuitOptimization::set_config(config);
-
-  if (JSON::check_key("truncate_verbose", config_))
-    JSON::get_value(verbose_, "truncate_verbose", config_);
-
-  if (JSON::check_key("truncate_enable", config_))
-    JSON::get_value(active_, "truncate_enable", config_);
-
-  if (JSON::check_key("initial_statevector", config_))
-    active_ = false;
-
-}
-
-void TruncateQubits::optimize_circuit(Circuit& circ,
-                             const opset_t &allowed_opset,
-                             OutputData &data) const {
-
-  if (!active_ || !can_apply(circ))
-    return;
-
-  reg_t new_mapping = generate_mapping(circ);
-
-  if (new_mapping.size() == circ.num_qubits)
-    return;
-
-  oplist_t new_ops;
-  for (const op_t& old_op: circ.ops)
-    new_ops.push_back(remap_qubits(old_op, new_mapping));
-
-  circ.ops = new_ops;
-  circ.num_qubits = new_mapping.size();
-
-  if (verbose_) {
-    data.add_additional_data("metadata",
-                             json_t::object({{"truncate_verbose", new_mapping}}));
-  }
-
-}
-
-reg_t TruncateQubits::generate_mapping(const Circuit& circ) const {
-  size_t not_used = circ.num_qubits + 1;
-  reg_t mapping = reg_t(circ.num_qubits, not_used);
-
-  for (const op_t& op: circ.ops)
-    for (size_t qubit: op.qubits)
-      mapping[qubit] = qubit;
-
-  mapping.erase(std::remove(mapping.begin(), mapping.end(), not_used), mapping.end());
-
-  return mapping;
-}
-
-op_t TruncateQubits::remap_qubits(const op_t op, const reg_t new_mapping) const {
-  op_t new_op = op;
-  new_op.qubits.clear();
-
-  for (const size_t qubit: op.qubits) {
-    size_t new_qubit = std::distance(new_mapping.begin(), find(new_mapping.begin(), new_mapping.end(), qubit));
-    new_op.qubits.push_back(new_qubit);
-  }
-  return new_op;
-
-}
-
-bool TruncateQubits::can_apply(const Circuit& circ) const {
-
-  for (const op_t& op: circ.ops)
-    if (!can_apply(op))
-      return false;
-
-  return true;
-}
-
-bool TruncateQubits::can_apply(const op_t& op) const {
-  switch (op.type) {
-  case optype_t::matrix_sequence: //TODO
-  case optype_t::kraus: //TODO
-  case optype_t::snapshot:
-  case optype_t::noise_switch:
-    return false;
-  default:
-    return true;
-  }
-}
-
 //-------------------------------------------------------------------------
+} // end namespace Transpile
 } // end namespace AER
 //-------------------------------------------------------------------------
 

--- a/src/transpile/truncate_qubits.hpp
+++ b/src/transpile/truncate_qubits.hpp
@@ -1,0 +1,153 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_transpile_truncate_qubits_hpp_
+#define _aer_transpile_truncate_qubits_hpp_
+
+#include "transpile/circuitopt.hpp"
+
+namespace AER {
+namespace Transpile {
+
+
+using uint_t = uint_t;
+using op_t = Operations::Op;
+using optype_t = Operations::OpType;
+using oplist_t = std::vector<op_t>;
+using opset_t = Operations::OpSet;
+using reg_t = std::vector<uint_t>;
+
+
+class TruncateQubits : public CircuitOptimization {
+public:
+
+  void set_config(const json_t &config) override;
+
+  // truncate unnecessary qubits
+  void optimize_circuit(Circuit& circ,
+                        const opset_t &opset,
+                        OutputData &data) const override;
+
+private:
+  // check this optimization can be applied
+  bool can_apply(const Circuit& circ) const;
+
+  // check this optimization can be applied
+  bool can_apply(const op_t& op) const;
+
+  // generate a new mapping. a value of reg_t is original and its index is the new mapping
+  reg_t generate_mapping(const Circuit& circ) const;
+
+  // remap qubits in an operation
+  op_t remap_qubits(const op_t op, const reg_t new_mapping)const;
+
+  // show debug info
+  bool verbose_ = false;
+
+  // disabled in config
+  bool active_ = true;
+};
+
+void TruncateQubits::set_config(const json_t &config) {
+
+  CircuitOptimization::set_config(config);
+
+  if (JSON::check_key("truncate_verbose", config_))
+    JSON::get_value(verbose_, "truncate_verbose", config_);
+
+  if (JSON::check_key("truncate_enable", config_))
+    JSON::get_value(active_, "truncate_enable", config_);
+
+  if (JSON::check_key("initial_statevector", config_))
+    active_ = false;
+
+}
+
+void TruncateQubits::optimize_circuit(Circuit& circ,
+                             const opset_t &allowed_opset,
+                             OutputData &data) const {
+
+  if (!active_ || !can_apply(circ))
+    return;
+
+  reg_t new_mapping = generate_mapping(circ);
+
+  if (new_mapping.size() == circ.num_qubits)
+    return;
+
+  oplist_t new_ops;
+  for (const op_t& old_op: circ.ops)
+    new_ops.push_back(remap_qubits(old_op, new_mapping));
+
+  circ.ops = new_ops;
+  circ.num_qubits = new_mapping.size();
+
+  if (verbose_) {
+    data.add_additional_data("metadata",
+                             json_t::object({{"truncate_verbose", new_mapping}}));
+  }
+
+}
+
+reg_t TruncateQubits::generate_mapping(const Circuit& circ) const {
+  size_t not_used = circ.num_qubits + 1;
+  reg_t mapping = reg_t(circ.num_qubits, not_used);
+
+  for (const op_t& op: circ.ops)
+    for (size_t qubit: op.qubits)
+      mapping[qubit] = qubit;
+
+  mapping.erase(std::remove(mapping.begin(), mapping.end(), not_used), mapping.end());
+
+  return mapping;
+}
+
+op_t TruncateQubits::remap_qubits(const op_t op, const reg_t new_mapping) const {
+  op_t new_op = op;
+  new_op.qubits.clear();
+
+  for (const size_t qubit: op.qubits) {
+    size_t new_qubit = std::distance(new_mapping.begin(), find(new_mapping.begin(), new_mapping.end(), qubit));
+    new_op.qubits.push_back(new_qubit);
+  }
+  return new_op;
+
+}
+
+bool TruncateQubits::can_apply(const Circuit& circ) const {
+
+  for (const op_t& op: circ.ops)
+    if (!can_apply(op))
+      return false;
+
+  return true;
+}
+
+bool TruncateQubits::can_apply(const op_t& op) const {
+  switch (op.type) {
+  case optype_t::matrix_sequence: //TODO
+  case optype_t::kraus: //TODO
+  case optype_t::snapshot:
+  case optype_t::noise_switch:
+    return false;
+  default:
+    return true;
+  }
+}
+
+//-------------------------------------------------------------------------
+} // end namespace Transpile
+} // end namespace AER
+//-------------------------------------------------------------------------
+#endif


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This expands operations that TruncateQubits circuit optimization works on. It now works for all non-snapshot operations, and a limited set of snapshots (currently probabilities, creg snapshots, and pauli expectation values). In particular this should improve performance of noisy simulations using a device coupling map as previously Kraus errors were not included in the truncation.

Other organisational changes:

* Moves circuitopts into a seperate `transpile` folder in src.
* Seperates Fusion and TruncateQubit optimizations into separate files

### Details and comments


