### PR TITLE
Delay measure circuit optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Added
 -   Added support for apply_measure in tensor_network_state. Also changed 
     sample_measure to use apply_measure (\#299)
 -   Added density matrix simulation method to QasmSimulator (\# 295, \# 253)
-
+-   Adds delay measure circuit optimization (\# 317)
 
 - Noise model inserter module (\# 239)
 

--- a/src/transpile/delay_measure.hpp
+++ b/src/transpile/delay_measure.hpp
@@ -1,0 +1,133 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_transpile_delay_measure_hpp_
+#define _aer_transpile_delay_measure_hpp_
+
+#include <unordered_map>
+
+#include "transpile/circuitopt.hpp"
+
+namespace AER {
+namespace Transpile {
+
+class DelayMeasure : public CircuitOptimization {
+public:
+
+  // DelayMeasure uses following configuration options
+  // - delay_measure_verbose (bool): if true, output generated gates in metadata (default: false)
+  // - delay_measure_enable (bool): if true, activate optimization (default: true)
+  void set_config(const json_t &config) override;
+
+  // Push back measurements to tail of circuit if no non-measure
+  // instructions follow on the same qubits
+  // This allows measure sampling to be used on more circuits
+  void optimize_circuit(Circuit& circ,
+                        Noise::NoiseModel& noise,
+                        const Operations::OpSet &opset,
+                        OutputData &data) const override;
+
+private:
+  // show debug info
+  bool verbose_ = false;
+
+  // disabled in config
+  bool active_ = true;
+};
+
+void DelayMeasure::set_config(const json_t &config) {
+  CircuitOptimization::set_config(config);
+  JSON::get_value(verbose_, "delay_measure_verbose", config);
+  JSON::get_value(active_, "delay_measure_enable", config);
+}
+
+void DelayMeasure::optimize_circuit(Circuit& circ,
+                                    Noise::NoiseModel& noise,
+                                    const Operations::OpSet &allowed_opset,
+                                    OutputData &data) const {
+  // Pass if we have quantum errors in the noise model
+  if (active_ == false || circ.shots <= 1 || noise.has_quantum_errors())
+    return; 
+
+  // Get position of first measure / readout error in circ
+  auto it = circ.ops.begin();
+  while (it != circ.ops.end()) {
+    const auto type = it->type;
+    if (type == Operations::OpType::measure ||
+        type == Operations::OpType::roerror)
+      break;
+    ++it;
+  }
+  // If there are no measure instructions we don't need to optimize
+  if (it == circ.ops.end())
+    return;
+
+  // Store measure and non measure instructions in the tail
+  // for possible later remapping
+  size_t pos = std::distance(circ.ops.begin(), it);
+  std::vector<Operations::Op> meas_ops;
+  meas_ops.reserve(circ.ops.size() - pos);
+  std::vector<Operations::Op> non_meas_ops;
+  non_meas_ops.reserve(circ.ops.size() - pos);
+
+  // Scan circuit to find position of first measure for all qubits;
+  std::unordered_set<uint_t> meas_qubits;
+  while (it != circ.ops.end()) {
+    // If any operations are conditional we abort
+    if (it->conditional)
+      return;
+    const auto type = it->type;
+    const auto qubits = it->qubits;
+    switch (type) {
+      case Operations::OpType::measure:
+      case Operations::OpType::roerror: {
+        meas_qubits.insert(qubits.begin(), qubits.end());
+        meas_ops.push_back(*it);
+        break;  
+      }
+      case Operations::OpType::snapshot: {
+        return;
+      }
+      default: {
+        for (const auto& qubit : qubits) {
+          if (meas_qubits.find(qubit) != meas_qubits.end()) {
+            return;
+          }
+        }
+        non_meas_ops.push_back(*it);
+      }
+    }
+    ++it;
+  }
+  // Check if there are any non-meas instructions in the tail
+  if (non_meas_ops.empty())
+    return;
+
+  // Now modify the circuit to add meas instructions
+  // after non meas instructions
+  circ.ops.erase(circ.ops.begin() + pos, circ.ops.end());
+  circ.ops.insert(circ.ops.end(), non_meas_ops.begin(), non_meas_ops.end());
+  circ.ops.insert(circ.ops.end(), meas_ops.begin(), meas_ops.end());
+  
+  if (verbose_)
+      data.add_additional_data("metadata",
+                               json_t::object({{"delay_measure_verbose", circ.ops}}));
+}
+
+
+//-------------------------------------------------------------------------
+} // end namespace Transpile
+} // end namespace AER
+//-------------------------------------------------------------------------
+#endif

--- a/test/terra/backends/qasm_simulator/qasm_delay_measure.py
+++ b/test/terra/backends/qasm_simulator/qasm_delay_measure.py
@@ -1,0 +1,126 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+QasmSimulator Integration Tests
+"""
+
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.compiler import assemble, transpile
+from qiskit.providers.aer import QasmSimulator
+from qiskit.providers.aer.noise import NoiseModel
+from qiskit.providers.aer.noise.errors import ReadoutError, depolarizing_error
+from test.benchmark.tools import quantum_volume_circuit, qft_circuit
+
+class QasmDelayMeasureTests:
+    """QasmSimulator delay measure sampling optimization tests."""
+
+    SIMULATOR = QasmSimulator()
+    BACKEND_OPTS = {}
+
+
+    def delay_measure_circuit(self):
+        """Test circuit that allows measure delay optimization"""
+        qr = QuantumRegister(2, 'qr')
+        cr = ClassicalRegister(2, 'cr')
+        circuit = QuantumCircuit(qr, cr)
+        circuit.x(0)
+        circuit.measure(0, 0)
+        circuit.barrier([0, 1])
+        circuit.x(1)
+        circuit.measure(0, 1)
+        return circuit
+
+    def test_delay_measure_enable(self):
+        """Test measure sampling works with delay measure optimization"""
+
+        # Circuit that allows delay measure
+        circuit = self.delay_measure_circuit()
+        shots = 100
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed_simulator=1)
+
+        # Delay measure default 
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options['optimize_ideal_threshold'] = 0
+        result = self.SIMULATOR.run(
+            qobj,
+            backend_options=backend_options).result()
+        self.is_completed(result)
+        metadata = result.results[0].metadata
+        self.assertTrue(metadata.get('measure_sampling'))
+
+        # Delay measure enabled
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options['delay_measure_enable'] = True
+        backend_options['optimize_ideal_threshold'] = 0
+        result = self.SIMULATOR.run(
+            qobj,
+            backend_options=backend_options).result()
+        self.is_completed(result)
+        metadata = result.results[0].metadata
+        self.assertTrue(metadata.get('measure_sampling'))
+
+        # Delay measure disabled
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options['delay_measure_enable'] = False
+        backend_options['optimize_ideal_threshold'] = 0
+        result = self.SIMULATOR.run(
+            qobj,
+            backend_options=backend_options).result()
+        self.is_completed(result)
+        metadata = result.results[0].metadata
+        self.assertFalse(metadata.get('measure_sampling'))
+
+    def test_delay_measure_verbose(self):
+        """Test delay measure with verbose option"""
+        circuit = self.delay_measure_circuit()
+        shots = 100
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed_simulator=1)
+
+        # Delay measure verbose enabled
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options['delay_measure_enable'] = True
+        backend_options['delay_measure_verbose'] = True
+        backend_options['optimize_ideal_threshold'] = 0
+
+        result = self.SIMULATOR.run(
+            qobj,
+            backend_options=backend_options).result()
+        self.is_completed(result)
+        metadata = result.results[0].metadata
+        self.assertTrue('delay_measure_verbose' in metadata)
+
+        # Delay measure verbose disabled
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options['delay_measure_enable'] = True
+        backend_options['delay_measure_verbose'] = False
+        backend_options['optimize_ideal_threshold'] = 0
+
+        result = self.SIMULATOR.run(
+            qobj,
+            backend_options=backend_options).result()
+        self.is_completed(result)
+        metadata = result.results[0].metadata
+        self.assertTrue('delay_measure_verbose' in metadata)
+
+        # Delay measure verbose default
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options['delay_measure_enable'] = True
+        backend_options['optimize_ideal_threshold'] = 1
+        backend_options['optimize_noise_threshold'] = 1
+
+        result = self.SIMULATOR.run(
+            qobj,
+            backend_options=backend_options).result()
+        self.is_completed(result)
+        metadata = result.results[0].metadata
+        self.assertTrue('delay_measure_verbose' in metadata)

--- a/test/terra/backends/test_qasm_simulator.py
+++ b/test/terra/backends/test_qasm_simulator.py
@@ -44,6 +44,7 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
 from test.terra.backends.qasm_simulator.qasm_thread_management import QasmThreadManagementTests
 from test.terra.backends.qasm_simulator.qasm_fusion import QasmFusionTests
+from test.terra.backends.qasm_simulator.qasm_delay_measure import QasmDelayMeasureTests
 from test.terra.backends.qasm_simulator.qasm_truncate import QasmQubitsTruncateTests
 from test.terra.backends.qasm_simulator.qasm_basics import QasmBasicsTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Follow on from #316 

This adds a circuit optimization pass that pushes measurements to the end of a circuit if no conditional operations, or other operations on the already measured qubits follow.

This is needed for measure sampling to work with the density matrix simulator when there are quantum errors on measure instructions.

### Details and comments


