### PR TITLE
Fix data accumulator not loading config

### DIFF
--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -599,6 +599,7 @@ json_t Controller::execute_circuit(Circuit &circ,
   // Initialize circuit json return
   json_t result;
   OutputData data;
+  data.set_config(config);
 
   // Execute in try block so we can catch errors and return the error message
   // for individual circuit failures.

--- a/test/terra/backends/qasm_simulator/qasm_measure.py
+++ b/test/terra/backends/qasm_simulator/qasm_measure.py
@@ -34,32 +34,30 @@ class QasmMeasureTests:
         shots = 100
         circuits = ref_measure.measure_circuits_deterministic(
             allow_sampling=True)
-        targets = ref_measure.measure_counts_deterministic(shots)
-        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        target_counts = ref_measure.measure_counts_deterministic(shots)
+        target_memory = ref_measure.measure_memory_deterministic(shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots, memory=True)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0)
-        # Test sampling was enabled
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            self.assertEqual(res.metadata["measure_sampling"], True)
+        self.compare_counts(result, circuits, target_counts, delta=0)
+        self.compare_memory(result, circuits, target_memory)
+        self.compare_result_metadata(result, circuits, "measure_sampling", True)
 
     def test_measure_deterministic_without_sampling(self):
         """Test QasmSimulator measure with deterministic counts without sampling"""
         shots = 100
         circuits = ref_measure.measure_circuits_deterministic(
             allow_sampling=False)
-        targets = ref_measure.measure_counts_deterministic(shots)
-        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        target_counts = ref_measure.measure_counts_deterministic(shots)
+        target_memory = ref_measure.measure_memory_deterministic(shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots, memory=True)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0)
-        # Test sampling was disabled
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            self.assertEqual(res.metadata["measure_sampling"], False)
+        self.compare_counts(result, circuits, target_counts, delta=0)
+        self.compare_memory(result, circuits, target_memory)
+        self.compare_result_metadata(result, circuits, "measure_sampling", False)
 
     def test_measure_nondeterministic_with_sampling(self):
         """Test QasmSimulator measure with non-deterministic counts with sampling"""
@@ -88,10 +86,7 @@ class QasmMeasureTests:
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
-        # Test sampling was disabled
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            self.assertEqual(res.metadata["measure_sampling"], False)
+        self.compare_result_metadata(result, circuits, "measure_sampling", False)
 
     def test_measure_sampling_with_readouterror(self):
         """Test QasmSimulator measure with deterministic counts with sampling and readout-error"""
@@ -110,11 +105,7 @@ class QasmMeasureTests:
             qobj, noise_model=noise_model,
             backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
-
-        # Test sampling was enable
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            self.assertEqual(res.metadata["measure_sampling"], True)
+        self.compare_result_metadata(result, circuits, "measure_sampling", True)
 
     def test_measure_sampling_with_quantum_noise(self):
         """Test QasmSimulator measure with deterministic counts with sampling and readout-error"""
@@ -137,14 +128,8 @@ class QasmMeasureTests:
             qobj, noise_model=noise_model,
             backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
-
-        method = self.BACKEND_OPTS.get("method")
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            if method == "density_matrix":
-                self.assertEqual(res.metadata["measure_sampling"], True)
-            else:
-                self.assertEqual(res.metadata["measure_sampling"], False)
+        sampling = (self.BACKEND_OPTS.get("method") == "density_matrix")
+        self.compare_result_metadata(result, circuits, "measure_sampling", sampling)
 
 
 class QasmMultiQubitMeasureTests:
@@ -161,32 +146,29 @@ class QasmMultiQubitMeasureTests:
         shots = 100
         circuits = ref_measure.multiqubit_measure_circuits_deterministic(
             allow_sampling=True)
-        targets = ref_measure.multiqubit_measure_counts_deterministic(shots)
-        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        target_counts = ref_measure.multiqubit_measure_counts_deterministic(shots)
+        target_memory = ref_measure.multiqubit_measure_memory_deterministic(shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots, memory=True)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0)
-        # Test sampling was enabled
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            self.assertEqual(res.metadata["measure_sampling"], True)
+        self.compare_counts(result, circuits, target_counts, delta=0)
+        self.compare_memory(result, circuits, target_memory)
+        self.compare_result_metadata(result, circuits, "measure_sampling", True)
 
     def test_measure_deterministic_multi_qubit_without_sampling(self):
         """Test QasmSimulator multi-qubit measure with deterministic counts without sampling"""
         shots = 100
         circuits = ref_measure.multiqubit_measure_circuits_deterministic(
             allow_sampling=False)
