### PR TITLE
Set max_workers parameter to ThreadPoolExecutor in AerJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Fixed
     with no identity component. (\#243)
 -   Fixed 2-qubit depolarizing-only error parameter calculation in
     basic_device_noise_model (\#243)
+-   Set maximum workers to ThreadPoolExecutor in AerJob to limit thread creation (\#259)
 
 [0.2.1](https://github.com/Qiskit/qiskit-aer/compare/0.2.0...0.2.1) - 2019-05-20
 ================================================================================

--- a/qiskit/providers/aer/aerjob.py
+++ b/qiskit/providers/aer/aerjob.py
@@ -50,7 +50,7 @@ class AerJob(BaseJob):
         _executor (futures.Executor): executor to handle asynchronous jobs
     """
 
-    _executor = futures.ThreadPoolExecutor()
+    _executor = futures.ThreadPoolExecutor(max_workers=1)
 
     def __init__(self, backend, job_id, fn, qobj, *args):
         super().__init__(backend, job_id)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
To fix #244.


### Details and comments
Add max_workers parameter to ThreadPoolExecutor in AerJob. If this value is not set, AerJob creates threads endlessly. 

