### PR TITLE
Add validation threshold to backend options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Added
 -   New simulation method for qasm simulator: tensor_network (\#56)
 -   Added superop qobj instruction and superoperator matrix utils (\# 289)
 -   Added support for conditional unitary, kraus, superop qobj instructions (\# 291)
+-   Add "validation_threshold" config parameter to Aer backends (\# 290)
 
 Changed
 -------

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -17,6 +17,7 @@ Qiskit Aer qasm simulator backend.
 import json
 import logging
 import datetime
+import os
 import time
 import uuid
 from numpy import ndarray
@@ -32,6 +33,10 @@ from ..aererror import AerError
 
 # Logger
 logger = logging.getLogger(__name__)
+
+# Location where we put external libraries that will be loaded at runtime
+# by the simulator extension
+LIBRARY_DIR = os.path.dirname(__file__)
 
 
 class AerJSONEncoder(json.JSONEncoder):
@@ -129,7 +134,7 @@ class AerBackend(BaseBackend):
             config["noise_model"] = noise_model
 
         # Add runtime config
-        config['library_dir'] = self.configuration().library_dir
+        config['library_dir'] = LIBRARY_DIR
         qobj.config = QasmQobjConfig.from_dict(config)
         # Get the JSON serialized string
         output = json.dumps(qobj, cls=AerJSONEncoder).encode('UTF-8')

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -14,7 +14,6 @@ Qiskit Aer qasm simulator backend.
 """
 
 import logging
-import os
 from math import log2
 from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
@@ -55,6 +54,9 @@ class QasmSimulator(AerBackend):
 
         * "zero_threshold" (double): Sets the threshold for truncating
             small values to zero in the result data (Default: 1e-10).
+
+        * "validation_threshold" (double): Sets the threshold for checking
+            if initial states are valid (Default: 1e-8).
 
         * "max_parallel_threads" (int): Sets the maximum number of CPU
             cores used by OpenMP for parallelization. If set to 0 the
@@ -165,10 +167,7 @@ class QasmSimulator(AerBackend):
             'name': 'TODO',
             'parameters': [],
             'qasm_def': 'TODO'
-        }],
-        # Location where we put external libraries that will be loaded at runtime
-        # by the simulator extension
-        'library_dir': os.path.dirname(__file__)
+        }]
     }
 
     def __init__(self, configuration=None, provider=None):

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -17,7 +17,6 @@ Qiskit Aer statevector simulator backend.
 """
 
 import logging
-import os
 from math import log2
 from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
@@ -42,6 +41,9 @@ class StatevectorSimulator(AerBackend):
 
         * "zero_threshold" (double): Sets the threshold for truncating
             small values to zero in the result data (Default: 1e-10).
+
+        * "validation_threshold" (double): Sets the threshold for checking
+            if the initial statevector is valid (Default: 1e-8).
 
         * "max_parallel_threads" (int): Sets the maximum number of CPU
             cores used by OpenMP for parallelization. If set to 0 the
@@ -92,10 +94,7 @@ class StatevectorSimulator(AerBackend):
                 'parameters': [],
                 'qasm_def': 'TODO'
             }
-        ],
-        # Location where we put external libraries that will be loaded at runtime
-        # by the simulator extension
-        'library_dir': os.path.dirname(__file__)
+        ]
     }
 
     def __init__(self, configuration=None, provider=None):

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -17,7 +17,6 @@ Qiskit Aer Unitary Simulator Backend.
 """
 
 import logging
-import os
 from math import log2, sqrt
 from qiskit.util import local_hardware_info
 from qiskit.providers.models import BackendConfiguration
@@ -43,6 +42,10 @@ class UnitarySimulator(AerBackend):
 
         * "initial_unitary" (matrix_like): Sets a custom initial unitary
             matrix for the simulation instead of identity (Default: None).
+
+        * "validation_threshold" (double): Sets the threshold for checking
+            if initial unitary and target unitary are unitary matrices.
+            (Default: 1e-8).
 
         * "zero_threshold" (double): Sets the threshold for truncating
             small values to zero in the result data (Default: 1e-10).
@@ -97,10 +100,7 @@ class UnitarySimulator(AerBackend):
                 'parameters': [],
                 'qasm_def': 'TODO'
             }
-        ],
-        # Location where we put external libraries that will be loaded at runtime
-        # by the simulator extension
-        'library_dir': os.path.dirname(__file__)
+        ]
     }
 
     def __init__(self, configuration=None, provider=None):

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -214,6 +214,9 @@ protected:
   // Circuit optimization
   std::vector<std::shared_ptr<Transpile::CircuitOptimization>> optimizations_;
 
+  // Validation threshold for validating states and operators
+  double validation_threshold_ = 1e-8;
+
   //-----------------------------------------------------------------------
   // Parallelization Config
   //-----------------------------------------------------------------------
@@ -267,6 +270,9 @@ void Controller::set_config(const json_t &config) {
   // Load noise model
   if (JSON::check_key("noise_model", config))
     noise_model_ = Noise::NoiseModel(config["noise_model"]);
+
+  // Load validation threshold
+  JSON::get_value(validation_threshold_, "validation_threshold", config);
 
   // Load OpenMP maximum thread settings
   if (JSON::check_key("max_parallel_threads", config))
@@ -322,6 +328,7 @@ void Controller::clear_config() {
   config_ = json_t();
   noise_model_ = Noise::NoiseModel();
   clear_parallelization();
+  validation_threshold_ = 1e-8;
 }
 
 void Controller::clear_parallelization() {

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -320,7 +320,7 @@ void QasmController::set_config(const json_t &config) {
     // Override simulator method to statevector
     simulation_method_ = Method::statevector;
     // Check initial state is normalized
-    if (!Utils::is_unit_vector(initial_statevector_, 1e-10)) {
+    if (!Utils::is_unit_vector(initial_statevector_, validation_threshold_)) {
       throw std::runtime_error("QasmController: initial_statevector is not a unit vector");
     }
   }

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -112,7 +112,7 @@ void StatevectorController::set_config(const json_t &config) {
   //Add custom initial state
   if (JSON::get_value(initial_state_, "initial_statevector", config)) {
     // Check initial state is normalized
-    if (!Utils::is_unit_vector(initial_state_, 1e-10))
+    if (!Utils::is_unit_vector(initial_state_, validation_threshold_))
       throw std::runtime_error("StatevectorController: initial_statevector is not a unit vector");
   }
 }

--- a/src/simulators/unitary/unitary_controller.hpp
+++ b/src/simulators/unitary/unitary_controller.hpp
@@ -104,7 +104,7 @@ void UnitaryController::set_config(const json_t &config) {
   //Add custom initial unitary
   if (JSON::get_value(initial_unitary_, "initial_unitary", config) ) {
     // Check initial state is unitary
-    if (!Utils::is_unitary(initial_unitary_, 1e-10))
+    if (!Utils::is_unitary(initial_unitary_, validation_threshold_))
       throw std::runtime_error("UnitaryController: initial_unitary is not unitary");
   }
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Moves `library_dir` config parameter for MacOS OpenMP hack to the base AerBackend class
* Adds a user configurable "validation_threshold" parameter to controller classes for validating initial states.
* Lowers default validation threshold parameter from 1e-10 to 1e-8 since it better suits typical precision from Numpy

### Details and comments


