### PR TITLE
Add controlled-u1 to basis_gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 
 Added
 -----
+-   Added multi-controlled phase gate to `QubitVector` and changed
+    multi-controlled Z and multi-controlled u1 gates to use this method (\# 258)
+-   Added optimized anti-diagonal single-qubit gates to QubitVector (\# 258)
 
 Changed
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,12 @@ Added
 
 Changed
 -------
+-   Improve performance of matrix fusion circuit optimization and move fusion
+    code out of `QubitVector` class and into Fusion optimization class (\#255)
 
 Removed
 -------
+-   Remove `matrix_sequence` Op type from `Op` class (\#255)
 
 Fixed
 -----
@@ -43,6 +46,7 @@ Fixed
 
 Added
 -----
+-   Added 2-qubit Pauli and reset approximation to noise transformation (\#236)
 -   Added `to_instruction` method to `ReadoutError` (\#257).
 
 Changed

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -187,7 +187,7 @@ class QasmSimulator(AerBackend):
             "id", "x", "y", "z", "h", "s", "sdg", "CX", "cx", "cz", "swap",
             "barrier", "reset", "measure", 'roerror'
         ]
-        unsupported_ch_instructions = ["u2", "u3"]
+        unsupported_ch_instructions = ["u2", "u3", "cu1"]
         # Check if noise model is Clifford:
         method = "automatic"
         if backend_options and "method" in backend_options:

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -157,7 +157,7 @@ class QasmSimulator(AerBackend):
         'description': 'A C++ simulator with realistic noise for qobj files',
         'coupling_map': None,
         'basis_gates': [
-            'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
+            'u1', 'u2', 'u3', 'cx', 'cz', 'cu1', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
             't', 'tdg', 'ccx', 'swap', 'multiplexer', 'snapshot', 'unitary', 'reset',
             'initialize', 'kraus', 'roerror'
         ],

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -83,7 +83,7 @@ class StatevectorSimulator(AerBackend):
         'max_shots': 1,
         'description': 'A C++ statevector simulator for qobj files',
         'coupling_map': None,
-        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
+        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'cu1', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'multiplexer', 'snapshot', 'unitary', 'reset', 'initialize'],
         'gates': [

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -88,7 +88,7 @@ class UnitarySimulator(AerBackend):
         'description': 'A Python simulator for computing the unitary'
                        'matrix for experiments in qobj files',
         'coupling_map': None,
-        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z',
+        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'cu1', 'id', 'x', 'y', 'z',
                         'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
                         'multiplexer', 'snapshot', 'unitary'],
         'gates': [

--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -88,20 +88,34 @@ private:
 // Matrix Functions
 //------------------------------------------------------------------------------
 
-// Vector conversion
+// Construct a matrix from a vector of matrix-row vectors
 template<class T> matrix<T> make_matrix(const std::vector<std::vector<T>> &mat);
-template<class T> matrix<T> devectorize_matrix(const std::vector<T> &vec);
-template<class T> std::vector<T> vectorize_matrix(const matrix<T> &mat);
-template<class T> std::vector<T> vectorize_diagonal_matrix(const matrix<T>& mat);
 
-// Transformations
+// Reshape a length column-major vectorized matrix into a square matrix
+template<class T> matrix<T> devectorize_matrix(const std::vector<T> &vec);
+
+// Vectorize a matrix by stacking matrix columns (column-major vectorization)
+template<class T> std::vector<T> vectorize_matrix(const matrix<T> &mat);
+
+// Return the transpose a matrix
 template <class T> matrix<T> transpose(const matrix<T> &A);
+
+// Return the adjoing (Hermitian-conjugate) of a matrix
 template <class T>
 matrix<std::complex<T>> dagger(const matrix<std::complex<T>> &A);
+
+// Return the complex conjugate of a matrix
 template <class T>
 matrix<std::complex<T>> conjugate(const matrix<std::complex<T>> &A);
+
+// Given a list of matrices for a multiplexer stacks and packs them 0/1/2/...
+// into a single 2^control x (2^target x 2^target) cmatrix_t) 
+// Equivalent to a 2^qubits x 2^target "flat" matrix
 template<class T>
 matrix<T> stacked_matrix(const std::vector<matrix<T>> &mmat);
+
+// Return a vector containing the diagonal of a matrix
+template<class T> std::vector<T> matrix_diagonal(const matrix<T>& mat);
 
 // Tracing
 template <class T> T trace(const matrix<T> &A);
@@ -510,16 +524,6 @@ std::vector<T> vectorize_matrix(const matrix<T>& mat) {
   return vec;
 }
 
-template<class T>
-std::vector<T> vectorize_diagonal_matrix(const matrix<T>& mat) {
-  std::vector<T> vec;
-  size_t size = std::min(mat.GetRows(), mat.GetColumns());
-  vec.resize(size, 0.);
-  for (size_t i=0; i < size; i++)
-    vec[i] = mat(i, i);
-  return vec;
-}
-
 template <class T>
 matrix<T> make_matrix(const std::vector<std::vector<T>> & mat) {
   size_t nrows = mat.size();
@@ -574,8 +578,6 @@ matrix<std::complex<T>> conj(const matrix<std::complex<T>> &A) {
   return temp;
 }
 
-// Given a list of matrices for a multiplexer, stacks and packs them 0/1/2/... into a single 2^control x (2^target x 2^target) cmatrix_t) 
-// Equivalent to a 2^qubits x 2^target "flat" matrix
 template <class T>
 matrix<T> stacked_matrix(const std::vector<matrix<T>> &mmat){
         size_t size_of_controls = mmat[0].GetRows(); // or GetColumns, as these matrices are (should be) square
@@ -605,6 +607,15 @@ matrix<T> stacked_matrix(const std::vector<matrix<T>> &mmat){
 	return stacked_matrix;
 }
 
+template<class T>
+std::vector<T> matrix_diagonal(const matrix<T>& mat) {
+  std::vector<T> vec;
+  size_t size = std::min(mat.GetRows(), mat.GetColumns());
+  vec.resize(size, 0.);
+  for (size_t i=0; i < size; i++)
+    vec[i] = mat(i, i);
+  return vec;
+}
 
 template <class T>
 T trace(const matrix<T> &A) {

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -1607,7 +1607,7 @@ void QubitVector<data_t>::apply_matrix(const uint_t qubit,
   }
   
   // Convert qubit to array register for lambda functions
-  areg_t<1> qubits({{qubit}});
+  areg_t<1> qubits = {{qubit}};
 
   // Check if anti-diagonal matrix and if so use optimized lambda
   if(mat[0] == 0.0 && mat[3] == 0.0) {

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -716,7 +716,7 @@ template <class statevec_t>
 void State<statevec_t>::apply_matrix(const Operations::Op &op) {
   if (op.qubits.empty() == false && op.mats[0].size() > 0) {
     if (Utils::is_diagonal(op.mats[0], .0)) {
-      BaseState::qreg_.apply_diagonal_matrix(op.qubits, Utils::vectorize_diagonal_matrix(op.mats[0]));
+      BaseState::qreg_.apply_diagonal_matrix(op.qubits, Utils::matrix_diagonal(op.mats[0]));
     } else {
       BaseState::qreg_.apply_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
     }

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -81,9 +81,9 @@ public:
 
   // Return the set of qobj gate instruction names supported by the State
   virtual stringset_t allowed_gates() const override {
-    return {"u1", "u2", "u3", "cx", "cz", "cy", "swap",
+    return {"u1", "u2", "u3", "cx", "cz", "cy", "cu1", "swap",
             "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx",
-            "mcx", "mcz", "mcy", "mcu1", "mcu2", "mcu3", "mcswap"};
+            "mcx", "mcz", "mcy", "mcz", "mcu1", "mcu2", "mcu3", "mcswap"};
   }
 
   // Return the set of qobj snapshot types supported by the State
@@ -285,23 +285,24 @@ template <class statevec_t>
 const stringmap_t<Gates> State<statevec_t>::gateset_({
   // Single qubit gates
   {"id", Gates::id},     // Pauli-Identity gate
-  {"x", Gates::mcx},       // Pauli-X gate
-  {"y", Gates::mcy},       // Pauli-Y gate
-  {"z", Gates::mcz},       // Pauli-Z gate
+  {"x", Gates::mcx},     // Pauli-X gate
+  {"y", Gates::mcy},     // Pauli-Y gate
+  {"z", Gates::mcz},     // Pauli-Z gate
   {"s", Gates::s},       // Phase gate (aka sqrt(Z) gate)
   {"sdg", Gates::sdg},   // Conjugate-transpose of Phase gate
   {"h", Gates::h},       // Hadamard gate (X + Z / sqrt(2))
   {"t", Gates::t},       // T-gate (sqrt(S))
   {"tdg", Gates::tdg},   // Conjguate-transpose of T gate
   // Waltz Gates
-  {"u1", Gates::mcu1},     // zero-X90 pulse waltz gate
-  {"u2", Gates::mcu2},     // single-X90 pulse waltz gate
-  {"u3", Gates::mcu3},     // two X90 pulse waltz gate
+  {"u1", Gates::mcu1},   // zero-X90 pulse waltz gate
+  {"u2", Gates::mcu2},   // single-X90 pulse waltz gate
+  {"u3", Gates::mcu3},   // two X90 pulse waltz gate
   // Two-qubit gates
-  {"cx", Gates::mcx},     // Controlled-X gate (CNOT)
-  {"cy", Gates::mcy},     // Controlled-Y gate
-  {"cz", Gates::mcz},     // Controlled-Z gate
-  {"swap", Gates::mcswap}, // SWAP gate
+  {"cx", Gates::mcx},        // Controlled-X gate (CNOT)
+  {"cy", Gates::mcy},        // Controlled-Y gate
+  {"cz", Gates::mcz},        // Controlled-Z gate
+  {"cu1", Gates::mcu1},      // Controlled-u1 gate
+  {"swap", Gates::mcswap},   // SWAP gate
   {"mcswap", Gates::mcswap}, // Multi-controlled SWAP gate
   // Multi-qubit controlled gates
   {"ccx", Gates::mcx},   // Controlled-CX gate (Toffoli)
@@ -561,7 +562,7 @@ void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
           BaseState::qreg_.apply_mcy({op.qubits[pos]});
           break;
         case 'Z':
-          BaseState::qreg_.apply_mcz({op.qubits[pos]});
+          BaseState::qreg_.apply_mcphase({op.qubits[pos]}, -1);
           break;
         default: {
           std::stringstream msg;
@@ -652,7 +653,7 @@ void State<statevec_t>::apply_gate(const Operations::Op &op) {
       break;
     case Gates::mcz:
       // Includes Z, CZ, CCZ, etc
-      BaseState::qreg_.apply_mcz(op.qubits);
+      BaseState::qreg_.apply_mcphase(op.qubits, -1);
       break;
     case Gates::id:
       break;
@@ -693,9 +694,8 @@ void State<statevec_t>::apply_gate(const Operations::Op &op) {
       break;
     case Gates::mcu1:
       // Includes u1, cu1, etc
-      apply_gate_mcu3(op.qubits, 0., 0., std::real(op.params[0]));
+      BaseState::qreg_.apply_mcphase(op.qubits, std::exp(complex_t(0, 1) * op.params[0]));
       break;
-
     default:
       // We shouldn't reach here unless there is a bug in gateset
       throw std::invalid_argument("QubitVector::State::invalid gate instruction \'" +

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -67,7 +67,7 @@ public:
 
   // Return the set of qobj gate instruction names supported by the State
   virtual stringset_t allowed_gates() const override {
-    return {"u1", "u2", "u3", "cx", "cz", "cy", "swap",
+    return {"u1", "u2", "u3", "cx", "cz", "cy", "cu1", "swap",
             "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx",
             "mcx", "mcz", "mcy", "mcu1", "mcu2", "mcu3", "mcswap"};
   }
@@ -187,9 +187,10 @@ const stringmap_t<Gates> State<data_t>::gateset_({
   {"u2", Gates::mcu2},  // single-X90 pulse waltz gate
   {"u3", Gates::mcu3},  // two X90 pulse waltz gate
   // Two-qubit gates
-  {"cx", Gates::mcx},  // Controlled-X gate (CNOT)
-  {"cy", Gates::mcy},  // Controlled-Z gate
-  {"cz", Gates::mcz},  // Controlled-Z gate
+  {"cx", Gates::mcx},   // Controlled-X gate (CNOT)
+  {"cy", Gates::mcy},   // Controlled-Z gate
+  {"cz", Gates::mcz},   // Controlled-Z gate
+  {"cu1", Gates::mcu1}, // Controlled-u1 gate
   {"swap", Gates::mcswap}, // SWAP gate
   // Three-qubit gates
   {"ccx", Gates::mcx},   // Controlled-CX gate (Toffoli)

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -322,7 +322,7 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
       break;
     case Gates::mcz:
       // Includes Z, CZ, CCZ, etc
-      BaseState::qreg_.apply_mcz(op.qubits);
+      BaseState::qreg_.apply_mcphase(op.qubits, -1);
       break;
     case Gates::id:
       break;
@@ -363,7 +363,7 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
       break;
     case Gates::mcu1:
       // Includes u1, cu1, etc
-      apply_gate_mcu3(op.qubits, 0., 0., std::real(op.params[0]));
+      BaseState::qreg_.apply_mcphase(op.qubits, std::exp(complex_t(0, 1) * op.params[0]));
       break;
     default:
       // We shouldn't reach here unless there is a bug in gateset

--- a/test/benchmark/quantum_fourier_transform_benchmarks.py
+++ b/test/benchmark/quantum_fourier_transform_benchmarks.py
@@ -1,0 +1,78 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Quantum Fourier Transform benchmark suite"""
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+
+from qiskit import QiskitError
+from qiskit.compiler import transpile, assemble
+from qiskit.providers.aer import QasmSimulator
+from .tools import quantum_fourier_transform_circuit, mixed_unitary_noise_model, \
+                   reset_noise_model, kraus_noise_model, no_noise
+
+
+class QuantumFourierTransformTimeSuite:
+    """
+    Benchmarking times for Quantum Fourier Transform with various noise configurations
+    - ideal (no noise)
+    - mixed state
+    - reset
+    - kraus
+
+    For each noise model, we want to test various configurations of number of
+    qubits
+
+    The methods defined in this class will be executed by ASV framework as many
+    times as the combination of all parameters exist in `self.params`, for
+    exmaple: self.params = ([1,2,3],[4,5,6]), will run all methdos 9 times:
+        time_method(1,4)
+        time_method(1,5)
+        time_method(1,6)
+        time_method(2,4)
+        time_method(2,5)
+        time_method(2,6)
+        time_method(3,4)
+        time_method(3,5)
+        time_method(3,6)
+    """
+
+    def __init__(self):
+        self.timeout = 60 * 20
+        self.qft_circuits = []
+        self.backend = QasmSimulator()
+        for num_qubits in (5, 10, 15):
+            circ = quantum_fourier_transform_circuit(num_qubits)
+            circ = transpile(circ)
+            qobj = assemble(circ, self.backend, shots=1)
+            self.qft_circuits.append(qobj)
+
+        self.param_names = ["Quantum Fourier Transform", "Noise Model"]
+        # This will run every benchmark for one of the combinations we have here:
+        # bench(qft_circuits, None) => bench(qft_circuits, mixed()) =>
+        # bench(qft_circuits, reset) => bench(qft_circuits, kraus())
+        self.params = (self.qft_circuits, [
+            no_noise(),
+            mixed_unitary_noise_model(),
+            reset_noise_model(),
+            kraus_noise_model()
+        ])
+
+
+    def setup(self, qobj, noise_model_wrapper):
+        pass
+
+
+    def time_quantum_fourier_transform(self, qobj, noise_model_wrapper):
+        result = self.backend.run(qobj, noise_model=noise_model_wrapper()).result()
+        if result.status != 'COMPLETED':
+            raise QiskitError("Simulation failed. Status: " + result.status)

--- a/test/benchmark/tools.py
+++ b/test/benchmark/tools.py
@@ -135,7 +135,7 @@ def qft_circuit(num_qubits, measure=True):
     # Create quantum/classical registers of size n
     qr = QuantumRegister(num_qubits)
     circuit = QuantumCircuit(qr)
-    
+
     for i in range(num_qubits):
         for j in range(i):
             circuit.cu1(math.pi/float(2**(i-j)), qr[i], qr[j])
@@ -187,4 +187,29 @@ def simple_cnot_circuit(num_qubits, measure=True):
 
     if measure:
         circuit = _add_measurements(circuit, qr)
+    return circuit
+
+
+# pylint: disable=invalid-name
+def quantum_fourier_transform_circuit(num_qubits):
+    """Create quantum fourier transform circuit.
+
+    Args:
+        num_qubits (int): Number of qubits
+
+    Returns:
+        QuantumCircuit: QFT circuit
+    """
+    qreg = QuantumRegister(num_qubits)
+    creg = ClassicalRegister(num_qubits)
+
+    circuit = QuantumCircuit(qreg, creg, name="qft")
+
+    n = len(qreg)
+
+    for i in range(n):
+        for j in range(i):
+            circuit.cu1(math.pi/float(2**(i-j)), qreg[i], qreg[j])
+        circuit.h(qreg[i])
+    circuit.measure(qreg, creg)
     return circuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds Controlled-U1 (`"cu1"`) to simulator basis gates. This greatly improves performance of ideal circuits with a lot of cu1 gates (like qft circuits).

### Details and comments

* Fixes a bug in previous implementation of `mcu1` in terms of `mcu3` in QubitVector, since the phase convention of cu3 didn't give a proper cu1.
* Adds optimized `apply_mcphase` method to `QubitVector` which is used to implement `u1, cu1, mcu1, z, cz, ccz, mcz, s, std, t, tdg`.
* Adds check for optimized implementation of anti-diagonal single-qubit gates to `apply_matrix` in qubit vector. This should slightly speed up the post-measurement/reset state update, and some Kraus errors (such as amplitude damping).

