### PR TITLE
Remove deprecated warning from Terra and change our as_dict() to to_dict()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Added
 
 Changed
 -------
+- Deprecate the use of ".as_dict()" in favor of ".to_dict()" (#228)
 - Set simulator seed from "seed_simulator" in qobj (#210)
 
 Removed

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -50,8 +50,8 @@ class AerJSONEncoder(json.JSONEncoder):
             return obj.tolist()
         if isinstance(obj, complex):
             return [obj.real, obj.imag]
-        if hasattr(obj, "as_dict"):
-            return obj.as_dict()
+        if hasattr(obj, "to_dict"):
+            return obj.to_dict()
         return super().default(obj)
 
 
@@ -117,7 +117,7 @@ class AerBackend(BaseBackend):
         original_config = qobj.config
         # Convert to dictionary and add new parameters
         # from noise model and backend options
-        config = original_config.as_dict()
+        config = original_config.to_dict()
         if backend_options is not None:
             for key, val in backend_options.items():
                 config[key] = val

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -197,7 +197,7 @@ class QasmSimulator(AerBackend):
 
         if clifford_noise:
             if method != "stabilizer" and noise_model:
-                for error in noise_model.as_dict()['errors']:
+                for error in noise_model.to_dict()['errors']:
                     if error['type'] == 'qerror':
                         for circ in error["instructions"]:
                             for instr in circ:

--- a/qiskit/providers/aer/noise/errors/errorutils.py
+++ b/qiskit/providers/aer/noise/errors/errorutils.py
@@ -298,7 +298,7 @@ def standard_gate_unitary(name):
             np.array([[1, 0], [0, np.exp(-1j * np.pi / 4)]], dtype=complex),
         ("cx", "CX", "cx_01"):
             np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]], dtype=complex),
-        ("cx_10"):
+        ("cx_10",):
             np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]], dtype=complex),
         ("cz", "CZ"):
             np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]], dtype=complex),

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -27,6 +27,7 @@ from .errorutils import kraus2instructions
 from .errorutils import circuit2superop
 from .errorutils import standard_instruction_channel
 from .errorutils import standard_instruction_operator
+from ...utils.helpers import deprecation
 
 logger = logging.getLogger(__name__)
 
@@ -284,6 +285,16 @@ class QuantumError:
                 position) + "of error outcomes {}".format(self.size))
 
     def as_dict(self):
