### PR TITLE
Do not limit the MPS simulator by the number of qubits

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -39,12 +39,13 @@ class QasmSimulator(AerBackend):
         ------------------------
         * "method" (str): Set the simulation method. Allowed values are:
             * "statevector": Uses a dense statevector simulation.
-            * "stabilizer": uses a Clifford stabilizer state simulator that
+            * "stabilizer": Uses a Clifford stabilizer state simulator that
             is only valid for Clifford circuits and noise models.
             * "extended_stabilizer": Uses an approximate simulator that
             decomposes circuits into stabilizer state terms, the number of
             which grows with the number of non-Clifford gates.
-            * "automatic": automatically run on stabilizer simulator if
+            * "tensor network": Uses a Matrix Product State (MPS) simulator.
+            * "automatic": Automatically run on stabilizer simulator if
             the circuit and noise model supports it. If there is enough
             available memory, uses the statevector method. Otherwise, uses
             the extended_stabilizer method (Default: "automatic").
@@ -230,6 +231,10 @@ class QasmSimulator(AerBackend):
                 logger.warning(
                     'No measurements in circuit "%s": '
                     'count data will return all zeros.', name)
+
+            if method == 'tensor_network':
+                return
+
             # Check qubits for statevector simulation
             if not clifford and method != "extended_stabilizer":
                 n_qubits = experiment.config.n_qubits


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When I try to run the MPS simulator with 40 qubits, I receive an error message stating that it exceeds the memory capability of my machine. The check that triggers the error assumes that I run the state vector simulator. This pull request fixes this.

### Details and comments

Strangely, @merav-aharoni told me that she is able to run the MPS simulator with hundreds of qubits without encountering this error.
