### PR TITLE
Noise transformation 2qubit

### DIFF
--- a/qiskit/providers/aer/noise/utils/noise_transformation.py
+++ b/qiskit/providers/aer/noise/utils/noise_transformation.py
@@ -241,17 +241,38 @@ def pauli_operators():
     }
     return [pauli_1_qubit, pauli_2_qubit]
 
+def reset_operators():
+    reset_0_to_0 = [{'name': 'reset', 'qubits': [0]}]
+    reset_0_to_1 = [{'name': 'reset', 'qubits': [0]}, {'name': 'x', 'qubits': [0]}]
+    reset_1_to_0 = [{'name': 'reset', 'qubits': [1]}]
+    reset_1_to_1 = [{'name': 'reset', 'qubits': [1]}, {'name': 'x', 'qubits': [1]}]
+    id_0 = [{'name': 'id', 'qubits': [0]}]
+    id_1 = [{'name': 'id', 'qubits': [1]}]
+
+    reset_1_qubit = {
+        'p': reset_0_to_0,
+        'q': reset_0_to_1
+    }
+
+    reset_2_qubit = {
+        'p0': reset_0_to_0 + id_1,
+        'q0': reset_0_to_1 + id_1,
+        'p1': reset_1_to_0 + id_0,
+        'q1': reset_1_to_1 + id_0,
+        'p0_p1': reset_0_to_0 + reset_1_to_0,
+        'p0_q1': reset_0_to_0 + reset_1_to_1,
+        'q0_p1': reset_0_to_1 + reset_1_to_0,
+        'q0_q1': reset_0_to_1 + reset_1_to_1,
+    }
+    return [reset_1_qubit, reset_2_qubit]
+
 class NoiseTransformer:
     """Transforms one quantum channel to another based on a specified criteria."""
 
     def __init__(self):
         self.named_operators = {
             'pauli': pauli_operators(),
-            'reset': [{
-                'p': [{'name': 'reset', 'qubits': [0]}],  # reset to |0>
-                'q': [{'name': 'reset', 'qubits': [0]},
-                      {'name': 'x', 'qubits': [0]}]  # reset to |1>
-            }],
+            'reset': reset_operators(),
             'clifford': [dict([(j, single_qubit_clifford_instructions(j))
                               for j in range(1, 24)])]
         }

--- a/qiskit/providers/aer/noise/utils/noise_transformation.py
+++ b/qiskit/providers/aer/noise/utils/noise_transformation.py
@@ -223,21 +223,21 @@ def pauli_operators():
                     'Z': [{'name': 'z', 'qubits': [0]}]
                     }
     pauli_2_qubit = {
-        'XI': [{'name': 'x', 'qubits': [0]}, {'name': 'id', 'qubits': [1]}],
-        'YI': [{'name': 'y', 'qubits': [0]}, {'name': 'id', 'qubits': [1]}],
-        'ZI': [{'name': 'z', 'qubits': [0]}, {'name': 'id', 'qubits': [1]}],
-        'IX': [{'name': 'id', 'qubits': [0]}, {'name': 'x', 'qubits': [1]}],
-        'IY': [{'name': 'id', 'qubits': [0]}, {'name': 'y', 'qubits': [1]}],
-        'IZ': [{'name': 'id', 'qubits': [0]}, {'name': 'z', 'qubits': [1]}],
-        'XX': [{'name': 'x', 'qubits': [0]}, {'name': 'x', 'qubits': [1]}],
-        'YY': [{'name': 'y', 'qubits': [0]}, {'name': 'y', 'qubits': [1]}],
-        'ZZ': [{'name': 'z', 'qubits': [0]}, {'name': 'z', 'qubits': [1]}],
-        'XY': [{'name': 'x', 'qubits': [0]}, {'name': 'y', 'qubits': [1]}],
-        'XZ': [{'name': 'x', 'qubits': [0]}, {'name': 'z', 'qubits': [1]}],
-        'YX': [{'name': 'y', 'qubits': [0]}, {'name': 'x', 'qubits': [1]}],
-        'YZ': [{'name': 'y', 'qubits': [0]}, {'name': 'z', 'qubits': [1]}],
-        'ZX': [{'name': 'z', 'qubits': [0]}, {'name': 'x', 'qubits': [1]}],
-        'ZY': [{'name': 'z', 'qubits': [0]}, {'name': 'y', 'qubits': [1]}],
+        'XI': [{'name': 'x', 'qubits': [1]}, {'name': 'id', 'qubits': [0]}],
+        'YI': [{'name': 'y', 'qubits': [1]}, {'name': 'id', 'qubits': [0]}],
+        'ZI': [{'name': 'z', 'qubits': [1]}, {'name': 'id', 'qubits': [0]}],
+        'IX': [{'name': 'id', 'qubits': [1]}, {'name': 'x', 'qubits': [0]}],
+        'IY': [{'name': 'id', 'qubits': [1]}, {'name': 'y', 'qubits': [0]}],
+        'IZ': [{'name': 'id', 'qubits': [1]}, {'name': 'z', 'qubits': [0]}],
+        'XX': [{'name': 'x', 'qubits': [1]}, {'name': 'x', 'qubits': [0]}],
+        'YY': [{'name': 'y', 'qubits': [1]}, {'name': 'y', 'qubits': [0]}],
+        'ZZ': [{'name': 'z', 'qubits': [1]}, {'name': 'z', 'qubits': [0]}],
+        'XY': [{'name': 'x', 'qubits': [1]}, {'name': 'y', 'qubits': [0]}],
+        'XZ': [{'name': 'x', 'qubits': [1]}, {'name': 'z', 'qubits': [0]}],
+        'YX': [{'name': 'y', 'qubits': [1]}, {'name': 'x', 'qubits': [0]}],
+        'YZ': [{'name': 'y', 'qubits': [1]}, {'name': 'z', 'qubits': [0]}],
+        'ZX': [{'name': 'z', 'qubits': [1]}, {'name': 'x', 'qubits': [0]}],
+        'ZY': [{'name': 'z', 'qubits': [1]}, {'name': 'y', 'qubits': [0]}],
     }
     return [pauli_1_qubit, pauli_2_qubit]
 

