### PR TITLE
Enable automatic density matrix method in QasmSimulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,14 @@ Added
 -   Add "validation_threshold" config parameter to Aer backends (\# 290)
 -   Added support for apply_measure in tensor_network_state. Also changed 
     sample_measure to use apply_measure (\#299)
+-   Added density matrix simulation method to QasmSimulator (\# 295, \# 253)
 
 
-- Noise model inserter module
+- Noise model inserter module (\# 239)
 
 Changed
 -------
-
+-   Added density matrix method to automatic QasmSimulator methods (\# 316)
 
 Removed
 -------

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -171,7 +171,7 @@ protected:
   // Otherwise return false. 
   // If throw_except is true an exception will be thrown directly.
   template <class state_t>
-  bool validate_memory_requirements(state_t &state,
+  bool validate_memory_requirements(const state_t &state,
                                     const Circuit &circ,
                                     bool throw_except = false) const;
 
@@ -430,9 +430,9 @@ bool Controller::validate_state(const state_t &state,
 }
 
 template <class state_t>
-bool Controller::validate_memory_requirements(state_t &state,
-                                  const Circuit &circ,
-                                  bool throw_except) const {
+bool Controller::validate_memory_requirements(const state_t &state,
+                                              const Circuit &circ,
+                                              bool throw_except) const {
   if (max_memory_mb_ == 0)
     return true;
 

--- a/src/base/state.hpp
+++ b/src/base/state.hpp
@@ -95,7 +95,8 @@ public:
   // Return an estimate of the required memory for implementing the
   // specified sequence of operations on a `num_qubit` sized State.
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops) = 0;
+                                    const std::vector<Operations::Op> &ops)
+                                    const = 0;
 
   //-----------------------------------------------------------------------
   // Optional: Load config settings

--- a/src/simulators/densitymatrix/densitymatrix_state.hpp
+++ b/src/simulators/densitymatrix/densitymatrix_state.hpp
@@ -108,7 +108,8 @@ public:
   // For this state the memory is indepdentent of the number of ops
   // and is approximately 16 * 1 << num_qubits bytes
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops) override;
+                                    const std::vector<Operations::Op> &ops)
+                                    const override;
 
   // Load the threshold for applying OpenMP parallelization
   // if the controller/engine allows threads for it
@@ -354,7 +355,8 @@ void State<densmat_t>::initialize_omp() {
 
 template <class densmat_t>
 size_t State<densmat_t>::required_memory_mb(uint_t num_qubits,
-                                            const std::vector<Operations::Op> &ops) {
+                                            const std::vector<Operations::Op> &ops)
+                                            const {
   // An n-qubit state vector as 2^n complex doubles
   // where each complex double is 16 bytes
   (void)ops; // avoid unused variable compiler warning

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -87,7 +87,8 @@ public:
   virtual void initialize_qreg(uint_t num_qubits, const chstate_t &state) override;
 
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops) override;
+                                    const std::vector<Operations::Op> &ops)
+                                    const override;
 
   virtual void set_config(const json_t &config) override;
 
@@ -785,7 +786,8 @@ void State::compute_extent(const Operations::Op &op, double &xi) const
 }
 
 size_t State::required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops)
+                                 const std::vector<Operations::Op> &ops)
+                                 const
 {
   size_t required_chi = compute_chi(ops);
   // 5 vectors of num_qubits*8byte words

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -95,7 +95,8 @@ public:
   // TODO: currently returns 0
   // Returns the required memory for storing an n-qubit state in megabytes.
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops) override;
+                                    const std::vector<Operations::Op> &ops)
+                                    const override;
 
   // Load any settings for the State class from a config JSON
   virtual void set_config(const json_t &config) override;
@@ -238,7 +239,8 @@ void State::initialize_qreg(uint_t num_qubits,
 //-------------------------------------------------------------------------
 
 size_t State::required_memory_mb(uint_t num_qubits,
-                                 const std::vector<Operations::Op> &ops) {
+                                 const std::vector<Operations::Op> &ops)
+                                 const  {
   (void)ops; // avoid unused variable compiler warning
   // The Clifford object requires very little memory.
   // A Pauli vector consists of 2 binary vectors each with

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -119,7 +119,8 @@ public:
   // For this state the memory is indepdentent of the number of ops
   // and is approximately 16 * 1 << num_qubits bytes
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops) override;
+                                    const std::vector<Operations::Op> &ops)
+                                    const override;
 
   // Load the threshold for applying OpenMP parallelization
   // if the controller/engine allows threads for it
