### PR TITLE
Truncate/remap qubits before calculating memory requirements or noise sampling

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -230,29 +230,3 @@ class QasmSimulator(AerBackend):
                 logger.warning(
                     'No measurements in circuit "%s": '
                     'count data will return all zeros.', name)
-            # Check qubits for statevector simulation
-            if not clifford and method != "extended_stabilizer":
-                n_qubits = experiment.config.n_qubits
-                max_qubits = self.configuration().n_qubits
-                if n_qubits > max_qubits:
-                    system_memory = int(local_hardware_info()['memory'])
-                    err_string = ('Number of qubits ({}) is greater than '
-                                  'maximum ({}) for "{}" (method=statevector) '
-                                  'with {} GB system memory')
-                    err_string = err_string.format(n_qubits, max_qubits,
-                                                   self.name(), system_memory)
-                    if method != "automatic":
-                        raise AerError(err_string + '.')
-
-                    if n_qubits > 63:
-                        raise AerError('{}, and has too many qubits to fall '
-                                       'back to the extended_stabilizer '
-                                       'method.'.format(err_string))
-                    if not ch_supported:
-                        raise AerError('{}, and contains instructions '
-                                       'not supported by the extended_etabilizer '
-                                       'method.'.format(err_string))
-                    logger.info(
-                        'The QasmSimulator will automatically '
-                        'switch to the Extended Stabilizer backend, based on '
-                        'the memory requirements.')

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -20,7 +20,6 @@ from qiskit.providers.models import BackendConfiguration
 from .aerbackend import AerBackend
 # pylint: disable=import-error
 from .qasm_controller_wrapper import qasm_controller_execute
