### PR TITLE
Disable truncation by default for non-Qasm controllers

### DIFF
--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -237,6 +237,8 @@ protected:
   int parallel_shots_;
   int parallel_state_update_;
 
+  // Truncate qubits
+  bool truncate_qubits_ = true;
 };
 
 
@@ -252,6 +254,9 @@ void Controller::set_config(const json_t &config) {
 
   // Load validation threshold
   JSON::get_value(validation_threshold_, "validation_threshold", config);
+
+  // Load qubit truncation
+  JSON::get_value(truncate_qubits_, "truncate_enable", config);
 
   // Load OpenMP maximum thread settings
   if (JSON::check_key("max_parallel_threads", config))
@@ -604,10 +609,11 @@ json_t Controller::execute_circuit(Circuit &circ,
   // for individual circuit failures.
   try {
     // Truncate unused qubits from circuit and noise model
-    Transpile::TruncateQubits truncate_pass;
-    truncate_pass.set_config(config);
-    truncate_pass.optimize_circuit(circ, noise, Operations::OpSet(), data);
-
+    if (truncate_qubits_) {
+      Transpile::TruncateQubits truncate_pass;
+      truncate_pass.set_config(config);
+      truncate_pass.optimize_circuit(circ, noise, Operations::OpSet(), data);
+    }
     // set parallelization for this circuit
     if (!explicit_parallelization_ && parallel_experiments_ == 1) {
       set_parallelization_circuit(circ, noise);

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -63,7 +63,8 @@ public:
   //-----------------------------------------------------------------------
   // Base class config override
   //-----------------------------------------------------------------------
-  
+  StatevectorController();
+
   // Load Controller, State and Data config from a JSON
   // config settings will be passed to the State and Data classes
   // Allowed config options:
@@ -103,6 +104,10 @@ private:
 // Implementations
 //=========================================================================
 
+StatevectorController::StatevectorController() : Base::Controller() {
+  // Disable qubit truncation by default
+  Base::Controller::truncate_qubits_ = false;
+}
 
 //-------------------------------------------------------------------------
 // Config

--- a/src/simulators/unitary/unitary_controller.hpp
+++ b/src/simulators/unitary/unitary_controller.hpp
@@ -56,7 +56,8 @@ public:
   //-----------------------------------------------------------------------
   // Base class config override
   //-----------------------------------------------------------------------
-  
+  UnitaryController();
+
   // Load Controller, State and Data config from a JSON
   // config settings will be passed to the State and Data classes
   // Allowed config options:
@@ -95,6 +96,11 @@ private:
 //=========================================================================
 // Implementation
 //=========================================================================
+
+UnitaryController::UnitaryController() : Base::Controller() {
+  // Disable qubit truncation by default
+  Base::Controller::truncate_qubits_ = false;
+}
 
 //-------------------------------------------------------------------------
 // Config


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Disables qubit truncation by default for the StatevectorSimulator and UnitarySimulator so that the size of the output isn't changed.

If someone wants to enable truncation on these backends they can still do so using `backend_options={"truncate_enable": True}`.

### Details and comments

The recent changes to applying truncation in the base controller before memory requirement calculations had the side effect of truncating the output of the Statevector and Unitary simulators which is a change in behaviour from previous versions.




