### PR TITLE
Use seed_simulator from qobj

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 
 Changed
 -------
+- Set simulator seed from "seed_simulator" in qobj (#210)
 
 Removed
 -------

--- a/qiskit/providers/aer/aererror.py
+++ b/qiskit/providers/aer/aererror.py
@@ -14,7 +14,7 @@
 Exception for errors raised by Qiskit Aer simulators backends.
 """
 
-from qiskit.qiskiterror import QiskitError
+from qiskit import QiskitError
 
 
 class AerError(QiskitError):

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -72,7 +72,7 @@ class AerBackend(BaseBackend):
 
         Raises:
             FileNotFoundError if backend executable is not available.
-            QiskitError: if there is no name in the configuration
+            AerError: if there is no name in the configuration
         """
         super().__init__(configuration, provider=provider)
         self._controller = controller

--- a/qiskit/providers/aer/noise/noiseerror.py
+++ b/qiskit/providers/aer/noise/noiseerror.py
@@ -14,7 +14,7 @@
 Exception for errors raised by Qiskit Aer noise module.
 """
 
-from qiskit.qiskiterror import QiskitError
+from qiskit import QiskitError
 
 
 class NoiseError(QiskitError):

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -622,7 +622,7 @@ json_t Controller::execute_circuit(Circuit &circ) {
     // Pass through circuit header and add metadata
     result["header"] = circ.header;
     result["shots"] = circ.shots;
-    result["seed"] = circ.seed;
+    result["seed_simulator"] = circ.seed;
     // Move any metadata from the subclass run_circuit data
     // to the experiment resultmetadata field
     if (JSON::check_key("metadata", result["data"])) {

--- a/src/framework/qobj.hpp
+++ b/src/framework/qobj.hpp
@@ -86,7 +86,8 @@ void Qobj::load_qobj_from_json(const json_t &js) {
   JSON::get_value(config, "config", js);
   JSON::get_value(header, "header", js);
   // Check for fixed seed
-  JSON::get_value(seed, "seed", config);
+  JSON::get_value(seed, "seed", config); // DEPRECIATED: Remove in 0.3.
+  JSON::get_value(seed, "seed_simulator", config);
   // Get type
   JSON::get_value(type, "type", js);
   if (type != "QASM") {

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -99,7 +99,7 @@ class QasmFusionTests:
         circuit = transpile([circuit],
                             backend=self.SIMULATOR,
                             basis_gates=noise_model.basis_gates)
-        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed=1)
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed_simulator=1)
 
         backend_options = self.BACKEND_OPTS.copy()
         backend_options['fusion_enable'] = True
@@ -128,7 +128,7 @@ class QasmFusionTests:
         circuit = self.create_statevector_circuit()
 
         shots = 100
-        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed=1)
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed_simulator=1)
 
         backend_options = self.BACKEND_OPTS.copy()
         backend_options['fusion_enable'] = True
@@ -197,7 +197,7 @@ class QasmFusionTests:
         """Test Fusion enable/disable option"""
         shots = 100
         circuit = self.create_statevector_circuit()
-        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed=0)
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed_simulator=1)
 
         backend_options = self.BACKEND_OPTS.copy()
         backend_options['fusion_enable'] = True
@@ -319,7 +319,7 @@ class QasmFusionTests:
 
         circuit.measure(qr, cr)
 
-        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed=1)
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed_simulator=1)
 
         backend_options = self.BACKEND_OPTS.copy()
         backend_options['fusion_enable'] = True

--- a/test/terra/backends/qasm_simulator/qasm_truncate.py
+++ b/test/terra/backends/qasm_simulator/qasm_truncate.py
@@ -10,7 +10,7 @@ QasmSimulator Integration Tests
 """
 import json
 from test.benchmark.tools import quantum_volume_circuit
-from qiskit import execute, compile, QuantumRegister, ClassicalRegister, QuantumCircuit, Aer
+from qiskit import execute, QuantumRegister, ClassicalRegister, QuantumCircuit, Aer
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer import noise
 from qiskit.providers.aer.noise import NoiseModel

--- a/test/terra/utils/mock.py
+++ b/test/terra/utils/mock.py
@@ -253,6 +253,6 @@ def new_fake_qobj():
                 QasmQobjInstruction(name='barrier', qubits=[1])
             ],
             header=QobjExperimentHeader(),
-            config=QasmQobjExperimentConfig(seed=123456)
+            config=QasmQobjExperimentConfig(seed_simulator=123456)
         )]
     )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changes the simulator to parse the optional RNG seed from the `"seed_simulator"` field in qobj config rather than `"seed"` field. The old `"seed"` field is still parsed for backwards compatibility, but will be overridden by the new field if both are present.

Closes #206 

### Details and comments


