### PR TITLE
Remove persistent config and noise model from controller

### DIFF
--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -139,16 +139,6 @@ int main(int argc, char **argv) {
     if (!config.empty())
       config_all.update(config.begin(), config.end());
 
-    // Check for OpenMP path for MacOS OpenMP double
-    // initialization crash hack
-    // Issue: https://github.com/Qiskit/qiskit-aer/issues/1
-    // If we don't do this we get a segment-fault on execution
-    if (JSON::check_key("config", qobj)) {
-      std::string path;
-      JSON::get_value(path, "library_dir", qobj["config"]);
-      AER::Hacks::maybe_load_openmp(path);
-    }
-
     // Initialize simulator
     AER::Simulator::QasmController sim;
     auto result = sim.execute(qobj);

--- a/qiskit/providers/aer/backends/wrappers/qasm_controller_wrapper.pyx
+++ b/qiskit/providers/aer/backends/wrappers/qasm_controller_wrapper.pyx
@@ -20,7 +20,7 @@ cdef extern from "simulators/qasm/qasm_controller.hpp" namespace "AER::Simulator
     cdef cppclass QasmController:
         QasmController() except +
 
-cdef extern from "base/controller.hpp" namespace "AER":
+cdef extern from "simulators/controller_execute.hpp" namespace "AER":
     cdef string controller_execute[QasmController](string &qobj) except +
 
 

--- a/qiskit/providers/aer/backends/wrappers/statevector_controller_wrapper.pyx
+++ b/qiskit/providers/aer/backends/wrappers/statevector_controller_wrapper.pyx
@@ -20,7 +20,7 @@ cdef extern from "simulators/statevector/statevector_controller.hpp" namespace "
     cdef cppclass StatevectorController:
         StatevectorController() except +
 
-cdef extern from "base/controller.hpp" namespace "AER":
+cdef extern from "simulators/controller_execute.hpp" namespace "AER":
     cdef string controller_execute[StatevectorController](string &qobj) except +
 
 

--- a/qiskit/providers/aer/backends/wrappers/unitary_controller_wrapper.pyx
+++ b/qiskit/providers/aer/backends/wrappers/unitary_controller_wrapper.pyx
@@ -20,7 +20,7 @@ cdef extern from "simulators/unitary/unitary_controller.hpp" namespace "AER::Sim
     cdef cppclass UnitaryController:
         UnitaryController() except +
 
-cdef extern from "base/controller.hpp" namespace "AER":
+cdef extern from "simulators/controller_execute.hpp" namespace "AER":
     cdef string controller_execute[UnitaryController](string &qobj) except +
 
 

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -337,9 +337,9 @@ void Controller::set_parallelization_experiments(const std::vector<Circuit>& cir
   if (max_parallel_experiments_ <= 0)
     return;
   // if memory allows, execute experiments in parallel
-  std::vector<size_t> required_memory_mb_list;
-  for (const Circuit &circ : circuits) {
-    required_memory_mb_list.push_back(required_memory_mb(circ, noise));
+  std::vector<size_t> required_memory_mb_list(circuits.size());
+  for (size_t j=0; j<circuits.size(); j++) {
+    required_memory_mb_list[j] = required_memory_mb(circuits[j], noise);
   }
   std::sort(required_memory_mb_list.begin(), required_memory_mb_list.end(), std::greater<size_t>());
   int total_memory = 0;

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -43,32 +43,8 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-#include "misc/hacks.hpp"
 
 namespace AER {
-
-//=========================================================================
-// Controller Execute interface
-//=========================================================================
-
-// This is used to make wrapping Controller classes in Cython easier
-// by handling the parsing of std::string input into JSON objects.
-template <class controller_t>
-std::string controller_execute(const std::string &qobj_str) {
-  controller_t controller;
-  auto qobj_js = json_t::parse(qobj_str);
-
-  // Fix for MacOS and OpenMP library double initialization crash.
-  // Issue: https://github.com/Qiskit/qiskit-aer/issues/1
-  if (JSON::check_key("config", qobj_js)) {
-    std::string path;
-    JSON::get_value(path, "library_dir", qobj_js["config"]);
-    Hacks::maybe_load_openmp(path);
-  }
-
-  return controller.execute(qobj_js).dump(-1);
-}
-
 namespace Base {
 
 //=========================================================================

--- a/src/simulators/controller_execute.hpp
+++ b/src/simulators/controller_execute.hpp
@@ -1,0 +1,47 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_controller_execute_hpp_
+#define _aer_controller_execute_hpp_
+
+#include <string>
+#include "framework/json.hpp"
+#include "misc/hacks.hpp"
+
+
+//=========================================================================
+// Controller Execute interface
+//=========================================================================
+
+
+// This is used to make wrapping Controller classes in Cython easier
+// by handling the parsing of std::string input into JSON objects.
+namespace AER { 
+template <class controller_t>
+std::string controller_execute(const std::string &qobj_str) {
+  controller_t controller;
+  auto qobj_js = json_t::parse(qobj_str);
+
+  // Fix for MacOS and OpenMP library double initialization crash.
+  // Issue: https://github.com/Qiskit/qiskit-aer/issues/1
+  if (JSON::check_key("config", qobj_js)) {
+    std::string path;
+    JSON::get_value(path, "library_dir", qobj_js["config"]);
+    Hacks::maybe_load_openmp(path);
+  }
+
+  return controller.execute(qobj_js).dump(-1);
+}
+} // end namespace AER
+#endif

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -380,6 +380,7 @@ OutputData QasmController::run_circuit(const Circuit &circ,
         return run_circuit_helper<Statevector::State<QV::QubitVector<double>>>(
                                                       circ,
                                                       noise,
+                                                      config,
                                                       shots,
                                                       rng_seed,
                                                       initial_statevector_,

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -598,7 +598,8 @@ void QasmController::run_circuit_with_noise(const Circuit &circ,
   while(shots-- > 0) {
     Circuit noise_circ = noise.sample_noise(circ, rng);
     if (noise_circ.num_qubits > circuit_opt_noise_threshold_) {
-      optimize_circuit(noise_circ, state, data);
+      Noise::NoiseModel dummy;
+      optimize_circuit(noise_circ, dummy, state, data);
     }
     run_single_shot(noise_circ, state, initial_state, data, rng);
   }                                   
@@ -616,7 +617,8 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
   // Optimize circuit for state type
   Circuit opt_circ = circ;
   if (circ.num_qubits > circuit_opt_ideal_threshold_) {
-    optimize_circuit(opt_circ, state, data);
+    Noise::NoiseModel dummy;
+    optimize_circuit(opt_circ, dummy, state, data);
   }
 
   // Check if measure sampler and optimization are valid

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -152,6 +152,7 @@ protected:
   // the required number of shots.
   virtual OutputData run_circuit(const Circuit &circ,
                                  const Noise::NoiseModel& noise,
+                                 const json_t &config,
                                  uint_t shots,
                                  uint_t rng_seed) const override;
 
@@ -185,6 +186,7 @@ protected:
   template <class State_t, class Initstate_t>
   OutputData run_circuit_helper(const Circuit &circ,
                                 const Noise::NoiseModel &noise,
+                                const json_t &config,
                                 uint_t shots,
                                 uint_t rng_seed,
                                 const Initstate_t &initial_state,
@@ -367,6 +369,7 @@ void QasmController::clear_config() {
 
 OutputData QasmController::run_circuit(const Circuit &circ,
                                        const Noise::NoiseModel& noise,
+                                       const json_t &config,
                                        uint_t shots,
                                        uint_t rng_seed) const {
   // Validate circuit for simulation method
@@ -386,6 +389,7 @@ OutputData QasmController::run_circuit(const Circuit &circ,
         return run_circuit_helper<Statevector::State<QV::QubitVector<float>>>(
                                                       circ,
                                                       noise,
+                                                      config,
                                                       shots,
                                                       rng_seed,
                                                       initial_statevector_,
@@ -396,6 +400,7 @@ OutputData QasmController::run_circuit(const Circuit &circ,
       // TODO: Stabilizer doesn't yet support custom state initialization
       return run_circuit_helper<Stabilizer::State>(circ,
                                                    noise,
+                                                   config,
                                                    shots,
                                                    rng_seed,
                                                    Clifford::Clifford(),
@@ -403,6 +408,7 @@ OutputData QasmController::run_circuit(const Circuit &circ,
     case Method::extended_stabilizer:
       return run_circuit_helper<ExtendedStabilizer::State>(circ,
                                                            noise,
+                                                           config,
                                                            shots,
                                                            rng_seed,
                                                            CHSimulator::Runner(),
@@ -412,6 +418,7 @@ OutputData QasmController::run_circuit(const Circuit &circ,
       // TODO: Tensor network doesn't yet support custom state initialization
       return run_circuit_helper<TensorNetworkState::State>(circ,
                                                            noise,
+                                                           config,
                                                            shots,
                                                            rng_seed,
                                                            TensorNetworkState::MPS(),
@@ -540,6 +547,7 @@ void QasmController::set_parallelization_circuit(const Circuit& circ,
 template <class State_t, class Initstate_t>
 OutputData QasmController::run_circuit_helper(const Circuit &circ,
                                               const Noise::NoiseModel &noise,
+                                              const json_t &config,
                                               uint_t shots,
                                               uint_t rng_seed,
                                               const Initstate_t &initial_state,
@@ -551,7 +559,7 @@ OutputData QasmController::run_circuit_helper(const Circuit &circ,
   validate_memory_requirements(state, circ, true);
 
   // Set state config
-  state.set_config(Base::Controller::config_);
+  state.set_config(config);
   state.set_parallalization(parallel_state_update_);
 
   // Rng engine
@@ -560,7 +568,7 @@ OutputData QasmController::run_circuit_helper(const Circuit &circ,
 
   // Output data container
   OutputData data;
-  data.set_config(Base::Controller::config_);
+  data.set_config(config);
   data.add_additional_data("metadata",
                            json_t::object({{"method", state.name()}}));
 

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -76,7 +76,8 @@ public:
 
 protected:
 
-  virtual size_t required_memory_mb(const Circuit& circuit) const override;
+  virtual size_t required_memory_mb(const Circuit& circuit,
+                                    const Noise::NoiseModel& noise) const override;
 
 private:
 
@@ -87,6 +88,7 @@ private:
   // This simulator will only return a single shot, regardless of the
   // input shot number
   virtual OutputData run_circuit(const Circuit &circ,
+                                 const Noise::NoiseModel& noise,
                                  uint_t shots,
                                  uint_t rng_seed) const override;
 
@@ -122,7 +124,8 @@ void StatevectorController::clear_config() {
   initial_state_ = cvector_t();
 }
 
-size_t StatevectorController::required_memory_mb(const Circuit& circ) const {
+size_t StatevectorController::required_memory_mb(const Circuit& circ,
+                                                 const Noise::NoiseModel& noise) const {
   Statevector::State<> state;
   return state.required_memory_mb(circ.num_qubits, circ.ops);
 }
@@ -132,13 +135,14 @@ size_t StatevectorController::required_memory_mb(const Circuit& circ) const {
 //-------------------------------------------------------------------------
 
 OutputData StatevectorController::run_circuit(const Circuit &circ,
+                                              const Noise::NoiseModel& noise,
                                               uint_t shots,
                                               uint_t rng_seed) const {
   // Initialize  state
   Statevector::State<> state;
 
   // Validate circuit and throw exception if invalid operations exist
-  validate_state(state, circ, noise_model_, true);
+  validate_state(state, circ, noise, true);
 
   // Check for custom initial state, and if so check it matches num qubits
   if (!initial_state_.empty()) {

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -89,6 +89,7 @@ private:
   // input shot number
   virtual OutputData run_circuit(const Circuit &circ,
                                  const Noise::NoiseModel& noise,
+                                 const json_t &config,
                                  uint_t shots,
                                  uint_t rng_seed) const override;
 
@@ -136,6 +137,7 @@ size_t StatevectorController::required_memory_mb(const Circuit& circ,
 
 OutputData StatevectorController::run_circuit(const Circuit &circ,
                                               const Noise::NoiseModel& noise,
+                                              const json_t &config,
                                               uint_t shots,
                                               uint_t rng_seed) const {
   // Initialize  state
@@ -156,7 +158,7 @@ OutputData StatevectorController::run_circuit(const Circuit &circ,
   }
 
   // Set config
-  state.set_config(Base::Controller::config_);
+  state.set_config(config);
   state.set_parallalization(parallel_state_update_);
   
   // Rng engine
@@ -165,7 +167,7 @@ OutputData StatevectorController::run_circuit(const Circuit &circ,
 
   // Output data container
   OutputData data;
-  data.set_config(Base::Controller::config_);
+  data.set_config(config);
   
   // Run single shot collecting measure data or snapshots
   if (initial_state_.empty())

--- a/src/simulators/unitary/unitary_controller.hpp
+++ b/src/simulators/unitary/unitary_controller.hpp
@@ -82,6 +82,7 @@ private:
   // input shot number
   virtual OutputData run_circuit(const Circuit &circ,
                                  const Noise::NoiseModel& noise,
+                                 const json_t &config,
                                  uint_t shots,
                                  uint_t rng_seed) const override;
   
@@ -128,6 +129,7 @@ size_t UnitaryController::required_memory_mb(const Circuit& circ,
 
 OutputData UnitaryController::run_circuit(const Circuit &circ,
                                           const Noise::NoiseModel& noise,
+                                          const json_t &config,
                                           uint_t shots,
                                           uint_t rng_seed) const {
   // Initialize state
@@ -154,7 +156,7 @@ OutputData UnitaryController::run_circuit(const Circuit &circ,
   }
 
   // Set state config
-  state.set_config(Base::Controller::config_);
+  state.set_config(config);
   state.set_parallalization(parallel_state_update_);
 
   // Rng engine (not actually needed for unitary controller)
@@ -163,7 +165,7 @@ OutputData UnitaryController::run_circuit(const Circuit &circ,
 
   // Output data container
   OutputData data;
-  data.set_config(Base::Controller::config_);
+  data.set_config(config);
 
   // Run single shot collecting measure data or snapshots
   if (initial_unitary_.empty())

--- a/src/simulators/unitary/unitary_controller.hpp
+++ b/src/simulators/unitary/unitary_controller.hpp
@@ -69,7 +69,8 @@ public:
 
 protected:
 
-  size_t required_memory_mb(const Circuit& circ) const override;
+  size_t required_memory_mb(const Circuit& circ,
+                            const Noise::NoiseModel& noise) const override;
 
 private:
 
@@ -80,6 +81,7 @@ private:
   // This simulator will only return a single shot, regardless of the
   // input shot number
   virtual OutputData run_circuit(const Circuit &circ,
+                                 const Noise::NoiseModel& noise,
                                  uint_t shots,
                                  uint_t rng_seed) const override;
   
@@ -114,7 +116,8 @@ void UnitaryController::clear_config() {
   initial_unitary_ = cmatrix_t();
 }
 
-size_t UnitaryController::required_memory_mb(const Circuit& circ) const {
+size_t UnitaryController::required_memory_mb(const Circuit& circ,
+                                             const Noise::NoiseModel& noise) const {
   QubitUnitary::State<> state;
   return state.required_memory_mb(circ.num_qubits, circ.ops);
 }
@@ -124,13 +127,14 @@ size_t UnitaryController::required_memory_mb(const Circuit& circ) const {
 //-------------------------------------------------------------------------
 
 OutputData UnitaryController::run_circuit(const Circuit &circ,
+                                          const Noise::NoiseModel& noise,
                                           uint_t shots,
                                           uint_t rng_seed) const {
   // Initialize state
   QubitUnitary::State<> state;
   
   // Validate circuit and throw exception if invalid operations exist
-  validate_state(state, circ, noise_model_, true);
+  validate_state(state, circ, noise, true);
 
   // Check for custom initial state, and if so check it matches num qubits
   if (!initial_unitary_.empty()) {

--- a/src/transpile/basic_opts.hpp
+++ b/src/transpile/basic_opts.hpp
@@ -30,13 +30,15 @@ using reg_t = std::vector<uint_t>;
 class ReduceBarrier : public CircuitOptimization {
 public:
   void optimize_circuit(Circuit& circ,
+                        Noise::NoiseModel& noise,
                         const opset_t &opset,
                         OutputData &data) const override;
 };
 
 void ReduceBarrier::optimize_circuit(Circuit& circ,
-                                 const opset_t &allowed_opset,
-                                 OutputData &data) const {
+                                     Noise::NoiseModel& noise,
+                                     const opset_t &allowed_opset,
+                                     OutputData &data) const {
 
   size_t idx = 0;
   for (size_t i = 0; i < circ.ops.size(); ++i) {
@@ -54,11 +56,13 @@ void ReduceBarrier::optimize_circuit(Circuit& circ,
 class Debug : public CircuitOptimization {
 public:
   void optimize_circuit(Circuit& circ,
+                        Noise::NoiseModel& noise,
                         const opset_t &opset,
                         OutputData &data) const override;
 };
 
 void Debug::optimize_circuit(Circuit& circ,
+                             Noise::NoiseModel& noise,
                              const opset_t &allowed_opset,
                              OutputData &data) const {
 

--- a/src/transpile/circuitopt.hpp
+++ b/src/transpile/circuitopt.hpp
@@ -25,6 +25,8 @@
 #include <vector>
 
 #include "framework/operations.hpp"
+#include "noise/noise_model.hpp"
+
 
 namespace AER {
 namespace Transpile {
@@ -36,6 +38,7 @@ public:
   virtual ~CircuitOptimization() = default;
 
   virtual void optimize_circuit(Circuit& circ,
+                                Noise::NoiseModel& noise,
                                 const Operations::OpSet &opset,
                                 OutputData &data) const = 0;
 

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -43,6 +43,7 @@ public:
   void set_config(const json_t &config) override;
 
   void optimize_circuit(Circuit& circ,
+                        Noise::NoiseModel& noise,
                         const opset_t &opset,
                         OutputData &data) const override;
 
@@ -169,6 +170,7 @@ void Fusion::dump(const Circuit& circuit) const {
 #endif
 
 void Fusion::optimize_circuit(Circuit& circ,
+                              Noise::NoiseModel& noise,
                               const opset_t &allowed_opset,
                               OutputData &data) const {
 

--- a/src/transpile/truncate_qubits.hpp
+++ b/src/transpile/truncate_qubits.hpp
@@ -26,7 +26,9 @@ public:
   void set_config(const json_t &config) override;
 
   // truncate unnecessary qubits
+  // TODO: truncate noise model as well
   void optimize_circuit(Circuit& circ,
+                        Noise::NoiseModel& noise,
                         const Operations::OpSet &opset,
                         OutputData &data) const override;
 
@@ -67,6 +69,7 @@ void TruncateQubits::set_config(const json_t &config) {
 }
 
 void TruncateQubits::optimize_circuit(Circuit& circ,
+                                      Noise::NoiseModel& noise,
                                       const Operations::OpSet &allowed_opset,
                                       OutputData &data) const {
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR reworks the controller class so that it doesn't store a single config or noise model.

* The config and noise model is now passed through execute functions so that the noise model or config can be modified in a thread safe way for each different circuit execution. 
* Adds nosie model to circuit optimization framework (though it is currently not used)
* Fixes an issue with the MacOS openmp hack that would cause a segfault if it wasn't loaded before any virtual function of the controller was called. This hack is now loaded by the `execute_controller` cython wrapped function, rather than in the `set_config` method.

### Details and comments


