### PR TITLE
Remove transpiler optimizations from the benchmarks

### DIFF
--- a/test/benchmark/__init__.py
+++ b/test/benchmark/__init__.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+""" Some __repr__ hooks for beauty-printing reports """
+
 from qiskit.qobj import Qobj
 from qiskit.providers.aer.noise import NoiseModel
 

--- a/test/benchmark/quantum_fourier_transform_benchmarks.py
+++ b/test/benchmark/quantum_fourier_transform_benchmarks.py
@@ -17,13 +17,15 @@
 from qiskit import QiskitError
 from qiskit.compiler import transpile, assemble
 from qiskit.providers.aer import QasmSimulator
-from .tools import quantum_fourier_transform_circuit, mixed_unitary_noise_model, \
-                   reset_noise_model, kraus_noise_model, no_noise
+from .tools import quantum_fourier_transform_circuit, \
+                   mixed_unitary_noise_model, reset_noise_model, \
+                   kraus_noise_model, no_noise
 
 
 class QuantumFourierTransformTimeSuite:
     """
-    Benchmarking times for Quantum Fourier Transform with various noise configurations
+    Benchmarking times for Quantum Fourier Transform with various noise
+    configurations:
     - ideal (no noise)
     - mixed state
     - reset
@@ -58,7 +60,8 @@ class QuantumFourierTransformTimeSuite:
             self.qft_circuits.append(qobj)
 
         self.param_names = ["Quantum Fourier Transform", "Noise Model"]
-        # This will run every benchmark for one of the combinations we have here:
+
+        # This will run every benchmark for one of the combinations we have:
         # bench(qft_circuits, None) => bench(qft_circuits, mixed()) =>
         # bench(qft_circuits, reset) => bench(qft_circuits, kraus())
         self.params = (self.qft_circuits, [
@@ -68,12 +71,13 @@ class QuantumFourierTransformTimeSuite:
             kraus_noise_model()
         ])
 
-
     def setup(self, qobj, noise_model_wrapper):
-        pass
-
+        """ Setup env before benchmarks start """
 
     def time_quantum_fourier_transform(self, qobj, noise_model_wrapper):
-        result = self.backend.run(qobj, noise_model=noise_model_wrapper()).result()
+        """ Benchmark QFT """
+        result = self.backend.run(
+            qobj, noise_model=noise_model_wrapper()
+        ).result()
         if result.status != 'COMPLETED':
             raise QiskitError("Simulation failed. Status: " + result.status)

--- a/test/benchmark/quantum_fourier_transform_benchmarks.py
+++ b/test/benchmark/quantum_fourier_transform_benchmarks.py
@@ -52,7 +52,8 @@ class QuantumFourierTransformTimeSuite:
         self.backend = QasmSimulator()
         for num_qubits in (5, 10, 15):
             circ = quantum_fourier_transform_circuit(num_qubits)
-            circ = transpile(circ)
+            circ = transpile(circ, basis_gates=['u1', 'u2', 'u3', 'cx'],
+                             optimization_level=0, seed_transpiler=1)
             qobj = assemble(circ, self.backend, shots=1)
             self.qft_circuits.append(qobj)
 

--- a/test/benchmark/quantum_volume_benchmarks.py
+++ b/test/benchmark/quantum_volume_benchmarks.py
@@ -52,15 +52,16 @@ class QuantumVolumeTimeSuite:
         self.backend = QasmSimulator()
         for num_qubits in (5, 10, 15):
             for depth in (10, ):
-                # We want always the same seed, as we want always the same circuits
-                # for the same value pairs of qubits,depth
+                # We want always the same seed, as we want always the same
+                # circuits for the same value pairs of qubits and depth
                 circ = quantum_volume_circuit(num_qubits, depth, seed=1)
                 circ = transpile(circ, basis_gates=['u1', 'u2', 'u3', 'cx'],
                                  optimization_level=0, seed_transpiler=1)
                 qobj = assemble(circ, self.backend, shots=1)
                 self.qv_circuits.append(qobj)
         self.param_names = ["Quantum Volume", "Noise Model"]
-        # This will run every benchmark for one of the combinations we have here:
+
+        # This will run every benchmark for one of the combinations we have:
         # bench(qv_circuits, None) => bench(qv_circuits, mixed()) =>
         # bench(qv_circuits, reset) => bench(qv_circuits, kraus())
         self.params = (self.qv_circuits, [
@@ -71,9 +72,12 @@ class QuantumVolumeTimeSuite:
         ])
 
     def setup(self, qobj, noise_model_wrapper):
-        pass
+        """ Setup enviornment before running the tests """
 
     def time_quantum_volume(self, qobj, noise_model_wrapper):
-        result = self.backend.run(qobj, noise_model=noise_model_wrapper()).result()
+        """ Benchmark for quantum volume """
+        result = self.backend.run(
+            qobj, noise_model=noise_model_wrapper()
+        ).result()
         if result.status != 'COMPLETED':
             raise QiskitError("Simulation failed. Status: " + result.status)

--- a/test/benchmark/quantum_volume_benchmarks.py
+++ b/test/benchmark/quantum_volume_benchmarks.py
@@ -55,7 +55,8 @@ class QuantumVolumeTimeSuite:
                 # We want always the same seed, as we want always the same circuits
                 # for the same value pairs of qubits,depth
                 circ = quantum_volume_circuit(num_qubits, depth, seed=1)
-                circ = transpile(circ, basis_gates=['u3', 'cx'])
+                circ = transpile(circ, basis_gates=['u1', 'u2', 'u3', 'cx'],
+                                 optimization_level=0, seed_transpiler=1)
                 qobj = assemble(circ, self.backend, shots=1)
                 self.qv_circuits.append(qobj)
         self.param_names = ["Quantum Volume", "Noise Model"]

--- a/test/benchmark/simple_benchmarks.py
+++ b/test/benchmark/simple_benchmarks.py
@@ -10,10 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+"""
+Airspeed Velocity (ASV) benchmarks suite for simple 1-qubit/2-qubit gates
+"""
+
 from qiskit import QiskitError
 from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
-from .tools import quantum_volume_circuit, mixed_unitary_noise_model, \
+from .tools import mixed_unitary_noise_model, \
                    reset_noise_model, kraus_noise_model, no_noise, \
                    simple_cnot_circuit, simple_u3_circuit
 
@@ -61,7 +65,10 @@ class SimpleU3TimeSuite:
         ])
 
     def time_simple_u3(self, qobj, noise_model_wrapper):
-        result = self.backend.run(qobj, noise_model=noise_model_wrapper()).result()
+        """ Benchmark for circuits with a simple u3 gate """
+        result = self.backend.run(
+            qobj, noise_model=noise_model_wrapper()
+        ).result()
         if result.status != 'COMPLETED':
             raise QiskitError("Simulation failed. Status: " + result.status)
 
@@ -92,6 +99,9 @@ class SimpleCxTimeSuite:
         ])
 
     def time_simple_cx(self, qobj, noise_model_wrapper):
-        result = self.backend.run(qobj, noise_model=noise_model_wrapper()).result()
+        """ Benchmark for circuits with a simple cx gate """
+        result = self.backend.run(
+            qobj, noise_model=noise_model_wrapper()
+        ).result()
         if result.status != 'COMPLETED':
             raise QiskitError("Simulation failed. Status: " + result.status)

--- a/test/benchmark/tools.py
+++ b/test/benchmark/tools.py
@@ -39,6 +39,7 @@ class NoiseWithDescription:
         return self._noise_model
 
 
+# pylint: disable=no-member
 def _add_measurements(circuit, qr):
     cr = ClassicalRegister(qr.size)
     meas = QuantumCircuit(qr, cr)
@@ -111,6 +112,7 @@ def quantum_volume_circuit(num_qubits, depth, measure=True, seed=None):
         # Decompose each SU(4) into CNOT + SU(2) and add to Ci
         for k in range(math.floor(num_qubits / 2)):
             # Generate random SU(4) matrix
+            # pylint: disable=invalid-name
             X = (rng.randn(4, 4) + 1j * rng.randn(4, 4))
             SU4, _ = linalg.qr(X)  # Q is a unitary matrix
             SU4 /= pow(linalg.det(SU4), 1 / 4)  # make Q a special unitary
@@ -119,6 +121,7 @@ def quantum_volume_circuit(num_qubits, depth, measure=True, seed=None):
     if measure is True:
         circuit = _add_measurements(circuit, qr)
     return circuit
+
 
 def qft_circuit(num_qubits, measure=True):
     """Create a qft circuit.
