### PR TITLE
Idle scheduler

### DIFF
--- a/qiskit/providers/aer/noise/utils/__init__.py
+++ b/qiskit/providers/aer/noise/utils/__init__.py
@@ -18,3 +18,4 @@ from .noise_remapper import remap_noise_model
 from .noise_transformation import NoiseTransformer
 from .noise_transformation import approximate_quantum_error
 from .noise_transformation import approximate_noise_model
+from .idle_scheduler import schedule_idle_gates

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -70,6 +70,7 @@ class IdleScheduler():
         # convert to circuit and back as hack to prevent nondeterminism in DAGCircuit
         layers = [circuit_to_dag(dag_to_circuit(l['graph'])) for l in dag.layers()]
         for layer in layers:
+            # print("idle times before node {}: {}".format(node.name, self.idle_times.values()))
             new_layer_graph = self.add_identities_to_layer(layer)
             new_dag.extend_back(new_layer_graph)
         return dag_to_circuit(new_dag)
@@ -89,7 +90,7 @@ class IdleScheduler():
 
         for node in layer.op_nodes():
             for qubit in node.qargs:
-                if node.op.name == 'barrier':  # special case
+                if node.op.name in ['barrier', 'snapshot']:  # special cases
                     self.idle_times[qubit] = 0
                 else:
                     self.idle_times[qubit] -= self.op_times.get(node.name, self.default_op_time)

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -22,7 +22,7 @@ from qiskit.converters import dag_to_circuit
 from qiskit.extensions.standard.iden import IdGate
 
 
-def schedule_idle_gates(circuit, op_times=None, default_op_time=1):
+def schedule_idle_gates(circuit, op_times=None, default_op_time=1, labels=None):
     """
     This function gets a circuit and returns a new one with the idle
     gates in place; each idle gate is labeled "id_<name>" where <name> is the name of
@@ -32,23 +32,27 @@ def schedule_idle_gates(circuit, op_times=None, default_op_time=1):
         circuit (QuantumCircuit): The circuit to add idle gates to
         op_times (dictionary): dictionary of times taken by specific gate types
         default_op_time (float or int): default time for gates not found in op_times
+        labels (string or dictionary): the label to give the id gate, either a uniform
+                label for all the id gates (string) or a dictionary mapping from the
+                gate type that caused the delay to the expected id gate label
 
     Returns:
         QuantumCircuit: The new circuit with the added idle gates
 
     """
-    scheduler = IdleScheduler(op_times, default_op_time)
+    scheduler = IdleScheduler(op_times, default_op_time, labels)
     return scheduler.schedule(circuit)
 
 
 class IdleScheduler():
     """Adds idle gates to given circuits"""
-    def __init__(self, op_times, default_op_time):
+    def __init__(self, op_times, default_op_time, id_gate_labels=None):
         if op_times is None:
             self.op_times = {}
         else:
             self.op_times = op_times
         self.default_op_time = default_op_time
+        self.id_gate_labels = id_gate_labels
         self.circuit = None
         self.idle_times = None
 
@@ -93,8 +97,17 @@ class IdleScheduler():
         id_time = self.op_times.get('id', self.default_op_time)
         for qubit in self.circuit.qubits:
             while self.idle_times[qubit] >= id_time:
-                id_gate = IdGate(label="id_{}".format(max_op_name))
+                id_gate = IdGate(label=self.id_gate_label(max_op_name))
                 layer.apply_operation_back(id_gate, [qubit], [])
                 self.idle_times[qubit] -= id_time
 
         return layer
