### PR TITLE
Fix bug in NoiseModel.add_nonlocal_quantum_error

### DIFF
--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -424,7 +424,7 @@ class NoiseModel:
             qs_str = self._qubits2str(qubits)
             nqs_str = self._qubits2str(noise_qubits)
             if qs_str in gate_qubit_dict:
-                noise_qubit_dict = gate_qubit_dict[nqs_str]
+                noise_qubit_dict = gate_qubit_dict[qs_str]
                 if nqs_str in noise_qubit_dict:
                     new_error = noise_qubit_dict[nqs_str].compose(error)
                     noise_qubit_dict[nqs_str] = new_error


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes bug in `NoiseModel.add_nonlocal_quantum_error` where there was a key error if multiple nonlocal errors were added to the qubit and instruction.

### Details and comments


