### PR TITLE
Add check if ops can be conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Added
 Changed
 -------
 
+-   When loading qobj check if all instructions are conditional and raise an
+    exception if an unsupported instruction is conditional (\#271)
 -   Deprecate the use of \".as\_dict()\" in favor of \".to\_dict()\"
     (\#228)
 -   Set simulator seed from \"seed\_simulator\" in qobj (\#210)

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -557,7 +557,7 @@ Op json_to_op_roerror(const json_t &js);
 
 // Optional instruction parameters
 enum class Allowed {Yes, No};
-void get_conditional(Allowed val, Op& op, const json_t &js);
+void add_condtional(const Allowed val, Op& op, const json_t &js);
 
 
 //------------------------------------------------------------------------------
@@ -627,7 +627,7 @@ json_t op_to_json(const Op &op) {
 //------------------------------------------------------------------------------
 
 
-void get_conditional(Allowed allowed, Op& op, const json_t &js) {
+void add_condtional(const Allowed allowed, Op& op, const json_t &js) {
   // Check conditional
   if (JSON::check_key("conditional", js)) {
     // If instruction isn't allow to be conditional throw an exception
@@ -666,7 +666,7 @@ Op json_to_op_gate(const json_t &js) {
     op.string_params = {op.name};
 
   // Conditional
-  get_conditional(Allowed::Yes, op, js);
+  add_condtional(Allowed::Yes, op, js);
 
   // Validation
   check_empty_name(op);
@@ -688,7 +688,7 @@ Op json_to_op_barrier(const json_t &js) {
   op.name = "barrier";
   JSON::get_value(op.qubits, "qubits", js);
   // Check conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
   return op;
 }
 
@@ -702,7 +702,7 @@ Op json_to_op_measure(const json_t &js) {
   JSON::get_value(op.registers, "register", js);
 
   // Conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
 
   // Validation
   check_empty_qubits(op);
@@ -724,7 +724,7 @@ Op json_to_op_reset(const json_t &js) {
   JSON::get_value(op.qubits, "qubits", js);
 
   // Conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
 
   // Validation
   check_empty_qubits(op);
@@ -741,7 +741,7 @@ Op json_to_op_initialize(const json_t &js) {
   JSON::get_value(op.params, "params", js);
 
   // Conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
 
   // Validation
   check_empty_qubits(op);
@@ -796,7 +796,7 @@ Op json_to_op_bfunc(const json_t &js) {
   }
 
   // Conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
 
   // Validation
   if (op.registers.empty()) {
@@ -815,7 +815,7 @@ Op json_to_op_roerror(const json_t &js) {
   JSON::get_value(op.probs, "probabilities", js); // DEPRECATED: Remove in 0.4
   JSON::get_value(op.probs, "params", js);
   // Conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
   return op;
 }
 
@@ -846,7 +846,7 @@ Op json_to_op_unitary(const json_t &js) {
   op.string_params.push_back(label);
 
   // Conditional
-  get_conditional(Allowed::Yes, op, js);
+  add_condtional(Allowed::Yes, op, js);
   return op;
 }
 
@@ -861,7 +861,7 @@ Op json_to_op_multiplexer(const json_t &js) {
   // Construct op
   auto op = make_multiplexer(qubits, mats, label);
   // Conditional
-  get_conditional(Allowed::Yes, op, js);
+  add_condtional(Allowed::Yes, op, js);
   return op;
 }
 
@@ -876,7 +876,7 @@ Op json_to_op_kraus(const json_t &js) {
   check_empty_qubits(op);
   check_duplicate_qubits(op);
   // Conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
   return op;
 }
 
@@ -887,7 +887,7 @@ Op json_to_op_noise_switch(const json_t &js) {
   op.name = "noise_switch";
   JSON::get_value(op.params, "params", js);
   // Conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
   return op;
 }
 
@@ -908,7 +908,7 @@ Op json_to_op_snapshot(const json_t &js) {
   // Default snapshot: has "type", "label", "qubits"
   auto op = json_to_op_snapshot_default(js);
   // Conditional
-  get_conditional(Allowed::No, op, js);
+  add_condtional(Allowed::No, op, js);
   return op;
 }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When loading qobj json this checks if each instruction type is allowed to be conditional. If an unsupported instruction is set as conditional an exception will be raised.

Adds conditional support to some instructions that were missing (unitary, multiplexer)

Fixes #268 by raising an error for job containing conditional measure instructions.

### Details and comments

* adds conditional "unitary" and "multiplexer" gates
* raises exception if qobj conditions conditionals for unsupported instructions: "measure", "reset", "initialize", "bfunc", "barrier", "snapshot", "noise_switch", "kraus", "roerror".