+
+    def id_gate_label(self, op_name):
+        label = "id_{}".format(op_name)
+        if self.id_gate_labels is not None:
+            if isinstance(self.id_gate_labels, str):
+                label = self.id_gate_labels
+            if isinstance(self.id_gate_labels, dict) and op_name in self.id_gate_labels:
+                label = self.id_gate_labels[op_name]
+        return label

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -1,0 +1,96 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Idle gates scheduler module
+
+The goal of this module is to add idle gates to a circuit instead of
+having blank spaces with no operations at times where no gate can be applied
+to the qubit (due to qubit dependenices or barriers)
+"""
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.converters import circuit_to_dag
+from qiskit.converters import dag_to_circuit
+from qiskit.extensions.standard.iden import IdGate
+
+
+def schedule_idle_gates(circuit, op_times={}, default_op_time=1):
+    """
+    This function gets a circuit and returns a new one with the idle
+    gates in place; each idle gate is labeled "id_<name>" where <name> is the name of
+    the slowest gate that runs in parallel
+
+    Args:
+        circuit (QuantumCircuit): The circuit to add idle gates to
+        op_times (dictionary): dictionary of times taken by specific gate types
+        default_op_time (float or int): default time for gates not found in op_times
+
+    Returns:
+        QuantumCircuit: The new circuit with the added idle gates
+
+    """
+    scheduler = IdleScheduler(op_times, default_op_time)
+    return scheduler.schedule(circuit)
+
+
+class IdleScheduler():
+    """Adds idle gates to given circuits"""
+    def __init__(self, op_times, default_op_time):
+        self.op_times = op_times
+        self.default_op_time = default_op_time
+        self.circuit = None
+        self.idle_times = None
+
+    def schedule(self, circuit):
+        """Adds the idle gates to the circuit
+            Args:
+               circuit (QuantumCircuit): The circuit to modify
+            Returns:
+               QuantumCircuit: The modified circuit
+       """
+        self.circuit = circuit
+        new_dag = DAGCircuit()
+        self.idle_times = {qubit: 0 for qubit in self.circuit.qubits}
+        dag = circuit_to_dag(circuit)
+        layers = list(dag.layers())
+        for layer in layers:
+            new_layer_graph = self.add_identities_to_layer(layer)
+            new_dag.extend_back(new_layer_graph)
+        return dag_to_circuit(new_dag)
+
+    def add_identities_to_layer(self, layer):
+        """Adds the idle gates to a specific layer in the circuit
+            Args:
+               layer (dict): The layer to modify (contains a circuit graph)
+            Returns:
+               dict: The modified layer
+        """
+        max_op_time, max_op_name = max(
+            [(self.op_times.get(node.name, self.default_op_time), node.name)
+             for node in layer['graph'].op_nodes()])
+        for qubit in self.idle_times.keys():
+            self.idle_times[qubit] += max_op_time
+
+        for node in layer['graph'].op_nodes():
+            for qubit in node.qargs:
+                if node.op.name == 'barrier':  # special case
+                    self.idle_times[qubit] = 0
+                else:
+                    self.idle_times[qubit] -= self.op_times.get(node.name, self.default_op_time)
+
+        id_time = self.op_times.get('id', self.default_op_time)
+        for qubit in self.circuit.qubits:
+            while (self.idle_times[qubit] >= id_time):
+                id_gate = IdGate(label="id_{}".format(max_op_name))
+                layer['graph'].apply_operation_back(id_gate, [qubit], [])
+                self.idle_times[qubit] -= id_time
+
+        return layer['graph']

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -81,6 +81,7 @@ class IdleScheduler():
         max_op_time, max_op_name = max(
             [(self.get_op_time((node.name, node.qargs)), node.name) for node in layer.op_nodes()]
         )
+
         for qubit in self.idle_times.keys():
             self.idle_times[qubit] += max_op_time
 

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -89,10 +89,10 @@ class IdleScheduler():
                 if node.op.name in ['barrier', 'snapshot']:  # special cases
                     self.idle_times[qubit] = 0
                 else:
-                    self.idle_times[qubit] -= self.op_times.get(node.name, self.default_op_time)
+                    self.idle_times[qubit] -= self.get_op_time((node.name, node.qargs))
 
-        id_time = self.op_times.get('id', self.default_op_time)
         for qubit in self.circuit.qubits:
+            id_time = self.get_op_time(('id', [qubit]))
             while self.idle_times[qubit] >= id_time:
                 id_gate = IdGate(label=self.id_gate_label(max_op_name))
                 layer.apply_operation_back(id_gate, [qubit], [])
@@ -146,10 +146,8 @@ class IdleScheduler():
             Returns:
                float: the time for the specified op
         """