@@ -143,6 +146,7 @@ def qft_circuit(num_qubits, measure=True):
         circuit = _add_measurements(circuit, qr)
     return circuit
 
+
 def simple_u3_circuit(num_qubits, measure=True):
     """Creates a simple circuit composed by u3 gates, with measurements or not
     at the end of each qubit.
@@ -165,8 +169,8 @@ def simple_u3_circuit(num_qubits, measure=True):
 
 
 def simple_cnot_circuit(num_qubits, measure=True):
-    """Creates a simple circuit composed by cnot gates, with measurements or not
-    at the end of each qubit.
+    """Creates a simple circuit composed by cnot gates, with measurements or
+    not at the end of each qubit.
 
     Args:
         num_qubits (int): Number of qubits

--- a/test/benchmark/tools.py
+++ b/test/benchmark/tools.py
@@ -18,7 +18,6 @@ from itertools import repeat
 from numpy import random
 from scipy import linalg
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.compiler import transpile
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors import depolarizing_error
 from qiskit.providers.aer.noise.errors import amplitude_damping_error
@@ -119,8 +118,7 @@ def quantum_volume_circuit(num_qubits, depth, measure=True, seed=None):
             circuit.unitary(SU4, qubits)
     if measure is True:
         circuit = _add_measurements(circuit, qr)
-    # Transpile to force it into u1,u2,u3,cx basis gates
-    return transpile(circuit, basis_gates=['u1', 'u2', 'u3', 'cx'])
+    return circuit
 
 def qft_circuit(num_qubits, measure=True):
     """Create a qft circuit.
@@ -143,8 +141,7 @@ def qft_circuit(num_qubits, measure=True):
 
     if measure is True:
         circuit = _add_measurements(circuit, qr)
-    # Transpile to force it into u1,u2,u3,cx basis gates
-    return transpile(circuit, basis_gates=['u1', 'u2', 'u3', 'cx'])
+    return circuit
 
 def simple_u3_circuit(num_qubits, measure=True):
     """Creates a simple circuit composed by u3 gates, with measurements or not


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Transpilation process is not mandatory in simulation, and it can add different optimizations to the circuits over time that will interfere in the results of the benchmarks, so we are removing it from all the benchmarks.

Anyway, I want to make sure that this assumption is correct @chriseclectic  :)

### Details and comments
We may notice visible performance peak in the benchmarks right after this PR, that is expected.

