### PR TITLE
Avoid reuse in azure pipelines and split build out

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,8 @@ steps:
       pip install --ignore-installed -r requirements-dev.txt
       python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
     displayName: 'Install Dependencies and Build Aer'
-  - bash: |
+  - script: |
       call activate qiskit-aer-$(Build.BuildNumber)
-      pip install 'dist\qiskit_aer*.whl'
+      pip install dist\qiskit_aer*.whl
       python -m unittest discover -s test/terra -v
     displayName: 'Install Aer and Run Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,6 @@ steps:
   - bash: |
       set -e
       source activate qiskit-aer-$(Build.BuildNumber)
-      pip install dist\qiskit_aer*.whl
+      pip install dist/qiskit_aer*.whl
       python -m unittest discover -s test/terra -v
     displayName: 'Install Aer and Run Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,9 @@ steps:
       call activate qiskit-aer-$(Build.BuildNumber)
       conda install --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python=%PYTHON_VERSION% numpy
     displayName: Install Anaconda packages
-  - script: |
-      call activate qiskit-aer-$(Build.BuildNumber)
+  - bash: |
+      set -e
+      source activate qiskit-aer-$(Build.BuildNumber)
       git clean -fdX
       python -m pip install --disable-pip-version-check pip==18
       pip install cython
@@ -36,8 +37,9 @@ steps:
       pip install --ignore-installed -r requirements-dev.txt
       python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
     displayName: 'Install Dependencies and Build Aer'
-  - script: |
-      call activate qiskit-aer-$(Build.BuildNumber)
+  - bash: |
+      set -e
+      source activate qiskit-aer-$(Build.BuildNumber)
       pip install dist\qiskit_aer*.whl
       python -m unittest discover -s test/terra -v
     displayName: 'Install Aer and Run Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,9 +35,9 @@ steps:
       pip install git+https://github.com/Qiskit/qiskit-terra.git
       pip install --ignore-installed -r requirements-dev.txt
       python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
-      pip install dist\qiskit_aer*
-    displayName: 'Install dependencies and build Aer'
-  - script: |
+    displayName: 'Install Dependencies and Build Aer'
+  - bash: |
       call activate qiskit-aer-$(Build.BuildNumber)
+      pip install 'dist\qiskit_aer*.whl'
       python -m unittest discover -s test/terra -v
-    displayName: 'Run Tests'
+    displayName: 'Install Aer and Run Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,14 +21,15 @@ strategy:
 steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
-  - script: conda create --yes --quiet --name qiskit-aer
+  - script: conda create --yes --quiet --name qiskit-aer-$(Build.BuildNumber)
     displayName: Create Anaconda environment
   - script: |
-      call activate qiskit-aer
-      conda install --yes --quiet --name qiskit-aer python=%PYTHON_VERSION% numpy
+      call activate qiskit-aer-$(Build.BuildNumber)
+      conda install --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python=%PYTHON_VERSION% numpy
     displayName: Install Anaconda packages
   - script: |
-      call activate qiskit-aer
+      call activate qiskit-aer-$(Build.BuildNumber)
+      git clean -fdX
       python -m pip install --disable-pip-version-check pip==18
       pip install cython
       pip install git+https://github.com/Qiskit/qiskit-terra.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,9 @@ steps:
       pip install git+https://github.com/Qiskit/qiskit-terra.git
       pip install --ignore-installed -r requirements-dev.txt
       python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
-      pip install --find-links=dist\ qiskit_aer
+      pip install dist\qiskit_aer*
+    displayName: 'Install dependencies and build Aer'
+  - script: |
+      call activate qiskit-aer-$(Build.BuildNumber)
       python -m unittest discover -s test/terra -v
-    displayName: 'Install dependencies and Run Tests'
+    displayName: 'Run Tests'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the azure pipelines runs for #258 the jobs are failing for what looks
like a mismatch with the installed aer python package and what should
have been built. Just to rule that out for runs this commit makes 2
changes. First it creates a conda environment/virtualenv with a unique
name for each run. Secondly it runs git clean to remove any old built
wheels (assuming there are any). This turned out not to be the cause
of the failure, but it still doesn't hurt to just rule this out in future builds
anyway. To fix the underlying issue this commit splits the test running
from the aer build into a separate stage in the job. It also changes the
pip command invocation to only install locally and not fallback to use
pypi if a wheel isn't built.

### Details and comments