### PR TITLE
Fix for #204, memory checking

### DIFF
--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -239,7 +239,7 @@ protected:
   // Parameters for parallelization management in configuration
   int max_parallel_experiments_;
   int max_parallel_shots_;
-  int max_memory_mb_;
+  size_t max_memory_mb_;
 
   // Parameters for parallelization management for experiments
   int parallel_experiments_;
@@ -425,7 +425,7 @@ bool Controller::validate_memory_requirements(state_t &state,
   if (max_memory_mb_ == 0)
     return true;
 
-  int required_mb = state.required_memory_mb(circ.num_qubits, circ.ops);
+  size_t required_mb = state.required_memory_mb(circ.num_qubits, circ.ops);
   if(max_memory_mb_ < required_mb) {
     if(throw_except) {
       std::string name = "";

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -794,7 +794,7 @@ size_t State::required_memory_mb(uint_t num_qubits,
   // Plus 2*CHSimulator::scalar_t which has 3 4 byte words
   // Plus 2*CHSimulator::pauli_t which has 2 8 byte words and one 4 byte word;
   double mb_per_state = 5e-5*num_qubits;//
-  size_t required_mb = std::ceil(mb_per_state*required_chi);
+  size_t required_mb = std::llrint(std::ceil(mb_per_state*required_chi));
   return required_mb;
   //Todo: Update this function to account for snapshots
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Resolves issue #204, where Qiskit-Aer wouldn't catch circuits that were too large for the system memory.


### Details and comments
The issue was caused by a `size_t` returned from `Aer::Base::State::required_memory_mb` being cast to `int` with value `0`, causing the memory check to pass erroneously.