-        targets = ref_measure.multiqubit_measure_counts_deterministic(shots)
-        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        target_counts = ref_measure.multiqubit_measure_counts_deterministic(shots)
+        target_memory = ref_measure.multiqubit_measure_memory_deterministic(shots)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots, memory=True)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
-        self.compare_counts(result, circuits, targets, delta=0)
-        # Test sampling was disabled
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            self.assertEqual(res.metadata["measure_sampling"], False)
+        self.compare_counts(result, circuits, target_counts, delta=0)
+        self.compare_memory(result, circuits, target_memory)
+        self.compare_result_metadata(result, circuits, "measure_sampling", False)
 
     def test_measure_nondeterministic_multi_qubit_with_sampling(self):
         """Test QasmSimulator measure with non-deterministic counts"""
@@ -199,10 +181,7 @@ class QasmMultiQubitMeasureTests:
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
-        # Test sampling was enabled
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            self.assertEqual(res.metadata["measure_sampling"], True)
+        self.compare_result_metadata(result, circuits, "measure_sampling", True)
 
     def test_measure_nondeterministic_multi_qubit_without_sampling(self):
         """Test QasmSimulator measure with non-deterministic counts"""
@@ -215,7 +194,4 @@ class QasmMultiQubitMeasureTests:
             qobj, backend_options=self.BACKEND_OPTS).result()
         self.is_completed(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
-
-        for res in result.results:
-            self.assertIn("measure_sampling", res.metadata)
-            self.assertEqual(res.metadata["measure_sampling"], False)
+        self.compare_result_metadata(result, circuits, "measure_sampling", False)

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -165,9 +165,24 @@ class QiskitAerTestCase(unittest.TestCase):
                    " {} != {}".format(output, target))
             self.assertDictAlmostEqual(output, target, delta=delta, msg=msg)
 
+    def compare_memory(self, result, circuits, targets, hex_counts=True):
+        """Compare memory list to target."""
+        for pos, test_case in enumerate(zip(circuits, targets)):
+            circuit, target = test_case
+            self.assertIn("memory", result.data(circuit))
+            if hex_counts:
+                # Don't use get_counts method which converts hex
+                output = result.data(circuit)["memory"]
+            else:
+                # Use get counts method which converts hex
+                output = result.get_memory(circuit)
+            msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
+                   " {} != {}".format(output, target))
+            self.assertEqual(output, target, msg=msg)
+
     def compare_result_metadata(self, result, circuits, key, targets):
         """Compare result metadata key value."""
-        if isinstance(targets, str):
+        if not isinstance(targets, (list, tuple)):
             targets = len(circuits) * [targets]
         for pos, test_case in enumerate(zip(circuits, targets)):
             circuit, target = test_case

--- a/test/terra/reference/ref_measure.py
+++ b/test/terra/reference/ref_measure.py
@@ -97,6 +97,30 @@ def measure_counts_deterministic(shots, hex_counts=True):
     return targets
 
 
+def measure_memory_deterministic(shots, hex_counts=True):
+    """Measure test circuits reference memory."""
+    targets = []
+    if hex_counts:
+        # Measure |00> state
+        targets.append(shots * ['0x0'])
+        # Measure |01> state
+        targets.append(shots * ['0x1'])
+        # Measure |10> state
+        targets.append(shots * ['0x2'])
+        # Measure |11> state
+        targets.append(shots * ['0x3'])
+    else:
+        # Measure |00> state
+        targets.append(shots * ['00'])
+        # Measure |01> state
+        targets.append(shots * ['01'])
+        # Measure |10> state
+        targets.append(shots * ['10'])
+        # Measure |11> state
+        targets.append(shots * ['11'])
+    return targets
+
+
 def measure_statevector_deterministic():
     """Measure test circuits reference counts."""
 
@@ -221,6 +245,27 @@ def multiqubit_measure_counts_deterministic(shots, hex_counts=True):
         targets.append({'101': shots})
         # 4-qubit measure |1010>
         targets.append({'1010': shots})
+    return targets
+
+
+def multiqubit_measure_memory_deterministic(shots, hex_counts=True):
+    """Multi-qubit measure test circuits reference memory."""
+
+    targets = []
+    if hex_counts:
+        # 2-qubit measure |10>
+        targets.append(shots * ['0x2'])
+        # 3-qubit measure |101>
+        targets.append(shots * ['0x5'])
+        # 4-qubit measure |1010>
+        targets.append(shots * ['0xa'])
+    else:
+        # 2-qubit measure |10>
+        targets.append(shots * ['10'])
+        # 3-qubit measure |101>
+        targets.append(shots * ['101'])
+        # 4-qubit measure |1010>
+        targets.append(shots * ['1010'])
     return targets
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Fixes #321 
* Adds measure tests for `memory=True`

### Details and comments

The `set_config` method of the `Data` accumulator for the base controller class wasn't being called, so any additional data such as `memory=True` was being discarded when accumulated.

