### PR TITLE
Update device noise model to use gate_length

### DIFF
--- a/qiskit/providers/aer/noise/device/parameters.py
+++ b/qiskit/providers/aer/noise/device/parameters.py
@@ -39,7 +39,6 @@ def gate_param_values(properties):
         qubits = gate.qubits
         # Check for gate time information
         gate_length = None  # default value
-        time_param = _check_for_item(gate.parameters, 'gate_time')  # deprecated
         time_param = _check_for_item(gate.parameters, 'gate_length')
         if hasattr(time_param, 'value'):
             gate_length = time_param.value
@@ -97,7 +96,6 @@ def gate_length_values(properties):
         name = gate.gate
         qubits = gate.qubits
         value = None  # default value
-        params = _check_for_item(gate.parameters, 'gate_time')  # deprecated
         params = _check_for_item(gate.parameters, 'gate_length')
         if hasattr(params, 'value'):
             value = params.value

--- a/qiskit/providers/aer/noise/device/parameters.py
+++ b/qiskit/providers/aer/noise/device/parameters.py
@@ -30,7 +30,7 @@ def gate_param_values(properties):
 
     Returns:
         list: A list of tuples (name, qubits, time, error). If gate
-              error or gate_time information is not available None
+              error or gate_length information is not available None
               will be returned for value.
     """
     values = []
@@ -38,19 +38,20 @@ def gate_param_values(properties):
         name = gate.gate
         qubits = gate.qubits
         # Check for gate time information
-        gate_time = None  # default value
-        time_param = _check_for_item(gate.parameters, 'gate_time')
+        gate_length = None  # default value
+        time_param = _check_for_item(gate.parameters, 'gate_time')  # deprecated
+        time_param = _check_for_item(gate.parameters, 'gate_length')
         if hasattr(time_param, 'value'):
-            gate_time = time_param.value
+            gate_length = time_param.value
             if hasattr(time_param, 'unit'):
                 # Convert gate time to ns
-                gate_time *= _NANOSECOND_UNITS.get(time_param.unit, 1)
+                gate_length *= _NANOSECOND_UNITS.get(time_param.unit, 1)
         # Check for gate error information
         gate_error = None  # default value
         error_param = _check_for_item(gate.parameters, 'gate_error')
         if hasattr(error_param, 'value'):
             gate_error = error_param.value
-        values.append((name, qubits, gate_time, gate_error))
+        values.append((name, qubits, gate_length, gate_error))
 
     return values
 
@@ -78,10 +79,10 @@ def gate_error_values(properties):
     return values
 
 
-def gate_time_values(properties):
-    """Get gate time values for backend gate from backend properties
+def gate_length_values(properties):
+    """Get gate length values for backend gate from backend properties
 
-    Gate time values are returned in nanosecond (ns) units.
+    Gate length values are returned in nanosecond (ns) units.
 
     Args:
         properties (BackendProperties): device backend properties
@@ -96,7 +97,8 @@ def gate_time_values(properties):
         name = gate.gate
         qubits = gate.qubits
         value = None  # default value
-        params = _check_for_item(gate.parameters, 'gate_time')
+        params = _check_for_item(gate.parameters, 'gate_time')  # deprecated
+        params = _check_for_item(gate.parameters, 'gate_length')
         if hasattr(params, 'value'):
             value = params.value
             if hasattr(params, 'unit'):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

(Most) Devices now return gate timing information in their properties under the key `"gate_length"`. Previously the device noise model was looking for `"gate_time"` key. This updates the device noise model to use the correct name.

It also renames the kwarg for adding custom gate times to `gate_lengths` and adds a deprecation warning if someone uses the old `gate_times` kwarg

Closes #336 

### Details and comments


