### PR TITLE
Add entries missing entries in mailmap from github user metadata

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -16,6 +16,7 @@
 #
 Ali Javadi-Abhari <ali.javadi@ibm.com> <ajavadia@users.noreply.github.com>
 Ali Javadi-Abhari <ali.javadi@ibm.com> <ajavadia@princeton.edu>
+Christian Claus <cclauss@me.com>
 Christopher J. Wood <cjwood@us.ibm.com>
 Diego M. Rodríguez <diego.plan9@gmail.com>
 Gadi Aleksandrowicz <gadia@il.ibm.com>
@@ -24,6 +25,7 @@ Hiroshi Horii <horii@jp.ibm.com> <HORII@jp.ibm.com>
 Hiroshi Horii <horii@jp.ibm.com> <hhorii@users.noreply.github.com>
 Hitomi Takahashi <hitomi@jp.ibm.com> <hitomi@jp.ibm.com>
 Hitomi Takahashi <hitomi@jp.ibm.com> <hitomi@hitominbookpuro.dhcp.hakozaki.ibm.com>
+Ikko Hamamura <ikkoham@users.noreply.github.com>
 Jay M. Gambetta <jay.gambetta@us.ibm.com>
 Joe Latone <jlatone@us.ibm.com>
 John A. Gunnels <john.a.gunnels@gmail.com>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds 2 missing entries to the mailmap for users whose github
username was used as the author name. It pulls their full name from
their github profiles.

### Details and comments