@@ -391,7 +392,8 @@ void State<statevec_t>::initialize_omp() {
 
 template <class statevec_t>
 size_t State<statevec_t>::required_memory_mb(uint_t num_qubits,
-                                             const std::vector<Operations::Op> &ops) {
+                                             const std::vector<Operations::Op> &ops)
+                                             const {
   // An n-qubit state vector as 2^n complex doubles
   // where each complex double is 16 bytes
   (void)ops; // avoid unused variable compiler warning

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -98,7 +98,8 @@ public:
   // For this state the memory is indepdentent of the number of ops
   // and is approximately 16 * 1 << 4 * num_qubits bytes
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops) override;
+                                    const std::vector<Operations::Op> &ops)
+                                    const override;
 
   // Load the threshold for applying OpenMP parallelization
   // if the controller/engine allows threads for it
@@ -251,7 +252,8 @@ void State<data_t>::apply_ops(const std::vector<Operations::Op> &ops,
 
 template <class data_t>
 size_t State<data_t>::required_memory_mb(uint_t num_qubits,
-                                 const std::vector<Operations::Op> &ops) {
+                                 const std::vector<Operations::Op> &ops)
+                                 const {
   // An n-qubit unitary as 2^4n complex doubles
   // where each complex double is 16 bytes
   (void)ops; // avoid unused variable compiler warning

--- a/src/simulators/tensor_network/tensor_network_state.hpp
+++ b/src/simulators/tensor_network/tensor_network_state.hpp
@@ -127,7 +127,8 @@ public:
   // For this state the memory is indepdentent of the number of ops
   // and is approximately 16 * 1 << num_qubits bytes
     virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops) override;
+                                    const std::vector<Operations::Op> &ops)
+                                    const override;
 
   // Load the threshold for applying OpenMP parallelization
   // if the controller/engine allows threads for it
@@ -370,7 +371,7 @@ void State::initialize_omp() {
 }
 
 size_t State::required_memory_mb(uint_t num_qubits,
-			      const std::vector<Operations::Op> &ops) {
+			      const std::vector<Operations::Op> &ops) const {
     // for each qubit we have a tensor structure. 
     // Initially, each tensor contains 2 matrices with a single complex double
     // Depending on the number of 2-qubit gates, 

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -94,7 +94,8 @@ public:
   // For this state the memory is indepdentent of the number of ops
   // and is approximately 16 * 1 << 2 * num_qubits bytes
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops) override;
+                                    const std::vector<Operations::Op> &ops)
+                                    const override;
 
   // Load the threshold for applying OpenMP parallelization
   // if the controller/engine allows threads for it
@@ -236,7 +237,8 @@ void State<data_t>::apply_ops(const std::vector<Operations::Op> &ops,
 
 template <class data_t>
 size_t State<data_t>::required_memory_mb(uint_t num_qubits,
-                                 const std::vector<Operations::Op> &ops) {
+                                 const std::vector<Operations::Op> &ops)
+                                 const {
   // An n-qubit unitary as 2^2n complex doubles
   // where each complex double is 16 bytes
   (void)ops; // avoid unused variable compiler warning

--- a/test/terra/backends/qasm_simulator/qasm_method.py
+++ b/test/terra/backends/qasm_simulator/qasm_method.py
@@ -46,12 +46,12 @@ class QasmMethodTests:
                 qobj, backend_options=self.BACKEND_OPTS).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         result = get_result()
         self.is_completed(result)
-        if method == 'statevector':
+        if method != 'automatic':
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         method)
         else:
             self.compare_result_metadata(result, circuits, 'method',
                                          'stabilizer')
@@ -85,12 +85,12 @@ class QasmMethodTests:
                 noise_model=noise_model).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         result = get_result()
         self.is_completed(result)
-        if method == 'statevector':
+        if method != 'automatic':
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         method)
         else:
             self.compare_result_metadata(result, circuits, 'method',
                                          'stabilizer')
@@ -115,13 +115,13 @@ class QasmMethodTests:
                 noise_model=noise_model).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
-        if method == 'statevector':
+        if method != 'automatic':
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         method)
         else:
             self.compare_result_metadata(result, circuits, 'method',
                                          'stabilizer')
