### PR TITLE
Fixed coeff in tensor_network_state simulation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Fixed
 -----
 - Bug in handling parallelization in matrix_product_state.cpp (PR \#292)
 
+- Added support for multiplication by coeff in tensor_network_state expectation value snapshots (PR \#294)
+
 
 [0.2.3](https://github.com/Qiskit/qiskit-aer/compare/0.2.2...0.2.3) - 2019-07-11
 ===============================================================================

--- a/src/simulators/tensor_network/matrix_product_state.cpp
+++ b/src/simulators/tensor_network/matrix_product_state.cpp
@@ -479,7 +479,6 @@ void MPS::probabilities_vector(rvector_t& probvector) const
 {
   MPS_Tensor mps_vec = state_vec(0, num_qubits_-1);
   uint_t length = 1ULL << num_qubits_;   // length = pow(2, num_qubits_)
-  complex_t data = 0;
   probvector.resize(length);
   #pragma omp parallel for
   for (int_t i = 0; i < static_cast<int_t>(length); i++) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The previous versions of snapshot_matrix_expval and snapshot_pauli_expval in tensor_network_state did not support multiplying the expectation value by the coeff parameter. I added this support now, to make sure we get the same results as provided by the statevector simulation method.


### Details and comments