-
         if len(op_data) == 2:
             op_data = (op_data[0], tuple(op_data[1]))
-
         if op_data in self.op_times:
             return self.op_times[op_data]
 

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -105,6 +105,12 @@ class IdleScheduler():
         return layer
 
     def id_gate_label(self, op_name):
+        """Given an op name, returns the label for id gates created by that op
+            Args:
+               op_name (string): The name of the op causing the creation of id gates
+            Returns:
+               string: the expected label, based on self.id_gate_labels
+        """
         label = "id_{}".format(op_name)
         if self.id_gate_labels is not None:
             if isinstance(self.id_gate_labels, str):

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -22,7 +22,7 @@ from qiskit.converters import dag_to_circuit
 from qiskit.extensions.standard.iden import IdGate
 
 
-def schedule_idle_gates(circuit, op_times={}, default_op_time=1):
+def schedule_idle_gates(circuit, op_times=None, default_op_time=1):
     """
     This function gets a circuit and returns a new one with the idle
     gates in place; each idle gate is labeled "id_<name>" where <name> is the name of
@@ -44,7 +44,10 @@ def schedule_idle_gates(circuit, op_times={}, default_op_time=1):
 class IdleScheduler():
     """Adds idle gates to given circuits"""
     def __init__(self, op_times, default_op_time):
-        self.op_times = op_times
+        if op_times is None:
+            self.op_times = {}
+        else:
+            self.op_times = op_times
         self.default_op_time = default_op_time
         self.circuit = None
         self.idle_times = None
@@ -88,7 +91,7 @@ class IdleScheduler():
 
         id_time = self.op_times.get('id', self.default_op_time)
         for qubit in self.circuit.qubits:
-            while (self.idle_times[qubit] >= id_time):
+            while self.idle_times[qubit] >= id_time:
                 id_gate = IdGate(label="id_{}".format(max_op_name))
                 layer['graph'].apply_operation_back(id_gate, [qubit], [])
                 self.idle_times[qubit] -= id_time

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -130,13 +130,13 @@ class IdleScheduler():
 
         if isinstance(op_times, list):
             for op_time in op_times:
-                if len(op_time) == 2: # (name, time)
+                if len(op_time) == 2:  # (name, time)
                     self.op_times[op_time[0]] = op_time[1]
-                if len(op_time) == 3: # (name, qubits, time)
+                if len(op_time) == 3:  # (name, qubits, time)
                     if op_time[1] is None:
                         self.op_times[op_time[0]] = op_time[2]
                     else:
-                        self.op_times[(op_time[0],tuple(op_time[1]))] = op_time[2]
+                        self.op_times[(op_time[0], tuple(op_time[1]))] = op_time[2]
 
     def get_op_time(self, op_data):
         """Gets the op time for the specified operator

--- a/qiskit/providers/aer/noise/utils/idle_scheduler.py
+++ b/qiskit/providers/aer/noise/utils/idle_scheduler.py
@@ -63,8 +63,8 @@ class IdleScheduler():
         new_dag = DAGCircuit()
         self.idle_times = {qubit: 0 for qubit in self.circuit.qubits}
         dag = circuit_to_dag(circuit)
-        # layers = list(dag.layers())
-        layers = [circuit_to_dag(dag_to_circuit(l['graph'])) for l in dag.layers()] #hack to prevent nondeterminism
+        # convert to circuit and back as hack to prevent nondeterminism in DAGCircuit
+        layers = [circuit_to_dag(dag_to_circuit(l['graph'])) for l in dag.layers()]
         for layer in layers:
             new_layer_graph = self.add_identities_to_layer(layer)
             new_dag.extend_back(new_layer_graph)

