### PR TITLE
Issue 232: Fix #elif preprocessor definitions

### DIFF
--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -26,7 +26,7 @@
 
 #if defined(__linux__) || defined(__APPLE__)
    #include <unistd.h>
-#elif _WIN64
+#elif defined(_WIN64)
    // This is needed because windows.h redefine min()/max() so interferes with std::min/max
    #define NOMINMAX
    #include <windows.h>
@@ -373,7 +373,7 @@ size_t Controller::get_system_memory_mb(void){
    auto pages = sysconf(_SC_PHYS_PAGES);
    auto page_size = sysconf(_SC_PAGE_SIZE);
    total_physical_memory = pages * page_size;
-#elif _WIN64
+#elif defined(_WIN64)
    MEMORYSTATUSEX status;
    status.dwLength = sizeof(status);
    GlobalMemoryStatusEx(&status);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #232 
`#elif` pre-processor conditional were missing the `defined( x )` keyword.
This will fix the problem.

### Details and comments