--- a/test/terra/noise/test_noise_transformation.py
+++ b/test/terra/noise/test_noise_transformation.py
@@ -23,6 +23,7 @@ from qiskit.providers.aer.noise.utils import approximate_noise_model
 from qiskit.providers.aer.noise.errors.standard_errors import amplitude_damping_error
 from qiskit.providers.aer.noise.errors.standard_errors import reset_error
 from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
+from qiskit.providers.aer.noise.errors.quantum_error import QuantumError
 
 try:
     import cvxopt
@@ -247,6 +248,41 @@ class TestNoiseTransformer(unittest.TestCase):
 
         self.assertErrorsAlmostEqual(error_1q, results_1q)
         self.assertErrorsAlmostEqual(error_2q, results_2q, places = 2)
+
+        paulis_2q = ['XY', 'ZZ', 'YI']
+        error_2q = pauli_error(zip(paulis_2q, probs))
+        results_2q = approximate_quantum_error(error_2q, operator_string="pauli")
+        self.assertErrorsAlmostEqual(error_2q, results_2q, places=2)
+
+    def test_reset_2_qubit(self):
+        # approximating amplitude damping using relaxation operators
+        gamma = 0.23
+        p = (gamma - numpy.sqrt(1 - gamma) + 1) / 2
+        q = 0
+        A0 = [[1, 0], [0, numpy.sqrt(1 - gamma)]]
+        A1 = [[0, numpy.sqrt(gamma)], [0, 0]]
+        error_1 = QuantumError([([{'name': 'kraus', 'qubits': [0], 'params': [A0, A1]},
+                                  {'name': 'id', 'qubits': [1]}
+                                  ], 1)])
+        error_2 = QuantumError([([{'name': 'kraus', 'qubits': [1], 'params': [A0, A1]},
+                                  {'name': 'id', 'qubits': [0]}
+                                  ], 1)])
+
+        expected_results_1 = QuantumError([
+            ([{'name': 'id', 'qubits': [0]}, {'name': 'id', 'qubits': [1]}], 1-p),
+            ([{'name': 'reset', 'qubits': [0]}, {'name': 'id', 'qubits': [1]}],p),
+        ])
+        expected_results_2 = QuantumError([
+            ([{'name': 'id', 'qubits': [1]}, {'name': 'id', 'qubits': [0]}], 1 - p),
+            ([{'name': 'reset', 'qubits': [1]}, {'name': 'id', 'qubits': [0]}], p),
+        ])
+
+        results_1 = approximate_quantum_error(error_1, operator_string="reset")
+        results_2 = approximate_quantum_error(error_2, operator_string="reset")
+
+        self.assertErrorsAlmostEqual(results_1, expected_results_1)
+        self.assertErrorsAlmostEqual(results_2, expected_results_2)
+
 
 
     def test_errors(self):

--- a/test/terra/noise/test_noise_transformation.py
+++ b/test/terra/noise/test_noise_transformation.py
@@ -234,6 +234,21 @@ class TestNoiseTransformer(unittest.TestCase):
         results_2 = approximate_quantum_error(error, operator_string="Pauli")
         self.assertErrorsAlmostEqual(results_1, results_2)
 
+    def test_paulis_1_and_2_qubits(self):
+        probs = [0.5, 0.3, 0.2]
+        paulis_1q = ['X', 'Y', 'Z']
+        paulis_2q = ['XI', 'YI', 'ZI']
+
+        error_1q = pauli_error(zip(paulis_1q, probs))
+        error_2q = pauli_error(zip(paulis_2q, probs))
+
+        results_1q = approximate_quantum_error(error_1q, operator_string="pauli")
+        results_2q = approximate_quantum_error(error_2q, operator_string="pauli")
+
+        self.assertErrorsAlmostEqual(error_1q, results_1q)
+        self.assertErrorsAlmostEqual(error_2q, results_2q, places = 2)
+
+
     def test_errors(self):
         gamma = 0.23
         error = amplitude_damping_error(gamma)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Extending the noise transformation module to support approximations of 2-qubit noises.


### Details and comments
The module now throws exception only for 3-qubit or more errors; additionaly, support for premade 2-qubit Pauli and reset operators was added.

