### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/qiskit/providers/aer/noise/errors/errorutils.py
+++ b/qiskit/providers/aer/noise/errors/errorutils.py
@@ -114,9 +114,9 @@ def standard_gate_instruction(instruction, ignore_phase=True):
                     standard_gate_unitary(pauli1),
                     standard_gate_unitary(pauli0))
                 if matrix_equal(mat_dagger, pmat, ignore_phase=ignore_phase):
-                    if pauli0 is "id":
+                    if pauli0 == "id":
                         return [{"name": pauli1, "qubits": [qubits[1]]}]
-                    elif pauli1 is "id":
+                    elif pauli1 == "id":
                         return [{"name": pauli0, "qubits": [qubits[0]]}]
                     else:
                         return [{
@@ -296,7 +296,7 @@ def standard_gate_unitary(name):
         return np.array(
             [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]],
             dtype=complex)
-    if name is "cx_10":
+    if name == "cx_10":
         return np.array(
             [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]],
             dtype=complex)

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -203,7 +203,7 @@ def _pauli_error_unitary(noise_ops, num_qubits):
                     qubits.append(qubit)
                 elif pstr != 'I':
                     raise NoiseError("Invalid Pauli string.")
-            if mat == 1:
+            if mat is 1:
                 prob_identity += prob
             else:
                 circ = make_unitary_instruction(

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -51,7 +51,7 @@ def kraus_error(noise_ops, standard_gates=True, canonical_kraus=False):
     kraus = Kraus(noise_ops)
     if canonical_kraus:
         # Convert to Choi and back to get canonical Kraus
-        kraus = Kraus(Choi(kraus))  
+        kraus = Kraus(Choi(kraus))
     return QuantumError(kraus, standard_gates=standard_gates)
 
 
@@ -203,7 +203,7 @@ def _pauli_error_unitary(noise_ops, num_qubits):
                     qubits.append(qubit)
                 elif pstr != 'I':
                     raise NoiseError("Invalid Pauli string.")
-            if mat is 1:
+            if mat == 1:
                 prob_identity += prob
             else:
                 circ = make_unitary_instruction(

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -632,7 +632,7 @@ class NoiseModel:
             error_type = error['type']
 
             # Add QuantumError
-            if error_type is 'qerror':
+            if error_type == 'qerror':
                 noise_ops = tuple(
                     zip(error['instructions'], error['probabilities']))
                 instruction_names = error['operations']
@@ -663,7 +663,7 @@ class NoiseModel:
                         qerror, instruction_names, warnings=False)
 
             # Add ReadoutError
-            elif error_type is 'roerror':
+            elif error_type == 'roerror':
                 probabilities = error['probabilities']
                 all_gate_qubits = error.get('gate_qubits', None)
                 roerror = ReadoutError(probabilities)


### PR DESCRIPTION
### Summary

Identity is not the same thing as equality in Python.  We want the latter in these instances.

### Details and comments

Use ==/!= to compare str, bytes, and int literals.

$ __python__
```python
>>> id = "i"
>>> id += 'd'
>>> id
'id'
>>> id == 'id'
True
>>> id is 'id'
False
>>> 0 == 0.0
True
>>> 0 is 0.0
False
```
