### PR TITLE
Density matrix simulator (ideal only)

### DIFF
--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -248,6 +248,9 @@ protected:
 
 void Controller::set_config(const json_t &config) {
 
+  // Load validation threshold
+  JSON::get_value(validation_threshold_, "validation_threshold", config);
+
   // Load OpenMP maximum thread settings
   if (JSON::check_key("max_parallel_threads", config))
     JSON::get_value(max_parallel_threads_, "max_parallel_threads", config);

--- a/src/simulators/densitymatrix/densitymatrix.hpp
+++ b/src/simulators/densitymatrix/densitymatrix.hpp
@@ -1,0 +1,358 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _qv_density_matrix_hpp_
+#define _qv_density_matrix_hpp_
+
+
+#include "framework/utils.hpp"
+#include "simulators/unitary/unitarymatrix.hpp"
+
+namespace QV {
+
+//============================================================================
+// DensityMatrix class
+//============================================================================
+
+// This class is derived from the UnitaryMatrix class and stores an N-qubit 
+// matrix as a 2*N-qubit vector.
+// The vector is formed using column-stacking vectorization as under this
+// convention left-matrix multiplication on qubit-n is equal to multiplication
+// of the vectorized 2*N qubit vector also on qubit-n.
+
+template <typename data_t = double>
+class DensityMatrix : public UnitaryMatrix<data_t> {
+
+public:
+  // Parent class aliases
+  using BaseVector = QubitVector<data_t>;
+  using BaseMatrix = UnitaryMatrix<data_t>;
+
+  //-----------------------------------------------------------------------
+  // Constructors and Destructor
+  //-----------------------------------------------------------------------
+
+  DensityMatrix() : DensityMatrix(0) {};
+  explicit DensityMatrix(size_t num_qubits);
+  DensityMatrix(const DensityMatrix& obj) = delete;
+  DensityMatrix &operator=(const DensityMatrix& obj) = delete;
+
+  //-----------------------------------------------------------------------
+  // Utility functions
+  //-----------------------------------------------------------------------
+
+  // Initializes the current vector so that all qubits are in the |0> state.
+  void initialize();
+
+  // Initializes the vector to a custom initial state.
+  // The vector can be either a statevector or a vectorized density matrix
+  // If the length of the data vector does not match either case for the
+  // number of qubits an exception is raised.
+  void initialize_from_vector(const cvector_t<double> &data);
+
+  //-----------------------------------------------------------------------
+  // Apply Matrices
+  //-----------------------------------------------------------------------
+
+  // Apply a N-qubit unitary matrix to the state vector.
+  // The matrix is input as vector of the column-major vectorized N-qubit matrix.
+  void apply_unitary_matrix(const reg_t &qubits, const cvector_t<double> &mat);
+
+  // Apply a N-qubit superoperator matrix to the state vector.
+  // The matrix is input as vector of the column-major vectorized N-qubit superop.
+  void apply_superop_matrix(const reg_t &qubits, const cvector_t<double> &mat);
+
+  // Apply a N-qubit diagonal unitary matrix to the state vector.
+  // The matrix is input as vector of the matrix diagonal.
+  void apply_diagonal_unitary_matrix(const reg_t &qubits, const cvector_t<double> &mat);
+
+  // Apply a N-qubit diagonal superoperator matrix to the state vector.
+  // The matrix is input as vector of the matrix diagonal.
+  void apply_diagonal_superop_matrix(const reg_t &qubits, const cvector_t<double> &mat);
+
+  //-----------------------------------------------------------------------
+  // Apply Specialized Gates
+  //-----------------------------------------------------------------------
+
+  // Apply a 2-qubit Controlled-NOT gate to the state vector
+  void apply_cnot(const uint_t qctrl, const uint_t qtrgt);
+
+  // Apply a 2-qubit Controlled-Z gate to the state vector
+  void apply_cz(const uint_t q0, const uint_t q1);
+
+  // Apply a 2-qubit SWAP gate to the state vector
+  void apply_swap(const uint_t q0, const uint_t q1);
+
+  // Apply a single-qubit Pauli-X gate to the state vector
+  void apply_x(const uint_t qubit);
+
+  // Apply a single-qubit Pauli-Y gate to the state vector
+  void apply_y(const uint_t qubit);
+
+  // Apply a single-qubit Pauli-Z gate to the state vector
+  void apply_z(const uint_t qubit);
+
+  // Apply a 3-qubit toffoli gate
+  void apply_toffoli(const uint_t qctrl0, const uint_t qctrl1, const uint_t qtrgt);
+
+  //-----------------------------------------------------------------------
+  // Z-measurement outcome probabilities
+  //-----------------------------------------------------------------------
+
+  // Return the Z-basis measurement outcome probability P(outcome) for
+  // outcome in [0, 2^num_qubits - 1]
+  virtual double probability(const uint_t outcome) const override;
+
+protected:
+
+  // Convert qubit indicies to vectorized-density matrix qubitvector indices
+  // For the QubitVector apply matrix function
+  reg_t superop_qubits(const reg_t &qubits) const;
+
+  // Construct a vectorized superoperator from a vectorized matrix
+  // This is equivalent to vec(tensor(conj(A), A))
+  cvector_t<double> vmat2vsuperop(const cvector_t<double> &vmat) const;
+
+  // Qubit threshold for when apply unitary will apply as two matrix multiplications
+  // rather than as a 2n-qubit superoperator matrix.
+  size_t apply_unitary_threshold_ = 4;
+};
+
+/*******************************************************************************
+ *
+ * Implementations
+ *
+ ******************************************************************************/
+
+
+//------------------------------------------------------------------------------
+// Constructors & Destructor
+//------------------------------------------------------------------------------
+
+template <typename data_t>
+DensityMatrix<data_t>::DensityMatrix(size_t num_qubits)
+  : UnitaryMatrix<data_t>(num_qubits) {};
+
+//------------------------------------------------------------------------------
+// Utility
+//------------------------------------------------------------------------------
+
+template <typename data_t>
+void DensityMatrix<data_t>::initialize() {
+  // Zero the underlying vector
+  BaseVector::zero();
+  // Set to be all |0> sate
+  BaseVector::data_[0] = 1.0;
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::initialize_from_vector(const cvector_t<double> &statevec) {
+  if (BaseVector::data_size_ == statevec.size()) {
+    // Use base class initialize for already vectorized matrix
+    BaseVector::initialize_from_vector(statevec);
+  } else if (BaseVector::data_size_ == statevec.size() * statevec.size()) {
+    // Convert statevector into density matrix
+    cvector_t<double> densitymat = AER::Utils::tensor_product(AER::Utils::conjugate(statevec),
+                                                      statevec);
+    std::move(densitymat.begin(), densitymat.end(), BaseVector::data_);
+  } else {
+    std::string error = "DensityMatrix::initialize input vector is incorrect length";
+    throw std::runtime_error(error);
+  }
+}
+
+//------------------------------------------------------------------------------
+// Apply matrix functions
+//------------------------------------------------------------------------------
+
+template <typename data_t>
+reg_t DensityMatrix<data_t>::superop_qubits(const reg_t &qubits) const {
+  reg_t superop_qubits = qubits;
+  // Number of qubits
+  const auto num_qubits = BaseMatrix::num_qubits();
+  for (const auto q: qubits) {
+    superop_qubits.push_back(q + num_qubits);
+  }
+  return superop_qubits;
+}
+
+template <typename data_t>
+cvector_t<double> DensityMatrix<data_t>::vmat2vsuperop(const cvector_t<double> &vmat) const {
+  // Get dimension of unvectorized matrix
+  size_t dim = size_t(std::sqrt(vmat.size()));
+  cvector_t<double> ret(dim * dim * dim * dim, 0.);
+  for (size_t i=0; i < dim; i++)
+    for (size_t j=0; j < dim; j++)
+      for (size_t k=0; k < dim; k++)
+        for (size_t l=0; l < dim; l++)
+          ret[dim*i+k+(dim*dim)*(dim*j+l)] = std::conj(vmat[i+dim*j])*vmat[k+dim*l];
+  return ret;
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_superop_matrix(const reg_t &qubits,
+                                                 const cvector_t<double> &mat) {
+  BaseVector::apply_matrix(superop_qubits(qubits), mat);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_diagonal_superop_matrix(const reg_t &qubits,
+                                                          const cvector_t<double> &diag) {
+  BaseVector::apply_diagonal_matrix(superop_qubits(qubits), diag);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_unitary_matrix(const reg_t &qubits,
+                                                 const cvector_t<double> &mat) {
+  // Check if we apply as two N-qubit matrix multiplications or a single 2N-qubit matrix mult.
+  if (qubits.size() > apply_unitary_threshold_) {
+    // Apply as two N-qubit matrix mults
+    auto num_qubits = BaseMatrix::num_qubits();
+    reg_t conj_qubits;
+    for (const auto q: qubits) {
+      conj_qubits.push_back(q + num_qubits);
+    }
+    // Apply id \otimes U
+    BaseVector::apply_matrix(qubits, mat);
+    // Apply conj(U) \otimes id
+    BaseVector::apply_matrix(conj_qubits, AER::Utils::conjugate(mat));
+  } else {
+    // Apply as single 2N-qubit matrix mult.
+    apply_superop_matrix(qubits, vmat2vsuperop(mat));
+  }
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_diagonal_unitary_matrix(const reg_t &qubits,
+                                                          const cvector_t<double> &diag) {
+  // Apply as single 2N-qubit matrix mult.
+  apply_diagonal_superop_matrix(qubits, AER::Utils::tensor_product(AER::Utils::conjugate(diag), diag));
+}
+
+//-----------------------------------------------------------------------
+// Apply Specialized Gates
+//-----------------------------------------------------------------------
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_cnot(const uint_t qctrl, const uint_t qtrgt) {
+  std::vector<std::pair<uint_t, uint_t>> pairs = {
+    {{1, 3}, {4, 12}, {5, 15}, {6, 14}, {7, 13}, {9, 11}}
+  };
+  const size_t nq = BaseMatrix::num_qubits();
+  const reg_t qubits = {{qctrl, qtrgt, qctrl + nq, qtrgt + nq}};
+  BaseVector::apply_permutation_matrix(qubits, pairs);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_cz(const uint_t q0, const uint_t q1) {
+  // Lambda function for CZ gate
+  auto lambda = [&](const areg_t<1ULL << 4> &inds)->void {
+    BaseVector::data_[inds[3]] *= -1.;
+    BaseVector::data_[inds[7]] *= -1.;
+    BaseVector::data_[inds[11]] *= -1.;
+    BaseVector::data_[inds[12]] *= -1.;
+    BaseVector::data_[inds[13]] *= -1.;
+    BaseVector::data_[inds[14]] *= -1.;
+  };
+  const auto nq =  BaseMatrix::num_qubits();
+  const areg_t<4> qubits = {{q0, q1, q0 + nq, q1 + nq}};
+  BaseVector::apply_lambda(lambda, qubits);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_swap(const uint_t q0, const uint_t q1) {
+  std::vector<std::pair<uint_t, uint_t>> pairs = {
+   {{1, 2}, {4, 8}, {5, 10}, {6, 9}, {7, 11}, {13, 14}}
+  };
+  const size_t nq = BaseMatrix::num_qubits();
+  const reg_t qubits = {{q0, q1, q0 + nq, q1 + nq}};
+  BaseVector::apply_permutation_matrix(qubits, pairs);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_x(const uint_t qubit) {
+  // Lambda function for X gate superoperator
+  auto lambda = [&](const areg_t<1ULL << 2> &inds)->void {
+    std::swap(BaseVector::data_[inds[0]], BaseVector::data_[inds[3]]);
+    std::swap(BaseVector::data_[inds[1]], BaseVector::data_[inds[2]]);
+  };
+  // Use the lambda function
+  const areg_t<2> qubits = {{qubit, qubit + BaseMatrix::num_qubits()}};
+  BaseVector::apply_lambda(lambda, qubits);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_y(const uint_t qubit) {
+  // Lambda function for Y gate superoperator
+  auto lambda = [&](const areg_t<1ULL << 2> &inds)->void {
+    std::swap(BaseVector::data_[inds[0]], BaseVector::data_[inds[3]]);
+    const std::complex<data_t> cache = std::complex<data_t>(-1) * BaseVector::data_[inds[1]];
+    BaseVector::data_[inds[1]] = std::complex<data_t>(-1) * BaseVector::data_[inds[2]];
+    BaseVector::data_[inds[2]] = cache;
+  };
+  // Use the lambda function
+  const areg_t<2> qubits = {{qubit, qubit + BaseMatrix::num_qubits()}};
+  BaseVector::apply_lambda(lambda, qubits);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_z(const uint_t qubit) {
+  // Lambda function for Z gate superoperator
+  auto lambda = [&](const areg_t<1ULL << 2> &inds)->void {
+    BaseVector::data_[inds[1]] *= -1;
+    BaseVector::data_[inds[2]] *= -1;
+  };
+  // Use the lambda function
+  const areg_t<2> qubits = {{qubit, qubit + BaseMatrix::num_qubits()}};
+  BaseVector::apply_lambda(lambda, qubits);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_toffoli(const uint_t qctrl0,
+                                          const uint_t qctrl1,
+                                          const uint_t qtrgt) {
+  std::vector<std::pair<uint_t, uint_t>> pairs = {
+    {{3, 7}, {11, 15}, {19, 23}, {24, 56}, {25, 57}, {26, 58}, {27, 63},
+    {28, 60}, {29, 61}, {30, 62}, {31, 59}, {35, 39}, {43,47}, {51, 55}}
+  };
+  const size_t nq = BaseMatrix::num_qubits();
+  const reg_t qubits = {{qctrl0, qctrl1, qtrgt,
+                         qctrl0 + nq, qctrl1 + nq, qtrgt + nq}};
+  BaseVector::apply_permutation_matrix(qubits, pairs);
+}
+
+//-----------------------------------------------------------------------
+// Z-measurement outcome probabilities
+//-----------------------------------------------------------------------
+
+template <typename data_t>
+double DensityMatrix<data_t>::probability(const uint_t outcome) const {
+  const auto shift = BaseMatrix::num_rows() + 1;
+  return std::real(BaseVector::data_[outcome * shift]);
+}
+
+//------------------------------------------------------------------------------
+} // end namespace QV
+//------------------------------------------------------------------------------
+
+// ostream overload for templated qubitvector
+template <typename data_t>
+inline std::ostream &operator<<(std::ostream &out, const QV::DensityMatrix<data_t>&m) {
+  out << m.matrix();
+  return out;
+}
+
+//------------------------------------------------------------------------------
+#endif // end module
+

--- a/src/simulators/densitymatrix/densitymatrix.hpp
+++ b/src/simulators/densitymatrix/densitymatrix.hpp
@@ -167,8 +167,9 @@ void DensityMatrix<data_t>::initialize_from_vector(const cvector_t<double> &stat
                                                       statevec);
     std::move(densitymat.begin(), densitymat.end(), BaseVector::data_);
   } else {
-    std::string error = "DensityMatrix::initialize input vector is incorrect length";
-    throw std::runtime_error(error);
+    throw std::runtime_error("DensityMatrix::initialize input vector is incorrect length. Expected: " +
+                             std::to_string(BaseVector::data_size_) + " Received: " +
+                             std::to_string(statevec.size()));
   }
 }
 

--- a/src/simulators/densitymatrix/densitymatrix_state.hpp
+++ b/src/simulators/densitymatrix/densitymatrix_state.hpp
@@ -39,6 +39,7 @@ enum class Gates {
 enum class Snapshots {
   cmemory, cregister, densitymatrix,
   probs, probs_var
+  /* TODO: The following expectation value snapshots still need to be implemented */
   //,expval_pauli, expval_pauli_var,
   //expval_matrix, expval_matrix_var
 };
@@ -87,10 +88,7 @@ public:
   // Return the set of qobj snapshot types supported by the State
   virtual stringset_t allowed_snapshots() const override {
     return {"density_matrix", "memory", "register",
-            "probabilities", "probabilities_with_variance"
-            //,"expectation_value_pauli", "expectation_value_pauli_with_variance",
-            // "expectation_value_matrix", "expectation_value_matrix_with_variance"
-            };
+            "probabilities", "probabilities_with_variance"};
   }
 
   // Apply a sequence of operations by looping over list
@@ -237,6 +235,8 @@ protected:
   //-----------------------------------------------------------------------
 
   // OpenMP qubit threshold
+  // NOTE: This is twice the number of qubits in the DensityMatrix since it
+  // refers to the equivalent qubit number in the underlying QubitVector class
   int omp_qubit_threshold_ = 14;
 
   // Threshold for chopping small values to zero in JSON
@@ -354,7 +354,7 @@ void State<densmat_t>::initialize_omp() {
 
 template <class densmat_t>
 size_t State<densmat_t>::required_memory_mb(uint_t num_qubits,
-                                             const std::vector<Operations::Op> &ops) {
+                                            const std::vector<Operations::Op> &ops) {
   // An n-qubit state vector as 2^n complex doubles
   // where each complex double is 16 bytes
   (void)ops; // avoid unused variable compiler warning

--- a/src/simulators/densitymatrix/densitymatrix_state.hpp
+++ b/src/simulators/densitymatrix/densitymatrix_state.hpp
@@ -1,0 +1,725 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_densitymatrix_state_hpp
+#define _aer_densitymatrix_state_hpp
+
+#include <algorithm>
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+#include "framework/utils.hpp"
+#include "framework/json.hpp"
+#include "base/state.hpp"
+#include "densitymatrix.hpp"
+
+
+namespace AER {
+namespace DensityMatrix {
+  
+// Allowed gates enum class
+enum class Gates {
+  u1, u2, u3, id, x, y, z, h, s, sdg, t, tdg, // single qubit
+  cx, cz, swap, // two qubit
+  ccx // three qubit
+};
+
+// Allowed snapshots enum class
+enum class Snapshots {
+  cmemory, cregister, densitymatrix,
+  probs, probs_var
+  //,expval_pauli, expval_pauli_var,
+  //expval_matrix, expval_matrix_var
+};
+
+//=========================================================================
+// DensityMatrix State subclass
+//=========================================================================
+
+template <class densmat_t = QV::DensityMatrix<double>>
+class State : public Base::State<densmat_t> {
+public:
+  using BaseState = Base::State<densmat_t>;
+
+  State() = default;
+  virtual ~State() = default;
+
+  //-----------------------------------------------------------------------
+  // Base class overrides
+  //-----------------------------------------------------------------------
+
+  // Return the string name of the State class
+  virtual std::string name() const override {return "density_matrix";}
+
+  // Return the set of qobj instruction types supported by the State
+  virtual Operations::OpSet::optypeset_t allowed_ops() const override {
+    return Operations::OpSet::optypeset_t({
+      Operations::OpType::gate,
+      Operations::OpType::measure,
+      Operations::OpType::reset,
+      Operations::OpType::snapshot,
+      Operations::OpType::barrier,
+      Operations::OpType::bfunc,
+      Operations::OpType::roerror,
+      Operations::OpType::matrix,
+      Operations::OpType::kraus,
+      Operations::OpType::superop
+    });
+  }
+
+  // Return the set of qobj gate instruction names supported by the State
+  virtual stringset_t allowed_gates() const override {
+    return {"U", "CX", "u1", "u2", "u3", "cx", "cz", "swap",
+            "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx"};
+  }
+
+  // Return the set of qobj snapshot types supported by the State
+  virtual stringset_t allowed_snapshots() const override {
+    return {"density_matrix", "memory", "register",
+            "probabilities", "probabilities_with_variance"
+            //,"expectation_value_pauli", "expectation_value_pauli_with_variance",
+            // "expectation_value_matrix", "expectation_value_matrix_with_variance"
+            };
+  }
+
+  // Apply a sequence of operations by looping over list
+  // If the input is not in allowed_ops an exeption will be raised.
+  virtual void apply_ops(const std::vector<Operations::Op> &ops,
+                         OutputData &data,
+                         RngEngine &rng) override;
+
+  // Initializes an n-qubit state to the all |0> state
+  virtual void initialize_qreg(uint_t num_qubits) override;
+
+  // Initializes to a specific n-qubit state
+  virtual void initialize_qreg(uint_t num_qubits,
+                               const densmat_t &state) override;
+
+  // Returns the required memory for storing an n-qubit state in megabytes.
+  // For this state the memory is indepdentent of the number of ops
+  // and is approximately 16 * 1 << num_qubits bytes
+  virtual size_t required_memory_mb(uint_t num_qubits,
+                                    const std::vector<Operations::Op> &ops) override;
+
+  // Load the threshold for applying OpenMP parallelization
+  // if the controller/engine allows threads for it
+  virtual void set_config(const json_t &config) override;
+
+  // Sample n-measurement outcomes without applying the measure operation
+  // to the system state
+  virtual std::vector<reg_t> sample_measure(const reg_t& qubits,
+                                            uint_t shots,
+                                            RngEngine &rng) override;
+
+  //-----------------------------------------------------------------------
+  // Additional methods
+  //-----------------------------------------------------------------------
+
+  // Initializes to a specific n-qubit state given as a complex std::vector
+  virtual void initialize_qreg(uint_t num_qubits, const cvector_t &state);
+
+  // Initializes to a specific n-qubit state given as a complex matrix
+  virtual void initialize_qreg(uint_t num_qubits, const cmatrix_t &state);
+
+  // Initialize OpenMP settings for the underlying DensityMatrix class
+  void initialize_omp();
+
+protected:
+
+  //-----------------------------------------------------------------------
+  // Apply instructions
+  //-----------------------------------------------------------------------
+
+  // Applies a sypported Gate operation to the state class.
+  // If the input is not in allowed_gates an exeption will be raised.
+  void apply_gate(const Operations::Op &op);
+
+  // Measure qubits and return a list of outcomes [q0, q1, ...]
+  // If a state subclass supports this function it then "measure"
+  // should be contained in the set returned by the 'allowed_ops'
+  // method.
+  virtual void apply_measure(const reg_t &qubits,
+                             const reg_t &cmemory,
+                             const reg_t &cregister,
+                             RngEngine &rng);
+
+  // Reset the specified qubits to the |0> state by tracing out qubits
+  void apply_reset(const reg_t &qubits);
+
+  // Apply a supported snapshot instruction
+  // If the input is not in allowed_snapshots an exeption will be raised.
+  virtual void apply_snapshot(const Operations::Op &op, OutputData &data);
+
+  // Apply a matrix to given qubits (identity on all other qubits)
+  void apply_matrix(const reg_t &qubits, const cmatrix_t & mat);
+
+  // Apply a vectorized matrix to given qubits (identity on all other qubits)
+  void apply_matrix(const reg_t &qubits, const cvector_t & vmat);
+
+  // Apply a Kraus error operation
+  void apply_kraus(const reg_t &qubits, const std::vector<cmatrix_t> &kraus);
+
+  //-----------------------------------------------------------------------
+  // Measurement Helpers
+  //-----------------------------------------------------------------------
+
+  // Return vector of measure probabilities for specified qubits
+  // If a state subclass supports this function it then "measure"
+  // should be contained in the set returned by the 'allowed_ops'
+  // method.
+  // TODO: move to private (no longer part of base class)
+  rvector_t measure_probs(const reg_t &qubits) const;
+
+  // Sample the measurement outcome for qubits
+  // return a pair (m, p) of the outcome m, and its corresponding
+  // probability p.
+  // Outcome is given as an int: Eg for two-qubits {q0, q1} we have
+  // 0 -> |q1 = 0, q0 = 0> state
+  // 1 -> |q1 = 0, q0 = 1> state
+  // 2 -> |q1 = 1, q0 = 0> state
+  // 3 -> |q1 = 1, q0 = 1> state
+  std::pair<uint_t, double>
+  sample_measure_with_prob(const reg_t &qubits, RngEngine &rng);
+
+
+  void measure_reset_update(const std::vector<uint_t> &qubits,
+                            const uint_t final_state,
+                            const uint_t meas_state,
+                            const double meas_prob);
+
+  //-----------------------------------------------------------------------
+  // Special snapshot types
+  //
+  // IMPORTANT: These methods are not marked const to allow modifying state
+  // during snapshot, but after the snapshot is applied the simulator
+  // should be left in the pre-snapshot state.
+  //-----------------------------------------------------------------------
+
+  // Snapshot current qubit probabilities for a measurement (average)
+  void snapshot_probabilities(const Operations::Op &op,
+                              OutputData &data,
+                              bool variance);
+
+  // Snapshot the expectation value of a Pauli operator
+  void snapshot_pauli_expval(const Operations::Op &op,
+                             OutputData &data,
+                             bool variance);
+
+  // Snapshot the expectation value of a matrix operator
+  void snapshot_matrix_expval(const Operations::Op &op,
+                              OutputData &data,
+                              bool variance);
+
+  //-----------------------------------------------------------------------
+  // Single-qubit gate helpers
+  //-----------------------------------------------------------------------
+
+  // Apply a waltz gate specified by parameters u3(theta, phi, lambda)
+  void apply_gate_u3(const uint_t qubit, const double theta, const double phi,
+                     const double lambda);
+
+  // Optimize phase gate with diagonal [1, phase]
+  void apply_gate_phase(const uint_t qubit, const complex_t phase);
+
+  //-----------------------------------------------------------------------
+  // Config Settings
+  //-----------------------------------------------------------------------
+
+  // OpenMP qubit threshold
+  int omp_qubit_threshold_ = 14;
+
+  // Threshold for chopping small values to zero in JSON
+  double json_chop_threshold_ = 1e-10;
+
+  // Table of allowed gate names to gate enum class members
+  const static stringmap_t<Gates> gateset_;
+
+  // Table of allowed snapshot types to enum class members
+  const static stringmap_t<Snapshots> snapshotset_;
+
+};
+
+
+//=========================================================================
+// Implementation: Allowed ops and gateset
+//=========================================================================
+
+template <class densmat_t>
+const stringmap_t<Gates> State<densmat_t>::gateset_({
+  // Single qubit gates
+  {"id", Gates::id},     // Pauli-Identity gate
+  {"x", Gates::x},       // Pauli-X gate
+  {"y", Gates::y},       // Pauli-Y gate
+  {"z", Gates::z},       // Pauli-Z gate
+  {"s", Gates::s},       // Phase gate (aka sqrt(Z) gate)
+  {"sdg", Gates::sdg},   // Conjugate-transpose of Phase gate
+  {"h", Gates::h},       // Hadamard gate (X + Z / sqrt(2))
+  {"t", Gates::t},       // T-gate (sqrt(S))
+  {"tdg", Gates::tdg},   // Conjguate-transpose of T gate
+  // Waltz Gates
+  {"u1", Gates::u1},     // zero-X90 pulse waltz gate
+  {"u2", Gates::u2},     // single-X90 pulse waltz gate
+  {"u3", Gates::u3},     // two X90 pulse waltz gate
+  {"U", Gates::u3},      // two X90 pulse waltz gate
+  // Two-qubit gates
+  {"CX", Gates::cx},     // Controlled-X gate (CNOT)
+  {"cx", Gates::cx},     // Controlled-X gate (CNOT)
+  {"cz", Gates::cz},     // Controlled-Z gate
+  {"swap", Gates::swap}, // SWAP gate
+  // Three-qubit gates
+  {"ccx", Gates::ccx}    // Controlled-CX gate (Toffoli)
+});
+
+
+template <class densmat_t>
+const stringmap_t<Snapshots> State<densmat_t>::snapshotset_({
+  {"density_matrix", Snapshots::densitymatrix},
+  {"probabilities", Snapshots::probs},
+  {"probabilities_with_variance", Snapshots::probs_var},
+  {"memory", Snapshots::cmemory},
+  {"register", Snapshots::cregister}
+});
+
+
+//=========================================================================
+// Implementation: Base class method overrides
+//=========================================================================
+
+//-------------------------------------------------------------------------
+// Initialization
+//-------------------------------------------------------------------------
+
+template <class densmat_t>
+void State<densmat_t>::initialize_qreg(uint_t num_qubits) {
+  initialize_omp();
+  BaseState::qreg_.set_num_qubits(num_qubits);
+  BaseState::qreg_.initialize();
+}
+
+template <class densmat_t>
+void State<densmat_t>::initialize_qreg(uint_t num_qubits,
+                                   const densmat_t &state) {
+  // Check dimension of state
+  if (state.num_qubits() != num_qubits) {
+    throw std::invalid_argument("DensityMatrix::State::initialize: initial state does not match qubit number");
+  }
+  initialize_omp();
+  BaseState::qreg_.set_num_qubits(num_qubits);
+  BaseState::qreg_.initialize_from_data(state.data(), 1ULL << 2 * num_qubits);
+}
+
+template <class densmat_t>
+void State<densmat_t>::initialize_qreg(uint_t num_qubits,
+                                        const cmatrix_t &state) {
+  if (state.size() != 1ULL << 2 * num_qubits) {
+    throw std::invalid_argument("DensityMatrix::State::initialize: initial state does not match qubit number");
+  }
+  initialize_omp();
+  BaseState::qreg_.set_num_qubits(num_qubits);
+  BaseState::qreg_.initialize_from_matrix(state);
+}
+
+template <class densmat_t>
+void State<densmat_t>::initialize_qreg(uint_t num_qubits,
+                                        const cvector_t &state) {
+  if (state.size() != 1ULL << 2 * num_qubits) {
+    throw std::invalid_argument("DensityMatrix::State::initialize: initial state does not match qubit number");
+  }
+  initialize_omp();
+  BaseState::qreg_.set_num_qubits(num_qubits);
+  BaseState::qreg_.initialize_from_vector(state);
+}
+
+template <class densmat_t>
+void State<densmat_t>::initialize_omp() {
+  BaseState::qreg_.set_omp_threshold(omp_qubit_threshold_);
+  if (BaseState::threads_ > 0)
+    BaseState::qreg_.set_omp_threads(BaseState::threads_); // set allowed OMP threads in qubitvector
+}
+
+//-------------------------------------------------------------------------
+// Utility
+//-------------------------------------------------------------------------
+
+template <class densmat_t>
+size_t State<densmat_t>::required_memory_mb(uint_t num_qubits,
+                                             const std::vector<Operations::Op> &ops) {
+  // An n-qubit state vector as 2^n complex doubles
+  // where each complex double is 16 bytes
+  (void)ops; // avoid unused variable compiler warning
+  size_t shift_mb = std::max<int_t>(0, num_qubits + 4 - 20);
+  size_t mem_mb = 1ULL << shift_mb;
+  return mem_mb;
+}
+
+template <class densmat_t>
+void State<densmat_t>::set_config(const json_t &config) {
+
+  // Set threshold for truncating snapshots
+  JSON::get_value(json_chop_threshold_, "chop_threshold", config);
+  BaseState::qreg_.set_json_chop_threshold(json_chop_threshold_);
+
+  // Set OMP threshold for state update functions
+  JSON::get_value(omp_qubit_threshold_, "statevector_parallel_threshold", config);
+}
+
+
+//=========================================================================
+// Implementation: apply operations
+//=========================================================================
+
+template <class densmat_t>
+void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
+                                 OutputData &data,
+                                 RngEngine &rng) {
+  // Simple loop over vector of input operations
+  for (const auto op: ops) {
+    // If conditional op check conditional
+    if (BaseState::creg_.check_conditional(op) == false)
+      return;
+    switch (op.type) {
+      case Operations::OpType::barrier:
+        break;
+      case Operations::OpType::reset:
+        apply_reset(op.qubits);
+        break;
+      case Operations::OpType::measure:
+        apply_measure(op.qubits, op.memory, op.registers, rng);
+        break;
+      case Operations::OpType::bfunc:
+        BaseState::creg_.apply_bfunc(op);
+        break;
+      case Operations::OpType::roerror:
+        BaseState::creg_.apply_roerror(op, rng);
+        break;
+      case Operations::OpType::gate:
+        apply_gate(op);
+        break;
+      case Operations::OpType::snapshot:
+        apply_snapshot(op, data);
+        break;
+      case Operations::OpType::matrix:
+        apply_matrix(op.qubits, op.mats[0]);
+        break;
+      case Operations::OpType::superop:
+        BaseState::qreg_.apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
+        break;
+      case Operations::OpType::kraus:
+        apply_kraus(op.qubits, op.mats);
+        break;
+      default:
+        throw std::invalid_argument("DensityMatrix::State::invalid instruction \'" +
+                                    op.name + "\'.");
+    }
+  }
+}
+
+
+//=========================================================================
+// Implementation: Snapshots
+//=========================================================================
+
+template <class densmat_t>
+void State<densmat_t>::apply_snapshot(const Operations::Op &op,
+                                       OutputData &data) {
+
+  // Look for snapshot type in snapshotset
+  auto it = snapshotset_.find(op.name);
+  if (it == snapshotset_.end())
+    throw std::invalid_argument("DensityMatrixState::invalid snapshot instruction \'" + 
+                                op.name + "\'.");
+  switch (it -> second) {
+    case Snapshots::densitymatrix:
+      BaseState::snapshot_state(op, data, "density_matrix");
+      break;
+    case Snapshots::cmemory:
+      BaseState::snapshot_creg_memory(op, data);
+      break;
+    case Snapshots::cregister:
+      BaseState::snapshot_creg_register(op, data);
+      break;
+    case Snapshots::probs:
+      // get probs as hexadecimal
+      snapshot_probabilities(op, data, false);
+      break;
+    case Snapshots::probs_var:
+      // get probs as hexadecimal
+      snapshot_probabilities(op, data, true);
+      break;
+    /* TODO
+    case Snapshots::expval_pauli: {
+      snapshot_pauli_expval(op, data, false);
+    } break;
+    case Snapshots::expval_matrix: {
+      snapshot_matrix_expval(op, data, false);
+    }  break;
+    
+    case Snapshots::expval_pauli_var: {
+      snapshot_pauli_expval(op, data, true);
+    } break;
+    case Snapshots::expval_matrix_var: {
+      snapshot_matrix_expval(op, data, true);
+    }  break;
+    */
+    default:
+      // We shouldn't get here unless there is a bug in the snapshotset
+      throw std::invalid_argument("DensityMatrix::State::invalid snapshot instruction \'" +
+                                  op.name + "\'.");
+  }
+}
+
+template <class densmat_t>
+void State<densmat_t>::snapshot_probabilities(const Operations::Op &op,
+                                               OutputData &data,
+                                               bool variance) {
+  // get probs as hexadecimal
+  auto probs = Utils::vec2ket(measure_probs(op.qubits),
+                              json_chop_threshold_, 16);
+  data.add_average_snapshot("probabilities", op.string_params[0],
+                            BaseState::creg_.memory_hex(), probs, variance);
+}
+
+
+//=========================================================================
+// Implementation: Matrix multiplication
+//=========================================================================
+
+template <class densmat_t>
+void State<densmat_t>::apply_gate(const Operations::Op &op) {
+  // Look for gate name in gateset
+  auto it = gateset_.find(op.name);
+  if (it == gateset_.end())
+    throw std::invalid_argument("DensityMatrixState::invalid gate instruction \'" + 
+                                op.name + "\'.");
+  switch (it -> second) {
+    case Gates::u3:
+      apply_gate_u3(op.qubits[0],
+                    std::real(op.params[0]),
+                    std::real(op.params[1]),
+                    std::real(op.params[2]));
+      break;
+    case Gates::u2:
+      apply_gate_u3(op.qubits[0],
+                    M_PI / 2.,
+                    std::real(op.params[0]),
+                    std::real(op.params[1]));
+      break;
+    case Gates::u1:
+      apply_gate_phase(op.qubits[0], std::exp(complex_t(0., 1.) * op.params[0]));
+      break;
+    case Gates::cx:
+      BaseState::qreg_.apply_cnot(op.qubits[0], op.qubits[1]);
+      break;
+    case Gates::cz:
+      BaseState::qreg_.apply_cz(op.qubits[0], op.qubits[1]);
+      break;
+    case Gates::id:
+      break;
+    case Gates::x:
+      BaseState::qreg_.apply_x(op.qubits[0]);
+      break;
+    case Gates::y:
+      BaseState::qreg_.apply_y(op.qubits[0]);
+      break;
+    case Gates::z:
+      BaseState::qreg_.apply_z(op.qubits[0]);
+      break;
+    case Gates::h:
+      apply_gate_u3(op.qubits[0], M_PI / 2., 0., M_PI);
+      break;
+    case Gates::s:
+      apply_gate_phase(op.qubits[0], complex_t(0., 1.));
+      break;
+    case Gates::sdg:
+      apply_gate_phase(op.qubits[0], complex_t(0., -1.));
+      break;
+    case Gates::t: {
+      const double isqrt2{1. / std::sqrt(2)};
+      apply_gate_phase(op.qubits[0], complex_t(isqrt2, isqrt2));
+    } break;
+    case Gates::tdg: {
+      const double isqrt2{1. / std::sqrt(2)};
+      apply_gate_phase(op.qubits[0], complex_t(isqrt2, -isqrt2));
+    } break;
+    case Gates::swap: {
+      BaseState::qreg_.apply_swap(op.qubits[0], op.qubits[1]);
+    } break;
+    case Gates::ccx:
+      BaseState::qreg_.apply_toffoli(op.qubits[0], op.qubits[1], op.qubits[2]);
+      break;
+    default:
+      // We shouldn't reach here unless there is a bug in gateset
+      throw std::invalid_argument("DensityMatrix::State::invalid gate instruction \'" +
+                                  op.name + "\'.");
+  }
+}
+
+
+template <class densmat_t>
+void State<densmat_t>::apply_matrix(const reg_t &qubits, const cmatrix_t &mat) {
+  if (mat.GetRows() == 1) {
+    BaseState::qreg_.apply_diagonal_unitary_matrix(qubits, Utils::vectorize_matrix(mat));
+  } else {
+    BaseState::qreg_.apply_unitary_matrix(qubits, Utils::vectorize_matrix(mat));
+  }
+}
+
+template <class densmat_t>
+void State<densmat_t>::apply_gate_u3(uint_t qubit, double theta, double phi, double lambda) {
+  BaseState::qreg_.apply_unitary_matrix(reg_t({qubit}), Utils::VMatrix::u3(theta, phi, lambda));
+}
+
+template <class densmat_t>
+void State<densmat_t>::apply_gate_phase(uint_t qubit, complex_t phase) {
+  cvector_t diag = {{1., phase}};
+  BaseState::qreg_.apply_diagonal_unitary_matrix(reg_t({qubit}), diag);
+}
+
+
+//=========================================================================
+// Implementation: Reset and Measurement Sampling
+//=========================================================================
+
+template <class densmat_t>
+void State<densmat_t>::apply_measure(const reg_t &qubits,
+                                      const reg_t &cmemory,
+                                      const reg_t &cregister,
+                                      RngEngine &rng) {
+  // Actual measurement outcome
+  const auto meas = sample_measure_with_prob(qubits, rng);
+  // Implement measurement update
+  measure_reset_update(qubits, meas.first, meas.first, meas.second);
+  const reg_t outcome = Utils::int2reg(meas.first, 2, qubits.size());
+  BaseState::creg_.store_measure(outcome, cmemory, cregister);
+}
+
+template <class densmat_t>
+rvector_t State<densmat_t>::measure_probs(const reg_t &qubits) const {
+  return BaseState::qreg_.probabilities(qubits);
+}
+
+template <class densmat_t>
+std::vector<reg_t> State<densmat_t>::sample_measure(const reg_t &qubits,
+                                                     uint_t shots,
+                                                     RngEngine &rng) {
+  // Generate flat register for storing
+  std::vector<double> rnds;
+  rnds.reserve(shots);
+  for (uint_t i = 0; i < shots; ++i)
+    rnds.push_back(rng.rand(0, 1));
+
+  auto allbit_samples = BaseState::qreg_.sample_measure(rnds);
+
+  // Convert to reg_t format
+  std::vector<reg_t> all_samples;
+  all_samples.reserve(shots);
+  for (int_t val : allbit_samples) {
+    reg_t allbit_sample = Utils::int2reg(val, 2, BaseState::qreg_.num_qubits());
+    reg_t sample;
+    sample.reserve(qubits.size());
+    for (uint_t qubit : qubits) {
+      sample.push_back(allbit_sample[qubit]);
+    }
+    all_samples.push_back(sample);
+  }
+  return all_samples;
+}
+
+
+template <class densmat_t>
+void State<densmat_t>::apply_reset(const reg_t &qubits) {
+  // TODO: This can be more efficient by adding reset
+  // to base class rather than doing a matrix multiplication
+  // where all but 1 row is zeros.
+  const auto reset_op = Utils::SMatrix::reset(1ULL << qubits.size());
+  BaseState::qreg_.apply_superop_matrix(qubits, Utils::vectorize_matrix(reset_op));
+}
+
+template <class densmat_t>
+std::pair<uint_t, double>
+State<densmat_t>::sample_measure_with_prob(const reg_t &qubits,
+                                            RngEngine &rng) {
+  rvector_t probs = measure_probs(qubits);
+  // Randomly pick outcome and return pair
+  uint_t outcome = rng.rand_int(probs);
+  return std::make_pair(outcome, probs[outcome]);
+}
+
+template <class densmat_t>
+void State<densmat_t>::measure_reset_update(const reg_t &qubits,
+                                             const uint_t final_state,
+                                             const uint_t meas_state,
+                                             const double meas_prob) {
+  // Update a state vector based on an outcome pair [m, p] from
+  // sample_measure_with_prob function, and a desired post-measurement final_state
+  // Single-qubit case
+  if (qubits.size() == 1) {
+    // Diagonal matrix for projecting and renormalizing to measurement outcome
+    cvector_t mdiag(2, 0.);
+    mdiag[meas_state] = 1. / std::sqrt(meas_prob);
+    BaseState::qreg_.apply_diagonal_unitary_matrix(qubits, mdiag);
+
+    // If it doesn't agree with the reset state update
+    if (final_state != meas_state) {
+      BaseState::qreg_.apply_x(qubits[0]);
+    }
+  }
+  // Multi qubit case
+  else {
+    // Diagonal matrix for projecting and renormalizing to measurement outcome
+    const size_t dim = 1ULL << qubits.size();
+    cvector_t mdiag(dim, 0.);
+    mdiag[meas_state] = 1. / std::sqrt(meas_prob);
+    BaseState::qreg_.apply_diagonal_unitary_matrix(qubits, mdiag);
+
+    // If it doesn't agree with the reset state update
+    // TODO This function could be optimized as a permutation update
+    if (final_state != meas_state) {
+      // build vectorized permutation matrix
+      cvector_t perm(dim * dim, 0.);
+      perm[final_state * dim + meas_state] = 1.;
+      perm[meas_state * dim + final_state] = 1.;
+      for (size_t j=0; j < dim; j++) {
+        if (j != final_state && j != meas_state)
+          perm[j * dim + j] = 1.;
+      }
+      // apply permutation to swap state
+      BaseState::qreg_.apply_unitary_matrix(qubits, perm);
+    }
+  }
+}
+
+
+//=========================================================================
+// Implementation: Kraus Noise
+//=========================================================================
+
+template <class densmat_t>
+void State<densmat_t>::apply_kraus(const reg_t &qubits,
+                                    const std::vector<cmatrix_t> &kmats) {
+  // Convert to Superoperator
+  const auto nrows = kmats[0].GetRows();
+  cmatrix_t superop(nrows * nrows, nrows * nrows);
+  for (const auto kraus : kmats) {
+    superop += Utils::tensor_product(Utils::conjugate(kraus), kraus);
+  }
+  BaseState::qreg_.apply_superop_matrix(qubits, Utils::vectorize_matrix(superop));
+}
+
+//-------------------------------------------------------------------------
+} // end namespace DensityMatrix
+//-------------------------------------------------------------------------
+} // end namespace AER
+//-------------------------------------------------------------------------
+#endif

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -38,9 +38,7 @@ using int_t = int64_t;
 using reg_t = std::vector<uint_t>;
 using indexes_t = std::unique_ptr<uint_t[]>;
 template <size_t N> using areg_t = std::array<uint_t, N>;
-template <typename T> using complex_t = std::complex<T>;
-template <typename T> using cvector_t = std::vector<complex_t<T>>;
-template <typename T> using rvector_t = std::vector<T>;
+template <typename T> using cvector_t = std::vector<std::complex<T>>;
 
 //============================================================================
 // BIT MASKS and indexing
@@ -131,14 +129,14 @@ public:
   //-----------------------------------------------------------------------
 
   // Element access
-  complex_t<data_t> &operator[](uint_t element);
-  complex_t<data_t> operator[](uint_t element) const;
+  std::complex<data_t> &operator[](uint_t element);
+  std::complex<data_t> operator[](uint_t element) const;
 
   // Returns a reference to the underlying data_t data class
-  complex_t<data_t>* &data() {return data_;}
+  std::complex<data_t>* &data() {return data_;}
 
   // Returns a copy of the underlying data_t data class
-  complex_t<data_t>* data() const {return data_;}
+  std::complex<data_t>* data() const {return data_;}
 
   //-----------------------------------------------------------------------
   // Utility functions
@@ -148,7 +146,7 @@ public:
   virtual void set_num_qubits(size_t num_qubits);
 
   // Returns the number of qubits for the current vector
-  uint_t num_qubits() const {return num_qubits_;}
+  virtual uint_t num_qubits() const {return num_qubits_;}
 
   // Returns the size of the underlying n-qubit vector
   uint_t size() const {return data_size_;}
@@ -218,7 +216,7 @@ public:
   void revert(bool keep);
 
   // Compute the inner product of current state with checkpoint state
-  complex_t<double> inner_product() const;
+  std::complex<double> inner_product() const;
 
   //-----------------------------------------------------------------------
   // Initialization
@@ -234,7 +232,7 @@ public:
 
   // Initializes the vector to a custom initial state.
   // If num_states does not match the number of qubits an exception is raised.
-  void initialize_from_data(const complex_t<data_t>* data, const size_t num_states);
+  void initialize_from_data(const std::complex<data_t>* data, const size_t num_states);
 
   //-----------------------------------------------------------------------
   // Apply Matrices
@@ -286,7 +284,7 @@ public:
   // If N=2 this implements an optimized CPhase gate
   // If N=3 this implements an optimized CCPhase gate
   // if phase = -1 this is a Z, CZ, CCZ gate
-  void apply_mcphase(const reg_t &qubits, const complex_t<double> phase);
+  void apply_mcphase(const reg_t &qubits, const std::complex<double> phase);
 
   // Apply a general multi-controlled single-qubit unitary gate
   // If N=1 this implements an optimized single-qubit U gate
@@ -305,25 +303,21 @@ public:
 
   // Return the Z-basis measurement outcome probability P(outcome) for
   // outcome in [0, 2^num_qubits - 1]
-  double probability(const uint_t outcome) const;
+  virtual double probability(const uint_t outcome) const;
 
   // Return the probabilities for all measurement outcomes in the current vector
   // This is equivalent to returning a new vector with  new[i]=|orig[i]|^2.
   // Eg. For 2-qubits this is [P(00), P(01), P(010), P(11)]
-  rvector_t<double> probabilities() const;
-
-  // Return the Z-basis measurement outcome probabilities [P(0), P(1)]
-  // for measurement of specified qubit
-  rvector_t<double> probabilities(const uint_t qubit) const;
+  virtual std::vector<double> probabilities() const;
 
   // Return the Z-basis measurement outcome probabilities [P(0), ..., P(2^N-1)]
   // for measurement of N-qubits.
-  rvector_t<double> probabilities(const reg_t &qubits) const;
+  virtual std::vector<double> probabilities(const reg_t &qubits) const;
 
   // Return M sampled outcomes for Z-basis measurement of all qubits
   // The input is a length M list of random reals between [0, 1) used for
   // generating samples.
-  std::vector<uint_t> sample_measure(const rvector_t<double> &rnds) const;
+  virtual reg_t sample_measure(const std::vector<double> &rnds) const;
 
   //-----------------------------------------------------------------------
   // Norms
@@ -401,8 +395,8 @@ protected:
   //-----------------------------------------------------------------------
   size_t num_qubits_;
   size_t data_size_;
-  complex_t<data_t>* data_;
-  complex_t<data_t>* checkpoint_;
+  std::complex<data_t>* data_;
+  std::complex<data_t>* checkpoint_;
 
   //-----------------------------------------------------------------------
   // Config settings
@@ -479,9 +473,9 @@ protected:
   //
   // where k is the index of the vector, val_re and val_im are the doubles
   // to store the reduction.
-  // Returns complex_t<data_t>(val_re, val_im)
+  // Returns std::complex<double>(val_re, val_im)
   template <typename Lambda>
-  complex_t<data_t> apply_reduction_lambda(Lambda&& func) const;
+  std::complex<double> apply_reduction_lambda(Lambda&& func) const;
 
   //-----------------------------------------------------------------------
   // Statevector block reduction with Lambda function
@@ -489,7 +483,7 @@ protected:
   // These functions loop through the indexes of the qubitvector data and
   // apply a reduction lambda function to each block specified by the qubits
   // argument. The reduction lambda stores the reduction in two doubles
-  // (val_re, val_im) and returns the complex result complex_t<data_t>(val_re, val_im)
+  // (val_re, val_im) and returns the complex result std::complex<double>(val_re, val_im)
   //
   // NOTE: The lambda functions can use the dynamic or static indexes
   // signature however if N is known at compile time the static case should
@@ -506,10 +500,10 @@ protected:
   //
   // where `inds` are the 2 ** N indexes for each N-qubit block returned by
   // the `indexes` function, `val_re` and `val_im` are the doubles to
-  // store the reduction returned as complex_t<data_t>(val_re, val_im).
+  // store the reduction returned as std::complex<double>(val_re, val_im).
   template <typename Lambda, typename list_t>
-  complex_t<data_t> apply_reduction_lambda(Lambda&& func,
-                                   const list_t &qubits) const;
+  std::complex<double> apply_reduction_lambda(Lambda&& func,
+                                              const list_t &qubits) const;
 
   // Apply a N-qubit complex matrix reduction lambda function to all blocks
   // of the statevector for the given qubits.
@@ -523,11 +517,11 @@ protected:
   // where `inds` are the 2 ** N indexes for each N-qubit block returned by
   // the `indexe`s function, `params` is a templated parameter class
   // (typically a complex vector), `val_re` and `val_im` are the doubles to
-  // store the reduction returned as complex_t<data_t>(val_re, val_im).
+  // store the reduction returned as std::complex<double>(val_re, val_im).
   template <typename Lambda, typename list_t, typename param_t>
-  complex_t<data_t> apply_reduction_lambda(Lambda&& func,
-                                   const list_t &qubits,
-                                   const param_t &params) const;
+  std::complex<double> apply_reduction_lambda(Lambda&& func,
+                                              const list_t &qubits,
+                                              const param_t &params) const;
 };
 
 /*******************************************************************************
@@ -548,7 +542,7 @@ inline void to_json(json_t &js, const QubitVector<data_t> &qv) {
 template <typename data_t>
 json_t QubitVector<data_t>::json() const {
   const int_t END = data_size_;
-  const json_t ZERO = complex_t<data_t>(0.0, 0.0);
+  const json_t ZERO = std::complex<data_t>(0.0, 0.0);
   json_t js = json_t(data_size_, ZERO);
   
   if (json_chop_threshold_ > 0) {
@@ -647,7 +641,7 @@ QubitVector<data_t>::~QubitVector() {
 //------------------------------------------------------------------------------
 
 template <typename data_t>
-complex_t<data_t> &QubitVector<data_t>::operator[](uint_t element) {
+std::complex<data_t> &QubitVector<data_t>::operator[](uint_t element) {
   // Error checking
   #ifdef DEBUG
   if (element > data_size_) {
@@ -660,7 +654,7 @@ complex_t<data_t> &QubitVector<data_t>::operator[](uint_t element) {
 }
 
 template <typename data_t>
-complex_t<data_t> QubitVector<data_t>::operator[](uint_t element) const {
+std::complex<data_t> QubitVector<data_t>::operator[](uint_t element) const {
   // Error checking
   #ifdef DEBUG
   if (element > data_size_) {
@@ -745,7 +739,7 @@ void QubitVector<data_t>::initialize_component(const reg_t &qubits, const cvecto
   const size_t N = qubits.size();
   auto lambda = [&](const indexes_t &inds, const cvector_t<data_t> &_state)->void {
     const uint_t DIM = 1ULL << N;
-    complex_t<data_t> cache = data_[inds[0]];  // the k-th component of non-initialized vector
+    std::complex<data_t> cache = data_[inds[0]];  // the k-th component of non-initialized vector
     for (size_t i = 0; i < DIM; i++) {
       data_[inds[i]] = cache * _state[i];  // set component to psi[k] * state[i]
     }    // (where psi is is the post-reset state of the non-initialized qubits)
@@ -799,14 +793,14 @@ void QubitVector<data_t>::set_num_qubits(size_t num_qubits) {
 
   // Allocate memory for new vector
   if (data_ == nullptr)
-    data_ = reinterpret_cast<complex_t<data_t>*>(malloc(sizeof(complex_t<data_t>) * data_size_));
+    data_ = reinterpret_cast<std::complex<data_t>*>(malloc(sizeof(std::complex<data_t>) * data_size_));
 }
 
 
 template <typename data_t>
 void QubitVector<data_t>::checkpoint() {
   if (!checkpoint_)
-    checkpoint_ = reinterpret_cast<complex_t<data_t>*>(malloc(sizeof(complex_t<data_t>) * data_size_));
+    checkpoint_ = reinterpret_cast<std::complex<data_t>*>(malloc(sizeof(std::complex<data_t>) * data_size_));
 
   const int_t END = data_size_;    // end for k loop
 #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
@@ -834,14 +828,14 @@ void QubitVector<data_t>::revert(bool keep) {
 }
 
 template <typename data_t>
-complex_t<double> QubitVector<data_t>::inner_product() const {
+std::complex<double> QubitVector<data_t>::inner_product() const {
 
   #ifdef DEBUG
   check_checkpoint();
   #endif
   // Lambda function for inner product with checkpoint state
   auto lambda = [&](int_t k, double &val_re, double &val_im)->void {
-    const complex_t<double> z = data_[k] * std::conj(checkpoint_[k]);
+    const std::complex<double> z = data_[k] * std::conj(checkpoint_[k]);
     val_re += std::real(z);
     val_im += std::imag(z);
   };
@@ -875,7 +869,7 @@ void QubitVector<data_t>::initialize_from_vector(const cvector_t<double> &statev
 }
 
 template <typename data_t>
-void QubitVector<data_t>::initialize_from_data(const complex_t<data_t>* statevec, const size_t num_states) {
+void QubitVector<data_t>::initialize_from_data(const std::complex<data_t>* statevec, const size_t num_states) {
   if (data_size_ != num_states) {
     std::string error = "QubitVector::initialize input vector is incorrect length (" +
                         std::to_string(data_size_) + "!=" + std::to_string(num_states) + ")";
@@ -996,7 +990,7 @@ void QubitVector<data_t>::apply_lambda(Lambda&& func,
 
 template <typename data_t>
 template<typename Lambda>
-complex_t<data_t> QubitVector<data_t>::apply_reduction_lambda(Lambda &&func) const {
+std::complex<double> QubitVector<data_t>::apply_reduction_lambda(Lambda &&func) const {
   // Reduction variables
   double val_re = 0.;
   double val_im = 0.;
@@ -1009,14 +1003,15 @@ complex_t<data_t> QubitVector<data_t>::apply_reduction_lambda(Lambda &&func) con
         std::forward<Lambda>(func)(k, val_re, val_im);
       }
   } // end omp parallel
-  return complex_t<data_t>(val_re, val_im);
+  return std::complex<double>(val_re, val_im);
 }
 
 
 template <typename data_t>
 template<typename Lambda, typename list_t>
-complex_t<data_t> QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
-                                                      const list_t &qubits) const {
+std::complex<double>
+QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
+                                            const list_t &qubits) const {
 
   // Error checking
   #ifdef DEBUG
@@ -1041,15 +1036,16 @@ complex_t<data_t> QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
       std::forward<Lambda>(func)(inds, val_re, val_im);
     }
   } // end omp parallel
-  return complex_t<data_t>(val_re, val_im);
+  return std::complex<double>(val_re, val_im);
 }
 
 
 template <typename data_t>
 template<typename Lambda, typename list_t, typename param_t>
-complex_t<data_t> QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
-                                                      const list_t &qubits,
-                                                      const param_t &params) const {
+std::complex<double>
+QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
+                                            const list_t &qubits,
+                                            const param_t &params) const {
 
   const auto NUM_QUBITS = qubits.size();
   // Error checking
@@ -1074,7 +1070,7 @@ complex_t<data_t> QubitVector<data_t>::apply_reduction_lambda(Lambda&& func,
       std::forward<Lambda>(func)(inds, params, val_re, val_im);
     }
   } // end omp parallel
-  return complex_t<data_t>(val_re, val_im);
+  return std::complex<double>(val_re, val_im);
 }
 
 
@@ -1101,7 +1097,7 @@ void QubitVector<data_t>::apply_matrix(const reg_t &qubits,
     case 2: {
       // Lambda function for 2-qubit matrix multiplication
       auto lambda = [&](const areg_t<4> &inds, const cvector_t<data_t> &_mat)->void {
-        std::array<complex_t<data_t>, 4> cache;
+        std::array<std::complex<data_t>, 4> cache;
         for (size_t i = 0; i < 4; i++) {
           const auto ii = inds[i];
           cache[i] = data_[ii];
@@ -1118,7 +1114,7 @@ void QubitVector<data_t>::apply_matrix(const reg_t &qubits,
     case 3: {
       // Lambda function for 3-qubit matrix multiplication
       auto lambda = [&](const areg_t<8> &inds, const cvector_t<data_t> &_mat)->void {
-        std::array<complex_t<data_t>, 8> cache;
+        std::array<std::complex<data_t>, 8> cache;
         for (size_t i = 0; i < 8; i++) {
           const auto ii = inds[i];
           cache[i] = data_[ii];
@@ -1135,7 +1131,7 @@ void QubitVector<data_t>::apply_matrix(const reg_t &qubits,
     case 4: {
       // Lambda function for 4-qubit matrix multiplication
       auto lambda = [&](const areg_t<16> &inds, const cvector_t<data_t> &_mat)->void {
-        std::array<complex_t<data_t>, 16> cache;
+        std::array<std::complex<data_t>, 16> cache;
         for (size_t i = 0; i < 16; i++) {
           const auto ii = inds[i];
           cache[i] = data_[ii];
@@ -1153,7 +1149,7 @@ void QubitVector<data_t>::apply_matrix(const reg_t &qubits,
       const uint_t DIM = BITS[N];
       // Lambda function for N-qubit matrix multiplication
       auto lambda = [&](const indexes_t &inds, const cvector_t<data_t> &_mat)->void {
-        auto cache = std::make_unique<complex_t<data_t>[]>(DIM);
+        auto cache = std::make_unique<std::complex<data_t>[]>(DIM);
         for (size_t i = 0; i < DIM; i++) {
           const auto ii = inds[i];
           cache[i] = data_[ii];
@@ -1182,7 +1178,7 @@ void QubitVector<data_t>::apply_multiplexer(const reg_t &control_qubits,
   const uint_t blocks = BITS[control_count];
   // Lambda function for stacked matrix multiplication
   auto lambda = [&](const indexes_t &inds, const cvector_t<data_t> &_mat)->void {
-    auto cache = std::make_unique<complex_t<data_t>[]>(DIM);
+    auto cache = std::make_unique<std::complex<data_t>[]>(DIM);
     for (uint_t i = 0; i < DIM; i++) {
       const auto ii = inds[i];
       cache[i] = data_[ii];
@@ -1283,6 +1279,28 @@ void QubitVector<data_t>::apply_permutation_matrix(const reg_t& qubits,
       apply_lambda(lambda, areg_t<4>({{qubits[0], qubits[1], qubits[2], qubits[3]}}));
       return;
     }
+    case 5: {
+      // Lambda function for permutation matrix
+      auto lambda = [&](const areg_t<32> &inds)->void {
+        for (const auto& p : pairs) {
+          std::swap(data_[inds[p.first]], data_[inds[p.second]]);
+        }
+      };
+      apply_lambda(lambda, areg_t<5>({{qubits[0], qubits[1], qubits[2],
+                                       qubits[3], qubits[4]}}));
+      return;
+    }
+    case 6: {
+      // Lambda function for permutation matrix
+      auto lambda = [&](const areg_t<64> &inds)->void {
+        for (const auto& p : pairs) {
+          std::swap(data_[inds[p.first]], data_[inds[p.second]]);
+        }
+      };
+      apply_lambda(lambda, areg_t<6>({{qubits[0], qubits[1], qubits[2],
+                                       qubits[3], qubits[4], qubits[5]}}));
+      return;
+    }
     default: {
       // Lambda function for permutation matrix
       auto lambda = [&](const indexes_t &inds)->void {
@@ -1355,13 +1373,13 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
   const size_t N = qubits.size();
   const size_t pos0 = MASKS[N - 1];
   const size_t pos1 = MASKS[N];
-  const complex_t<data_t> I(0., 1.);
+  const std::complex<data_t> I(0., 1.);
 
   switch (N) {
     case 1: {
       // Lambda function for Y gate
       auto lambda = [&](const areg_t<2> &inds)->void {
-        const complex_t<data_t> cache = data_[inds[pos0]];
+        const std::complex<data_t> cache = data_[inds[pos0]];
         data_[inds[pos0]] = -I * data_[inds[pos1]];
         data_[inds[pos1]] = I * cache;
       };
@@ -1371,7 +1389,7 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
     case 2: {
       // Lambda function for CY gate
       auto lambda = [&](const areg_t<4> &inds)->void {
-        const complex_t<data_t> cache = data_[inds[pos0]];
+        const std::complex<data_t> cache = data_[inds[pos0]];
         data_[inds[pos0]] = -I * data_[inds[pos1]];
         data_[inds[pos1]] = I * cache;
       };
@@ -1381,7 +1399,7 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
     case 3: {
       // Lambda function for CCY gate
       auto lambda = [&](const areg_t<8> &inds)->void {
-        const complex_t<data_t> cache = data_[inds[pos0]];
+        const std::complex<data_t> cache = data_[inds[pos0]];
         data_[inds[pos0]] = -I * data_[inds[pos1]];
         data_[inds[pos1]] = I * cache;
       };
@@ -1391,7 +1409,7 @@ void QubitVector<data_t>::apply_mcy(const reg_t &qubits) {
     default: {
       // Lambda function for general multi-controlled Y gate
       auto lambda = [&](const indexes_t &inds)->void {
-        const complex_t<data_t> cache = data_[inds[pos0]];
+        const std::complex<data_t> cache = data_[inds[pos0]];
         data_[inds[pos0]] = -I * data_[inds[pos1]];
         data_[inds[pos1]] = I * cache;
       };
@@ -1436,7 +1454,7 @@ void QubitVector<data_t>::apply_mcswap(const reg_t &qubits) {
 }
 
 template <typename data_t>
-void QubitVector<data_t>::apply_mcphase(const reg_t &qubits, const complex_t<double> phase) {
+void QubitVector<data_t>::apply_mcphase(const reg_t &qubits, const std::complex<double> phase) {
   const size_t N = qubits.size();
   switch (N) {
     case 1: {
@@ -1629,7 +1647,7 @@ void QubitVector<data_t>::apply_matrix(const uint_t qubit,
     // else we have a general anti-diagonal matrix
     auto lambda = [&](const areg_t<2> &inds,
                       const cvector_t<data_t> &_mat)->void {
-      const complex_t<data_t> cache = data_[inds[0]];
+      const std::complex<data_t> cache = data_[inds[0]];
       data_[inds[0]] = _mat[2] * data_[inds[1]];
       data_[inds[1]] = _mat[1] * cache;
     };
@@ -1785,7 +1803,7 @@ double QubitVector<data_t>::norm(const reg_t &qubits, const cvector_t<double> &m
                         double &val_re, double &val_im)->void {
         (void)val_im; // unused
         for (size_t i = 0; i < 4; i++) {
-          complex_t<data_t> vi = 0;
+          std::complex<data_t> vi = 0;
           for (size_t j = 0; j < 4; j++)
             vi += _mat[i + 4 * j] * data_[inds[j]];
           val_re += std::real(vi * std::conj(vi));
@@ -1800,7 +1818,7 @@ double QubitVector<data_t>::norm(const reg_t &qubits, const cvector_t<double> &m
                         double &val_re, double &val_im)->void {
         (void)val_im; // unused
         for (size_t i = 0; i < 8; i++) {
-          complex_t<data_t> vi = 0;
+          std::complex<data_t> vi = 0;
           for (size_t j = 0; j < 8; j++)
             vi += _mat[i + 8 * j] * data_[inds[j]];
           val_re += std::real(vi * std::conj(vi));
@@ -1815,7 +1833,7 @@ double QubitVector<data_t>::norm(const reg_t &qubits, const cvector_t<double> &m
                         double &val_re, double &val_im)->void {
         (void)val_im; // unused
         for (size_t i = 0; i < 16; i++) {
-          complex_t<data_t> vi = 0;
+          std::complex<data_t> vi = 0;
           for (size_t j = 0; j < 16; j++)
             vi += _mat[i + 16 * j] * data_[inds[j]];
           val_re += std::real(vi * std::conj(vi));
@@ -1831,7 +1849,7 @@ double QubitVector<data_t>::norm(const reg_t &qubits, const cvector_t<double> &m
                         double &val_re, double &val_im)->void {
         (void)val_im; // unused
         for (size_t i = 0; i < DIM; i++) {
-          complex_t<data_t> vi = 0;
+          std::complex<data_t> vi = 0;
           for (size_t j = 0; j < DIM; j++)
             vi += _mat[i + DIM * j] * data_[inds[j]];
           val_re += std::real(vi * std::conj(vi));
@@ -1967,19 +1985,15 @@ double QubitVector<data_t>::norm_diagonal(const uint_t qubit, const cvector_t<do
  * Probabilities
  *
  ******************************************************************************/
-
 template <typename data_t>
 double QubitVector<data_t>::probability(const uint_t outcome) const {
-  const auto v = data_[outcome];
-  return std::real(v * std::conj(v));
+  return std::real(data_[outcome] * std::conj(data_[outcome]));
 }
 
 template <typename data_t>
-rvector_t<double> QubitVector<data_t>::probabilities() const {
-  rvector_t<double> probs(data_size_);
-  const int_t END = data_size_;
-  probs.assign(data_size_, 0.);
-
+std::vector<double> QubitVector<data_t>::probabilities() const {
+  const int_t END = 1LL << num_qubits();
+  std::vector<double> probs(END, 0.);
 #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
   for (int_t j=0; j < END; j++) {
     probs[j] = probability(j);
@@ -1988,15 +2002,11 @@ rvector_t<double> QubitVector<data_t>::probabilities() const {
 }
 
 template <typename data_t>
-rvector_t<double> QubitVector<data_t>::probabilities(const reg_t &qubits) const {
+std::vector<double> QubitVector<data_t>::probabilities(const reg_t &qubits) const {
 
   const size_t N = qubits.size();
-
-  if (N == 1)
-    return probabilities(qubits[0]);
-
   const int_t DIM = BITS[N];
-  const int_t END = BITS[num_qubits_ - N];
+  const int_t END = BITS[num_qubits() - N];
 
   // Error checking
   #ifdef DEBUG
@@ -2004,18 +2014,15 @@ rvector_t<double> QubitVector<data_t>::probabilities(const reg_t &qubits) const 
     check_qubit(qubit);
   #endif
 
-  if (N == 0)
-    return rvector_t<double>({norm()});
-
   auto qubits_sorted = qubits;
   std::sort(qubits_sorted.begin(), qubits_sorted.end());
   if ((N == num_qubits_) && (qubits == qubits_sorted))
     return probabilities();
 
-  rvector_t<double> probs(DIM, 0.);
+  std::vector<double> probs(DIM, 0.);
   #pragma omp parallel if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
   {
-    rvector_t<data_t> probs_private(DIM, 0.);
+    std::vector<data_t> probs_private(DIM, 0.);
     #pragma omp for
       for (int_t k = 0; k < END; k++) {
         auto idx = indexes(qubits, qubits_sorted, k);
@@ -2033,37 +2040,12 @@ rvector_t<double> QubitVector<data_t>::probabilities(const reg_t &qubits) const 
 }
 
 //------------------------------------------------------------------------------
-// Single-qubit specialization
-//------------------------------------------------------------------------------
-
-template <typename data_t>
-rvector_t<double> QubitVector<data_t>::probabilities(const uint_t qubit) const {
-
-  // Error handling
-  #ifdef DEBUG
-  check_qubit(qubit);
-  #endif
-
-  // Lambda function for single qubit probs as reduction
-  // p(0) stored as real part p(1) as imag part
-  auto lambda = [&](const areg_t<2> &inds,
-                    double &val_p0,
-                    double &val_p1)->void {
-    val_p0 += probability(inds[0]);
-    val_p1 += probability(inds[1]);
-  };
-  auto p0p1 = apply_reduction_lambda(lambda, areg_t<1>({{qubit}}));
-  return rvector_t<double>({std::real(p0p1), std::imag(p0p1)});
-}
-
-
-//------------------------------------------------------------------------------
 // Sample measure outcomes
 //------------------------------------------------------------------------------
 template <typename data_t>
-reg_t QubitVector<data_t>::sample_measure(const rvector_t<double> &rnds) const {
+reg_t QubitVector<data_t>::sample_measure(const std::vector<double> &rnds) const {
 
-  const int_t END = data_size_;
+  const int_t END = 1LL << num_qubits();
   const int_t SHOTS = rnds.size();
   reg_t samples;
   samples.assign(SHOTS, 0);
@@ -2080,7 +2062,7 @@ reg_t QubitVector<data_t>::sample_measure(const rvector_t<double> &rnds) const {
         double p = .0;
         int_t sample;
         for (sample = 0; sample < END - 1; ++sample) {
-          p += std::real(std::conj(data_[sample]) * data_[sample]);
+          p += probability(sample);
           if (rnd < p)
             break;
         }
@@ -2091,7 +2073,7 @@ reg_t QubitVector<data_t>::sample_measure(const rvector_t<double> &rnds) const {
   // Qubit number is above index size, loop over index blocks
   else {
     // Initialize indexes
-    rvector_t<double> idxs;
+    std::vector<double> idxs;
     idxs.assign(INDEX_END, 0.0);
     uint_t loop = (END >> INDEX_SIZE);
     #pragma omp parallel if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
@@ -2103,7 +2085,7 @@ reg_t QubitVector<data_t>::sample_measure(const rvector_t<double> &rnds) const {
         double p = .0;
         for (uint_t j = 0; j < loop; ++j) {
           uint_t k = base | j;
-          p = std::real(std::conj(data_[k]) * data_[k]);
+          p = probability(k);
           total += p;
         }
         idxs[i] = total;
@@ -2126,7 +2108,7 @@ reg_t QubitVector<data_t>::sample_measure(const rvector_t<double> &rnds) const {
         }
 
         for (; sample < END - 1; ++sample) {
-          p += std::real(std::conj(data_[sample]) * data_[sample]);
+          p += probability(sample);
           if (rnd < p){
             break;
           }

--- a/src/simulators/unitary/unitarymatrix.hpp
+++ b/src/simulators/unitary/unitarymatrix.hpp
@@ -52,19 +52,19 @@ public:
   //-----------------------------------------------------------------------
 
   // Set the size of the vector in terms of qubit number
-  inline void set_num_qubits(size_t num_qubits);
+  virtual void set_num_qubits(size_t num_qubits) override;
 
   // Return the number of rows in the matrix
   size_t num_rows() const {return rows_;}
 
   // Returns the number of qubits for the current vector
-  inline uint_t num_qubits() const { return num_qubits_;}
+  virtual uint_t num_qubits() const override { return num_qubits_;}
 
   // Returns a copy of the underlying data_t data as a complex vector
   AER::cmatrix_t matrix() const;
 
   // Return the trace of the unitary
-  complex_t<double> trace() const;
+  std::complex<double> trace() const;
 
   // Return JSON serialization of UnitaryMatrix;
   json_t json() const;
@@ -130,7 +130,7 @@ template <class data_t>
 json_t UnitaryMatrix<data_t>::json() const {
   const int_t nrows = rows_;
   // Initialize empty matrix
-  const json_t ZERO = complex_t<double>(0.0, 0.0);
+  const json_t ZERO = std::complex<double>(0.0, 0.0);
   json_t js = json_t(nrows, json_t(nrows, ZERO));
   
   if (BaseVector::json_chop_threshold_ > 0) {
@@ -253,7 +253,7 @@ void UnitaryMatrix<data_t>::set_num_qubits(size_t num_qubits) {
 }
 
 template <class data_t>
-complex_t<double> UnitaryMatrix<data_t>::trace() const {
+std::complex<double> UnitaryMatrix<data_t>::trace() const {
   const int_t NROWS = rows_;
   const int_t DIAG = NROWS + 1;
   double val_re = 0.;
@@ -266,7 +266,7 @@ complex_t<double> UnitaryMatrix<data_t>::trace() const {
     val_im += std::imag(BaseVector::data_[k * DIAG]);
   }
   }
-  return complex_t<double>(val_re, val_im);
+  return std::complex<double>(val_re, val_im);
 }
 
 

--- a/test/terra/backends/test_qasm_density_matrix_simulator.py
+++ b/test/terra/backends/test_qasm_density_matrix_simulator.py
@@ -1,0 +1,60 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+QasmSimulator Integration Tests
+"""
+
+import unittest
+from test.terra import common
+from test.terra.backends.qasm_simulator.qasm_measure import QasmMeasureTests
+from test.terra.backends.qasm_simulator.qasm_reset import QasmResetTests
+from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalGateTests
+from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalUnitaryTests
+from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalKrausTests
+from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalSuperOpTests
+from test.terra.backends.qasm_simulator.qasm_cliffords import QasmCliffordTests
+from test.terra.backends.qasm_simulator.qasm_cliffords import QasmCliffordTestsWaltzBasis
+from test.terra.backends.qasm_simulator.qasm_cliffords import QasmCliffordTestsMinimalBasis
+from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTests
+from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsWaltzBasis
+from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsMinimalBasis
+from test.terra.backends.qasm_simulator.qasm_algorithms import QasmAlgorithmTests
+from test.terra.backends.qasm_simulator.qasm_algorithms import QasmAlgorithmTestsWaltzBasis
+from test.terra.backends.qasm_simulator.qasm_algorithms import QasmAlgorithmTestsMinimalBasis
+from test.terra.backends.qasm_simulator.qasm_extra import QasmExtraTests
+
+
+class TestQasmDensityMatrixSimulator(common.QiskitAerTestCase,
+                                     QasmMeasureTests,
+                                     QasmResetTests,
+                                     QasmConditionalGateTests,
+                                     QasmConditionalUnitaryTests,
+                                     QasmConditionalKrausTests,
+                                     QasmConditionalSuperOpTests,
+                                     QasmCliffordTests,
+                                     QasmCliffordTestsWaltzBasis,
+                                     QasmCliffordTestsMinimalBasis,
+                                     QasmNonCliffordTests,
+                                     QasmNonCliffordTestsWaltzBasis,
+                                     QasmNonCliffordTestsMinimalBasis,
+                                     QasmAlgorithmTests,
+                                     QasmAlgorithmTestsWaltzBasis,
+                                     QasmAlgorithmTestsMinimalBasis,
+                                     QasmExtraTests):
+    """QasmSimulator density_matrix method tests."""
+
+    BACKEND_OPTS = {"method": "density_matrix"}
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds density matrix simulator method to `QasmSimulator` (closes #39)

Currently this won't every be used automatically. It must be specified with
```
backend_options={'method': 'density_matrix'}
```

### Details and comments

TODO in follow up PRs

* Update `DensityMatrix::State` class to support newer gates added in `QubitVector::State` class
* superoperator noise sampling for density matrix simulator
* readout error with density matrix