### PR TITLE
Changed name of MPS simulation method to matrix_product_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Fixed
 
 - Added support for multiplication by coeff in tensor_network_state expectation value snapshots (PR \#294)
 
+- Change name of qasm simulation method from tensor_network to matrix_product_state (\#320)
+
 
 [0.2.3](https://github.com/Qiskit/qiskit-aer/compare/0.2.2...0.2.3) - 2019-07-11
 ===============================================================================

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -43,7 +43,7 @@ class QasmSimulator(AerBackend):
             * "extended_stabilizer": Uses an approximate simulator that
             decomposes circuits into stabilizer state terms, the number of
             which grows with the number of non-Clifford gates.
-            * "tensor network": Uses a Matrix Product State (MPS) simulator.
+            * "matrix_product_state": Uses a Matrix Product State (MPS) simulator.
             * "automatic": Automatically run on stabilizer simulator if
             the circuit and noise model supports it. If there is enough
             available memory, uses the statevector method. Otherwise, uses

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -137,7 +137,7 @@ protected:
     density_matrix,
     stabilizer,
     extended_stabilizer,
-    tensor_network
+    matrix_product_state
   };
 
   // Simulation precision
@@ -309,9 +309,9 @@ void QasmController::set_config(const json_t &config) {
     else if (method == "extended_stabilizer") {
       simulation_method_ = Method::extended_stabilizer;
     }
-    else if (method == "tensor_network") 
+    else if (method == "matrix_product_state") 
     {
-      simulation_method_ = Method::tensor_network;
+      simulation_method_ = Method::matrix_product_state;
     }
     else if (method != "automatic") {
       throw std::runtime_error(std::string("QasmController: Invalid simulation method (") +
@@ -442,15 +442,14 @@ OutputData QasmController::run_circuit(const Circuit &circ,
                                                            CHSimulator::Runner(),
                                                            Method::extended_stabilizer);
 
-    case Method::tensor_network:
-      // TODO: Tensor network doesn't yet support custom state initialization
+    case Method::matrix_product_state:
       return run_circuit_helper<TensorNetworkState::State>(circ,
                                                            noise,
                                                            config,
                                                            shots,
                                                            rng_seed,
                                                            TensorNetworkState::MPS(),
-                                                           Method::tensor_network);
+                                                           Method::matrix_product_state);
 
     default:
       throw std::runtime_error("QasmController:Invalid simulation method");
@@ -483,10 +482,10 @@ QasmController::simulation_method(const Circuit &circ,
         validate_state(ExtendedStabilizer::State(), circ, noise_model, true);
       return Method::extended_stabilizer;
     }
-    case Method::tensor_network: {
+    case Method::matrix_product_state: {
       if (validate)
         validate_state(TensorNetworkState::State(), circ, noise_model, true);
-      return Method::tensor_network;
+      return Method::matrix_product_state;
     }
     case Method::automatic: {
       // If circuit and noise model are Clifford run on Stabilizer simulator
@@ -559,7 +558,7 @@ size_t QasmController::required_memory_mb(const Circuit& circ,
       ExtendedStabilizer::State state;
       return state.required_memory_mb(circ.num_qubits, circ.ops);
     }
-    case Method::tensor_network: {
+    case Method::matrix_product_state: {
       TensorNetworkState::State state;
       return state.required_memory_mb(circ.num_qubits, circ.ops);
     }
@@ -577,7 +576,7 @@ void QasmController::set_parallelization_circuit(const Circuit& circ,
   const auto method = simulation_method(circ, noise_model, false);
   switch (method) {
     case Method::statevector:
-    case Method::tensor_network: {
+    case Method::matrix_product_state: {
       if ((noise_model.is_ideal() || !noise_model.has_quantum_errors()) &&
           check_measure_sampling_opt(circ, Method::statevector).first) {
         parallel_shots_ = 1;

--- a/test/terra/backends/qasm_simulator/matrix_product_state_measure.py
+++ b/test/terra/backends/qasm_simulator/matrix_product_state_measure.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """
-Tensor Network Integration Tests
+Matrix product state integration tests
 This set of tests is copied from qasm_measure.py, but without some
 functionality that has not been supported yet (specifically the 'iden'
 operation).
@@ -20,8 +20,8 @@ from test.terra.reference import ref_measure
 from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
 
-class QasmTensorNetworkMeasureTests:
-    """QasmSimulator tensor_network measure tests."""
+class QasmMatrixProductStateMeasureTests:
+    """QasmSimulator matrix_product_state measure tests."""
 
     SIMULATOR = QasmSimulator()
     BACKEND_OPTS = {}

--- a/test/terra/backends/qasm_simulator/matrix_product_state_method.py
+++ b/test/terra/backends/qasm_simulator/matrix_product_state_method.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """
-Tensor Network Integration Tests
+Matrix product state integration tests
 This set of tests runs all the circuits from test/terra/references/: ref_1q_clifford and ref_2q_clifford,
 with the exception of those with the multiplexer gate which is not supported yet.
 """
@@ -28,13 +28,13 @@ from qiskit.providers.aer import QasmSimulator
 
 logger = logging.getLogger(__name__)
 
-class QasmTensorNetworkMethodTests:
-    """QasmSimulator tensor_network method tests."""
+class QasmMatrixProductStateMethodTests:
+    """QasmSimulator matrix_product_state method tests."""
 
-    BACKEND_OPTS = {"method": "tensor_network"}
+    BACKEND_OPTS = {"method": "matrix_product_state"}
     
     def test_method_deterministic_without_sampling(self):
-        """TestTensorNetwork method with deterministic counts without sampling"""
+        """Test matrix product state method with deterministic counts without sampling"""
         deterministic_tests = [(ref_1q_clifford.h_gate_circuits_deterministic, ref_1q_clifford.h_gate_counts_deterministic),
              (ref_1q_clifford.x_gate_circuits_deterministic, ref_1q_clifford.x_gate_counts_deterministic),
              (ref_1q_clifford.z_gate_circuits_deterministic, ref_1q_clifford.z_gate_counts_deterministic),

--- a/test/terra/backends/test_qasm_matrix_product_state.py
+++ b/test/terra/backends/test_qasm_matrix_product_state.py
@@ -11,20 +11,20 @@
 # that they have been altered from the originals.
 
 """
-Tensor Network Integration Tests
+Matrix Product State Integration Tests
 """
 
 import unittest
 from test.terra import common
-from test.terra.backends.qasm_simulator.tensor_network_method import QasmTensorNetworkMethodTests
-from test.terra.backends.qasm_simulator.tensor_network_measure import QasmTensorNetworkMeasureTests
+from test.terra.backends.qasm_simulator.matrix_product_state_method import QasmMatrixProductStateMethodTests
+from test.terra.backends.qasm_simulator.matrix_product_state_measure import QasmMatrixProductStateMeasureTests
 
 
-class TestQasmTensorNetworkSimulator(common.QiskitAerTestCase,
-                                   QasmTensorNetworkMethodTests,
-                                   QasmTensorNetworkMeasureTests):
+class TestQasmMatrixProductStateSimulator(common.QiskitAerTestCase,
+                                   QasmMatrixProductStateMethodTests,
+                                   QasmMatrixProductStateMeasureTests):
 
-    BACKEND_OPTS = {"method": "tensor_network"}
+    BACKEND_OPTS = {"method": "matrix_product_state"}
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Changed name of simulation method from tensor_network to matrix_product_state.
After the release, we will consider changing the name of the tensor_network_state.hpp file and class, but for now we are only changing the method name.


### Details and comments
See issue # 314.

