### PR TITLE
Fix depolarizing error and basic device noise model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ Removed
 
 Fixed
 -----
--   Fixed 2-qubit depolarizing only error rate calculation in
-    \"basic_device_noise_model\" (\#243)
+-   Change maximum parameter for depolarizing_error to allow for error channel
+    with no identity component. (\#243)
+-   Fixed 2-qubit depolarizing-only error parameter calculation in
+    basic_device_noise_model (\#243)
 
 [0.2.1](https://github.com/Qiskit/qiskit-aer/compare/0.2.0...0.2.1) - 2019-05-20
 ================================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Removed
 
 Fixed
 -----
+-   Fixed 2-qubit depolarizing only error rate calculation in
+    \"basic_device_noise_model\" (\#243)
 
 [0.2.1](https://github.com/Qiskit/qiskit-aer/compare/0.2.0...0.2.1) - 2019-05-20
 ================================================================================

--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -268,13 +268,6 @@ def _device_depolarizing_error(qubits,
     num_qubits = len(qubits)
     dim = 2 ** num_qubits
 
-    # If the device reports an error_param greater than the maximum
-    # allowed for a depolarzing error model:
-    #   error_param <= dim / (dim + 1)
-    # we truncated the depolarizing error probability to the maximum value
-    if error_param is not None:
-        error_param = min(error_param, dim / (dim + 1))
-
     if not thermal_relaxation:
         # Model gate error entirely as depolarizing error
         if error_param is not None and error_param > 0:
@@ -305,6 +298,12 @@ def _device_depolarizing_error(qubits,
                              "1 and 2-qubit gates when using "
                              "thermal_relaxation=True.")
     if depol_param > 0:
+        # If the device reports an error_param greater than the maximum
+        # allowed for a depolarzing error model we will get a non-physical
+        # depolarizing parameter.
+        # In this case we truncate it to 1 so that the error channel is a
+        # completely depolarizing channel E(rho) = id / d
+        depol_param = min(depol_param, 1.0)
         error = depolarizing_error(
             depol_param, num_qubits, standard_gates=standard_gates)
     return error

--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -265,18 +265,23 @@ def _device_depolarizing_error(qubits,
     # with dim = 2 ** N for an N-qubit gate error.
 
     error = None
+    num_qubits = len(qubits)
     if not thermal_relaxation:
         # Model gate error entirely as depolarizing error
-        p_depol = _depol_error_value_one_qubit(error_param)
+        if error_param is not None and error_param > 0:
+            dim = 2 ** num_qubits
+            p_depol = dim * error_param / (dim - 1)
+        else:
+            p_depol = 0
     else:
         # Model gate error as thermal relaxation and depolarizing
         # error.
         # Get depolarizing probability
-        if len(qubits) == 1:
+        if num_qubits == 1:
             t1, t2, _ = relax_params[qubits[0]]
             p_depol = _depol_error_value_one_qubit(
                 error_param, gate_time, t1=t1, t2=t2)
-        elif len(qubits) == 2:
+        elif num_qubits == 2:
             q0_t1, q0_t2, _ = relax_params[qubits[0]]
             q1_t1, q1_t2, _ = relax_params[qubits[1]]
             p_depol = _depol_error_value_two_qubit(
@@ -292,7 +297,7 @@ def _device_depolarizing_error(qubits,
                              "thermal_relaxation=True.")
     if p_depol > 0:
         error = depolarizing_error(
-            p_depol, len(qubits), standard_gates=standard_gates)
+            p_depol, num_qubits, standard_gates=standard_gates)
     return error
 
 

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -267,12 +267,12 @@ def _pauli_error_standard(noise_ops, num_qubits):
     return error
 
 
-def depolarizing_error(prob, num_qubits, standard_gates=True):
+def depolarizing_error(param, num_qubits, standard_gates=True):
     """
     Depolarizing quantum error channel.
 
     Args:
-        prob (double): completely depolarizing channel error probability.
+        param (double): depolarizing error parameter.
         num_qubits (int): the number of qubits for the error channel.
         standard_gates (bool): if True return the operators as standard qobj
                                Pauli gate instructions. If false return as
@@ -284,21 +284,32 @@ def depolarizing_error(prob, num_qubits, standard_gates=True):
 
     Raises:
         NoiseError: If noise parameters are invalid.
-    """
 
-    if prob < 0 or prob > 1:
-        raise NoiseError(
-            "Depolarizing probability must be in between 0 and 1.")
+    Additional Information:
+        The depolarizing channel is defined as:
+            E(ρ) = (1 - λ) ρ + λ * (I / 2 ** n)
+            with 0 <= λ <= 4 ** n / (4 ** n - 1)
+        where λ is the depolarizing error param and n is the number of
+        qubits.
+        If λ = 0 this is the identity channel E(ρ) = ρ
+        If λ = 1 this is a completely depolarizing channel E(ρ) = I / 2 ** n
+        if λ = 4 ** n / (4 ** n - 1) this is a uniform Pauli error channel
+            E(ρ) = sum_j P_j ρ P_j / (4 ** n - 1) for all P_j != I.
+    """
     if not isinstance(num_qubits, int) or num_qubits < 1:
         raise NoiseError("num_qubits must be a positive integer.")
+    # Check that the depolarizing parameter gives a valid CPTP
+    num_terms = 4**num_qubits
+    max_param = num_terms / (num_terms - 1)
+    if param < 0 or param > max_param:
+        raise NoiseError("Depolarizing parameter must be in between 0 "
+                         "and {}.".format(max_param))
 
     # Rescale completely depolarizing channel error probs
     # with the identity component removed
-    num_terms = 4**num_qubits  # terms in completely depolarizing channel
-    prob_error = prob / num_terms
-    prob_iden = 1 - (
-        num_terms - 1) * prob_error  # subtract off non-identity terms
-    probs = [prob_iden] + (num_terms - 1) * [prob_error]
+    prob_iden = 1 - param / max_param
+    prob_pauli = param / num_terms
+    probs = [prob_iden] + (num_terms - 1) * [prob_pauli]
     # Generate pauli strings. The order doesn't matter as long
     # as the all identity string is first.
     paulis = [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

1. Change `depolarizing_error` parameter to allow values greater than 1 if channel is still CPTP
2. Fix basic_device_noise_model to use correct depol param calculation for n-qubit gate with n>1.
3. Truncate depolarizing error param calculated in basic_device_noise_model to max allowed if gate error is too large (Fixes #241)

### Details and comments

#### Depolarizing Error

The error parameter in depolarizing error was interpreted as a probability with maximum value of 1 corresponding to a completely depolarizing channel. This allows larger values than 1 (so no-longer a probability) which return error channels with a reduced identity component, up to a maximum where there is no identity component. Ie for single-qubit the Pauli error `[(X, 1/3), (Y, 1/3), (Z, 1/3)]`.

#### Device noise model
In `basic_device_noise_model` when `thermal_relaxation=False` the depolarizing error probability was being calculated using the single-qubit depolarizing channel fidelity in all cases rather than the n-qubit fidelity for an n-qubit gate error. This fixes it to use the correct n-qubit equation.

Also if the gate error is larger than the maximum for the depolarizing error it will simply truncate it to the maximum allowed error rate for the model rather than throw an exception that the resulting error objects are non-CPTP.