--- a/test/terra/noise/test_idle_scheduler.py
+++ b/test/terra/noise/test_idle_scheduler.py
@@ -66,6 +66,27 @@ class TestIdleScheduler(unittest.TestCase):
 
         self.assertEqual(target_circuit, result_circuit)
 
+    def test_op_times_simple(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.iden(qr[1])
+        target_circuit.y(qr[2])
+        target_circuit.iden(qr[2])
+
+        result_circuit1 = schedule_idle_gates(circuit, op_times=[('x', None, 2)])
+        result_circuit2 = schedule_idle_gates(circuit, op_times=[('x', 2)])
+        result_circuit3 = schedule_idle_gates(circuit, op_times=[('x', [qr[0]], 2)])
+
+        self.assertEqual(target_circuit, result_circuit1)
+        self.assertEqual(target_circuit, result_circuit2)
+        self.assertEqual(target_circuit, result_circuit3)
+
     def test_small_circuit_double_id_time(self):
         qr = QuantumRegister(3, 'qr')
         circuit = QuantumCircuit(qr)
@@ -230,22 +251,3 @@ class TestIdleScheduler(unittest.TestCase):
 if __name__ == '__main__':
      unittest.main()
 
-    # qr = QuantumRegister(2, 'qr')
-    # circuit = QuantumCircuit(qr)
-    # circuit.x(qr[0])
-    # circuit.y(qr[1])
-    # # circuit.snapshot('0')
-    # circuit.x(qr[0])
-    # circuit.y(qr[1])
-    #
-    # target_circuit = QuantumCircuit(qr)
-    # target_circuit.x(qr[0])
-    # target_circuit.y(qr[1])
-    # # target_circuit.snapshot('0')
-    # target_circuit.x(qr[0])
-    # target_circuit.y(qr[1])
-    # target_circuit.iden(qr[1])
-    #
-    #
-    # result_circuit = schedule_idle_gates(circuit, op_times={'x': 2})
-    #

--- a/test/terra/noise/test_idle_scheduler.py
+++ b/test/terra/noise/test_idle_scheduler.py
@@ -22,6 +22,22 @@ class TestIdleScheduler(unittest.TestCase):
     def assertCircuitsEqual(self, lhs, rhs):
         self.assertEqual(circuit_to_dag(lhs), circuit_to_dag(rhs))
 
+    def test_circuits_equal(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.y(qr[2])
+
+        circuit1 = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
+        circuit2 = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
+
+        self.assertCircuitsEqual(circuit1, circuit2)
+
     def test_small_circuit(self):
         qr = QuantumRegister(3, 'qr')
         circuit = QuantumCircuit(qr)
@@ -46,10 +62,11 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.x(qr[0])
         target_circuit.iden(qr[1])
         target_circuit.iden(qr[1])
-        target_circuit.iden(qr[2])
         target_circuit.y(qr[2])
+        target_circuit.iden(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, op_times={'x': 2})
+
         self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_id_time(self):
@@ -93,10 +110,11 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.iden(qr[1])
         target_circuit.iden(qr[1])
         target_circuit.y(qr[2])
-        target_circuit.iden(qr[2])
         target_circuit.y(qr[2])
+        target_circuit.iden(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
+
         self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_barrier_circuit(self):

--- a/test/terra/noise/test_idle_scheduler.py
+++ b/test/terra/noise/test_idle_scheduler.py
@@ -87,6 +87,22 @@ class TestIdleScheduler(unittest.TestCase):
         self.assertEqual(target_circuit, result_circuit2)
         self.assertEqual(target_circuit, result_circuit3)
 
+    def test_op_times_cx(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.cx(qr[0], qr[1])
+        target_circuit.iden(qr[2])
+        target_circuit.cx(qr[1], qr[2])
+        target_circuit.iden(qr[0])
+        target_circuit.iden(qr[0])
+
+        result_circuit = schedule_idle_gates(circuit, op_times=[('cx', [qr[0],qr[1]], 1),('cx', [qr[1],qr[2]], 2)])
+        self.assertEqual(target_circuit, result_circuit)
+
     def test_small_circuit_double_id_time(self):
         qr = QuantumRegister(3, 'qr')
         circuit = QuantumCircuit(qr)

--- a/test/terra/noise/test_idle_scheduler.py
+++ b/test/terra/noise/test_idle_scheduler.py
@@ -15,16 +15,12 @@ IdleScheduler class tests
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.providers.aer.noise.utils import schedule_idle_gates
+from qiskit.converters import circuit_to_dag
 import unittest
 
 class TestIdleScheduler(unittest.TestCase):
     def assertCircuitsEqual(self, lhs, rhs):
-        #Note: this only compares gate names, not additional parameters
-        #this is an ad-hoc comparision for the test we perform here
-        for lhs_data, rhs_data in zip(lhs.data, rhs.data):
-            self.assertEqual(lhs_data[0], rhs_data[0])
-            self.assertEqual(lhs_data[1], rhs_data[1])
-            self.assertEqual(lhs_data[2], rhs_data[2])
+        self.assertEqual(circuit_to_dag(lhs), circuit_to_dag(rhs))
 
     def test_small_circuit(self):
         qr = QuantumRegister(3, 'qr')
@@ -35,7 +31,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit = QuantumCircuit(qr)
         target_circuit.x(qr[0])
         target_circuit.iden(qr[1])
-        target_circuit.z(qr[2])
+        target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit)
         self.assertCircuitsEqual(target_circuit, result_circuit)

--- a/test/terra/noise/test_idle_scheduler.py
+++ b/test/terra/noise/test_idle_scheduler.py
@@ -1,0 +1,146 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+IdleScheduler class tests
+"""
+
+from qiskit import QuantumRegister, QuantumCircuit
+from qiskit.providers.aer.noise.utils import schedule_idle_gates
+import unittest
+
+class TestIdleScheduler(unittest.TestCase):
+    def test_small_circuit(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.y(qr[2])
+
+        result_circuit = schedule_idle_gates(circuit)
+        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+
+    def test_small_circuit_double_x_time(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.iden(qr[1])
+        target_circuit.iden(qr[2])
+        target_circuit.y(qr[2])
+
+        result_circuit = schedule_idle_gates(circuit, op_times={'x': 2})
+        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+
+    def test_small_circuit_double_id_time(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.y(qr[2])
+
+        result_circuit = schedule_idle_gates(circuit, op_times={'id': 2})
+        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+
+    def test_small_circuit_double_id_and_x_time(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.y(qr[2])
+
+        result_circuit = schedule_idle_gates(circuit, op_times={'id': 2, 'x':2})
+        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+
+    def test_small_circuit_double_id_and_x_time_double_length(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.iden(qr[1])
+        target_circuit.y(qr[2])
+        target_circuit.iden(qr[2])
+        target_circuit.y(qr[2])
+
+        result_circuit = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
+        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+
+    def test_barrier_circuit(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+        circuit.barrier()
+        circuit.x(qr[1])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.y(qr[2])
+        target_circuit.barrier()
+        target_circuit.iden(qr[0])
+        target_circuit.x(qr[1])
+        target_circuit.iden(qr[2])
+
+        result_circuit = schedule_idle_gates(circuit)
+        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+
+    def test_small_circuit_nondefault_time(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.y(qr[2])
+
+        result_circuit = schedule_idle_gates(circuit, default_op_time=0.3153)
+        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+
+    def test_small_circuit_nondefault_time_and_different_x_y(self):
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.y(qr[2])
+
+        target_circuit = QuantumCircuit(qr)
+        target_circuit.x(qr[0])
+        target_circuit.iden(qr[1])
+        target_circuit.iden(qr[1])
+        target_circuit.iden(qr[1])
+        target_circuit.y(qr[2])
+
+        result_circuit = schedule_idle_gates(circuit, default_op_time=0.3153, op_times={'x': 0.974, 'y': 0.734})
+        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())

--- a/test/terra/noise/test_idle_scheduler.py
+++ b/test/terra/noise/test_idle_scheduler.py
@@ -15,7 +15,6 @@ IdleScheduler class tests
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.providers.aer.noise.utils import schedule_idle_gates
-from qiskit.converters import circuit_to_dag
 import unittest
 
 class TestIdleScheduler(unittest.TestCase):
@@ -162,3 +161,30 @@ class TestIdleScheduler(unittest.TestCase):
 
         result_circuit = schedule_idle_gates(circuit, default_op_time=0.3153, op_times={'x': 0.974, 'y': 0.734})
         self.assertEqual(target_circuit, result_circuit)
+
+    def test_labels(self):
+        qr = QuantumRegister(2, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.x(qr[0])
+        circuit.barrier()
+        circuit.y(qr[0])
+        circuit.barrier()
+        circuit.h(qr[0])
+        circuit.barrier()
+
+        result_circuit = schedule_idle_gates(circuit)
+        labels = [gate[0].label for gate in result_circuit if gate[0].name == 'id']
+        target_labels = ['id_x', 'id_y', 'id_h']
+        self.assertEqual(target_labels, labels)
+
+        result_circuit = schedule_idle_gates(circuit, labels="uniform_id_label")
+        labels = [gate[0].label for gate in result_circuit if gate[0].name == 'id']
+        target_labels = ['uniform_id_label', 'uniform_id_label', 'uniform_id_label']
+        self.assertEqual(target_labels, labels)
+
+        result_circuit = schedule_idle_gates(circuit, labels={'x': 'id_label_for_x', 'y': 'y_id_label', 'h': '123'})
+        labels = [gate[0].label for gate in result_circuit if gate[0].name == 'id']
+        target_labels = ['id_label_for_x', 'y_id_label', '123']
+        self.assertEqual(target_labels, labels)
+
+

--- a/test/terra/noise/test_idle_scheduler.py
+++ b/test/terra/noise/test_idle_scheduler.py
@@ -19,9 +19,6 @@ from qiskit.converters import circuit_to_dag
 import unittest
 
 class TestIdleScheduler(unittest.TestCase):
-    def assertCircuitsEqual(self, lhs, rhs):
-        self.assertEqual(circuit_to_dag(lhs), circuit_to_dag(rhs))
-
     def test_circuits_equal(self):
         qr = QuantumRegister(3, 'qr')
         circuit = QuantumCircuit(qr)
@@ -33,10 +30,9 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.iden(qr[1])
         target_circuit.y(qr[2])
 
-        circuit1 = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
-        circuit2 = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
+        result_circuit = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
 
-        self.assertCircuitsEqual(circuit1, circuit2)
+        self.assertEqual(target_circuit, result_circuit)
 
     def test_small_circuit(self):
         qr = QuantumRegister(3, 'qr')
@@ -50,7 +46,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit)
-        self.assertCircuitsEqual(target_circuit, result_circuit)
+        self.assertEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_x_time(self):
         qr = QuantumRegister(3, 'qr')
@@ -67,7 +63,7 @@ class TestIdleScheduler(unittest.TestCase):
 
         result_circuit = schedule_idle_gates(circuit, op_times={'x': 2})
 
-        self.assertCircuitsEqual(target_circuit, result_circuit)
+        self.assertEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_id_time(self):
         qr = QuantumRegister(3, 'qr')
@@ -80,7 +76,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, op_times={'id': 2})
-        self.assertCircuitsEqual(target_circuit, result_circuit)
+        self.assertEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_id_and_x_time(self):
         qr = QuantumRegister(3, 'qr')
@@ -94,7 +90,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, op_times={'id': 2, 'x':2})
-        self.assertCircuitsEqual(target_circuit, result_circuit)
+        self.assertEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_id_and_x_time_double_length(self):
         qr = QuantumRegister(3, 'qr')
@@ -115,7 +111,7 @@ class TestIdleScheduler(unittest.TestCase):
 
         result_circuit = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
 
-        self.assertCircuitsEqual(target_circuit, result_circuit)
+        self.assertEqual(target_circuit, result_circuit)
 
     def test_barrier_circuit(self):
         qr = QuantumRegister(3, 'qr')
@@ -135,7 +131,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.iden(qr[2])
 
         result_circuit = schedule_idle_gates(circuit)
-        self.assertCircuitsEqual(target_circuit, result_circuit)
+        self.assertEqual(target_circuit, result_circuit)
 
     def test_small_circuit_nondefault_time(self):
         qr = QuantumRegister(3, 'qr')
@@ -149,7 +145,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, default_op_time=0.3153)
-        self.assertCircuitsEqual(target_circuit, result_circuit)
+        self.assertEqual(target_circuit, result_circuit)
 
     def test_small_circuit_nondefault_time_and_different_x_y(self):
         qr = QuantumRegister(3, 'qr')
@@ -165,4 +161,4 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, default_op_time=0.3153, op_times={'x': 0.974, 'y': 0.734})
-        self.assertCircuitsEqual(target_circuit, result_circuit)
+        self.assertEqual(target_circuit, result_circuit)

--- a/test/terra/noise/test_idle_scheduler.py
+++ b/test/terra/noise/test_idle_scheduler.py
@@ -18,6 +18,14 @@ from qiskit.providers.aer.noise.utils import schedule_idle_gates
 import unittest
 
 class TestIdleScheduler(unittest.TestCase):
+    def assertCircuitsEqual(self, lhs, rhs):
+        #Note: this only compares gate names, not additional parameters
+        #this is an ad-hoc comparision for the test we perform here
+        for lhs_data, rhs_data in zip(lhs.data, rhs.data):
+            self.assertEqual(lhs_data[0], rhs_data[0])
+            self.assertEqual(lhs_data[1], rhs_data[1])
+            self.assertEqual(lhs_data[2], rhs_data[2])
+
     def test_small_circuit(self):
         qr = QuantumRegister(3, 'qr')
         circuit = QuantumCircuit(qr)
@@ -27,10 +35,10 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit = QuantumCircuit(qr)
         target_circuit.x(qr[0])
         target_circuit.iden(qr[1])
-        target_circuit.y(qr[2])
+        target_circuit.z(qr[2])
 
         result_circuit = schedule_idle_gates(circuit)
-        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+        self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_x_time(self):
         qr = QuantumRegister(3, 'qr')
@@ -46,7 +54,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, op_times={'x': 2})
-        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+        self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_id_time(self):
         qr = QuantumRegister(3, 'qr')
@@ -59,7 +67,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, op_times={'id': 2})
-        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+        self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_id_and_x_time(self):
         qr = QuantumRegister(3, 'qr')
@@ -73,7 +81,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, op_times={'id': 2, 'x':2})
-        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+        self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_small_circuit_double_id_and_x_time_double_length(self):
         qr = QuantumRegister(3, 'qr')
@@ -93,7 +101,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, op_times={'id': 2, 'x': 2})
-        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+        self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_barrier_circuit(self):
         qr = QuantumRegister(3, 'qr')
@@ -113,7 +121,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.iden(qr[2])
 
         result_circuit = schedule_idle_gates(circuit)
-        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+        self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_small_circuit_nondefault_time(self):
         qr = QuantumRegister(3, 'qr')
@@ -127,7 +135,7 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, default_op_time=0.3153)
-        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+        self.assertCircuitsEqual(target_circuit, result_circuit)
 
     def test_small_circuit_nondefault_time_and_different_x_y(self):
         qr = QuantumRegister(3, 'qr')
@@ -143,4 +151,4 @@ class TestIdleScheduler(unittest.TestCase):
         target_circuit.y(qr[2])
 
         result_circuit = schedule_idle_gates(circuit, default_op_time=0.3153, op_times={'x': 0.974, 'y': 0.734})
-        self.assertEqual(target_circuit.qasm(), result_circuit.qasm())
+        self.assertCircuitsEqual(target_circuit, result_circuit)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This modules addressed issue #211 and adds a utility to add idle gates to better
simulate passing time when gates for other qubits are being applied.