@@ -146,14 +146,18 @@ class QasmMethodTests:
                 noise_model=noise_model).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
             self.assertRaises(AerError, get_result)
         else:
             result = get_result()
             self.is_completed(result)
+            if method == 'automatic':
+                target_method = 'density_matrix'
+            else:
+                target_method = method
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         target_method)
 
     def test_backend_method_clifford_circuits_and_kraus_noise(self):
         """Test statevector method is used for Clifford circuit"""
@@ -176,14 +180,18 @@ class QasmMethodTests:
                 noise_model=noise_model).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
             self.assertRaises(AerError, get_result)
         else:
             result = get_result()
             self.is_completed(result)
+            if method == 'automatic':
+                target_method = 'density_matrix'
+            else:
+                target_method = method
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         target_method)
 
     # ---------------------------------------------------------------------
     # Test non-Clifford circuits with clifford and non-clifford noise
@@ -201,14 +209,18 @@ class QasmMethodTests:
                 qobj, backend_options=self.BACKEND_OPTS).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
             self.assertRaises(AerError, get_result)
         else:
             result = get_result()
             self.is_completed(result)
+            if method == 'automatic':
+                target_method = 'statevector'
+            else:
+                target_method = method
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         target_method)
 
     def test_backend_method_nonclifford_circuit_and_reset_noise(self):
         """Test statevector method is used for Clifford circuit"""
@@ -239,14 +251,18 @@ class QasmMethodTests:
                 noise_model=noise_model).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
             self.assertRaises(AerError, get_result)
         else:
             result = get_result()
             self.is_completed(result)
+            if method == 'automatic':
+                target_method = 'density_matrix'
+            else:
+                target_method = method
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         target_method)
 
     def test_backend_method_nonclifford_circuit_and_pauli_noise(self):
         """Test statevector method is used for Clifford circuit"""
@@ -268,14 +284,18 @@ class QasmMethodTests:
                 noise_model=noise_model).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
             self.assertRaises(AerError, get_result)
         else:
             result = get_result()
             self.is_completed(result)
+            if method == 'automatic':
+                target_method = 'density_matrix'
+            else:
+                target_method = method
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         target_method)
 
     def test_backend_method_nonclifford_circuit_and_unitary_noise(self):
         """Test statevector method is used for Clifford circuit"""
@@ -297,14 +317,18 @@ class QasmMethodTests:
                 noise_model=noise_model).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
             self.assertRaises(AerError, get_result)
         else:
             result = get_result()
             self.is_completed(result)
+            if method == 'automatic':
+                target_method = 'density_matrix'
+            else:
+                target_method = method
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         target_method)
 
     def test_backend_method_nonclifford_circuit_and_kraus_noise(self):
         """Test statevector method is used for Clifford circuit"""
@@ -327,11 +351,15 @@ class QasmMethodTests:
                 noise_model=noise_model).result()
 
         # Check simulation method
-        method = self.BACKEND_OPTS.get('method')
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
             self.assertRaises(AerError, get_result)
         else:
             result = get_result()
             self.is_completed(result)
+            if method == 'automatic':
+                target_method = 'density_matrix'
+            else:
+                target_method = method
             self.compare_result_metadata(result, circuits, 'method',
-                                         'statevector')
+                                         target_method)

--- a/test/terra/backends/test_qasm_density_matrix_simulator.py
+++ b/test/terra/backends/test_qasm_density_matrix_simulator.py
@@ -42,10 +42,12 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmReadoutNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
-
+# Other tests
+from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
 
 
 class TestQasmDensityMatrixSimulator(common.QiskitAerTestCase,
+                                     QasmMethodTests,
                                      QasmMeasureTests,
                                      QasmMultiQubitMeasureTests,
                                      QasmResetTests,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This enables the density matrix method to be automatically used by the QasmSimulator

It will be enabled for circuit executions satisfying the following conditions:

1. Circuit has a noise model with quantum noise
1. Circuit has no intermediate measurements
1. The density matrix can fit in the available memory
1. Number of shots > 2 ** num_qubits

The last condition is based on the heuristic that applying a single instruction on a density matrix is approx `2 ** num_qubits` times slower than applying to a statevector due to the larger dimension, so the density matrix method should come out ahead when the number of shots exceeds this difference.

### Details and comments