-from ..aererror import AerError
 from ..version import __version__
 
 logger = logging.getLogger(__name__)

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -403,7 +403,7 @@ bool Controller::validate_state(const state_t &state,
                                 const Noise::NoiseModel &noise,
                                 bool throw_except) {
   // First check if a noise model is valid a given state
-  bool noise_valid = noise.ideal() || state.validate_opset(noise.opset());
+  bool noise_valid = noise.is_ideal() || state.validate_opset(noise.opset());
   bool circ_valid = state.validate_opset(circ.opset());
   if (noise_valid && circ_valid)
   {
@@ -645,8 +645,8 @@ json_t Controller::execute_circuit(Circuit &circ,
           throw std::runtime_error(error_msg);
 
       // Accumulate results across shots
-      for (uint_t j=0; j<par_data.size(); j++) {
-        data.combine(par_data[j]);
+      for (auto &datum : par_data) {
+        data.combine(datum);
       }
     }
     // Report success

--- a/src/framework/data.hpp
+++ b/src/framework/data.hpp
@@ -281,7 +281,17 @@ OutputData& OutputData::combine(OutputData &data) {
   // Note that this will override any fields that have the same value
   for (auto it = data.additional_data_.begin();
        it != data.additional_data_.end(); ++it) {
-    additional_data_[it.key()] = it.value();
+    // Check if key exists
+    if (additional_data_.find(it.key()) == additional_data_.end()) {
+      // If it doesn't add the data
+      additional_data_[it.key()] = it.value();
+    } else {
+      // If it does we append the data.
+      // Note that this will overwrite any subkeys with same name
+      for (auto it2 = it.value().begin(); it2 != it.value().end(); it2++) {
+        additional_data_[it.key()][it2.key()] = it2.value();
+      }
+    }
   }
 
   // Clear any remaining data from other container

--- a/src/noise/noise_model.hpp
+++ b/src/noise/noise_model.hpp
@@ -54,6 +54,39 @@ public:
   // can be done in a thread-safe manner
   Circuit sample_noise(const Circuit &circ, RngEngine &rng) const;
 
+  //-----------------------------------------------------------------------
+  // Checking if errors types are in noise model
+  //-----------------------------------------------------------------------
+
+  // Return True if noise model contains no readout errors
+  inline bool ideal_readout() const {
+    return readout_errors_.empty();
+  }
+
+  // Return True if noise model contains no quantum errors
+  inline bool ideal_quantum() const {
+    return ideal_local_quantum() && ideal_nonlocal_quantum();
+  }
+
+  // Return True if noise model contains no nonlocal quantum errors
+  inline bool ideal_nonlocal_quantum() const {
+    return !nonlocal_quantum_errors_;
+  }
+
+  // Return True if noise model contains no local quantum errors
+  inline bool ideal_local_quantum() const {
+    return !local_quantum_errors_;
+  }
+
+  // Return true if the noise model is ideal
+  inline bool ideal() const {
+    return ideal_quantum() && ideal_readout();
+  }
+
+  //-----------------------------------------------------------------------
+  // Add errors to noise model
+  //-----------------------------------------------------------------------
+
   // Load a noise model from JSON
   void load_from_json(const json_t &js);
 
@@ -67,15 +100,38 @@ public:
   void add_readout_error(const ReadoutError &error,
                          const std::vector<reg_t> &op_qubits = {});
   
-  // Return true if the noise model is ideal
-  inline bool ideal() const {
-    return !(local_quantum_errors_ || nonlocal_quantum_errors_) && readout_errors_.empty();
-  }
-
   // Set which single qubit gates should use the X90 waltz error model
   inline void set_x90_gates(const stringset_t &x90_gates) {
     x90_gates_ = x90_gates;
   }
+
+  //-----------------------------------------------------------------------
+  // Utils
+  //-----------------------------------------------------------------------
+
+  // Remap the qubits in the noise model.
+  // A remapping is entered as a map {old: new}
+  // Any qubits not in the mapping are assumed to be mapped to themselves.
+  // Hence the sets of all keys and all values of the map must be equal.
+  void remap_qubits(const std::unordered_map<uint_t, uint_t> &mapping);
+
+  // Return vector of noise qubits for non local error on specified label and qubits
+  // If no nonlocal error exists an empty set is returned.
+  std::set<uint_t> nonlocal_noise_qubits(const std::string label, const reg_t &qubits) const;
+
+  // Return vector of qubit registers for all readout errors in noise model.
+  // The empty reg is used to an all-qubit readout error.
+  std::vector<reg_t> readout_error_keys() const;
+
+  // Return vector of key pairs for all non-local quantum errors in the noise
+  // model. Vector elements are tuples (label, qubits, noise_qubits) where
+  // label is the string label for the error instruction, qubits is the reg of
+  // qubits the instruction is applied to, and noise_qubits is the reg of
+  // qubits the error is applied to.
+  // The empty noise_qubit reg is used for local quantum errors.
+  // The empty qubit reg is used for all-qubit quantum errors.
+  using keytuple_t = std::tuple<std::string, reg_t, reg_t>;
+  std::vector<keytuple_t> quantum_error_keys() const;
 
   // Set threshold for applying u1 rotation angles.
   // an Op for u1(theta) will only be added if |theta| > 0 and |theta - 2*pi| > 0
@@ -140,6 +196,9 @@ private:
   // List of readout errors
   std::vector<ReadoutError> readout_errors_;
 
+  // Set of qubits used in noise model
+  std::set<uint_t> noise_qubits_;
+
   using inner_table_t = stringmap_t<std::vector<size_t>>;
   using outer_table_t = stringmap_t<inner_table_t>;
 
@@ -156,6 +215,8 @@ private:
   // Helper function to convert reg to string for key of unordered maps/sets
   std::string reg2string(const reg_t &reg) const;
   reg_t string2reg(std::string s) const;
+  std::string remap_string(const std::string key,
+                           const std::unordered_map<uint_t, uint_t> &mapping) const;
 
   // Table of single-qubit gates to use a Waltz X90 based error model
   stringset_t x90_gates_;
@@ -263,8 +324,11 @@ void NoiseModel::add_readout_error(const ReadoutError &error,
   if (op_qubits.empty()) {
     readout_error_table_[""].push_back(error_pos);
   } else {
-    for (const auto &qubits : op_qubits)
+    for (const auto &qubits : op_qubits) {
       readout_error_table_[reg2string(qubits)].push_back(error_pos);
+      for (const auto &qubit : qubits)
+        noise_qubits_.insert(qubit);
+    }
   }
 }
 
@@ -303,8 +367,11 @@ void NoiseModel::add_local_quantum_error(const QuantumError &error,
   const auto error_pos = quantum_errors_.size() - 1;
   // Add error index to the error table
   for (const auto &gate: op_labels)
-    for (const auto &qubits : op_qubits)
+    for (const auto &qubits : op_qubits) {
       local_quantum_error_table_[gate][reg2string(qubits)].push_back(error_pos);
+      for (const auto &qubit : qubits)
+        noise_qubits_.insert(qubit);
+    }
 }
 
 
@@ -323,9 +390,15 @@ void NoiseModel::add_nonlocal_quantum_error(const QuantumError &error,
   const auto error_pos = quantum_errors_.size() - 1;
   // Add error index to the error table
   for (const auto &gate: op_labels)
-    for (const auto &qubits_gate : op_qubits)
-      for (const auto &qubits_noise : noise_qubits)
+    for (const auto &qubits_gate : op_qubits) {
+      for (const auto &qubit : qubits_gate)
+        noise_qubits_.insert(qubit);
+      for (const auto &qubits_noise : noise_qubits) {
         nonlocal_quantum_error_table_[gate][reg2string(qubits_gate)][reg2string(qubits_noise)].push_back(error_pos);
+        for (const auto &qubit : qubits_noise)
+          noise_qubits_.insert(qubit);
+      }
+    }
 }
 
 
@@ -606,6 +679,168 @@ reg_t NoiseModel::string2reg(std::string s) const {
     s.erase(0, pos + 1);
   }
   return result;
+}
+
+
+//=========================================================================
+// Qubit Remapping
+//=========================================================================
+
+std::set<uint_t> NoiseModel::nonlocal_noise_qubits(const std::string label,
+                                                   const reg_t& qubits) const {
+  std::set<uint_t> all_noise_qubits;
+  // Check if label has noise
+  const auto outer_it = nonlocal_quantum_error_table_.find(label);
+  if (outer_it != nonlocal_quantum_error_table_.end()) {
+    const auto outer_table = outer_it->second;
+    const auto it = outer_table.find(reg2string(qubits));
+    // Check if label on specified qubits has noise
+    if (it != outer_table.end()) {
+      // Add all noise qubit errors to the return value
+      const auto inner_table = it->second;
+      for (const auto &pair : inner_table) {
+        auto noise_qubits = string2reg(pair.first);
+        for (const auto& qubit : noise_qubits) {
+          all_noise_qubits.insert(qubit);
+        }
+      }
+    }
+  }
+  return all_noise_qubits;
+}
+
+
+std::string NoiseModel::remap_string(const std::string key,
+                                     const std::unordered_map<uint_t, uint_t> &mapping) const{
+  reg_t qubits = string2reg(key);
+  for (size_t j=0; j<qubits.size(); j++)
+    qubits[j] = mapping.at(qubits[j]);
+  return reg2string(qubits);
+}
+
+
+void NoiseModel::remap_qubits(const std::unordered_map<uint_t, uint_t> &mapping) {
+
+  // If noise model is ideal we have no need to remap
+  if (ideal())
+    return;
+
+  // We only need the mapping for qubits in the noise model.
+  // We add qubits not specified in the mapping as trivial mapping to themselves
+  // We also validate the mapping while building the full mapping
+  std::unordered_map<uint_t, uint_t> full_mapping;
+  std::set<uint_t> qubits_in;
+  std::set<uint_t> qubits_out;
+  for (const auto &qubit : noise_qubits_) {
+    qubits_in.insert(qubit);
+    if (mapping.find(qubit) == mapping.end()) {
+      full_mapping[qubit] = qubit;
+      qubits_out.insert(qubit);
+    } else {
+      auto mapped_qubit = mapping.at(qubit);
+      full_mapping[qubit] = mapped_qubit;
+      qubits_out.insert(mapped_qubit);
+    }
+  }
+  // Check mapping is valid
+  if (qubits_in != qubits_out) {
+    throw std::invalid_argument("NoiseModel: qubit remapping is invalid.");
+  }
+
+  // Remap readout error
+  if (!ideal_readout()) {
+    inner_table_t new_readout_error_table;
+    for (const auto& pair : readout_error_table_) {
+      new_readout_error_table[remap_string(pair.first, full_mapping)] = pair.second;
+    }
+    readout_error_table_ = new_readout_error_table;
+    new_readout_error_table.clear();
+  }
+
+  // Remap local quantum error
+  if (!ideal_local_quantum()) {
+    for (auto& outer_pair : local_quantum_error_table_) {
+      // Get reference to the inner table we need to change the keys for
+      auto& inner_table = outer_pair.second;
+      // Make a temporary table to store remapped table
+      inner_table_t new_table;
+      for (const auto& inner_pair : inner_table) {
+        new_table[remap_string(inner_pair.first, full_mapping)] = inner_pair.second;
+      }
+      // Replace inner table with the remapped table
+      inner_table = new_table;
+    }
+  }
+
+  // Remap nonlocal quantum error
+    if (!ideal_nonlocal_quantum()) {
+    for (auto& pair : nonlocal_quantum_error_table_) {
+      // Get reference to the middle table we need to change the keys for
+      auto& outer_table = pair.second;
+      // Make a temporary table to store remapped outer table
+      outer_table_t new_outer_table;
+      for (auto& outer_pair : outer_table) {
+        // Remap inner table
+        auto& inner_table = outer_pair.second;
+        inner_table_t new_inner_table;
+        for (const auto& inner_pair : inner_table) {
+          new_inner_table[remap_string(inner_pair.first, full_mapping)] = inner_pair.second;
+        }
+        // Update outer table with remapped inner table
+        new_outer_table[remap_string(outer_pair.first, full_mapping)] = new_inner_table;
+      }
+      outer_table = new_outer_table;
+    }
+  }
+}
+
+
+std::vector<reg_t> NoiseModel::readout_error_keys() const {
+  // If ideal readout return an empty vector
+  if (ideal_readout())
+    return std::vector<reg_t>();
+
+  // Otherwise construct the vector
+  std::vector<reg_t> ret;
+  ret.reserve(readout_error_table_.size());
+  for (const auto& pair: readout_error_table_) {
+    ret.push_back(string2reg(pair.first));
+  }
+  return ret;
+}
+
+
+std::vector<NoiseModel::keytuple_t>
+NoiseModel::quantum_error_keys() const {
+  // If ideal readout return an empty vector
+  if (ideal_quantum())
+    return std::vector<keytuple_t>();
+
+  // Otherwise construct the vector
+  std::vector<keytuple_t> ret;
+  ret.reserve(local_quantum_error_table_.size() + nonlocal_quantum_error_table_.size());
+
+  // Add local quantum errors
+  for (const auto& outer_pair: local_quantum_error_table_) {
+    auto label = outer_pair.first;
+    for (const auto& inner_pair : outer_pair.second) {
+      auto qubits = string2reg(inner_pair.first);
+      ret.push_back(keytuple_t({label, qubits, reg_t()}));
+    }
+  }
+
+  // Add nonlocal quantum errors
+  for (const auto& outer_pair: nonlocal_quantum_error_table_) {
+    auto label = outer_pair.first;
+    for (const auto& middle_pair : outer_pair.second) {
+      const reg_t qubits = string2reg(middle_pair.first);
+      for (const auto& inner_pair : middle_pair.second) {
+        const reg_t noise_qubits = string2reg(inner_pair.first);
+        ret.push_back(keytuple_t({label, qubits, noise_qubits}));
+      } 
+    }
+  }
+  return ret;
 }
 
 //=========================================================================

--- a/src/noise/noise_model.hpp
+++ b/src/noise/noise_model.hpp
@@ -58,29 +58,29 @@ public:
   // Checking if errors types are in noise model
   //-----------------------------------------------------------------------
 
-  // Return True if noise model contains no readout errors
-  inline bool ideal_readout() const {
-    return readout_errors_.empty();
+  // Return True if noise model contains readout errors
+  inline bool has_readout_erros() const {
+    return !readout_errors_.empty();
   }
 
-  // Return True if noise model contains no quantum errors
-  inline bool ideal_quantum() const {
-    return ideal_local_quantum() && ideal_nonlocal_quantum();
+  // Return True if noise model contains quantum errors
+  inline bool has_quantum_errors() const {
+    return local_quantum_errors_ || nonlocal_quantum_errors_;
   }
 
-  // Return True if noise model contains no nonlocal quantum errors
-  inline bool ideal_nonlocal_quantum() const {
-    return !nonlocal_quantum_errors_;
+  // Return True if noise model contains nonlocal quantum errors
+  inline bool has_nonlocal_quantum_errors() const {
+    return nonlocal_quantum_errors_;
   }
 
-  // Return True if noise model contains no local quantum errors
-  inline bool ideal_local_quantum() const {
-    return !local_quantum_errors_;
+  // Return True if noise model contains local quantum errors
+  inline bool has_local_quantum_errors() const {
+    return local_quantum_errors_;
   }
 
   // Return true if the noise model is ideal
   inline bool ideal() const {
-    return ideal_quantum() && ideal_readout();
+    return !has_readout_errors() && !has_quantum_errors();
   }
 
   //-----------------------------------------------------------------------
@@ -734,7 +734,7 @@ void NoiseModel::remap_qubits(const std::unordered_map<uint_t, uint_t> &mapping)
   }
 
   // Remap readout error
-  if (!ideal_readout()) {
+  if (has_readout_errors()) {
     inner_table_t new_readout_error_table;
     for (const auto& pair : readout_error_table_) {
       new_readout_error_table[remap_string(pair.first, full_mapping)] = pair.second;
@@ -744,7 +744,7 @@ void NoiseModel::remap_qubits(const std::unordered_map<uint_t, uint_t> &mapping)
   }
 
   // Remap local quantum error
-  if (!ideal_local_quantum()) {
+  if (has_local_quantum_errors()) {
     for (auto& outer_pair : local_quantum_error_table_) {
       // Get reference to the inner table we need to change the keys for
       auto& inner_table = outer_pair.second;
@@ -759,7 +759,7 @@ void NoiseModel::remap_qubits(const std::unordered_map<uint_t, uint_t> &mapping)
   }
 
   // Remap nonlocal quantum error
-    if (!ideal_nonlocal_quantum()) {
+  if (has_nonlocal_quantum_errors()) {
     for (auto& pair : nonlocal_quantum_error_table_) {
       // Get reference to the middle table we need to change the keys for
       auto& outer_table = pair.second;

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -566,7 +566,7 @@ void QasmController::set_parallelization_circuit(const Circuit& circ,
   switch (simulation_method(circ, noise_model, false)) {
     case Method::statevector:
     case Method::tensor_network: {
-      if (noise_model.ideal() && check_measure_sampling_opt(circ, Method::statevector).first) {
+      if (noise_model.is_ideal() && check_measure_sampling_opt(circ, Method::statevector).first) {
         parallel_shots_ = 1;
         parallel_state_update_ = max_parallel_threads_;
         return;
@@ -611,7 +611,7 @@ OutputData QasmController::run_circuit_helper(const Circuit &circ,
                            json_t::object({{"method", state.name()}}));
 
   // Check if there is noise for the implementation
-  if (noise.ideal()) {
+  if (noise.is_ideal()) {
     run_circuit_without_noise(circ, shots, state, initial_state, method, data, rng);
   } else {
     run_circuit_with_noise(circ, noise, shots, state, initial_state, method, data, rng);

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -18,7 +18,6 @@
 #include "base/controller.hpp"
 #include "transpile/basic_opts.hpp"
 #include "transpile/fusion.hpp"
-#include "transpile/truncate_qubits.hpp"
 #include "simulators/extended_stabilizer/extended_stabilizer_state.hpp"
 #include "simulators/statevector/statevector_state.hpp"
 #include "simulators/stabilizer/stabilizer_state.hpp"
@@ -284,7 +283,6 @@ protected:
 QasmController::QasmController() {
   add_circuit_optimization(Transpile::ReduceBarrier());
   add_circuit_optimization(Transpile::Fusion());
-  add_circuit_optimization(Transpile::TruncateQubits());
 }
 
 //-------------------------------------------------------------------------

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -1672,7 +1672,7 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
     if (diag[1] == 1.0)
       return; // Identity
 
-    if (diag[1] == (0., -1.)) { // [[1, 0], [0, -i]]
+    if (diag[1] == std::complex<double>(0., -1.)) { // [[1, 0], [0, -i]]
       auto lambda = [&](const areg_t<2> &inds,
                         const cvector_t<data_t> &_mat)->void {
         const auto k = inds[1];
@@ -1683,7 +1683,7 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
       apply_lambda(lambda, areg_t<1>({{qubit}}), convert(diag));
       return;
     }
-    if (diag[1] == (0., 1.)) {
+    if (diag[1] == std::complex<double>(0., 1.)) {
       // [[1, 0], [0, i]]
       auto lambda = [&](const areg_t<2> &inds,
                         const cvector_t<data_t> &_mat)->void {
@@ -1714,7 +1714,7 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
     return;
   } else if (diag[1] == 1.0) {
     // [[z, 0], [0, 1]] matrix
-    if (diag[0] == (0., -1.)) {
+    if (diag[0] == std::complex<double>(0., -1.)) {
       // [[-i, 0], [0, 1]]
       auto lambda = [&](const areg_t<2> &inds,
                         const cvector_t<data_t> &_mat)->void {
@@ -1726,7 +1726,7 @@ void QubitVector<data_t>::apply_diagonal_matrix(const uint_t qubit,
       apply_lambda(lambda, areg_t<1>({{qubit}}), convert(diag));
       return;
     } 
-    if (diag[0] == (0., 1.)) {
+    if (diag[0] == std::complex<double>(0., 1.)) {
       // [[i, 0], [0, 1]]
       auto lambda = [&](const areg_t<2> &inds,
                         const cvector_t<data_t> &_mat)->void {

--- a/src/transpile/truncate_qubits.hpp
+++ b/src/transpile/truncate_qubits.hpp
@@ -172,7 +172,7 @@ TruncateQubits::generate_mapping(const reg_t& active_qubits,
 
   // Now we need to complete the mapping by adding qubits not in the input space
   // This is required for remapping the noise model.
-  if (!noise.ideal()) {
+  if (!noise.is_ideal()) {
     uint_t unused_qubit = active_qubits.size();
     for (uint_t qubit=0; qubit<circ.num_qubits; qubit++) {
       if (mapping.find(qubit) == mapping.end()) {

--- a/src/transpile/truncate_qubits.hpp
+++ b/src/transpile/truncate_qubits.hpp
@@ -15,6 +15,8 @@
 #ifndef _aer_transpile_truncate_qubits_hpp_
 #define _aer_transpile_truncate_qubits_hpp_
 
+#include <unordered_map>
+
 #include "transpile/circuitopt.hpp"
 
 namespace AER {
@@ -23,10 +25,11 @@ namespace Transpile {
 class TruncateQubits : public CircuitOptimization {
 public:
 
+  using mapping_t = std::unordered_map<uint_t, uint_t>;
+
   void set_config(const json_t &config) override;
 
-  // truncate unnecessary qubits
-  // TODO: truncate noise model as well
+  // Truncate unused qubits
   void optimize_circuit(Circuit& circ,
                         Noise::NoiseModel& noise,
                         const Operations::OpSet &opset,
@@ -39,12 +42,18 @@ private:
   // check this optimization can be applied
   bool can_apply(const Operations::Op& op) const;
 
+  // Generate a list of qubits that are used in the input circuit and noise model
+  reg_t get_active_qubits(const Circuit& circ,
+                          const Noise::NoiseModel& noise) const;
+
   // generate a new mapping. a value of reg_t is original and its index is the new mapping
-  reg_t generate_mapping(const Circuit& circ) const;
+  mapping_t generate_mapping(const reg_t& active_qubits,
+                             const Circuit& circ,
+                             const Noise::NoiseModel& noise) const;
 
   // remap qubits in an operation
-  reg_t remap_qubits(const reg_t &qubits,
-                     const reg_t &mapping) const;
+  void remap_qubits(reg_t &qubits,
+                    const mapping_t &mapping) const;
 
   // show debug info
   bool verbose_ = false;
@@ -57,78 +66,129 @@ void TruncateQubits::set_config(const json_t &config) {
 
   CircuitOptimization::set_config(config);
 
-  if (JSON::check_key("truncate_verbose", config_))
-    JSON::get_value(verbose_, "truncate_verbose", config_);
-
-  if (JSON::check_key("truncate_enable", config_))
-    JSON::get_value(active_, "truncate_enable", config_);
-
-  if (JSON::check_key("initial_statevector", config_))
+  if (JSON::check_key("truncate_verbose", config)) {
+    JSON::get_value(verbose_, "truncate_verbose", config);
+  }
+  if (JSON::check_key("truncate_enable", config)) {
+    JSON::get_value(active_, "truncate_enable", config);
+  }
+  if (JSON::check_key("initial_statevector", config)) {
     active_ = false;
-
+  }
 }
 
 void TruncateQubits::optimize_circuit(Circuit& circ,
                                       Noise::NoiseModel& noise,
                                       const Operations::OpSet &allowed_opset,
                                       OutputData &data) const {
-
+  
+  // Check if circuit operations allow remapping
+  // Remapped circuits must return the same output data as the
+  // original circuit
   if (!active_ || !can_apply(circ))
     return;
 
-  reg_t new_mapping = generate_mapping(circ);
-
-  if (new_mapping.size() == circ.num_qubits)
+  // Get qubits actually used in the circuit
+  // If this is all qubits we don't need to remap
+  reg_t active_qubits = get_active_qubits(circ, noise);
+  if (active_qubits.size() == circ.num_qubits)
     return;
 
+  // Generate the qubit mapping {original_qubit: new_qubit}
+  mapping_t mapping = generate_mapping(active_qubits, circ, noise);
+
+  // Remap circuit operations
   for (Operations::Op& op: circ.ops) {
-    // Remap qubits
-    reg_t new_qubits = remap_qubits(op.qubits, new_mapping);
+    remap_qubits(op.qubits, mapping);
     // Remap regs
-    std::vector<reg_t> new_regs;
-    for (reg_t &reg : op.regs)
-      new_regs.push_back(remap_qubits(reg, new_mapping));
-
-    op.qubits = new_qubits;
-    op.regs = new_regs;
+    for (reg_t &reg : op.regs) {
+      remap_qubits(reg, mapping);
+    }
   }
+  // Update the number of qubits in the circuit 
+  circ.num_qubits = active_qubits.size();
 
-  circ.num_qubits = new_mapping.size();
+  // Remap noise model
+  noise.remap_qubits(mapping);
 
   if (verbose_) {
-    data.add_additional_data("metadata",
-                             json_t::object({{"truncate_verbose", new_mapping}}));
+    json_t metadata;
+    metadata["truncate_qubits"]["active_qubits"] = active_qubits;
+    metadata["truncate_qubits"]["mapping"] = mapping;
+    data.add_additional_data("metadata", metadata);
   }
-
 }
 
-reg_t TruncateQubits::generate_mapping(const Circuit& circ) const {
+reg_t TruncateQubits::get_active_qubits(const Circuit& circ,
+                                        const Noise::NoiseModel& noise) const {
+
   size_t not_used = circ.num_qubits + 1;
-  reg_t mapping = reg_t(circ.num_qubits, not_used);
+  reg_t active_qubits = reg_t(circ.num_qubits, not_used);
 
   for (const Operations::Op& op: circ.ops) {
     for (size_t qubit: op.qubits)
-      mapping[qubit] = qubit;
+      active_qubits[qubit] = qubit;
     for (const reg_t &reg: op.regs)
       for (size_t qubit: reg)
-        mapping[qubit] = qubit;
+        active_qubits[qubit] = qubit;
+    
+    // Add noise model qubits
+    // The label for checking noise is either stored in string_params
+    // or is the op name
+    std::string label = "";
+    if (op.string_params.size() == 1) {
+      label = op.string_params[0];
+    }
+    if (label == "")
+      label = op.name;
+    const auto noise_reg = noise.nonlocal_noise_qubits(label, op.qubits);
+    for (size_t qubit: noise_reg) {
+      // A noise model might have more qubits in it than are in
+      // the original circuit. In this case we only add qubits
+      // up to the number of qubits in the circuit
+      if (qubit < circ.num_qubits)
+        active_qubits[qubit] = qubit;
+    }
   }
 
-  mapping.erase(std::remove(mapping.begin(), mapping.end(), not_used),
-                mapping.end());
+  // Erase unused qubits for the list
+  active_qubits.erase(std::remove(active_qubits.begin(), active_qubits.end(), not_used),
+                active_qubits.end());
+  return active_qubits;
+}
 
+TruncateQubits::mapping_t
+TruncateQubits::generate_mapping(const reg_t& active_qubits, 
+                                 const Circuit& circ,
+                                 const Noise::NoiseModel& noise) const {
+  // Convert to mapping
+  mapping_t mapping;
+  for (const auto & qubit : active_qubits) {
+    size_t new_qubit = std::distance(active_qubits.begin(),
+                                     find(active_qubits.begin(),
+                                     active_qubits.end(), qubit));
+    mapping[qubit] = new_qubit;
+  }
+
+  // Now we need to complete the mapping by adding qubits not in the input space
+  // This is required for remapping the noise model.
+  if (!noise.ideal()) {
+    uint_t unused_qubit = active_qubits.size();
+    for (uint_t qubit=0; qubit<circ.num_qubits; qubit++) {
+      if (mapping.find(qubit) == mapping.end()) {
+        mapping[qubit] = unused_qubit;
+        unused_qubit++; // increment unused qubit position
+      }
+    }
+  }
   return mapping;
 }
 
-reg_t TruncateQubits::remap_qubits(const reg_t &qubits,
-                                   const reg_t &mapping) const {
-  reg_t new_qubits;
-  for (const size_t qubit: qubits) {
-    size_t new_qubit = std::distance(mapping.begin(),
-                                     find(mapping.begin(), mapping.end(), qubit));
-    new_qubits.push_back(new_qubit);
+
+void TruncateQubits::remap_qubits(reg_t& qubits, const mapping_t &mapping) const {
+  for (size_t j=0; j<qubits.size(); j++) {
+   qubits[j] = mapping.at(qubits[j]);
   }
-  return new_qubits;
 }
 
 bool TruncateQubits::can_apply(const Circuit& circ) const {

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -58,7 +58,7 @@ class QasmFusionTests:
             return noise
 
     def check_mat_exist(self, result):
-        fusion_gates = result.as_dict(
+        fusion_gates = result.to_dict(
         )['results'][0]['metadata']['fusion_verbose']
         for gate in fusion_gates:
             print(gate)
@@ -80,12 +80,12 @@ class QasmFusionTests:
         self.is_completed(result)
 
         self.assertTrue(
-            'results' in result.as_dict(), msg="results must exist in result")
+            'results' in result.to_dict(), msg="results must exist in result")
         self.assertTrue(
-            'metadata' in result.as_dict()['results'][0],
+            'metadata' in result.to_dict()['results'][0],
             msg="metadata must exist in results[0]")
         self.assertTrue(
-            'fusion_verbose' not in result.as_dict()['results'][0]['metadata'],
+            'fusion_verbose' not in result.to_dict()['results'][0]['metadata'],
             msg="fusion must not work for clifford")
 
     def test_noise_fusion(self):
@@ -113,12 +113,12 @@ class QasmFusionTests:
         self.is_completed(result)
 
         self.assertTrue(
-            'results' in result.as_dict(), msg="results must exist in result")
+            'results' in result.to_dict(), msg="results must exist in result")
         self.assertTrue(
-            'metadata' in result.as_dict()['results'][0],
+            'metadata' in result.to_dict()['results'][0],
             msg="metadata must exist in results[0]")
         self.assertTrue(
-            'fusion_verbose' in result.as_dict()['results'][0]['metadata'],
+            'fusion_verbose' in result.to_dict()['results'][0]['metadata'],
             msg="verbose must work with noise")
 
     def test_fusion_verbose(self):
@@ -140,13 +140,13 @@ class QasmFusionTests:
             backend_options=backend_options).result()
         self.is_completed(result_verbose)
         self.assertTrue(
-            'results' in result_verbose.as_dict(),
+            'results' in result_verbose.to_dict(),
             msg="results must exist in result")
         self.assertTrue(
-            'metadata' in result_verbose.as_dict()['results'][0],
+            'metadata' in result_verbose.to_dict()['results'][0],
             msg="metadata must exist in results[0]")
         self.assertTrue(
-            'fusion_verbose' in result_verbose.as_dict()['results'][0]
+            'fusion_verbose' in result_verbose.to_dict()['results'][0]
             ['metadata'],
             msg="fusion must work for satevector")
 
@@ -162,13 +162,13 @@ class QasmFusionTests:
             backend_options=backend_options).result()
         self.is_completed(result_nonverbose)
         self.assertTrue(
-            'results' in result_nonverbose.as_dict(),
+            'results' in result_nonverbose.to_dict(),
             msg="results must exist in result")
         self.assertTrue(
-            'metadata' in result_nonverbose.as_dict()['results'][0],
+            'metadata' in result_nonverbose.to_dict()['results'][0],
             msg="metadata must exist in results[0]")
         self.assertTrue(
-            'fusion_verbose' not in result_nonverbose.as_dict()['results'][0]
+            'fusion_verbose' not in result_nonverbose.to_dict()['results'][0]
             ['metadata'],
             msg="verbose must not work if fusion_verbose is False")
 
@@ -181,13 +181,13 @@ class QasmFusionTests:
             qobj, backend_options=backend_options).result()
         self.is_completed(result_default)
         self.assertTrue(
-            'results' in result_default.as_dict(),
+            'results' in result_default.to_dict(),
             msg="results must exist in result")
         self.assertTrue(
-            'metadata' in result_default.as_dict()['results'][0],
+            'metadata' in result_default.to_dict()['results'][0],
             msg="metadata must exist in results[0]")
         self.assertTrue(
-            'fusion_verbose' not in result_default.as_dict()['results'][0]
+            'fusion_verbose' not in result_default.to_dict()['results'][0]
             ['metadata'],
             msg="verbose must not work if fusion_verbose is False")
 
@@ -209,13 +209,13 @@ class QasmFusionTests:
             backend_options=backend_options).result()
         self.is_completed(result_verbose)
         self.assertTrue(
-            'results' in result_verbose.as_dict(),
+            'results' in result_verbose.to_dict(),
             msg="results must exist in result")
         self.assertTrue(
-            'metadata' in result_verbose.as_dict()['results'][0],
+            'metadata' in result_verbose.to_dict()['results'][0],
             msg="metadata must exist in results[0]")
         self.assertTrue(
-            'fusion_verbose' in result_verbose.as_dict()['results'][0]
+            'fusion_verbose' in result_verbose.to_dict()['results'][0]
             ['metadata'],
             msg="fusion must work for satevector")
 
@@ -231,13 +231,13 @@ class QasmFusionTests:
             backend_options=backend_options).result()
         self.is_completed(result_disabled)
         self.assertTrue(
-            'results' in result_disabled.as_dict(),
+            'results' in result_disabled.to_dict(),
             msg="results must exist in result")
         self.assertTrue(
-            'metadata' in result_disabled.as_dict()['results'][0],
+            'metadata' in result_disabled.to_dict()['results'][0],
             msg="metadata must exist in results[0]")
         self.assertTrue(
-            'fusion_verbose' not in result_disabled.as_dict()['results'][0]
+            'fusion_verbose' not in result_disabled.to_dict()['results'][0]
             ['metadata'],
             msg="fusion must not work with fusion_enable is False")
 
@@ -248,13 +248,13 @@ class QasmFusionTests:
             qobj, backend_options=backend_options).result()
         self.is_completed(result_default)
         self.assertTrue(
-            'results' in result_default.as_dict(),
+            'results' in result_default.to_dict(),
             msg="results must exist in result")
         self.assertTrue(
-            'metadata' in result_default.as_dict()['results'][0],
+            'metadata' in result_default.to_dict()['results'][0],
             msg="metadata must exist in results[0]")
         self.assertTrue(
-            'fusion_verbose' not in result_default.as_dict()['results'][0]
+            'fusion_verbose' not in result_default.to_dict()['results'][0]
             ['metadata'],
             msg="fusion must not work by default for satevector")
 

--- a/test/terra/backends/qasm_simulator/qasm_truncate.py
+++ b/test/terra/backends/qasm_simulator/qasm_truncate.py
@@ -142,6 +142,67 @@ class QasmQubitsTruncateTests:
         return BackendProperties.from_dict(properties)
 
     
+    def test_truncate_ideal_sparse_circuit(self):
+        """Test qubit truncation for large circuit with unused qubits."""
+        
+        # Circuit that uses just 2-qubits
+        circuit = QuantumCircuit(50, 2)
+        circuit.x(10)
+        circuit.x(20)
+        circuit.measure(10, 0)
+        circuit.measure(20, 1)
+
+
+        qasm_sim = Aer.get_backend('qasm_simulator')
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options["truncate_verbose"] = True
+        backend_options['optimize_ideal_threshold'] = 1
+        backend_options['optimize_noise_threshold'] = 1
+
+        result = execute(circuit, 
+                         qasm_sim, 
+                         shots=100,
+                         backend_options=backend_options).result()
+        metadata = result.results[0].metadata
+        self.assertTrue('truncate_qubits' in metadata, msg="truncate_qubits must work.")
+        active_qubits = sorted(metadata['truncate_qubits'].get('active_qubits', []))
+        mapping = sorted(metadata['truncate_qubits'].get('mapping', []))
+        self.assertEqual(active_qubits, [10, 20])
+        self.assertIn(mapping, [[[10, 0], [20, 1]], [[10, 1], [20, 0]]])
+
+    def test_truncate_nonlocal_noise(self):
+        """Test qubit truncation with non-local noise."""
+        
+        # Circuit that uses just 2-qubits
+        circuit = QuantumCircuit(10, 1)
+        circuit.x(5)
+        circuit.measure(5, 0)
+
+        # Add non-local 2-qubit depolarizing error
+        # that acts on qubits [4, 6] when X applied to qubit 5
+        noise_model = NoiseModel()
+        error = depolarizing_error(0.1, 2)
+        noise_model.add_nonlocal_quantum_error(error, ['x'], [5], [4, 6])
+
+        qasm_sim = Aer.get_backend('qasm_simulator')
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options["truncate_verbose"] = True
+        backend_options['optimize_ideal_threshold'] = 1
+        backend_options['optimize_noise_threshold'] = 1
+
+        result = execute(circuit, 
+                         qasm_sim, 
+                         shots=100,
+                         noise_model=noise_model,
+                         backend_options=backend_options).result()
+        metadata = result.results[0].metadata
+        self.assertTrue('truncate_qubits' in metadata, msg="truncate_qubits must work.")
+        active_qubits = sorted(metadata['truncate_qubits'].get('active_qubits', []))
+        mapping = metadata['truncate_qubits'].get('mapping', [])
+        active_remapped = sorted([i[1] for i in mapping if i[0] in active_qubits])
+        self.assertEqual(active_qubits, [4, 5, 6])
+        self.assertEqual(active_remapped, [0, 1, 2])
+
     def test_truncate(self):
         """Test truncation with noise model option"""
         circuit = self.create_circuit_for_truncate()
@@ -160,7 +221,7 @@ class QasmQubitsTruncateTests:
                             backend_options=backend_options).result()
                             
         self.assertTrue('truncate_qubits' in result.to_dict()['results'][0]['metadata'], msg="truncate_qubits must work.")
-           
+
     def test_no_truncate(self):
         """Test truncation with noise model option"""
         circuit = self.create_circuit_for_truncate()

--- a/test/terra/backends/qasm_simulator/qasm_truncate.py
+++ b/test/terra/backends/qasm_simulator/qasm_truncate.py
@@ -159,7 +159,7 @@ class QasmQubitsTruncateTests:
                             coupling_map=[[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 0]], # 10-qubit device
                             backend_options=backend_options).result()
                             
-        self.assertTrue('truncate_verbose' in result.to_dict()['results'][0]['metadata'], msg="truncate_verbose must work.")
+        self.assertTrue('truncate_qubits' in result.to_dict()['results'][0]['metadata'], msg="truncate_qubits must work.")
            
     def test_no_truncate(self):
         """Test truncation with noise model option"""
@@ -178,7 +178,7 @@ class QasmQubitsTruncateTests:
                             coupling_map=[[1, 0], [1, 2], [1, 3], [2, 0], [2, 1], [2, 3], [3, 0], [3, 1], [3, 2]], # 4-qubit device
                             backend_options=backend_options).result()
                             
-        self.assertFalse('truncate_verbose' in result.to_dict()['results'][0]['metadata'], msg="truncate_verbose must work.")
+        self.assertFalse('truncate_qubits' in result.to_dict()['results'][0]['metadata'], msg="truncate_qubits must work.")
 
     
     def test_truncate_disable(self):
@@ -199,5 +199,5 @@ class QasmQubitsTruncateTests:
                             coupling_map=[[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 9], [9, 0]], # 10-qubit device
                             backend_options=backend_options).result()
                             
-        self.assertFalse('truncate_verbose' in result.to_dict()['results'][0]['metadata'], msg="truncate_verbose must not work.")
+        self.assertFalse('truncate_qubits' in result.to_dict()['results'][0]['metadata'], msg="truncate_qubits must not work.")
      

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -160,7 +160,7 @@ class TestQuantumError(common.QiskitAerTestCase):
         Ay = np.sqrt(0.25) * standard_gate_unitary('y')
         Az = np.sqrt(0.25) * standard_gate_unitary('z')
         error_dict = QuantumError([Ai, Ax, Ay, Az],
-                                  standard_gates=True).as_dict()
+                                  standard_gates=True).to_dict()
         self.assertEqual(error_dict['type'], 'qerror')
         self.assertAlmostEqual(
             np.linalg.norm(
@@ -178,7 +178,7 @@ class TestQuantumError(common.QiskitAerTestCase):
         Ay = np.sqrt(0.25) * standard_gate_unitary('y')
         Az = np.sqrt(0.25) * standard_gate_unitary('z')
         error_dict = QuantumError([Ai, Ax, Ay, Az],
-                                  standard_gates=False).as_dict()
+                                  standard_gates=False).to_dict()
         self.assertEqual(error_dict['type'], 'qerror')
         self.assertAlmostEqual(
             np.linalg.norm(

--- a/test/terra/noise/test_readout_error.py
+++ b/test/terra/noise/test_readout_error.py
@@ -81,7 +81,7 @@ class TestReadoutError(common.QiskitAerTestCase):
         roerror = ReadoutError(probs)
         self.assertEqual(roerror.number_of_qubits, 1)
         self.assertEqual(roerror.probabilities.tolist(), probs)
-        self.assertEqual(roerror.as_dict(), roerror_dict)
+        self.assertEqual(roerror.to_dict(), roerror_dict)
 
     def test_2qubit(self):
         """Test 2-qubit readout error"""
@@ -96,7 +96,7 @@ class TestReadoutError(common.QiskitAerTestCase):
         roerror = ReadoutError(probs)
         self.assertEqual(roerror.number_of_qubits, 2)
         self.assertEqual(roerror.probabilities.tolist(), probs)
-        self.assertEqual(roerror.as_dict(), roerror_dict)
+        self.assertEqual(roerror.to_dict(), roerror_dict)
 
     def test_tensor(self):
         """Test tensor of two readout errors."""
@@ -114,7 +114,7 @@ class TestReadoutError(common.QiskitAerTestCase):
 
         self.assertEqual(error.number_of_qubits, 2)
         self.assertEqual(error.probabilities.tolist(), probs)
-        self.assertEqual(error.as_dict(), error_dict)
+        self.assertEqual(error.to_dict(), error_dict)
 
     def test_expand(self):
         """Test expand of two readout errors."""
@@ -132,7 +132,7 @@ class TestReadoutError(common.QiskitAerTestCase):
 
         self.assertEqual(error.number_of_qubits, 2)
         self.assertEqual(error.probabilities.tolist(), probs)
-        self.assertEqual(error.as_dict(), error_dict)
+        self.assertEqual(error.to_dict(), error_dict)
 
     def test_compose(self):
         """Test compose of two readout errors."""
@@ -150,7 +150,7 @@ class TestReadoutError(common.QiskitAerTestCase):
 
         self.assertEqual(error.number_of_qubits, 1)
         self.assertEqual(error.probabilities.tolist(), probs)
-        self.assertEqual(error.as_dict(), error_dict)
+        self.assertEqual(error.to_dict(), error_dict)
 
     def test_compose_front(self):
         """Test front compose of two readout errors."""
@@ -168,7 +168,7 @@ class TestReadoutError(common.QiskitAerTestCase):
 
         self.assertEqual(error.number_of_qubits, 1)
         self.assertEqual(error.probabilities.tolist(), probs)
-        self.assertEqual(error.as_dict(), error_dict)
+        self.assertEqual(error.to_dict(), error_dict)
 
     def test_equal(self):
         """Test two readout errors are equal"""

--- a/test/terra/noise/test_standard_errors.py
+++ b/test/terra/noise/test_standard_errors.py
@@ -85,7 +85,7 @@ class TestNoise(common.QiskitAerTestCase):
         unitary = np.diag([1, -1, 1, -1])
         error = coherent_unitary_error(unitary)
         ref = mixed_unitary_error([(unitary, 1)])
-        self.assertEqual(error.as_dict(), ref.as_dict())
+        self.assertEqual(error.to_dict(), ref.to_dict())
 
     def test_pauli_error_raise_invalid(self):
         """Test exception for invalid Pauli string"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds a remap qubits function to C++ `NoiseModel` class
* Updates the truncate qubit optimization pass to remap the noise model for the given  truncation
* Applies this optimization in the Controller class before calculating memory requirements for parallelization.

Closes #285, #218 

### Details and comments