+        """
+        DEPRECATED: Use to_dict()
+        Returns:
+            dict: The current error as a dictionary.
+        """
+        deprecation("QuantumError::as_dict() method is deprecated and will be removed after 0.3."
+                    "Use '.to_dict()' instead")
+        return self.to_dict()
+
+    def to_dict(self):
         """Return the current error as a dictionary."""
         error = {
             "type": "qerror",

--- a/qiskit/providers/aer/noise/errors/readout_error.py
+++ b/qiskit/providers/aer/noise/errors/readout_error.py
@@ -22,6 +22,7 @@ from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT, RTOL_DEFAULT
 
 from ..noiseerror import NoiseError
 from .errorutils import qubits_from_mat
+from ...utils.helpers import deprecation
 
 
 class ReadoutError:
@@ -141,6 +142,16 @@ class ReadoutError:
         return False
 
     def as_dict(self):
+        """
+        DEPRECATED: Use to_dict()
+        Returns:
+            dict: The current error as a dictionary.
+        """
+        deprecation("ReadoutError::as_dict() method is deprecated and will be removed after 0.3."
+                    "Use '.to_dict()' instead")
+        return self.to_dict()
+
+    def to_dict(self):
         """Return the current error as a dictionary."""
         error = {
             "type": "roerror",

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -23,6 +23,7 @@ from qiskit.providers.aer.backends.qasm_simulator import QasmSimulator
 from .noiseerror import NoiseError
 from .errors.quantum_error import QuantumError
 from .errors.readout_error import ReadoutError
+from ..utils.helpers import deprecation
 
 logger = logging.getLogger(__name__)
 
@@ -551,6 +552,22 @@ class NoiseModel:
 
     def as_dict(self, serializable=False):
         """
+        DEPRECATED: Use to_dict()
+        Returns a dictionary for noise model.
+
+        Args:
+            serializable (bool): if `True`, return a dict containing only types
+                that can be serializable by the stdlib `json` module.
+
+        Returns:
+            dict: a dictionary for a noise model.
+        """
+        deprecation("NoiseModel::as_dict() method is deprecated and will be removed after 0.3."
+                    "Use '.to_dict()' instead")
+        self.to_dict(serializable)
+
+    def to_dict(self, serializable=False):
+        """
         Return dictionary for noise model.
 
         Args:
@@ -564,14 +581,14 @@ class NoiseModel:
 
         # Add default quantum errors
         for name, error in self._default_quantum_errors.items():
-            error_dict = error.as_dict()
+            error_dict = error.to_dict()
             error_dict["operations"] = [name]
             error_list.append(error_dict)
 
         # Add specific qubit errors
         for name, qubit_dict in self._local_quantum_errors.items():
             for qubits_str, error in qubit_dict.items():
-                error_dict = error.as_dict()
+                error_dict = error.to_dict()
                 error_dict["operations"] = [name]
                 error_dict["gate_qubits"] = [self._str2qubits(qubits_str)]
                 error_list.append(error_dict)
@@ -580,7 +597,7 @@ class NoiseModel:
         for name, qubit_dict in self._nonlocal_quantum_errors.items():
             for qubits_str, noise_qubit_dict in qubit_dict.items():
                 for noise_qubits_str, error in noise_qubit_dict.items():
-                    error_dict = error.as_dict()
+                    error_dict = error.to_dict()
                     error_dict["operations"] = [name]
                     error_dict["gate_qubits"] = [self._str2qubits(qubits_str)]
                     error_dict["noise_qubits"] = [
@@ -590,12 +607,12 @@ class NoiseModel:
 
         # Add default readout error
         if self._default_readout_error is not None:
-            error_dict = self._default_readout_error.as_dict()
+            error_dict = self._default_readout_error.to_dict()
             error_list.append(error_dict)
 
         # Add local readout error
         for qubits_str, error in self._local_readout_errors.items():
-            error_dict = error.as_dict()
+            error_dict = error.to_dict()
             error_dict["gate_qubits"] = [self._str2qubits(qubits_str)]
             error_list.append(error_dict)
 

--- a/qiskit/providers/aer/noise/utils/noise_remapper.py
+++ b/qiskit/providers/aer/noise/utils/noise_remapper.py
@@ -84,7 +84,7 @@ def remap_noise_model(noise_model, remapping, discard_qubits=False, warnings=Tru
         raise NoiseError('Duplicate qubits in remapping: {}'.format(inv_map))
 
     # Convert noise model to dict
-    nm_dict = noise_model.as_dict()
+    nm_dict = noise_model.to_dict()
 
     # Indexes of errors to keep
     new_errors = []

--- a/qiskit/providers/aer/noise/utils/noise_transformation.py
+++ b/qiskit/providers/aer/noise/utils/noise_transformation.py
@@ -152,7 +152,7 @@ def approximate_noise_model(model, *,
             operator_string=operator_string,
             operator_dict=operator_dict,
             operator_list=operator_list)
-        error_dict = error.as_dict()
+        error_dict = error.to_dict()
         error_dict["operations"] = [operation]
         error_list.append(error_dict)
 
@@ -164,7 +164,7 @@ def approximate_noise_model(model, *,
                 operator_string=operator_string,
                 operator_dict=operator_dict,
                 operator_list=operator_list)
-            error_dict = error.as_dict()
+            error_dict = error.to_dict()
             error_dict["operations"] = [operation]
             error_dict["gate_qubits"] = [model._str2qubits(qubits_str)]
             error_list.append(error_dict)
@@ -178,7 +178,7 @@ def approximate_noise_model(model, *,
                     operator_string=operator_string,
                     operator_dict=operator_dict,
                     operator_list=operator_list)
-                error_dict = error.as_dict()
+                error_dict = error.to_dict()
                 error_dict["operations"] = [operation]
                 error_dict["gate_qubits"] = [model._str2qubits(qubits_str)]
                 error_dict["noise_qubits"] = [model._str2qubits(noise_str)]
@@ -191,7 +191,7 @@ def approximate_noise_model(model, *,
             operator_string=operator_string,
             operator_dict=operator_dict,
             operator_list=operator_list)
-        error_dict = error.as_dict()
+        error_dict = error.to_dict()
         error_list.append(error_dict)
 
     # Add local readout error
@@ -201,7 +201,7 @@ def approximate_noise_model(model, *,
             operator_string=operator_string,
             operator_dict=operator_dict,
             operator_list=operator_list)
-        error_dict = error.as_dict()
+        error_dict = error.to_dict()
         error_dict["gate_qubits"] = [model._str2qubits(qubits_str)]
         error_list.append(error_dict)
 

--- a/qiskit/providers/aer/utils/__init__.py
+++ b/qiskit/providers/aer/utils/__init__.py
@@ -13,3 +13,4 @@
 """Utilities"""
 
 from . import qobj_utils
+from . import helpers

--- a/qiskit/providers/aer/utils/helpers.py
+++ b/qiskit/providers/aer/utils/helpers.py
@@ -1,0 +1,22 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+A bunch of usefull helper functions
+"""
+
+from warnings import warn
+
+
+def deprecation(message):
+    """ Shows a deprecation message to the user """
+    warn(message, DeprecationWarning, stacklevel=2)

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -756,8 +756,6 @@ class TestNoise(common.QiskitAerTestCase):
         error1 = pauli_error([['X', 1]], standard_gates=False)
         error2 = pauli_error([['X', 1]], standard_gates=True)
 
-        print("error1: {}\nerror2: {}".format(error1, error2))
-
         model1 = NoiseModel()
         model1.add_all_qubit_quantum_error(error1, ['u3'], False)
         model1.add_quantum_error(error1, ['u3'], [2], False)


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes: #227
* Removing deprecation warnings from Terra by using to_dict()
* Deprecating our as_dict() methods in favor of to_dict()


### Details and comments
We have changed all our as_dict() methods from the API to keep consitency with Terra, as we needed to change `NoiseModel` at least.

I have created a new Python helper class where we can put our global helper functions.

### TODO
- [x] Write an entry in the changelog
