### PR TITLE
Add superoperator utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 Added
 -----
 -   New simulation method for qasm simulator: tensor_network (\#56)
-
+-   Added superop qobj instruction and superoperator matrix utils (\# 289)
 
 Changed
 -------

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -36,7 +36,7 @@ enum class RegComparison {Equal, NotEqual, Less, LessEqual, Greater, GreaterEqua
 // Enum class for operation types
 enum class OpType {
   gate, measure, reset, bfunc, barrier, snapshot,
-  matrix, multiplexer, kraus, roerror, noise_switch, initialize
+  matrix, multiplexer, kraus, superop, roerror, noise_switch, initialize
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
@@ -67,6 +67,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     break;
   case OpType::kraus:
     stream << "kraus";
+    break;
+  case OpType::superop:
+    stream << "superop";
     break;
   case OpType::roerror:
     stream << "roerror";
@@ -401,6 +404,15 @@ inline Op make_unitary(const reg_t &qubits, const cmatrix_t &mat, std::string la
   return op;
 }
 
+inline Op make_superop(const reg_t &qubits, const cmatrix_t &mat) {
+  Op op;
+  op.type = OpType::superop;
+  op.name = "superop";
+  op.qubits = qubits;
+  op.mats = {mat};
+  return op;
+}
+
 inline Op make_fusion(const reg_t &qubits, const cmatrix_t &mat, const std::vector<Op>& fusioned_ops, std::string label = "") {
   Op op;
   op.type = OpType::matrix;
@@ -548,6 +560,7 @@ Op json_to_op_snapshot_pauli(const json_t &js);
 
 // Matrices
 Op json_to_op_unitary(const json_t &js);
+Op json_to_op_superop(const json_t &js);
 Op json_to_op_multiplexer(const json_t &js);
 Op json_to_op_kraus(const json_t &js);
 Op json_to_op_noise_switch(const json_t &js);
@@ -582,6 +595,8 @@ Op json_to_op(const json_t &js) {
   // Arbitrary matrix gates
   if (name == "unitary")
     return json_to_op_unitary(js);
+  if (name == "superop")
+    return json_to_op_superop(js);
   // Snapshot
   if (name == "snapshot")
     return json_to_op_snapshot(js);
@@ -850,6 +865,24 @@ Op json_to_op_unitary(const json_t &js) {
   return op;
 }
 
+Op json_to_op_superop(const json_t &js) {
+  // Warning: we don't check superoperator is valid!
+  Op op;
+  op.type = OpType::superop;
+  op.name = "superop";
+  JSON::get_value(op.qubits, "qubits", js);
+  JSON::get_value(op.mats, "params", js);
+  // Check conditional
+  add_condtional(Allowed::Yes, op, js);
+  // Validation
+  check_empty_qubits(op);
+  check_duplicate_qubits(op);
+  if (op.mats.size() != 1) {
+    throw std::invalid_argument("\"superop\" params must be a single matrix.");
+  }
+  return op;
+}
+
 Op json_to_op_multiplexer(const json_t &js) {
   // Parse parameters
   reg_t qubits;
@@ -876,7 +909,7 @@ Op json_to_op_kraus(const json_t &js) {
   check_empty_qubits(op);
   check_duplicate_qubits(op);
   // Conditional
-  add_condtional(Allowed::No, op, js);
+  add_condtional(Allowed::Yes, op, js);
   return op;
 }
 

--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -78,6 +78,129 @@ public:
     return (label_map_.find(name) != label_map_.end());
   }
 
+private:
+  // Lookup table that returns a pointer to the static data member
+  const static stringmap_t<const cmatrix_t*> label_map_;
+};
+
+//------------------------------------------------------------------------------
+// Static Vectorized Matrices
+//------------------------------------------------------------------------------
+class VMatrix {
+public:
+  // Single-qubit gates
+  const static cvector_t I;     // name: "id"
+  const static cvector_t X;     // name: "x"
+  const static cvector_t Y;     // name: "y"
+  const static cvector_t Z;     // name: "z"
+  const static cvector_t H;     // name: "h"
+  const static cvector_t S;     // name: "s"
+  const static cvector_t SDG;   // name: "sdg"
+  const static cvector_t T;     // name: "t"
+  const static cvector_t TDG;   // name: "tdg"
+  const static cvector_t X90;   // name: "x90"
+
+  // Two-qubit gates
+  const static cvector_t CX;    // name: "cx"
+  const static cvector_t CZ;    // name: "cz"
+  const static cvector_t SWAP;  // name: "swap"
+  const static cvector_t CR;    // TODO
+  const static cvector_t CR90;  // TODO
+
+  // Identity Matrix
+  static cvector_t identity(size_t dim);
+
+  // Single-qubit waltz gates
+  static cvector_t u1(double lam);
+  static cvector_t u2(double phi, double lam);
+  static cvector_t u3(double theta, double phi, double lam);
+
+  // Complex arguments are implemented by taking std::real
+  // of the input
+  static cvector_t u1(complex_t lam) {return u1(std::real(lam));}
+  static cvector_t u2(complex_t phi, complex_t lam) {
+    return u2(std::real(phi), std::real(lam));
+  }
+  static cvector_t u3(complex_t theta, complex_t phi, complex_t lam) {
+    return u3(std::real(theta), std::real(phi), std::real(lam));
+  };
+
+  // Return the matrix for a named matrix string
+  // Allowed names correspond to all the const static single-qubit
+  // and two-qubit gate members
+  static const cvector_t from_name(const std::string &name) {
+    return *label_map_.at(name);
+  }
+
+  // Check if the input name string is allowed
+  static bool allowed_name(const std::string &name) {
+    return (label_map_.find(name) != label_map_.end());
+  }
+
+
+private:
+  // Lookup table that returns a pointer to the static data member
+  const static stringmap_t<const cvector_t*> label_map_;
+};
+
+
+//------------------------------------------------------------------------------
+// Static Superoperator Matrices
+//------------------------------------------------------------------------------
+
+class SMatrix {
+public:
+  // Single-qubit gates
+  const static cmatrix_t I;     // name: "id"
+  const static cmatrix_t X;     // name: "x"
+  const static cmatrix_t Y;     // name: "y"
+  const static cmatrix_t Z;     // name: "z"
+  const static cmatrix_t H;     // name: "h"
+  const static cmatrix_t S;     // name: "s"
+  const static cmatrix_t SDG;   // name: "sdg"
+  const static cmatrix_t T;     // name: "t"
+  const static cmatrix_t TDG;   // name: "tdg"
+  const static cmatrix_t X90;   // name: "x90"
+
+  // Two-qubit gates
+  const static cmatrix_t CX;    // name: "cx"
+  const static cmatrix_t CZ;    // name: "cz"
+  const static cmatrix_t SWAP;  // name: "swap"
+
+  // Identity Matrix
+  static cmatrix_t identity(size_t dim);
+
+  // Single-qubit waltz gates
+  static cmatrix_t u1(double lam);
+  static cmatrix_t u2(double phi, double lam);
+  static cmatrix_t u3(double theta, double phi, double lam);
+
+  // Complex arguments are implemented by taking std::real
+  // of the input
+  static cmatrix_t u1(complex_t lam) {return u1(std::real(lam));}
+  static cmatrix_t u2(complex_t phi, complex_t lam) {
+    return u2(std::real(phi), std::real(lam));
+  }
+  static cmatrix_t u3(complex_t theta, complex_t phi, complex_t lam) {
+    return u3(std::real(theta), std::real(phi), std::real(lam));
+  };
+
+  // Return superoperator matrix for reset instruction
+  // on specified dim statespace.
+  // The returned matrix is (dim * dim, dim * dim).
+  static cmatrix_t reset(size_t dim);
+
+  // Return the matrix for a named matrix string
+  // Allowed names correspond to all the const static single-qubit
+  // and two-qubit gate members
+  static const cmatrix_t from_name(const std::string &name) {
+    return *label_map_.at(name);
+  }
+
+  // Check if the input name string is allowed
+  static bool allowed_name(const std::string &name) {
+    return (label_map_.find(name) != label_map_.end());
+  }
 
 private:
   // Lookup table that returns a pointer to the static data member
@@ -131,6 +254,7 @@ template <class T> matrix<T> partial_trace_b(const matrix<T> &rho, size_t dimB);
 
 // Tensor product
 template <class T> matrix<T> tensor_product(const matrix<T> &A, const matrix<T> &B);
+template <class T> matrix<T> unitary_superop(const matrix<T> &mat);
 
 // concatenate
 // Returns a matrix that is the concatenation of two matrices A, B
@@ -152,7 +276,6 @@ template <class T> matrix<T> elementwise_multiplication(const matrix<T> &A, cons
 template <class T> T sum(const matrix<T> &A);
 
 // Matrix comparison
-
 template <class T>
 bool is_square(const matrix<T> &mat);
 
@@ -392,65 +515,6 @@ cmatrix_t Matrix::u3(double theta, double phi, double lambda) {
   return mat;
 }
 
-//------------------------------------------------------------------------------
-// Static Vectorized Matrices
-//------------------------------------------------------------------------------
-class VMatrix {
-public:
-  // Single-qubit gates
-  const static cvector_t I;     // name: "id"
-  const static cvector_t X;     // name: "x"
-  const static cvector_t Y;     // name: "y"
-  const static cvector_t Z;     // name: "z"
-  const static cvector_t H;     // name: "h"
-  const static cvector_t S;     // name: "s"
-  const static cvector_t SDG;   // name: "sdg"
-  const static cvector_t T;     // name: "t"
-  const static cvector_t TDG;   // name: "tdg"
-  const static cvector_t X90;   // name: "x90"
-
-  // Two-qubit gates
-  const static cvector_t CX;    // name: "cx"
-  const static cvector_t CZ;    // name: "cz"
-  const static cvector_t SWAP;  // name: "swap"
-  const static cvector_t CR;    // TODO
-  const static cvector_t CR90;  // TODO
-
-  // Identity Matrix
-  static cvector_t identity(size_t dim);
-
-  // Single-qubit waltz gates
-  static cvector_t u1(double lam);
-  static cvector_t u2(double phi, double lam);
-  static cvector_t u3(double theta, double phi, double lam);
-
-  // Complex arguments are implemented by taking std::real
-  // of the input
-  static cvector_t u1(complex_t lam) {return u1(std::real(lam));}
-  static cvector_t u2(complex_t phi, complex_t lam) {
-    return u2(std::real(phi), std::real(lam));
-  }
-  static cvector_t u3(complex_t theta, complex_t phi, complex_t lam) {
-    return u3(std::real(theta), std::real(phi), std::real(lam));
-  };
-
-  // Return the matrix for a named matrix string
-  // Allowed names correspond to all the const static single-qubit
-  // and two-qubit gate members
-  static const cvector_t from_name(const std::string &name) {
-    return *label_map_.at(name);
-  }
-
-  // Check if the input name string is allowed
-  static bool allowed_name(const std::string &name) {
-    return (label_map_.find(name) != label_map_.end());
-  }
-
-
-private:
-  // Lookup table that returns a pointer to the static data member
-  const static stringmap_t<const cvector_t*> label_map_;
-};
 
 //==============================================================================
 // Implementations: Static Matrices
@@ -529,6 +593,81 @@ cvector_t VMatrix::u3(double theta, double phi, double lambda) {
   mat[1 + 1 * 2] = std::exp(i * (phi + lambda)) * std::cos(theta / 2.);
   return mat;
 }
+
+//==============================================================================
+// Implementations: Static Matrices
+//==============================================================================
+
+const cmatrix_t SMatrix::I = unitary_superop(Matrix::I);
+
+const cmatrix_t SMatrix::X = unitary_superop(Matrix::X);
+
+const cmatrix_t SMatrix::Y = unitary_superop(Matrix::Y);
+
+const cmatrix_t SMatrix::Z = unitary_superop(Matrix::Z);
+
+const cmatrix_t SMatrix::S = unitary_superop(Matrix::S);
+
+const cmatrix_t SMatrix::SDG = unitary_superop(Matrix::SDG);
+
+const cmatrix_t SMatrix::T = unitary_superop(Matrix::T);
+
+const cmatrix_t SMatrix::TDG = unitary_superop(Matrix::TDG);
+
+const cmatrix_t SMatrix::H = unitary_superop(Matrix::H);
+
+const cmatrix_t SMatrix::X90 = unitary_superop(Matrix::X90);
+
+const cmatrix_t SMatrix::CX = unitary_superop(Matrix::CX);
+
+const cmatrix_t SMatrix::CZ = unitary_superop(Matrix::CZ);
+
+const cmatrix_t SMatrix::SWAP = unitary_superop(Matrix::SWAP);
+
+// Lookup table
+const stringmap_t<const cmatrix_t*> SMatrix::label_map_ = {
+  {"id", &SMatrix::I}, {"x", &SMatrix::X}, {"y", &SMatrix::Y}, {"z", &SMatrix::Z},
+  {"h", &SMatrix::H}, {"s", &SMatrix::S}, {"sdg", &SMatrix::SDG},
+  {"t", &SMatrix::T}, {"tdg", &SMatrix::TDG}, {"x90", &SMatrix::X90},
+  {"cx", &SMatrix::CX}, {"cz", &SMatrix::CZ}, {"swap", &SMatrix::SWAP}
+};
+
+cmatrix_t SMatrix::identity(size_t dim) {
+  return Matrix::identity(dim * dim);
+}
+
+
+cmatrix_t SMatrix::u1(double lambda) {
+  cmatrix_t mat(4, 4);
+  mat(0, 0) = {1., 0.};
+  mat(1, 1) = std::exp(complex_t(0., lambda));
+  mat(2, 2) = std::exp(complex_t(0., -lambda));
+  mat(3, 3) = {1., 0.};
+  return mat;
+}
+
+
+cmatrix_t SMatrix::u2(double phi, double lambda) {
+  return tensor_product(Matrix::u2(-phi, -lambda),
+                        Matrix::u2(phi, lambda));
+}
+
+
+cmatrix_t SMatrix::u3(double theta, double phi, double lambda) {
+  return tensor_product(Matrix::u3(theta, -phi, -lambda),
+                        Matrix::u3(theta, phi, lambda));
+}
+
+
+cmatrix_t SMatrix::reset(size_t dim) {
+  cmatrix_t mat(dim * dim, dim * dim);
+  for (size_t j=0; j < dim; j++) {
+    mat(0, j * (dim + 1)) = 1.;
+  }
+  return mat;
+}
+
+
 //==============================================================================
 // Implementations: Matrix functions
 //==============================================================================
@@ -793,6 +932,10 @@ matrix<T> tensor_product(const matrix<T> &A, const matrix<T> &B) {
     }
   }
   return temp;
+}
+
+template <class T> matrix<T> unitary_superop(const matrix<T> &mat) {
+  return tensor_product(conjugate(mat), mat);
 }
 
 template <class T>

--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -117,6 +117,13 @@ matrix<T> stacked_matrix(const std::vector<matrix<T>> &mmat);
 // Return a vector containing the diagonal of a matrix
 template<class T> std::vector<T> matrix_diagonal(const matrix<T>& mat);
 
+// Inplace transformations
+template <class T> matrix<T>& transpose_inplace(matrix<T> &A);
+template <class T>
+matrix<std::complex<T>>& dagger_inplace(matrix<std::complex<T>> &A);
+template <class T>
+matrix<std::complex<T>>& conjugate_inplace(matrix<std::complex<T>> &A);
+
 // Tracing
 template <class T> T trace(const matrix<T> &A);
 template <class T> matrix<T> partial_trace_a(const matrix<T> &rho, size_t dimA);
@@ -158,7 +165,10 @@ bool is_equal(const matrix<T> &mat1, const matrix<T> &mat2, double threshold);
 template <class T>
 bool is_diagonal(const matrix<T> &mat, double threshold);
 
-template <class T>
+template <class T> 
+std::pair<bool, double> is_identity_phase(const matrix<T> &mat, double threshold);
+
+template <class T> 
 bool is_identity(const matrix<T> &mat, double threshold);
 
 template <class T>
@@ -183,6 +193,10 @@ bool is_cptp_kraus(const std::vector<matrix<T>> &kraus, double threshold);
 // Return true of the vector has norm-1.
 template <typename T>
 double is_unit_vector(const std::vector<T> &vec);
+
+// Conjugate a vector
+template <typename T>
+std::vector<std::complex<T>> conjugate(const std::vector<std::complex<T>> &v);
 
 // Compute the Euclidean 2-norm of a vector
 template <typename T>
@@ -559,7 +573,7 @@ matrix<T> make_matrix(const std::vector<std::vector<T>> & mat) {
 template <class T>
 matrix<T> transpose(const matrix<T> &A) {
   // Transposes a Matrix
-  size_t rows = A.GetRows(), cols = A.GetColumns();
+  const size_t rows = A.GetRows(), cols = A.GetColumns();
   matrix<T> temp(cols, rows);
   for (size_t i = 0; i < rows; i++) {
     for (size_t j = 0; j < cols; j++) {
@@ -573,11 +587,11 @@ matrix<T> transpose(const matrix<T> &A) {
 template <class T>
 matrix<std::complex<T>> dagger(const matrix<std::complex<T>> &A) {
   // Take the Hermitian conjugate of a complex matrix
-  size_t cols = A.GetColumns(), rows = A.GetRows();
+  const size_t cols = A.GetColumns(), rows = A.GetRows();
   matrix<std::complex<T>> temp(cols, rows);
   for (size_t i = 0; i < rows; i++) {
     for (size_t j = 0; j < cols; j++) {
-      temp(j, i) = conj(A(i, j));
+      temp(j, i) = std::conj(A(i, j));
     }
   }
   return temp;
@@ -585,13 +599,13 @@ matrix<std::complex<T>> dagger(const matrix<std::complex<T>> &A) {
 
 
 template <class T>
-matrix<std::complex<T>> conj(const matrix<std::complex<T>> &A) {
+matrix<std::complex<T>> conjugate(const matrix<std::complex<T>> &A) {
   // Take the complex conjugate of a complex matrix
-  size_t rows = A.GetRows(), cols = A.GetColumns();
+  const size_t rows = A.GetRows(), cols = A.GetColumns();
   matrix<std::complex<T>> temp(rows, cols);
   for (size_t i = 0; i < rows; i++) {
     for (size_t j = 0; j < cols; j++) {
-      temp(i, j) = conj(A(i, j));
+      temp(i, j) = std::conj(A(i, j));
     }
   }
   return temp;
@@ -635,6 +649,51 @@ std::vector<T> matrix_diagonal(const matrix<T>& mat) {
     vec[i] = mat(i, i);
   return vec;
 }
+
+template <class T> 
+matrix<T>& transpose_inplace(matrix<T> &A) {
+  // Transposes a Matrix
+  const size_t rows = A.GetRows(), cols = A.GetColumns();
+  for (size_t i = 0; i < rows; i++) {
+    for (size_t j = i + 1; j < cols; j++) {
+      const auto tmp = A(i, j);
+      A(i, j) = A(j, i);
+      A(j, i) = tmp;
+    }
+  }
+  return A;
+}
+
+
+template <class T>
+matrix<std::complex<T>>& dagger_inplace(matrix<std::complex<T>> &A) {
+  // Take the Hermitian conjugate of a complex matrix
+  const size_t cols = A.GetColumns(), rows = A.GetRows();
+  matrix<std::complex<T>> temp(cols, rows);
+  for (size_t i = 0; i < rows; i++) {
+    A(i, i) = conj(A(i, i));
+    for (size_t j = i + 1; j < cols; j++) {
+      const auto tmp = conj(A(i, j));
+      A(i, j) = conj(A(j, i));
+      A(j, i) = tmp;
+    }
+  }
+  return A;
+}
+
+
+template <class T>
+matrix<std::complex<T>>& conj_inplace(matrix<std::complex<T>> &A) {
+  // Take the complex conjugate of a complex matrix
+  const size_t rows = A.GetRows(), cols = A.GetColumns();
+  for (size_t i = 0; i < rows; i++) {
+    for (size_t j = 0; j < cols; j++) {
+      A(i, j) = conj(A(i, j));
+    }
+  }
+  return A;
+}
+
 
 template <class T>
 T trace(const matrix<T> &A) {
@@ -873,21 +932,56 @@ bool is_diagonal(const matrix<T> &mat, double threshold) {
 }
 
 
-template <class T>
-bool is_identity(const matrix<T> &mat, double threshold) {
-  // Check U matrix is identity
+template <class T> 
+std::pair<bool, double> is_identity_phase(const matrix<T> &mat, double threshold) {
+  
+  // To check if identity we first check we check that:
+  // 1. U(0,0) = exp(i * theta)
+  // 2. U(i, i) = U(0, 0)
+  // 3. U(i, j) = 0 for j != i 
+  auto failed = std::make_pair(false, 0.0);
+
+  // Check condition 1.
+  const auto u00 = mat(0, 0);
+  //if (std::norm(std::abs(u00) - 1.0) > threshold)
+  //  return failed;
+  if (std::norm(std::abs(u00) - 1.0) > threshold) {
+    return failed;
+  }
+  const auto theta = std::arg(u00);
+
+  // Check conditions 2 and 3
   double delta = 0.;
   const auto nrows = mat.GetRows();
   const auto ncols = mat.GetColumns();
   if (nrows != ncols)
-    return false;
+    return failed;
   for (size_t i=0; i < nrows; i++) {
     for (size_t j=0; j < ncols; j++) {
-      T val = (i==j) ? 1 : 0;
-      delta += std::real(std::abs(mat(i, j) - val));
+      auto val = (i==j) ? std::norm(mat(i, j) - u00)
+                        : std::norm(mat(i, j));
+      if (val > threshold) {
+        return failed; // fail fast if single entry differs
+      } else
+        delta += val; // accumulate difference
     }
   }
-  return (delta < threshold);
+  // Check small errors didn't accumulate
+  if (delta > threshold) {
+    return failed;
+  }
+  // Otherwise we pass
+  return std::make_pair(true, theta);
+}
+
+template <class T> 
+bool is_identity(const matrix<T> &mat, double threshold) {
+  // Check mat(0, 0) == 1
+  if (std::norm(mat(0, 0) - T(1)) > threshold)
+    return false;
+  // If this passes now use is_identity_phase (and we know
+  // phase will be zero).
+  return is_identity_phase(mat, threshold).first;
 }
 
 template <class T>
@@ -903,7 +997,7 @@ bool is_diagonal_identity(const matrix<T> &mat, double threshold) {
   return (delta < threshold);
 }
 
-template <class T>
+template <class T> 
 bool is_unitary(const matrix<T> &mat, double threshold) {
   size_t nrows = mat.GetRows();
   size_t ncols = mat.GetColumns();
@@ -954,6 +1048,14 @@ bool is_unit_vector(const std::vector<T> &vec, double threshold) {
 }
 
 template <typename T>
+std::vector<std::complex<T>> conjugate(const std::vector<std::complex<T>> &v) {
+  std::vector<std::complex<T>> ret;
+  std::transform(v.cbegin(), v.cend(), std::back_inserter(ret),
+                [] (const std::complex<T> &c) -> std::complex<T> { return std::conj(c); });
+  return ret;
+}
+
+template <typename T>
 double norm(const std::vector<T> &vec) {
   double val = 0.0;
   for (const auto v : vec) {
@@ -977,7 +1079,7 @@ matrix<T> outer_product(const std::vector<T> &ket, const std::vector<T> &bra) {
 template <typename T>
 std::vector<T> tensor_product(const std::vector<T> &vec1,
                               const std::vector<T> &vec2) {
-  std::vector<double> ret;
+  std::vector<T> ret;
   ret.reserve(vec1.size() * vec2.size());
   for (const auto &a : vec1)
     for (const auto &b : vec2) {

--- a/src/simulators/tensor_network/matrix_product_state.cpp
+++ b/src/simulators/tensor_network/matrix_product_state.cpp
@@ -366,7 +366,7 @@ cmatrix_t MPS::density_matrix(const reg_t &qubits) const
   #endif
   for(int_t i = 0; i < static_cast<int_t>(size); i++) {
     for(int_t j = 0; j < static_cast<int_t>(size); j++) {
-      rho(i,j) = AER::Utils::sum( AER::Utils::elementwise_multiplication(psi.get_data(i), AER::Utils::conj(psi.get_data(j))) );
+      rho(i,j) = AER::Utils::sum( AER::Utils::elementwise_multiplication(psi.get_data(i), AER::Utils::conjugate(psi.get_data(j))) );
     }
   }
   return rho;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Includes from features from PR #253 to break it up into smaller PRs.

* Adds standard gate superoperator matrices to utils.
* Adds a `"superop"` qobj instruction type
* Allows "superop" and "kraus" instructions to be conditional since these could be used for errors on conditional gates in qiskit circuits.

### Details and comments


