### PR TITLE
Fix non-OpenMP builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ endif()
 #
 # Looking for external libraries
 #
+message(STATUS "Looking for OpenMP support...")
 find_package(OpenMP QUIET)
 # This is a hack for building with Apple's LLVM, which doesn't support OpenMP yet
 # so we need to link with an external library: libomp.
@@ -136,12 +137,15 @@ if(OPENMP_FOUND)
 		# the Terra Addon, see issue: https://github.com/Qiskit/qiskit-aer/issues/1
 		if(NOT SKBUILD)
 			set(OPENMP_EXTERNAL_LIB "${OpenMP_${OpenMP_CXX_LIB_NAMES}_LIBRARY}")
-			message("Adding Clang: ${OPENMP_EXTERNAL_LIB}")
+			message(STATUS "Adding Clang: ${OPENMP_EXTERNAL_LIB}")
 		endif()
 	endif()
-	message("OpenMP found!")
+	message(STATUS "OpenMP found!")
+else()
+	message(STATUS "WARNING: No OpenMP support found!")
 endif()
 
+message(STATUS "Looking for NLOHMANN Json library...")
 set(NLOHMANN_JSON_PATH ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
 find_package(nlohmann_json REQUIRED)
 find_package(Threads)
@@ -160,7 +164,7 @@ else()
 endif()
 
 if(WIN32)
-	message("Uncompressing OpenBLAS static library...")
+	message(STATUS "Uncompressing OpenBLAS static library...")
 	execute_process(COMMAND ${CMAKE_COMMAND} -E tar "xvfj" "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/win64/lib/openblas.7z"
 		WORKING_DIRECTORY  "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/win64/lib/")
 endif()
@@ -172,7 +176,7 @@ if(NOT BLAS_FOUND)
 	find_package(BLAS REQUIRED)
 endif()
 
-message("BLAS: ${BLAS_LIBRARIES}")
+message(STATUS "BLAS library found: ${BLAS_LIBRARIES}")
 
 # Set dependent libraries
 set(AER_LIBRARIES

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -42,8 +42,8 @@
 
 #ifdef _OPENMP
 #include <omp.h>
-#include "misc/hacks.hpp"
 #endif
+#include "misc/hacks.hpp"
 
 namespace AER {
 


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Non-OpenMP builds are allowed (because not all the possible platforms do support it), but there was a bug in the build system where non-OpenMP builds were failing at compile time.
I have improved messaging while building too


### Details and comments


