### PR TITLE
Add to_instruction to ReadoutError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Fixed
 
 Added
 -----
--   Added `to_instruction` method to `ReadoutError`.
+-   Added `to_instruction` method to `ReadoutError` (\#257).
 
 Changed
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Fixed
 
 Added
 -----
+-   Added `to_instruction` method to `ReadoutError`.
 
 Changed
 -------

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -159,7 +159,7 @@ class QasmSimulator(AerBackend):
         'basis_gates': [
             'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
             't', 'tdg', 'ccx', 'swap', 'multiplexer', 'snapshot', 'unitary', 'reset',
-            'initialize', 'kraus'
+            'initialize', 'kraus', 'roerror'
         ],
         'gates': [{
             'name': 'TODO',
@@ -185,7 +185,7 @@ class QasmSimulator(AerBackend):
         """
         clifford_instructions = [
             "id", "x", "y", "z", "h", "s", "sdg", "CX", "cx", "cz", "swap",
-            "barrier", "reset", "measure"
+            "barrier", "reset", "measure", 'roerror'
         ]
         unsupported_ch_instructions = ["u2", "u3"]
         # Check if noise model is Clifford:

--- a/qiskit/providers/aer/noise/errors/readout_error.py
+++ b/qiskit/providers/aer/noise/errors/readout_error.py
@@ -18,6 +18,7 @@ import copy
 import numpy as np
 from numpy.linalg import norm
 
+from qiskit.circuit import Instruction
 from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT, RTOL_DEFAULT
 
 from ..noiseerror import NoiseError
@@ -140,6 +141,10 @@ class ReadoutError:
         if delta == 0:
             return True
         return False
+
+    def to_instruction(self):
+        """Convet the ReadoutError to a circuit Instruction."""
+        return Instruction("roerror", 0, self.number_of_qubits, self._probabilities)
 
     def as_dict(self):
         """

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -771,7 +771,8 @@ Op json_to_op_roerror(const json_t &js) {
   op.name = "roerror";
   JSON::get_value(op.memory, "memory", js);
   JSON::get_value(op.registers, "register", js);
-  JSON::get_value(op.probs, "probabilities", js);
+  JSON::get_value(op.probs, "probabilities", js); // DEPRECIATED: Remove in 0.4
+  JSON::get_value(op.probs, "params", js);
   return op;
 }
 

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -105,7 +105,7 @@ struct Op {
   uint_t conditional_reg;   // (opt) the (single) register location to look up for conditional
   RegComparison bfunc;      // (opt) boolean function relation
 
-  // DEPRECATED: old style conditionals (will be removed when Terra supports new style)
+  // DEPRECATED: Old style conditionals (remove in 0.3)
   bool old_conditional = false;     // is gate old style conditional gate
   std::string old_conditional_mask; // hex string for conditional mask
   std::string old_conditional_val;  // hex string for conditional value
@@ -634,7 +634,7 @@ Op json_to_op_gate(const json_t &js) {
       op.conditional_reg = js["conditional"];
       op.conditional = true;
     } else {
-      // DEPRECIATED: old style conditional
+      // DEPRECATED: old style conditional (remove in 0.3)
       JSON::get_value(op.old_conditional_mask, "mask", js["conditional"]);
       JSON::get_value(op.old_conditional_val, "val", js["conditional"]);
       op.old_conditional = true;
@@ -771,7 +771,7 @@ Op json_to_op_roerror(const json_t &js) {
   op.name = "roerror";
   JSON::get_value(op.memory, "memory", js);
   JSON::get_value(op.registers, "register", js);
-  JSON::get_value(op.probs, "probabilities", js); // DEPRECIATED: Remove in 0.4
+  JSON::get_value(op.probs, "probabilities", js); // DEPRECATED: Remove in 0.4
   JSON::get_value(op.probs, "params", js);
   return op;
 }

--- a/test/terra/noise/test_readout_error.py
+++ b/test/terra/noise/test_readout_error.py
@@ -176,6 +176,24 @@ class TestReadoutError(common.QiskitAerTestCase):
         error2 = ReadoutError(np.array([[0.9, 0.1], [0.5, 0.5]]))
         self.assertEqual(error1, error2)
 
+    def test_to_instruction(self):
+        """Test conversion of ReadoutError to Instruction."""
+        # 1-qubit case
+        probs1 = [[0.8, 0.2], [0.5, 0.5]]
+        instr1 = ReadoutError(probs1).to_instruction()
+        self.assertEqual(instr1.name, "roerror")
+        self.assertEqual(instr1.num_clbits, 1)
+        self.assertEqual(instr1.num_qubits, 0)
+        self.assertTrue(np.allclose(instr1.params, probs1))
+
+        # 2-qubit case
+        probs2 = np.kron(probs1, probs1)
+        instr2 = ReadoutError(probs2).to_instruction()
+        self.assertEqual(instr2.name, "roerror")
+        self.assertEqual(instr2.num_clbits, 2)
+        self.assertEqual(instr2.num_qubits, 0)
+        self.assertTrue(np.allclose(instr2.params, probs2))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds missing `to_instruction` method to `ReadoutError` object. This allows directly inserting readout errors into a `QuantumCircuit` for simulation in `Aer` like with `QuantumError` objects which can be directly inserted into circuits as `"kraus"` instructions.

### Details and comments

Example: 2-qubit readout error

```python
from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, execute
from qiskit.providers.aer import QasmSimulator, noise

# make readout error probabilities
roerror1 = noise.errors.ReadoutError([[0.9, 0.1], [0.4, 0.6]])
roerror2 = roerror1.tensor(roerror1)

# Make circuit and add readout error after measurement
q = QuantumRegister(2, 'q')
c = ClassicalRegister(2, 'c')
qc = QuantumCircuit(q, c)
qc.x(q[1])
qc.measure(q, c)
qc.append(roerror2, cargs=[c[0], c[1]])

# Execute
result = execute(qc, QasmSimulator(), shots=10000).result()
result.get_counts(0)
```