### PR TITLE
Add tox.ini to start using tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ contrib/standalone/version.hpp
 *.env
 *.idea/
 test/.asv
+
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+minversion = 2.1
+envlist = py35, py36, py37, lint
+skipsdist = True
+
+[testenv]
+install_command = pip install -U {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  LANGUAGE=en_US
+  LC_ALL=en_US.utf-8
+deps =
+  -r requirements-dev.txt
+  git+https://github.com/Qiskit/qiskit-terra.git
+commands =
+    python setup.py bdist_wheel -- -- -j4
+    pip install --find-links={toxinidir}/dist qiskit_aer
+    python -m unittest discover -s test -v
+
+[testenv:lint]
+deps =
+  pycodestyle
+  pylint
+  git+https://github.com/Qiskit/qiskit-terra.git
+commands =
+  pycodestyle --ignore=E402,W504 --max-line-length=100 qiskit/providers/aer
+  pylint -j 2 -rn qiskit/providers/aer


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support for using tox by adding a tox.ini. This makes
it very simple for users and contributors to run tests and style checks
locally by just using the `tox` command. It will handle building and
installing aer and it's dependencies in a virtualenv to isolate it from
system python for testing. This is also a common tool for python
projects, as many (if not most) other python projects use it. Most of
the other qiskit elements also support using it.

### Details and comments


