### PR TITLE
Add Result and ExperimentResult structs

### DIFF
--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
     // Initialize simulator
     AER::Simulator::QasmController sim;
     auto result = sim.execute(qobj);
-    out << result.dump(4) << std::endl;
+    out << result.json().dump(4) << std::endl;
 
     // Check if execution was successful.
     bool success = false;

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -161,17 +161,6 @@ class AerBackend(BaseBackend):
             if output:
                 logger.error('Output: %s', output)
             raise AerError("simulation terminated without returning valid output.")
-        # Check results
-        # TODO: Once https://github.com/Qiskit/qiskit-terra/issues/1023
-        #       is merged this should be updated to deal with errors using
-        #       the Result object methods
-        if not output.get("success", False):
-            # Check for error message in the failed circuit
-            for res in output.get('results', []):
-                if not res.get('success', False):
-                    raise AerError(res.get("status", None))
-            # If no error was found check for error message at qobj level
-            raise AerError(output.get("status", None))
 
     def _validate(self, qobj, backend_options, noise_model):
         """Validate the qobj, backend_options, noise_model for the backend"""

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -41,7 +41,7 @@
 #include "framework/rng.hpp"
 #include "framework/creg.hpp"
 #include "framework/results/result.hpp"
-#include "framework/results/data.hpp"
+#include "framework/results/experiment_data.hpp"
 #include "noise/noise_model.hpp"
 #include "transpile/circuitopt.hpp"
 #include "transpile/truncate_qubits.hpp"
@@ -148,7 +148,7 @@ protected:
   // Abstract method for executing a circuit.
   // This method must initialize a state and return output data for
   // the required number of shots.
-  virtual OutputData run_circuit(const Circuit &circ,
+  virtual ExperimentData run_circuit(const Circuit &circ,
                                  const Noise::NoiseModel &noise,
                                  const json_t &config,
                                  uint_t shots,
@@ -185,7 +185,7 @@ protected:
   void optimize_circuit(Circuit &circ,
                         Noise::NoiseModel& noise,
                         state_t& state,
-                        OutputData &data) const;
+                        ExperimentData &data) const;
 
   //-----------------------------------------------------------------------
   // Config
@@ -464,7 +464,7 @@ template <class state_t>
 void Controller::optimize_circuit(Circuit &circ,
                                   Noise::NoiseModel& noise,
                                   state_t& state,
-                                  OutputData &data) const {
+                                  ExperimentData &data) const {
 
   Operations::OpSet allowed_opset;
   allowed_opset.optypes = state.allowed_ops();
@@ -594,7 +594,7 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
 
   // Initialize circuit json return
   ExperimentResult exp_result;
-  OutputData data;
+  ExperimentData data;
   data.set_config(config);
 
   // Execute in try block so we can catch errors and return the error message
@@ -627,7 +627,7 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
       }
 
       // Vector to store parallel thread output data
-      std::vector<OutputData> par_data(parallel_shots_);
+      std::vector<ExperimentData> par_data(parallel_shots_);
       std::vector<std::string> error_msgs(parallel_shots_);
       #pragma omp parallel for if (parallel_shots_ > 1) num_threads(parallel_shots_)
       for (int i = 0; i < parallel_shots_; i++) {

--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -38,9 +38,10 @@
 
 // Base Controller
 #include "framework/qobj.hpp"
-#include "framework/data.hpp"
 #include "framework/rng.hpp"
 #include "framework/creg.hpp"
+#include "framework/results/result.hpp"
+#include "framework/results/data.hpp"
 #include "noise/noise_model.hpp"
 #include "transpile/circuitopt.hpp"
 #include "transpile/truncate_qubits.hpp"
@@ -111,7 +112,7 @@ public:
 
   // Load a QOBJ from a JSON file and execute on the State type
   // class.
-  virtual json_t execute(const json_t &qobj);
+  virtual Result execute(const json_t &qobj);
 
   //-----------------------------------------------------------------------
   // Config settings
@@ -140,9 +141,9 @@ protected:
   // Parallel execution of a circuit
   // This function manages parallel shot configuration and internally calls
   // the `run_circuit` method for each shot thread
-  virtual json_t execute_circuit(Circuit &circ,
-                                 Noise::NoiseModel &noise,
-                                 const json_t &config);
+  virtual ExperimentResult execute_circuit(Circuit &circ,
+                                           Noise::NoiseModel &noise,
+                                           const json_t &config);
 
   // Abstract method for executing a circuit.
   // This method must initialize a state and return output data for
@@ -479,19 +480,9 @@ void Controller::optimize_circuit(Circuit &circ,
 // Qobj and Circuit Execution to JSON output
 //-------------------------------------------------------------------------
 
-json_t Controller::execute(const json_t &qobj_js) {
+Result Controller::execute(const json_t &qobj_js) {
   // Start QOBJ timer
   auto timer_start = myclock_t::now();
-
-  // Generate empty return JSON that matches Result spec
-  json_t result;
-  result["qobj_id"] = nullptr;
-  result["success"] = true;
-  result["status"] = nullptr;
-  result["backend_name"] = nullptr;
-  result["backend_version"] = nullptr;
-  result["date"] = nullptr;
-  result["job_id"] = nullptr;
 
   // Load QOBJ in a try block so we can catch parsing errors and still return
   // a valid JSON output containing the error message.
@@ -510,19 +501,21 @@ json_t Controller::execute(const json_t &qobj_js) {
   }
   catch (std::exception &e) {
     // qobj was invalid, return valid output containing error message
-    result["success"] = false;
-    result["status"] = std::string("ERROR: Failed to load qobj: ") + e.what();
+    Result result;
+    result.status = Result::Status::error;
+    result.message = std::string("Failed to load qobj: ") + e.what();
     return result;
   }
+  // Qobj was loaded successfully, now we proceed
+  // Generate empty return JSON that matches Result spec
+  Result result(qobj.circuits.size());
 
   // Get QOBJ id and pass through header to result
-  result["qobj_id"] = qobj.id;
+  result.qobj_id = qobj.id;
   if (!qobj.header.empty()) // NOLINT
-      result["header"] = qobj.header;
+      result.header = qobj.header;
 
-  // Qobj was loaded successfully, now we proceed
   try {
-
     // Set max_parallel_threads_
     if (max_parallel_threads_ < 1)
     #ifdef _OPENMP
@@ -537,73 +530,70 @@ json_t Controller::execute(const json_t &qobj_js) {
     }
 
   #ifdef _OPENMP
-    result["metadata"]["omp_enabled"] = true;
+    result.metadata["omp_enabled"] = true;
   #else
-    result["metadata"]["omp_enabled"] = false;
+    result.metadata["omp_enabled"] = false;
   #endif
-    result["metadata"]["parallel_experiments"] = parallel_experiments_;
-    result["metadata"]["max_memory_mb"] = max_memory_mb_;
+    result.metadata["parallel_experiments"] = parallel_experiments_;
+    result.metadata["max_memory_mb"] = max_memory_mb_;
     const int num_circuits = qobj.circuits.size();
 
   #ifdef _OPENMP
     if (parallel_shots_ > 1 || parallel_state_update_ > 1)
       omp_set_nested(1);
   #endif
-    // Initialize container to store parallel circuit output
-    result["results"] = std::vector<json_t>(num_circuits);
     if (parallel_experiments_ > 1) {
       // Parallel circuit execution
       #pragma omp parallel for num_threads(parallel_experiments_)
-      for (int j = 0; j < num_circuits; ++j) {
+      for (int j = 0; j < result.results.size(); ++j) {
         // Make a copy of the noise model for each circuit execution
         auto circ_noise_model = noise_model;
-        result["results"][j] = execute_circuit(qobj.circuits[j],
-                                               circ_noise_model,
-                                               config);
+        result.results[j] = execute_circuit(qobj.circuits[j],
+                                            circ_noise_model,
+                                            config);
       }
     } else {
       // Serial circuit execution
       for (int j = 0; j < num_circuits; ++j) {
         // Make a copy of the noise model for each circuit execution
         auto circ_noise_model = noise_model;
-        result["results"][j] = execute_circuit(qobj.circuits[j],
-                                               circ_noise_model,
-                                               config);
+        result.results[j] = execute_circuit(qobj.circuits[j],
+                                            circ_noise_model,
+                                            config);
       }
     }
 
-    // check success
-    for (const auto& experiment: result["results"]) {
-      if (experiment["success"].get<bool>() == false) {
-        result["success"] = false;
+    // Check each experiment result for completed status.
+    // If only some experiments completed return partial completed status.
+    result.status = Result::Status::completed;
+    for (const auto& experiment: result.results) {
+      if (experiment.status != ExperimentResult::Status::completed) {
+        result.status = Result::Status::partial_completed;
         break;
       }
     }
-    // Set status to completed
-    result["status"] = std::string("COMPLETED");
-
     // Stop the timer and add total timing data
     auto timer_stop = myclock_t::now();
-    result["metadata"]["time_taken"] = std::chrono::duration<double>(timer_stop - timer_start).count();
+    result.metadata["time_taken"] = std::chrono::duration<double>(timer_stop - timer_start).count();
   }
   // If execution failed return valid output reporting error
   catch (std::exception &e) {
-    result["success"] = false;
-    result["status"] = std::string("ERROR: ") + e.what();
+    result.status = Result::Status::error;
+    result.message = e.what();
   }
   return result;
 }
 
 
-json_t Controller::execute_circuit(Circuit &circ,
-                                   Noise::NoiseModel& noise,
-                                   const json_t &config) {
+ExperimentResult Controller::execute_circuit(Circuit &circ,
+                                             Noise::NoiseModel& noise,
+                                             const json_t &config) {
 
   // Start individual circuit timer
   auto timer_start = myclock_t::now(); // state circuit timer
 
   // Initialize circuit json return
-  json_t result;
+  ExperimentResult exp_result;
   OutputData data;
   data.set_config(config);
 
@@ -658,37 +648,33 @@ json_t Controller::execute_circuit(Circuit &circ,
       }
     }
     // Report success
-    result["data"] = data;
-    result["success"] = true;
-    result["status"] = std::string("DONE");
+    exp_result.data = data;
+    exp_result.status = ExperimentResult::Status::completed;
 
     // Pass through circuit header and add metadata
-    result["header"] = circ.header;
-    result["shots"] = circ.shots;
-    result["seed_simulator"] = circ.seed;
+    exp_result.header = circ.header;
+    exp_result.shots = circ.shots;
+    exp_result.seed = circ.seed;
     // Move any metadata from the subclass run_circuit data
-    // to the experiment result's metadata field
-    if (JSON::check_key("metadata", result["data"])) {
-
-      for(auto& metadata: result["data"]["metadata"].items()) {
-        result["metadata"][metadata.key()] = metadata.value();
-      }
-      // Remove the metadata field from data
-      result["data"].erase("metadata");
+    // to the experiment resultmetadata field
+    for(auto& metadatum: exp_result.data.metadata().items()) {
+      exp_result.add_metadata(metadatum.key(), metadatum.value());
     }
-    result["metadata"]["parallel_shots"] = parallel_shots_;
-    result["metadata"]["parallel_state_update"] = parallel_state_update_;
+    // Remove the metatdata field from data
+    exp_result.data.metadata().clear();
+    exp_result.metadata["parallel_shots"] = parallel_shots_;
+    exp_result.metadata["parallel_state_update"] = parallel_state_update_;
     // Add timer data
     auto timer_stop = myclock_t::now(); // stop timer
     double time_taken = std::chrono::duration<double>(timer_stop - timer_start).count();
-    result["time_taken"] = time_taken;
+    exp_result.time_taken = time_taken;
   }
   // If an exception occurs during execution, catch it and pass it to the output
   catch (std::exception &e) {
-    result["success"] = false;
-    result["status"] = std::string("ERROR: ") + e.what();
+    exp_result.status = ExperimentResult::Status::error;
+    exp_result.message = e.what();
   }
-  return result;
+  return exp_result;
 }
 
 //-------------------------------------------------------------------------

--- a/src/base/state.hpp
+++ b/src/base/state.hpp
@@ -18,8 +18,8 @@
 #include "framework/json.hpp"
 #include "framework/operations.hpp"
 #include "framework/types.hpp"
-#include "framework/data.hpp"
 #include "framework/creg.hpp"
+#include "framework/results/data.hpp"
 
 namespace AER {
 namespace Base {

--- a/src/base/state.hpp
+++ b/src/base/state.hpp
@@ -19,7 +19,7 @@
 #include "framework/operations.hpp"
 #include "framework/types.hpp"
 #include "framework/creg.hpp"
-#include "framework/results/data.hpp"
+#include "framework/results/experiment_data.hpp"
 
 namespace AER {
 namespace Base {
@@ -82,7 +82,7 @@ public:
   // If this sequence contains operations not in allowed_operations
   // an exeption will be thrown.
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         OutputData &data,
+                         ExperimentData &data,
                          RngEngine &rng)  = 0;
 
   // Initializes the State to the default state.
@@ -159,8 +159,8 @@ public:
                        const std::string &memory_hex,
                        const std::string &register_hex);
 
-  // Add current creg classical bit values to a OutputData container
-  void add_creg_to_data(OutputData &data) const;
+  // Add current creg classical bit values to a ExperimentData container
+  void add_creg_to_data(ExperimentData &data) const;
 
   //-----------------------------------------------------------------------
   // Standard snapshots
@@ -168,15 +168,15 @@ public:
 
   // Snapshot the current statevector (single-shot)
   // if type_label is the empty string the operation type will be used for the type
-  void snapshot_state(const Operations::Op &op, OutputData &data,
+  void snapshot_state(const Operations::Op &op, ExperimentData &data,
                       std::string name = "") const;
 
   // Snapshot the classical memory bits state (single-shot)
-  void snapshot_creg_memory(const Operations::Op &op, OutputData &data,
+  void snapshot_creg_memory(const Operations::Op &op, ExperimentData &data,
                             std::string name = "memory") const;
 
   // Snapshot the classical register bits state (single-shot)
-  void snapshot_creg_register(const Operations::Op &op, OutputData &data,
+  void snapshot_creg_register(const Operations::Op &op, ExperimentData &data,
                               std::string name = "register") const;
 
   //-----------------------------------------------------------------------
@@ -279,7 +279,7 @@ void State<state_t>::initialize_creg(uint_t num_memory,
 
 template <class state_t>
 void State<state_t>::snapshot_state(const Operations::Op &op,
-                                    OutputData &data,
+                                    ExperimentData &data,
                                     std::string name) const {
   name = (name.empty()) ? op.name : name;
   data.add_singleshot_snapshot(name, op.string_params[0], qreg_);
@@ -288,7 +288,7 @@ void State<state_t>::snapshot_state(const Operations::Op &op,
 
 template <class state_t>
 void State<state_t>::snapshot_creg_memory(const Operations::Op &op,
-                                          OutputData &data,
+                                          ExperimentData &data,
                                           std::string name) const {
   data.add_singleshot_snapshot(name,
                                op.string_params[0],
@@ -298,7 +298,7 @@ void State<state_t>::snapshot_creg_memory(const Operations::Op &op,
 
 template <class state_t>
 void State<state_t>::snapshot_creg_register(const Operations::Op &op,
-                                            OutputData &data,
+                                            ExperimentData &data,
                                             std::string name) const {
   data.add_singleshot_snapshot(name,
                                op.string_params[0],
@@ -307,7 +307,7 @@ void State<state_t>::snapshot_creg_register(const Operations::Op &op,
 
 
 template <class state_t>
-void State<state_t>::add_creg_to_data(OutputData &data) const {
+void State<state_t>::add_creg_to_data(ExperimentData &data) const {
   if (creg_.memory_size() > 0) {
     std::string memory_hex = creg_.memory_hex();
     data.add_memory_count(memory_hex);

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -12,8 +12,8 @@
  * that they have been altered from the originals.
  */
 
-#ifndef _aer_framework_data_hpp_
-#define _aer_framework_data_hpp_
+#ifndef _aer_framework_experiment_data_hpp_
+#define _aer_framework_experiment_data_hpp_
 
 #include "framework/json.hpp"
 #include "framework/utils.hpp"
@@ -34,7 +34,7 @@ namespace AER {
  * - "register" (bool): Return register array in circuit data [Default: False]
  **************************************************************************/
 
-class OutputData {
+class ExperimentData {
 public:
   //----------------------------------------------------------------
   // Measurement
@@ -120,16 +120,16 @@ public:
   // Combine engines for accumulating data
   // Second engine should no longer be used after combining
   // as this function should use move semantics to minimize copying
-  OutputData& combine(OutputData &eng);
+  ExperimentData& combine(ExperimentData &eng);
 
   // Operator overload for combine
   // Note this operator is not defined to be const on the input argument
-  inline OutputData& operator+=(OutputData &eng) {return combine(eng);}
+  inline ExperimentData& operator+=(ExperimentData &eng) {return combine(eng);}
 
 protected:
 
   //----------------------------------------------------------------
-  // OutputData
+  // ExperimentData
   //----------------------------------------------------------------
 
   // Measure outcomes
@@ -162,7 +162,7 @@ protected:
 // Implementations
 //============================================================================
 
-void OutputData::set_config(const json_t &config) {
+void ExperimentData::set_config(const json_t &config) {
   JSON::get_value(return_counts_, "counts", config);
   JSON::get_value(return_memory_, "memory", config);
   JSON::get_value(return_register_, "register", config);
@@ -170,21 +170,21 @@ void OutputData::set_config(const json_t &config) {
 }
 
 
-void OutputData::add_memory_count(const std::string &memory) {
+void ExperimentData::add_memory_count(const std::string &memory) {
   // Memory bits value
   if (return_counts_ && !memory.empty()) {
     counts_[memory] += 1;
   }
 }
 
-void OutputData::add_memory_singleshot(const std::string &memory) {
+void ExperimentData::add_memory_singleshot(const std::string &memory) {
   // Memory bits value
   if (return_memory_ && !memory.empty()) {
     memory_.push_back(memory);
   }
 }
 
-void OutputData::add_register_singleshot(const std::string &reg) {
+void ExperimentData::add_register_singleshot(const std::string &reg) {
   if (return_register_ && !reg.empty()) {
       register_.push_back(reg);
   }
@@ -192,7 +192,7 @@ void OutputData::add_register_singleshot(const std::string &reg) {
 
 
 template <typename T>
-void OutputData::add_singleshot_snapshot(const std::string &type,
+void ExperimentData::add_singleshot_snapshot(const std::string &type,
                                           const std::string &label,
                                           const T &datum) {
   if (return_snapshots_) {                                              
@@ -203,7 +203,7 @@ void OutputData::add_singleshot_snapshot(const std::string &type,
 
 
 template <typename T>
-void OutputData::add_average_snapshot(const std::string &type,
+void ExperimentData::add_average_snapshot(const std::string &type,
                                       const std::string &label,
                                       const std::string &memory,
                                       const T &datum,
@@ -215,12 +215,12 @@ void OutputData::add_average_snapshot(const std::string &type,
 }
 
 
-void OutputData::clear_singleshot_snapshot(const std::string &type) {
+void ExperimentData::clear_singleshot_snapshot(const std::string &type) {
   singleshot_snapshots_.erase(type);
 }
 
 
-void OutputData::clear_singleshot_snapshot(const std::string &type,
+void ExperimentData::clear_singleshot_snapshot(const std::string &type,
                                             const std::string &label) {
   if (singleshot_snapshots_.find(type) != singleshot_snapshots_.end()) {
     singleshot_snapshots_[type].erase(label);
@@ -228,12 +228,12 @@ void OutputData::clear_singleshot_snapshot(const std::string &type,
 }
 
 
-void OutputData::clear_average_snapshot(const std::string &type) {
+void ExperimentData::clear_average_snapshot(const std::string &type) {
   average_snapshots_.erase(type);
 }
 
 
-void OutputData::clear_average_snapshot(const std::string &type,
+void ExperimentData::clear_average_snapshot(const std::string &type,
                                              const std::string &label) {
   if (average_snapshots_.find(type) != average_snapshots_.end()) {
     average_snapshots_[type].erase(label);
@@ -242,7 +242,7 @@ void OutputData::clear_average_snapshot(const std::string &type,
 
 
 template <typename T>
-void OutputData::add_additional_data(const std::string &key, const T &data) {
+void ExperimentData::add_additional_data(const std::string &key, const T &data) {
   if (return_additional_data_) {
     json_t js = data; // use implicit to_json conversion function for T
     if (JSON::check_key(key, additional_data_))
@@ -253,13 +253,13 @@ void OutputData::add_additional_data(const std::string &key, const T &data) {
 }
 
 
-void OutputData::clear_additional_data(const std::string &key) {
+void ExperimentData::clear_additional_data(const std::string &key) {
   additional_data_.erase(key);
 }
 
 
 template <typename T>
-void OutputData::add_metadata(const std::string &key, const T &data) {
+void ExperimentData::add_metadata(const std::string &key, const T &data) {
   json_t js = data; // use implicit to_json conversion function for T
   if (JSON::check_key(key, additional_data_))
     metadata_[key].update(js.begin(), js.end());
@@ -268,12 +268,12 @@ void OutputData::add_metadata(const std::string &key, const T &data) {
 }
 
 
-void OutputData::clear_metadata(const std::string &key) {
+void ExperimentData::clear_metadata(const std::string &key) {
   metadata_.erase(key);
 }
 
 
-void OutputData::clear() {
+void ExperimentData::clear() {
   // Clear measure and counts
   counts_.clear();
   memory_.clear();
@@ -287,7 +287,7 @@ void OutputData::clear() {
 }
 
 
-OutputData& OutputData::combine(OutputData &data) {
+ExperimentData& ExperimentData::combine(ExperimentData &data) {
   // Combine measure
   std::move(data.memory_.begin(), data.memory_.end(),
             std::back_inserter(memory_));
@@ -332,7 +332,7 @@ OutputData& OutputData::combine(OutputData &data) {
 }
 
 
-json_t OutputData::json() const {
+json_t ExperimentData::json() const {
 
   // Initialize output as additional data JSON
   json_t tmp = additional_data_;
@@ -370,7 +370,7 @@ json_t OutputData::json() const {
 //------------------------------------------------------------------------------
 // Implicit JSON conversion function
 //------------------------------------------------------------------------------
-inline void to_json(json_t &js, const OutputData &data) {
+inline void to_json(json_t &js, const ExperimentData &data) {
   js = data.json();
 }
 

--- a/src/framework/results/experiment_result.hpp
+++ b/src/framework/results/experiment_result.hpp
@@ -15,7 +15,7 @@
 #ifndef _aer_framework_results_experiment_result_hpp_
 #define _aer_framework_results_experiment_result_hpp_
 
-#include "framework/results/data.hpp"
+#include "framework/results/experiment_data.hpp"
 
 namespace AER {
 
@@ -30,7 +30,7 @@ public:
   enum class Status {empty, completed, error};
 
   // Experiment data
-  OutputData data;
+  ExperimentData data;
   uint_t shots;
   uint_t seed;
   double time_taken;

--- a/src/framework/results/experiment_result.hpp
+++ b/src/framework/results/experiment_result.hpp
@@ -1,0 +1,111 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_results_experiment_result_hpp_
+#define _aer_framework_results_experiment_result_hpp_
+
+#include "framework/results/data.hpp"
+
+namespace AER {
+
+//============================================================================
+// Result container for Qiskit-Aer
+//============================================================================
+
+struct ExperimentResult {
+public:
+
+  // Status 
+  enum class Status {empty, completed, error};
+
+  // Experiment data
+  OutputData data;
+  uint_t shots;
+  uint_t seed;
+  double time_taken;
+
+  // Success and status
+  Status status = Status::empty;
+  std::string message; // error message
+
+  // Metadata
+  json_t header;
+  json_t metadata;
+
+  // Clear all metadata for given key
+  void clear_metadata(const std::string &key);
+  
+  // Append metadata for a given key.
+  // This assumes the metadata value is a dictionary and appends
+  // any new values
+  template <typename T>
+  void add_metadata(const std::string &key, const T &data);
+
+  // Serialize engine data to JSON
+  json_t json() const;
+};
+
+
+//------------------------------------------------------------------------------
+// Add metadata
+//------------------------------------------------------------------------------
+template <typename T>
+void ExperimentResult::add_metadata(const std::string &key, const T &meta) {
+  json_t js = meta; // use implicit to_json conversion function for T
+  if (JSON::check_key(key, metadata))
+    metadata[key].update(js.begin(), js.end());
+  else
+    metadata[key] = js;
+}
+
+void ExperimentResult::clear_metadata(const std::string &key) {
+  metadata.erase(key);
+}
+
+//------------------------------------------------------------------------------
+// JSON serialization
+//------------------------------------------------------------------------------
+json_t ExperimentResult::json() const {
+  // Initialize output as additional data JSON
+  json_t result;
+  result["data"] = data;
+  result["shots"] = shots;
+  result["seed_simulator"] = seed;
+  result["success"] = (status == Status::completed);
+  switch (status) {
+    case Status::completed:
+      result["status"] = std::string("DONE");
+      break;
+    case Status::error:
+      result["status"] = std::string("ERROR: ") + message;
+      break;
+    case Status::empty:
+      result["status"] = std::string("EMPTY");
+  }
+  result["time_taken"] = time_taken;
+  if (header.empty() == false)
+    result["header"] = header;
+  if (metadata.empty() == false)
+    result["metadata"] = metadata;
+  return result;
+}
+
+inline void to_json(json_t &js, const ExperimentResult &result) {
+  js = result.json();
+}
+
+//------------------------------------------------------------------------------
+} // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/results/result.hpp
+++ b/src/framework/results/result.hpp
@@ -1,0 +1,130 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_results_result_hpp_
+#define _aer_framework_results_result_hpp_
+
+#include "framework/results/experiment_result.hpp"
+
+namespace AER {
+
+//============================================================================
+// Result container for Qiskit-Aer
+//============================================================================
+
+struct Result {
+public:
+
+  // Result status:
+  // completed: all experiments were executed successfully
+  // partial: only some experiments were executed succesfully
+  enum class Status {empty, completed, partial_completed, error};
+
+  // Constructor
+  Result(size_t num_exp = 0) {results.resize(num_exp);}
+
+  // Experiment results
+  std::vector<ExperimentResult> results;
+
+  // Job metadata
+  std::string backend_name;
+  std::string backend_version;
+  std::string qobj_id;
+  std::string job_id;
+  std::string date;
+  
+  // Success and status
+  Status status = Status::empty; // Result status
+  std::string message; // error message
+
+  // Metadata
+  json_t header;
+  json_t metadata;
+
+  // Size and resize
+  auto size() {return results.size();}
+  void resize(size_t size) {results.resize(size);}
+
+  // Clear all metadata for given key
+  void clear_metadata(const std::string &key);
+  
+  // Append metadata for a given key.
+  // This assumes the metadata value is a dictionary and appends
+  // any new values
+  template <typename T>
+  void add_metadata(const std::string &key, const T &data);
+
+  // Serialize engine data to JSON
+  json_t json() const;
+};
+
+
+//------------------------------------------------------------------------------
+// Add metadata
+//------------------------------------------------------------------------------
+template <typename T>
+void Result::add_metadata(const std::string &key, const T &data) {
+  json_t js = data; // use implicit to_json conversion function for T
+  if (JSON::check_key(key, metadata))
+    metadata[key].update(js.begin(), js.end());
+  else
+    metadata[key] = js;
+}
+
+void Result::clear_metadata(const std::string &key) {
+  metadata.erase(key);
+}
+
+//------------------------------------------------------------------------------
+// JSON serialization
+//------------------------------------------------------------------------------
+json_t Result::json() const {
+  // Initialize output as additional data JSON
+  json_t result;
+  result["qobj_id"] = qobj_id;
+  
+  result["backend_name"] = backend_name;
+  result["backend_version"] = backend_version;
+  result["date"] = date;
+  result["job_id"] = job_id;
+  result["results"] = results;
+  if (header.empty() == false)
+    result["header"] = header;
+  if (metadata.empty() == false)
+    result["metadata"] = metadata;
+  result["success"] = (status == Status::completed);
+  switch (status) {
+    case Status::completed:
+      result["status"] = std::string("COMPLETED");
+      break;
+    case Status:: partial_completed:
+      result["status"] = std::string("PARTIAL COMPLETED");
+      break;
+    case Status::error:
+      result["status"] = std::string("ERROR: ") + message;
+      break;
+    case Status::empty:
+      result["status"] = std::string("EMPTY");
+  }
+  return result;
+}
+
+inline void to_json(json_t &js, const Result &result) {
+  js = result.json();
+}
+
+//------------------------------------------------------------------------------
+} // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/results/snapshot.hpp
+++ b/src/framework/results/snapshot.hpp
@@ -12,8 +12,8 @@
  * that they have been altered from the originals.
  */
 
-#ifndef _aer_framework_snapshot_hpp_
-#define _aer_framework_snapshot_hpp_
+#ifndef _aer_framework_results_snapshot_hpp_
+#define _aer_framework_results_snapshot_hpp_
 
 #include "framework/types.hpp"
 

--- a/src/noise/quantum_error.hpp
+++ b/src/noise/quantum_error.hpp
@@ -333,7 +333,7 @@ void QuantumError::compute_superoperator() {
     superop.initialize_qreg(get_num_qubits());
     // Apply each gate in the circuit
     // We don't need output data or RNG for this
-    OutputData data;
+    ExperimentData data;
     RngEngine rng;
     superop.apply_ops(circuits_[j], data, rng);
     superoperator_ += probabilities_[j] * superop.qreg().matrix();

--- a/src/simulators/controller_execute.hpp
+++ b/src/simulators/controller_execute.hpp
@@ -41,7 +41,7 @@ std::string controller_execute(const std::string &qobj_str) {
     Hacks::maybe_load_openmp(path);
   }
 
-  return controller.execute(qobj_js).dump(-1);
+  return controller.execute(qobj_js).json().dump(-1);
 }
 } // end namespace AER
 #endif

--- a/src/simulators/densitymatrix/densitymatrix_state.hpp
+++ b/src/simulators/densitymatrix/densitymatrix_state.hpp
@@ -94,7 +94,7 @@ public:
   // Apply a sequence of operations by looping over list
   // If the input is not in allowed_ops an exeption will be raised.
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         OutputData &data,
+                         ExperimentData &data,
                          RngEngine &rng) override;
 
   // Initializes an n-qubit state to the all |0> state
@@ -158,7 +158,7 @@ protected:
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const Operations::Op &op, OutputData &data);
+  virtual void apply_snapshot(const Operations::Op &op, ExperimentData &data);
 
   // Apply a matrix to given qubits (identity on all other qubits)
   void apply_matrix(const reg_t &qubits, const cmatrix_t & mat);
@@ -207,17 +207,17 @@ protected:
 
   // Snapshot current qubit probabilities for a measurement (average)
   void snapshot_probabilities(const Operations::Op &op,
-                              OutputData &data,
+                              ExperimentData &data,
                               bool variance);
 
   // Snapshot the expectation value of a Pauli operator
   void snapshot_pauli_expval(const Operations::Op &op,
-                             OutputData &data,
+                             ExperimentData &data,
                              bool variance);
 
   // Snapshot the expectation value of a matrix operator
   void snapshot_matrix_expval(const Operations::Op &op,
-                              OutputData &data,
+                              ExperimentData &data,
                               bool variance);
 
   //-----------------------------------------------------------------------
@@ -383,7 +383,7 @@ void State<densmat_t>::set_config(const json_t &config) {
 
 template <class densmat_t>
 void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
-                                 OutputData &data,
+                                 ExperimentData &data,
                                  RngEngine &rng) {
   // Simple loop over vector of input operations
   for (const auto op: ops) {
@@ -434,7 +434,7 @@ void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
 
 template <class densmat_t>
 void State<densmat_t>::apply_snapshot(const Operations::Op &op,
-                                       OutputData &data) {
+                                       ExperimentData &data) {
 
   // Look for snapshot type in snapshotset
   auto it = snapshotset_.find(op.name);
@@ -487,8 +487,8 @@ void State<densmat_t>::apply_snapshot(const Operations::Op &op,
 
 template <class densmat_t>
 void State<densmat_t>::snapshot_probabilities(const Operations::Op &op,
-                                              OutputData &data,
-                                              bool variance) {
+                                               ExperimentData &data,
+                                               bool variance) {
   // get probs as hexadecimal
   auto probs = Utils::vec2ket(measure_probs(op.qubits),
                               json_chop_threshold_, 16);

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -79,7 +79,7 @@ public:
   //Apply a sequence of operations to the cicuit. For each operation,
   //we loop over the terms in the decomposition in parallel
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         OutputData &data,
+                         ExperimentData &data,
                          RngEngine &rng) override;
 
   virtual void initialize_qreg(uint_t num_qubits) override;
@@ -108,7 +108,7 @@ protected:
   //circuit to a single state. This is used to optimize a circuit with a large
   //initial clifford fraction, or for running stabilizer circuits.
   void apply_stabilizer_circuit(const std::vector<Operations::Op> &ops,
-                                      OutputData &data,
+                                      ExperimentData &data,
                                       RngEngine &rng);
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
@@ -132,12 +132,12 @@ protected:
 
   //Take a snapshot of the simulation state
   //TODO: Improve the CHSimulator::to_json method.
-  void apply_snapshot(const Operations::Op &op, OutputData &data, RngEngine &rng);
+  void apply_snapshot(const Operations::Op &op, ExperimentData &data, RngEngine &rng);
   //Convert a decomposition to a state-vector
-  void statevector_snapshot(const Operations::Op &op, OutputData &data, RngEngine &rng);
+  void statevector_snapshot(const Operations::Op &op, ExperimentData &data, RngEngine &rng);
   //Compute probabilities from a stabilizer rank decomposition
   //TODO: Check ordering/output format...
-  void probabilities_snapshot(const Operations::Op &op, OutputData &data, RngEngine &rng);
+  void probabilities_snapshot(const Operations::Op &op, ExperimentData &data, RngEngine &rng);
 
   const static stringmap_t<Gates> gateset_;
   const static stringmap_t<Snapshots> snapshotset_;
@@ -320,7 +320,7 @@ bool State::check_measurement_opt(const std::vector<Operations::Op> &ops) const
 // Implementation: Operations
 //-------------------------------------------------------------------------
 
-void State::apply_ops(const std::vector<Operations::Op> &ops, OutputData &data,
+void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentData &data,
                          RngEngine &rng)
 {
   std::pair<bool, size_t> stabilizer_opts = check_stabilizer_opt(ops);
@@ -452,7 +452,7 @@ void State::apply_ops_parallel(const std::vector<Operations::Op> &ops, RngEngine
 }
 
 void State::apply_stabilizer_circuit(const std::vector<Operations::Op> &ops,
-                                      OutputData &data, RngEngine &rng)
+                                      ExperimentData &data, RngEngine &rng)
 {
   for (const auto op: ops)
   {
@@ -631,7 +631,7 @@ void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank)
   }
 }
 
-void State::apply_snapshot(const Operations::Op &op, OutputData &data, RngEngine &rng)
+void State::apply_snapshot(const Operations::Op &op, ExperimentData &data, RngEngine &rng)
 {
   auto it = snapshotset_.find(op.name);
   if (it == snapshotset_.end())
@@ -663,7 +663,7 @@ void State::apply_snapshot(const Operations::Op &op, OutputData &data, RngEngine
   }
 }
 
-void State::statevector_snapshot(const Operations::Op &op, OutputData &data, RngEngine &rng)
+void State::statevector_snapshot(const Operations::Op &op, ExperimentData &data, RngEngine &rng)
 {
   cvector_t statevector;
   BaseState::qreg_.state_vector(statevector, rng);
@@ -675,7 +675,7 @@ void State::statevector_snapshot(const Operations::Op &op, OutputData &data, Rng
   data.add_singleshot_snapshot("statevector", op.string_params[0], statevector);
 }
 
-void State::probabilities_snapshot(const Operations::Op &op, OutputData &data, RngEngine &rng)
+void State::probabilities_snapshot(const Operations::Op &op, ExperimentData &data, RngEngine &rng)
 {
   rvector_t probs;
   if (op.qubits.size() == 0)

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -113,7 +113,7 @@ public:
   // Apply a sequence of operations by looping over list
   // If the input is not in allowed_ops an exception will be raised.
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         OutputData &data,
+                         ExperimentData &data,
                          RngEngine &rng) override;
 
   // Initializes an n-qubit state to the all |0> state
@@ -181,7 +181,7 @@ protected:
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exception will be raised.
-  virtual void apply_snapshot(const Operations::Op &op, OutputData &data);
+  virtual void apply_snapshot(const Operations::Op &op, ExperimentData &data);
 
   // Apply a matrix to given qubits (identity on all other qubits)
   // We assume matrix to be 2x2
@@ -231,22 +231,22 @@ protected:
 
   // Snapshot current qubit probabilities for a measurement (average)
   void snapshot_probabilities(const Operations::Op &op,
-                              OutputData &data,
+                              ExperimentData &data,
                               bool variance);
 
   // Snapshot the expectation value of a Pauli operator
   void snapshot_pauli_expval(const Operations::Op &op,
-                             OutputData &data,
+                             ExperimentData &data,
                              bool variance);
 
   // Snapshot the expectation value of a matrix operator
   void snapshot_matrix_expval(const Operations::Op &op,
-                              OutputData &data,
+                              ExperimentData &data,
                               bool variance);
 
   // Snapshot the state vector
   void snapshot_state(const Operations::Op &op,
-		      OutputData &data,
+		      ExperimentData &data,
 		      std::string name = "");
 
   //-----------------------------------------------------------------------
@@ -410,7 +410,7 @@ void State::set_config(const json_t &config) {
 //=========================================================================
 
 void State::apply_ops(const std::vector<Operations::Op> &ops,
-                      OutputData &data,
+                      ExperimentData &data,
                       RngEngine &rng) {
 
   // Simple loop over vector of input operations
@@ -459,7 +459,7 @@ void State::apply_ops(const std::vector<Operations::Op> &ops,
 //=========================================================================
 
 void State::snapshot_pauli_expval(const Operations::Op &op,
-				  OutputData &data,
+				  ExperimentData &data,
 				  bool variance){
   if (op.params_expval_pauli.empty()) {
     throw std::invalid_argument("Invalid expval snapshot (Pauli components are empty).");
@@ -479,7 +479,7 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
 }
 
 void State::snapshot_matrix_expval(const Operations::Op &op,
-				   OutputData &data,
+				   ExperimentData &data,
 				   bool variance){
   if (op.params_expval_matrix.empty()) {
     throw std::invalid_argument("Invalid matrix snapshot (components are empty).");
@@ -501,7 +501,7 @@ void State::snapshot_matrix_expval(const Operations::Op &op,
 }
 
 void State::snapshot_state(const Operations::Op &op,
-			   OutputData &data,
+			   ExperimentData &data,
 			   std::string name) {
   cvector_t statevector;
   qreg_.full_state_vector(statevector);
@@ -510,7 +510,7 @@ void State::snapshot_state(const Operations::Op &op,
 }
 
 void State::snapshot_probabilities(const Operations::Op &op,
-				   OutputData &data,
+				   ExperimentData &data,
 				   bool variance) {
   MatrixProductState::MPS_Tensor full_tensor = qreg_.state_vec(0, qreg_.num_qubits()-1);
   rvector_t prob_vector;
@@ -674,7 +674,7 @@ std::vector<reg_t> State::sample_measure(const reg_t &qubits,
   return all_samples;
 }
 
-void State::apply_snapshot(const Operations::Op &op, OutputData &data) {
+void State::apply_snapshot(const Operations::Op &op, ExperimentData &data) {
   // Look for snapshot type in snapshotset
 
   auto it = snapshotset_.find(op.name);

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -660,12 +660,10 @@ OutputData QasmController::run_circuit_helper(const Circuit &circ,
   // Output data container
   OutputData data;
   data.set_config(config);
-  data.add_additional_data("metadata",
-                           json_t::object({{"method", state.name()}}));
+  data.add_metadata("method", state.name());
   // Add measure sampling to metadata
   // Note: this will set to `true` if sampling is enabled for the circuit
-  data.add_additional_data("metadata",
-                            json_t::object({{"measure_sampling", false}}));
+  data.add_metadata("measure_sampling", false);
 
   // Choose execution method based on noise and method
   if (noise.is_ideal()) {
@@ -760,8 +758,7 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
     ops = std::vector<Operations::Op>(opt_circ.ops.begin() + pos, opt_circ.ops.end());
     measure_sampler(ops, shots, state, data, rng);
     // Add measure sampling metadata
-    data.add_additional_data("metadata",
-                             json_t::object({{"measure_sampling", true}}));
+    data.add_metadata("measure_sampling", true);
   }  
 }
 

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -153,7 +153,7 @@ protected:
   // Abstract method for executing a circuit.
   // This method must initialize a state and return output data for
   // the required number of shots.
-  virtual OutputData run_circuit(const Circuit &circ,
+  virtual ExperimentData run_circuit(const Circuit &circ,
                                  const Noise::NoiseModel& noise,
                                  const json_t &config,
                                  uint_t shots,
@@ -187,7 +187,7 @@ protected:
 
   // Execute n-shots of a circuit on the input state
   template <class State_t, class Initstate_t>
-  OutputData run_circuit_helper(const Circuit &circ,
+  ExperimentData run_circuit_helper(const Circuit &circ,
                                 const Noise::NoiseModel &noise,
                                 const json_t &config,
                                 uint_t shots,
@@ -202,7 +202,7 @@ protected:
   void run_single_shot(const Circuit &circ,
                        State_t &state,
                        const Initstate_t &initial_state,
-                       OutputData &data,
+                       ExperimentData &data,
                        RngEngine &rng) const;
 
   // Execute a n-shots of a circuit without noise.
@@ -215,7 +215,7 @@ protected:
                                  State_t &state,
                                  const Initstate_t &initial_state,
                                  const Method method,
-                                 OutputData &data,
+                                 ExperimentData &data,
                                  RngEngine &rng) const;
 
   // Execute n-shots of a circuit with noise by sampling a new noisy
@@ -226,7 +226,7 @@ protected:
                               uint_t shots,
                               State_t &state,
                               const Initstate_t &initial_state,
-                              OutputData &data,
+                              ExperimentData &data,
                               RngEngine &rng) const;
 
   //----------------------------------------------------------------
@@ -239,7 +239,7 @@ protected:
   void measure_sampler(const std::vector<Operations::Op> &meas_ops,
                        uint_t shots,
                        State_t &state,
-                       OutputData &data,
+                       ExperimentData &data,
                        RngEngine &rng) const;
 
   // Check if measure sampling optimization is valid for the input circuit
@@ -373,7 +373,7 @@ void QasmController::clear_config() {
 // Base class override
 //-------------------------------------------------------------------------
 
-OutputData QasmController::run_circuit(const Circuit &circ,
+ExperimentData QasmController::run_circuit(const Circuit &circ,
                                        const Noise::NoiseModel& noise,
                                        const json_t &config,
                                        uint_t shots,
@@ -636,7 +636,7 @@ void QasmController::set_parallelization_circuit(const Circuit& circ,
 //-------------------------------------------------------------------------
 
 template <class State_t, class Initstate_t>
-OutputData QasmController::run_circuit_helper(const Circuit &circ,
+ExperimentData QasmController::run_circuit_helper(const Circuit &circ,
                                               const Noise::NoiseModel &noise,
                                               const json_t &config,
                                               uint_t shots,
@@ -658,7 +658,7 @@ OutputData QasmController::run_circuit_helper(const Circuit &circ,
   rng.set_seed(rng_seed);
 
   // Output data container
-  OutputData data;
+  ExperimentData data;
   data.set_config(config);
   data.add_metadata("method", state.name());
   // Add measure sampling to metadata
@@ -694,7 +694,7 @@ template <class State_t, class Initstate_t>
 void QasmController::run_single_shot(const Circuit &circ,
                                      State_t &state,
                                      const Initstate_t &initial_state,
-                                     OutputData &data,
+                                     ExperimentData &data,
                                      RngEngine &rng) const {
   initialize_state(circ, state, initial_state);
   state.apply_ops(circ.ops, data, rng);
@@ -708,7 +708,7 @@ void QasmController::run_circuit_with_noise(const Circuit &circ,
                                             uint_t shots,
                                             State_t &state,
                                             const Initstate_t &initial_state,
-                                            OutputData &data,
+                                            ExperimentData &data,
                                             RngEngine &rng) const {
   // Sample a new noise circuit and optimize for each shot
   while(shots-- > 0) {
@@ -729,7 +729,7 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
                                                State_t &state,
                                                const Initstate_t &initial_state,
                                                const Method method,
-                                               OutputData &data,
+                                               ExperimentData &data,
                                                RngEngine &rng) const {
   // Optimize circuit for state type
   Circuit opt_circ = circ;
@@ -814,7 +814,7 @@ template <class State_t>
 void QasmController::measure_sampler(const std::vector<Operations::Op> &meas_roerror_ops,
                                      uint_t shots,
                                      State_t &state,
-                                     OutputData &data,
+                                     ExperimentData &data,
                                      RngEngine &rng) const {
 
   // Check if meas_circ is empty, and if so return initial creg

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -82,7 +82,7 @@ public:
   // Apply a sequence of operations by looping over list
   // If the input is not in allowed_ops an exeption will be raised.
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         OutputData &data,
+                         ExperimentData &data,
                          RngEngine &rng) override;
 
   // Initializes an n-qubit state to the all |0> state
@@ -133,7 +133,7 @@ protected:
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const Operations::Op &op, OutputData &data);
+  virtual void apply_snapshot(const Operations::Op &op, ExperimentData &data);
 
   //-----------------------------------------------------------------------
   // Measurement Helpers
@@ -152,17 +152,17 @@ protected:
 
   // Snapshot the stabilizer state of the simulator.
   // This returns a list of stabilizer generators
-  void snapshot_stabilizer(const Operations::Op &op, OutputData &data);
+  void snapshot_stabilizer(const Operations::Op &op, ExperimentData &data);
                             
   // Snapshot current qubit probabilities for a measurement (average)
   void snapshot_probabilities(const Operations::Op &op,
-                              OutputData &data,
+                              ExperimentData &data,
                               bool variance);
 
   /* TODO
   // Snapshot the expectation value of a Pauli operator
   void snapshot_pauli_expval(const Operations::Op &op,
-                             OutputData &data,
+                             ExperimentData &data,
                              bool variance);
   */
 
@@ -271,7 +271,7 @@ void State::set_config(const json_t &config) {
 //=========================================================================
 
 void State::apply_ops(const std::vector<Operations::Op> &ops,
-                      OutputData &data,
+                      ExperimentData &data,
                       RngEngine &rng) {
   // Simple loop over vector of input operations
   for (const auto op: ops) {
@@ -419,7 +419,7 @@ std::vector<reg_t> State::sample_measure(const reg_t &qubits,
 //=========================================================================
 
 void State::apply_snapshot(const Operations::Op &op,
-                           OutputData &data) {
+                           ExperimentData &data) {
 
 // Look for snapshot type in snapshotset
   auto it = snapshotset_.find(op.name);
@@ -450,7 +450,7 @@ void State::apply_snapshot(const Operations::Op &op,
 }
 
 
-void State::snapshot_stabilizer(const Operations::Op &op, OutputData &data) {
+void State::snapshot_stabilizer(const Operations::Op &op, ExperimentData &data) {
   // We don't want to snapshot the full Clifford table, only the
   // stabilizer part. First Convert simulator clifford table to JSON
   json_t clifford = BaseState::qreg_;
@@ -462,7 +462,7 @@ void State::snapshot_stabilizer(const Operations::Op &op, OutputData &data) {
 
 
 void State::snapshot_probabilities(const Operations::Op &op,
-                                   OutputData &data,
+                                   ExperimentData &data,
                                    bool variance) {
   // Check number of qubits being measured is less than 64.
   // otherwise we cant use 64-bit int logic.

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -88,7 +88,7 @@ private:
 
   // This simulator will only return a single shot, regardless of the
   // input shot number
-  virtual OutputData run_circuit(const Circuit &circ,
+  virtual ExperimentData run_circuit(const Circuit &circ,
                                  const Noise::NoiseModel& noise,
                                  const json_t &config,
                                  uint_t shots,
@@ -140,7 +140,7 @@ size_t StatevectorController::required_memory_mb(const Circuit& circ,
 // Run circuit
 //-------------------------------------------------------------------------
 
-OutputData StatevectorController::run_circuit(const Circuit &circ,
+ExperimentData StatevectorController::run_circuit(const Circuit &circ,
                                               const Noise::NoiseModel& noise,
                                               const json_t &config,
                                               uint_t shots,
@@ -171,7 +171,7 @@ OutputData StatevectorController::run_circuit(const Circuit &circ,
   rng.set_seed(rng_seed);
 
   // Output data container
-  OutputData data;
+  ExperimentData data;
   data.set_config(config);
   
   // Run single shot collecting measure data or snapshots

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -105,7 +105,7 @@ public:
   // Apply a sequence of operations by looping over list
   // If the input is not in allowed_ops an exeption will be raised.
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         OutputData &data,
+                         ExperimentData &data,
                          RngEngine &rng) override;
 
   // Initializes an n-qubit state to the all |0> state
@@ -174,7 +174,7 @@ protected:
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const Operations::Op &op, OutputData &data);
+  virtual void apply_snapshot(const Operations::Op &op, ExperimentData &data);
 
   // Apply a matrix to given qubits (identity on all other qubits)
   void apply_matrix(const Operations::Op &op);
@@ -232,17 +232,17 @@ protected:
 
   // Snapshot current qubit probabilities for a measurement (average)
   void snapshot_probabilities(const Operations::Op &op,
-                              OutputData &data,
+                              ExperimentData &data,
                               SnapshotDataType type);
 
   // Snapshot the expectation value of a Pauli operator
   void snapshot_pauli_expval(const Operations::Op &op,
-                             OutputData &data,
+                             ExperimentData &data,
                              SnapshotDataType type);
 
   // Snapshot the expectation value of a matrix operator
   void snapshot_matrix_expval(const Operations::Op &op,
-                              OutputData &data,
+                              ExperimentData &data,
                               SnapshotDataType type);
 
   //-----------------------------------------------------------------------
@@ -424,7 +424,7 @@ void State<statevec_t>::set_config(const json_t &config) {
 
 template <class statevec_t>
 void State<statevec_t>::apply_ops(const std::vector<Operations::Op> &ops,
-                                 OutputData &data,
+                                 ExperimentData &data,
                                  RngEngine &rng) {
 
   // Simple loop over vector of input operations
@@ -478,7 +478,7 @@ void State<statevec_t>::apply_ops(const std::vector<Operations::Op> &ops,
 
 template <class statevec_t>
 void State<statevec_t>::apply_snapshot(const Operations::Op &op,
-                                       OutputData &data) {
+                                       ExperimentData &data) {
 
   // Look for snapshot type in snapshotset
   auto it = snapshotset_.find(op.name);
@@ -530,7 +530,7 @@ void State<statevec_t>::apply_snapshot(const Operations::Op &op,
 
 template <class statevec_t>
 void State<statevec_t>::snapshot_probabilities(const Operations::Op &op,
-                                               OutputData &data,
+                                               ExperimentData &data,
                                                SnapshotDataType type) {
   // get probs as hexadecimal
   auto probs = Utils::vec2ket(measure_probs(op.qubits),
@@ -543,7 +543,7 @@ void State<statevec_t>::snapshot_probabilities(const Operations::Op &op,
 
 template <class statevec_t>
 void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
-                                              OutputData &data,
+                                              ExperimentData &data,
                                               SnapshotDataType type) {
   // Check empty edge case
   if (op.params_expval_pauli.empty()) {
@@ -614,7 +614,7 @@ void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
 
 template <class statevec_t>
 void State<statevec_t>::snapshot_matrix_expval(const Operations::Op &op,
-                                               OutputData &data,
+                                               ExperimentData &data,
                                                SnapshotDataType type) {
   // Check empty edge case
   if (op.params_expval_matrix.empty()) {

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -84,7 +84,7 @@ public:
   // Apply a sequence of operations by looping over list
   // If the input is not in allowed_ops an exeption will be raised.
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         OutputData &data,
+                         ExperimentData &data,
                          RngEngine &rng) override;
 
   // Initializes an n-qubit unitary to the identity matrix
@@ -129,7 +129,7 @@ protected:
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const Operations::Op &op, OutputData &data);
+  virtual void apply_snapshot(const Operations::Op &op, ExperimentData &data);
 
   // Apply a matrix to given qubits (identity on all other qubits)
   void apply_matrix(const reg_t &qubits, const cmatrix_t & mat);
@@ -216,7 +216,7 @@ const stringmap_t<Gates> State<data_t>::gateset_({
 
 template <class data_t>
 void State<data_t>::apply_ops(const std::vector<Operations::Op> &ops,
-                                  OutputData &data,
+                                  ExperimentData &data,
                                   RngEngine &rng) {
   // Simple loop over vector of input operations
   for (const auto op: ops) {
@@ -462,7 +462,7 @@ void State<statevec_t>::apply_gate_u3(const uint_t qubit,
 
 template <class data_t>
 void State<data_t>::apply_snapshot(const Operations::Op &op,
-                                   OutputData &data) {
+                                   ExperimentData &data) {
   // Look for snapshot type in snapshotset
   if (op.name == "superopertor" || op.name == "state") {
     BaseState::snapshot_state(op, data, "superoperator");

--- a/src/simulators/unitary/unitary_controller.hpp
+++ b/src/simulators/unitary/unitary_controller.hpp
@@ -81,7 +81,7 @@ private:
 
   // This simulator will only return a single shot, regardless of the
   // input shot number
-  virtual OutputData run_circuit(const Circuit &circ,
+  virtual ExperimentData run_circuit(const Circuit &circ,
                                  const Noise::NoiseModel& noise,
                                  const json_t &config,
                                  uint_t shots,
@@ -133,7 +133,7 @@ size_t UnitaryController::required_memory_mb(const Circuit& circ,
 // Run circuit
 //-------------------------------------------------------------------------
 
-OutputData UnitaryController::run_circuit(const Circuit &circ,
+ExperimentData UnitaryController::run_circuit(const Circuit &circ,
                                           const Noise::NoiseModel& noise,
                                           const json_t &config,
                                           uint_t shots,
@@ -170,7 +170,7 @@ OutputData UnitaryController::run_circuit(const Circuit &circ,
   rng.set_seed(rng_seed);
 
   // Output data container
-  OutputData data;
+  ExperimentData data;
   data.set_config(config);
 
   // Run single shot collecting measure data or snapshots

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -80,7 +80,7 @@ public:
   // Apply a sequence of operations by looping over list
   // If the input is not in allowed_ops an exeption will be raised.
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         OutputData &data,
+                         ExperimentData &data,
                          RngEngine &rng) override;
 
   // Initializes an n-qubit unitary to the identity matrix
@@ -125,7 +125,7 @@ protected:
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const Operations::Op &op, OutputData &data);
+  virtual void apply_snapshot(const Operations::Op &op, ExperimentData &data);
 
   // Apply a matrix to given qubits (identity on all other qubits)
   void apply_matrix(const reg_t &qubits, const cmatrix_t & mat);
@@ -210,7 +210,7 @@ const stringmap_t<Gates> State<data_t>::gateset_({
 
 template <class data_t>
 void State<data_t>::apply_ops(const std::vector<Operations::Op> &ops,
-                                  OutputData &data,
+                                  ExperimentData &data,
                                   RngEngine &rng) {
   // Simple loop over vector of input operations
   for (const auto op: ops) {
@@ -414,7 +414,7 @@ void State<statevec_t>::apply_gate_mcu3(const reg_t& qubits,
 
 template <class data_t>
 void State<data_t>::apply_snapshot(const Operations::Op &op,
-                                   OutputData &data) {
+                                   ExperimentData &data) {
   // Look for snapshot type in snapshotset
   if (op.name == "unitary" || op.name == "state") {
     BaseState::snapshot_state(op, data);

--- a/src/transpile/basic_opts.hpp
+++ b/src/transpile/basic_opts.hpp
@@ -32,13 +32,13 @@ public:
   void optimize_circuit(Circuit& circ,
                         Noise::NoiseModel& noise,
                         const opset_t &opset,
-                        OutputData &data) const override;
+                        ExperimentData &data) const override;
 };
 
 void ReduceBarrier::optimize_circuit(Circuit& circ,
                                      Noise::NoiseModel& noise,
                                      const opset_t &allowed_opset,
-                                     OutputData &data) const {
+                                     ExperimentData &data) const {
 
   size_t idx = 0;
   for (size_t i = 0; i < circ.ops.size(); ++i) {
@@ -58,13 +58,13 @@ public:
   void optimize_circuit(Circuit& circ,
                         Noise::NoiseModel& noise,
                         const opset_t &opset,
-                        OutputData &data) const override;
+                        ExperimentData &data) const override;
 };
 
 void Debug::optimize_circuit(Circuit& circ,
                              Noise::NoiseModel& noise,
                              const opset_t &allowed_opset,
-                             OutputData &data) const {
+                             ExperimentData &data) const {
 
   oplist_t::iterator it = circ.ops.begin();
   while (it != circ.ops.end()) {

--- a/src/transpile/circuitopt.hpp
+++ b/src/transpile/circuitopt.hpp
@@ -40,7 +40,7 @@ public:
   virtual void optimize_circuit(Circuit& circ,
                                 Noise::NoiseModel& noise,
                                 const Operations::OpSet &opset,
-                                OutputData &data) const = 0;
+                                ExperimentData &data) const = 0;
 
   virtual void set_config(const json_t &config);
 

--- a/src/transpile/delay_measure.hpp
+++ b/src/transpile/delay_measure.hpp
@@ -121,8 +121,7 @@ void DelayMeasure::optimize_circuit(Circuit& circ,
   circ.ops.insert(circ.ops.end(), meas_ops.begin(), meas_ops.end());
   
   if (verbose_)
-      data.add_additional_data("metadata",
-                               json_t::object({{"delay_measure_verbose", circ.ops}}));
+      data.add_metadata("delay_measure_verbose", circ.ops);
 }
 
 

--- a/src/transpile/delay_measure.hpp
+++ b/src/transpile/delay_measure.hpp
@@ -36,7 +36,7 @@ public:
   void optimize_circuit(Circuit& circ,
                         Noise::NoiseModel& noise,
                         const Operations::OpSet &opset,
-                        OutputData &data) const override;
+                        ExperimentData &data) const override;
 
 private:
   // show debug info
@@ -55,7 +55,7 @@ void DelayMeasure::set_config(const json_t &config) {
 void DelayMeasure::optimize_circuit(Circuit& circ,
                                     Noise::NoiseModel& noise,
                                     const Operations::OpSet &allowed_opset,
-                                    OutputData &data) const {
+                                    ExperimentData &data) const {
   // Pass if we have quantum errors in the noise model
   if (active_ == false || circ.shots <= 1 || noise.has_quantum_errors())
     return; 

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -45,7 +45,7 @@ public:
   void optimize_circuit(Circuit& circ,
                         Noise::NoiseModel& noise,
                         const opset_t &opset,
-                        OutputData &data) const override;
+                        ExperimentData &data) const override;
 
 private:
   bool can_ignore(const op_t& op) const;
@@ -172,7 +172,7 @@ void Fusion::dump(const Circuit& circuit) const {
 void Fusion::optimize_circuit(Circuit& circ,
                               Noise::NoiseModel& noise,
                               const opset_t &allowed_opset,
-                              OutputData &data) const {
+                              ExperimentData &data) const {
 
   if (circ.num_qubits < threshold_
       || !active_)

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -209,8 +209,7 @@ void Fusion::optimize_circuit(Circuit& circ,
       circ.ops.erase(circ.ops.begin() + idx, circ.ops.end());
 
     if (verbose_)
-      data.add_additional_data("metadata",
-                               json_t::object({{"fusion_verbose", circ.ops}}));
+      data.add_metadata("fusion_verbose", circ.ops);
   }
 
 #ifdef DEBUG

--- a/src/transpile/truncate_qubits.hpp
+++ b/src/transpile/truncate_qubits.hpp
@@ -33,7 +33,7 @@ public:
   void optimize_circuit(Circuit& circ,
                         Noise::NoiseModel& noise,
                         const Operations::OpSet &opset,
-                        OutputData &data) const override;
+                        ExperimentData &data) const override;
 
 private:
   // check this optimization can be applied
@@ -80,7 +80,7 @@ void TruncateQubits::set_config(const json_t &config) {
 void TruncateQubits::optimize_circuit(Circuit& circ,
                                       Noise::NoiseModel& noise,
                                       const Operations::OpSet &allowed_opset,
-                                      OutputData &data) const {
+                                      ExperimentData &data) const {
   
   // Check if circuit operations allow remapping
   // Remapped circuits must return the same output data as the

--- a/src/transpile/truncate_qubits.hpp
+++ b/src/transpile/truncate_qubits.hpp
@@ -112,10 +112,10 @@ void TruncateQubits::optimize_circuit(Circuit& circ,
   noise.remap_qubits(mapping);
 
   if (verbose_) {
-    json_t metadata;
-    metadata["truncate_qubits"]["active_qubits"] = active_qubits;
-    metadata["truncate_qubits"]["mapping"] = mapping;
-    data.add_additional_data("metadata", metadata);
+    json_t truncate_metadata;
+    truncate_metadata["active_qubits"] = active_qubits;
+    truncate_metadata["mapping"] = mapping;
+    data.add_metadata("truncate_qubits", truncate_metadata);
   }
 }
 

--- a/test/terra/backends/qasm_simulator/matrix_product_state_measure.py
+++ b/test/terra/backends/qasm_simulator/matrix_product_state_measure.py
@@ -38,7 +38,7 @@ class QasmMatrixProductStateMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
         # Test sampling was enabled
         for res in result.results:
@@ -54,7 +54,7 @@ class QasmMatrixProductStateMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
         # Test sampling was enabled
         for res in result.results:
@@ -73,7 +73,7 @@ class QasmMatrixProductStateMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
         # Test sampling was enabled
         for res in result.results:

--- a/test/terra/backends/qasm_simulator/matrix_product_state_method.py
+++ b/test/terra/backends/qasm_simulator/matrix_product_state_method.py
@@ -66,6 +66,6 @@ class QasmMatrixProductStateMethodTests:
                 targets  = test[1](shots)
                 job = execute(circuits, QasmSimulator(), backend_options=self.BACKEND_OPTS, shots=shots)
                 result = job.result()
-                self.is_completed(result)
+                self.assertTrue(getattr(result, 'success', False))
                 self.compare_counts(result, circuits, targets, delta = delta*shots)
 

--- a/test/terra/backends/qasm_simulator/qasm_algorithms.py
+++ b/test/terra/backends/qasm_simulator/qasm_algorithms.py
@@ -35,7 +35,7 @@ class QasmAlgorithmTests:
         targets = ref_algorithms.grovers_counts(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_teleport_default_basis_gates(self):
@@ -45,7 +45,7 @@ class QasmAlgorithmTests:
         targets = ref_algorithms.teleport_counts(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
 
@@ -71,7 +71,7 @@ class QasmAlgorithmTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_teleport_waltz_basis_gates(self):
@@ -85,7 +85,7 @@ class QasmAlgorithmTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
 
@@ -107,7 +107,7 @@ class QasmAlgorithmTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_teleport_minimal_basis_gates(self):
@@ -118,5 +118,5 @@ class QasmAlgorithmTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_basics.py
+++ b/test/terra/backends/qasm_simulator/qasm_basics.py
@@ -30,7 +30,7 @@ class QasmBasicsTests:
         quantum_circuit = transpile(succeed_circuit, mocked_backend)
         qobj = assemble(quantum_circuit)
         result = mocked_backend.run(qobj).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
 
     def test_simulation_failed(self):
         """Test the we properly manage simulation failures."""

--- a/test/terra/backends/qasm_simulator/qasm_cliffords.py
+++ b/test/terra/backends/qasm_simulator/qasm_cliffords.py
@@ -36,7 +36,7 @@ class QasmCliffordTests:
         targets = ref_1q_clifford.h_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_h_gate_nondeterministic_default_basis_gates(self):
@@ -47,7 +47,7 @@ class QasmCliffordTests:
         targets = ref_1q_clifford.h_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -61,7 +61,7 @@ class QasmCliffordTests:
         targets = ref_1q_clifford.x_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -75,7 +75,7 @@ class QasmCliffordTests:
         targets = ref_1q_clifford.z_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -89,7 +89,7 @@ class QasmCliffordTests:
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -103,7 +103,7 @@ class QasmCliffordTests:
         targets = ref_1q_clifford.s_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_s_gate_nondeterministic_default_basis_gates(self):
@@ -118,7 +118,7 @@ class QasmCliffordTests:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -136,7 +136,7 @@ class QasmCliffordTests:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_sdg_gate_nondeterministic_default_basis_gates(self):
@@ -147,7 +147,7 @@ class QasmCliffordTests:
         targets = ref_1q_clifford.sdg_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -161,7 +161,7 @@ class QasmCliffordTests:
         targets = ref_2q_clifford.cx_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cx_gate_nondeterministic_default_basis_gates(self):
@@ -172,7 +172,7 @@ class QasmCliffordTests:
         targets = ref_2q_clifford.cx_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -186,7 +186,7 @@ class QasmCliffordTests:
         targets = ref_2q_clifford.cz_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cz_gate_nondeterministic_default_basis_gates(self):
@@ -197,7 +197,7 @@ class QasmCliffordTests:
         targets = ref_2q_clifford.cz_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -211,7 +211,7 @@ class QasmCliffordTests:
         targets = ref_2q_clifford.swap_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_swap_gate_nondeterministic_default_basis_gates(self):
@@ -222,7 +222,7 @@ class QasmCliffordTests:
         targets = ref_2q_clifford.swap_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
 
@@ -247,7 +247,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_h_gate_nondeterministic_waltz_basis_gates(self):
@@ -262,7 +262,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -280,7 +280,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -299,7 +299,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_z_gate_deterministic_minimal_basis_gates(self):
@@ -311,7 +311,7 @@ class QasmCliffordTestsWaltzBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -325,7 +325,7 @@ class QasmCliffordTestsWaltzBasis:
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_y_gate_deterministic_waltz_basis_gates(self):
@@ -340,7 +340,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -358,7 +358,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_s_gate_nondeterministic_waltz_basis_gates(self):
@@ -373,7 +373,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -391,7 +391,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_sdg_gate_nondeterministic_waltz_basis_gates(self):
@@ -406,7 +406,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -424,7 +424,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cx_gate_nondeterministic_waltz_basis_gates(self):
@@ -439,7 +439,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -457,7 +457,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cz_gate_nondeterministic_waltz_basis_gates(self):
@@ -472,7 +472,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -490,7 +490,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_swap_gate_nondeterministic_waltz_basis_gates(self):
@@ -505,7 +505,7 @@ class QasmCliffordTestsWaltzBasis:
             shots=shots,
             basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
 
@@ -528,7 +528,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_h_gate_nondeterministic_minimal_basis_gates(self):
@@ -540,7 +540,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -555,7 +555,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -571,7 +571,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -587,7 +587,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -603,7 +603,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_s_gate_nondeterministic_minimal_basis_gates(self):
@@ -615,7 +615,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -630,7 +630,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_sdg_gate_nondeterministic_minimal_basis_gates(self):
@@ -642,7 +642,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -657,7 +657,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cx_gate_nondeterministic_minimal_basis_gates(self):
@@ -669,7 +669,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -684,7 +684,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cz_gate_nondeterministic_minimal_basis_gates(self):
@@ -696,7 +696,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -711,7 +711,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_swap_gate_nondeterministic_minimal_basis_gates(self):
@@ -723,7 +723,7 @@ class QasmCliffordTestsMinimalBasis:
         job = execute(
             circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -737,7 +737,7 @@ class QasmCliffordTestsMinimalBasis:
         targets = ref_2q_clifford.multiplexer_cx_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_multiplexer_cx_gate_nondeterministic_default_basis_gates(self):
@@ -748,5 +748,5 @@ class QasmCliffordTestsMinimalBasis:
         targets = ref_2q_clifford.multiplexer_cx_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_conditional.py
+++ b/test/terra/backends/qasm_simulator/qasm_conditional.py
@@ -36,7 +36,7 @@ class QasmConditionalGateTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_conditional_gates_2bit(self):
@@ -48,7 +48,7 @@ class QasmConditionalGateTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
 
@@ -70,7 +70,7 @@ class QasmConditionalUnitaryTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_conditional_unitary_2bit(self):
@@ -82,7 +82,7 @@ class QasmConditionalUnitaryTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
 
@@ -104,7 +104,7 @@ class QasmConditionalKrausTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_conditional_kraus_2bit(self):
@@ -116,7 +116,7 @@ class QasmConditionalKrausTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
 
@@ -138,7 +138,7 @@ class QasmConditionalSuperOpTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_conditional_superop_2bit(self):
@@ -150,5 +150,5 @@ class QasmConditionalSuperOpTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)

--- a/test/terra/backends/qasm_simulator/qasm_delay_measure.py
+++ b/test/terra/backends/qasm_simulator/qasm_delay_measure.py
@@ -54,7 +54,7 @@ class QasmDelayMeasureTests:
         result = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         metadata = result.results[0].metadata
         self.assertTrue(metadata.get('measure_sampling'))
 
@@ -65,7 +65,7 @@ class QasmDelayMeasureTests:
         result = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         metadata = result.results[0].metadata
         self.assertTrue(metadata.get('measure_sampling'))
 
@@ -76,7 +76,7 @@ class QasmDelayMeasureTests:
         result = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         metadata = result.results[0].metadata
         self.assertFalse(metadata.get('measure_sampling'))
 
@@ -95,7 +95,7 @@ class QasmDelayMeasureTests:
         result = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         metadata = result.results[0].metadata
         self.assertIn('delay_measure_verbose', metadata)
 
@@ -108,7 +108,7 @@ class QasmDelayMeasureTests:
         result = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         metadata = result.results[0].metadata
         self.assertNotIn('delay_measure_verbose', metadata)
 
@@ -121,6 +121,6 @@ class QasmDelayMeasureTests:
         result = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         metadata = result.results[0].metadata
         self.assertNotIn('delay_measure_verbose', metadata)

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -77,7 +77,7 @@ class QasmFusionTests:
 
         result = self.SIMULATOR.run(
             qobj, backend_options=backend_options).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
 
         self.assertTrue(
             'results' in result.to_dict(), msg="results must exist in result")
@@ -110,7 +110,7 @@ class QasmFusionTests:
             qobj,
             noise_model=noise_model,
             backend_options=backend_options).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
 
         self.assertTrue(
             'results' in result.to_dict(), msg="results must exist in result")
@@ -138,7 +138,7 @@ class QasmFusionTests:
         result_verbose = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_verbose)
+        self.assertTrue(getattr(result_verbose, 'success', 'False'))
         self.assertTrue(
             'results' in result_verbose.to_dict(),
             msg="results must exist in result")
@@ -160,7 +160,7 @@ class QasmFusionTests:
         result_nonverbose = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_nonverbose)
+        self.assertTrue(getattr(result_nonverbose, 'success', 'False'))
         self.assertTrue(
             'results' in result_nonverbose.to_dict(),
             msg="results must exist in result")
@@ -179,7 +179,7 @@ class QasmFusionTests:
 
         result_default = self.SIMULATOR.run(
             qobj, backend_options=backend_options).result()
-        self.is_completed(result_default)
+        self.assertTrue(getattr(result_default, 'success', 'False'))
         self.assertTrue(
             'results' in result_default.to_dict(),
             msg="results must exist in result")
@@ -207,7 +207,7 @@ class QasmFusionTests:
         result_verbose = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_verbose)
+        self.assertTrue(getattr(result_verbose, 'success', 'False'))
         self.assertTrue(
             'results' in result_verbose.to_dict(),
             msg="results must exist in result")
@@ -229,7 +229,7 @@ class QasmFusionTests:
         result_disabled = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_disabled)
+        self.assertTrue(getattr(result_disabled, 'success', 'False'))
         self.assertTrue(
             'results' in result_disabled.to_dict(),
             msg="results must exist in result")
@@ -246,7 +246,7 @@ class QasmFusionTests:
 
         result_default = self.SIMULATOR.run(
             qobj, backend_options=backend_options).result()
-        self.is_completed(result_default)
+        self.assertTrue(getattr(result_default, 'success', 'False'))
         self.assertTrue(
             'results' in result_default.to_dict(),
             msg="results must exist in result")
@@ -327,7 +327,7 @@ class QasmFusionTests:
         result_fusion = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_fusion)
+        self.assertTrue(getattr(result_fusion, 'success', 'False'))
 
         backend_options = self.BACKEND_OPTS.copy()
         backend_options['fusion_enable'] = False
@@ -339,7 +339,7 @@ class QasmFusionTests:
         result_nonfusion = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_nonfusion)
+        self.assertTrue(getattr(result_nonfusion, 'success', 'False'))
 
         self.assertDictAlmostEqual(
             result_fusion.get_counts(circuit),
@@ -365,7 +365,7 @@ class QasmFusionTests:
         result_fusion = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_fusion)
+        self.assertTrue(getattr(result_fusion, 'success', 'False'))
 
         backend_options = self.BACKEND_OPTS.copy()
         backend_options['fusion_enable'] = False
@@ -377,7 +377,7 @@ class QasmFusionTests:
         result_nonfusion = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_nonfusion)
+        self.assertTrue(getattr(result_nonfusion, 'success', 'False'))
         
         self.assertDictAlmostEqual(
             result_fusion.get_counts(circuit),
@@ -402,7 +402,7 @@ class QasmFusionTests:
         result_fusion = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_fusion)
+        self.assertTrue(getattr(result_fusion, 'success', 'False'))
 
         backend_options = self.BACKEND_OPTS.copy()
         backend_options['fusion_enable'] = False
@@ -414,7 +414,7 @@ class QasmFusionTests:
         result_nonfusion = self.SIMULATOR.run(
             qobj,
             backend_options=backend_options).result()
-        self.is_completed(result_nonfusion)
+        self.assertTrue(getattr(result_nonfusion, 'success', 'False'))
         
         self.assertDictAlmostEqual(
             result_fusion.get_counts(circuit),

--- a/test/terra/backends/qasm_simulator/qasm_initialize.py
+++ b/test/terra/backends/qasm_simulator/qasm_initialize.py
@@ -37,7 +37,7 @@ class QasmInitializeTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_initialize_2(self):
@@ -50,7 +50,7 @@ class QasmInitializeTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_initialize_sampling_opt(self):
@@ -61,5 +61,5 @@ class QasmInitializeTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_measure.py
+++ b/test/terra/backends/qasm_simulator/qasm_measure.py
@@ -39,7 +39,7 @@ class QasmMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots, memory=True)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, target_counts, delta=0)
         self.compare_memory(result, circuits, target_memory)
         self.compare_result_metadata(result, circuits, "measure_sampling", True)
@@ -54,7 +54,7 @@ class QasmMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots, memory=True)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, target_counts, delta=0)
         self.compare_memory(result, circuits, target_memory)
         self.compare_result_metadata(result, circuits, "measure_sampling", False)
@@ -68,7 +68,7 @@ class QasmMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
         # Test sampling was enabled
         for res in result.results:
@@ -84,7 +84,7 @@ class QasmMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
         self.compare_result_metadata(result, circuits, "measure_sampling", False)
 
@@ -104,7 +104,7 @@ class QasmMeasureTests:
         result = self.SIMULATOR.run(
             qobj, noise_model=noise_model,
             backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_result_metadata(result, circuits, "measure_sampling", True)
 
     def test_measure_sampling_with_quantum_noise(self):
@@ -127,7 +127,7 @@ class QasmMeasureTests:
         result = self.SIMULATOR.run(
             qobj, noise_model=noise_model,
             backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         sampling = (self.BACKEND_OPTS.get("method") == "density_matrix")
         self.compare_result_metadata(result, circuits, "measure_sampling", sampling)
 
@@ -151,7 +151,7 @@ class QasmMultiQubitMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots, memory=True)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, target_counts, delta=0)
         self.compare_memory(result, circuits, target_memory)
         self.compare_result_metadata(result, circuits, "measure_sampling", True)
@@ -179,7 +179,7 @@ class QasmMultiQubitMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
         self.compare_result_metadata(result, circuits, "measure_sampling", True)
 
@@ -192,6 +192,6 @@ class QasmMultiQubitMeasureTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
         self.compare_result_metadata(result, circuits, "measure_sampling", False)

--- a/test/terra/backends/qasm_simulator/qasm_method.py
+++ b/test/terra/backends/qasm_simulator/qasm_method.py
@@ -41,17 +41,14 @@ class QasmMethodTests:
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj, backend_options=self.BACKEND_OPTS).result()
-
+        result = self.SIMULATOR.run(
+            qobj, backend_options=self.BACKEND_OPTS).result()
+        success = getattr(result, 'success', False)
+        self.assertTrue(success)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
-        result = get_result()
-        self.is_completed(result)
         if method != 'automatic':
-            self.compare_result_metadata(result, circuits, 'method',
-                                         method)
+            self.compare_result_metadata(result, circuits, 'method', method)
         else:
             self.compare_result_metadata(result, circuits, 'method',
                                          'stabilizer')
@@ -78,19 +75,15 @@ class QasmMethodTests:
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS,
-                noise_model=noise_model).result()
-
+        result = self.SIMULATOR.run(qobj,
+                                    backend_options=self.BACKEND_OPTS,
+                                    noise_model=noise_model).result()
+        success = getattr(result, 'success', False)
+        self.assertTrue(success)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
-        result = get_result()
-        self.is_completed(result)
         if method != 'automatic':
-            self.compare_result_metadata(result, circuits, 'method',
-                                         method)
+            self.compare_result_metadata(result, circuits, 'method', method)
         else:
             self.compare_result_metadata(result, circuits, 'method',
                                          'stabilizer')
@@ -107,21 +100,14 @@ class QasmMethodTests:
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
-
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS,
-                noise_model=noise_model).result()
-
-        # Check simulation method
-        method = self.BACKEND_OPTS.get('method', 'automatic')
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        success = getattr(result, 'success', False)
+        self.assertTrue(success)
+        # Check simulation method
+        method = self.BACKEND_OPTS.get('method', 'automatic')
         if method != 'automatic':
-            self.compare_result_metadata(result, circuits, 'method',
-                                         method)
+            self.compare_result_metadata(result, circuits, 'method', method)
         else:
             self.compare_result_metadata(result, circuits, 'method',
                                          'stabilizer')
@@ -138,20 +124,16 @@ class QasmMethodTests:
         circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
-
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS,
-                noise_model=noise_model).result()
-
+        result = self.SIMULATOR.run(qobj,
+                                    backend_options=self.BACKEND_OPTS,
+                                    noise_model=noise_model).result()
+        success = getattr(result, 'success', False)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
-            self.assertRaises(AerError, get_result)
+            self.assertFalse(success)
         else:
-            result = get_result()
-            self.is_completed(result)
+            self.assertTrue(success)
             if method == 'automatic':
                 target_method = 'density_matrix'
             else:
@@ -173,19 +155,16 @@ class QasmMethodTests:
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS,
-                noise_model=noise_model).result()
-
+        result = self.SIMULATOR.run(qobj,
+                                    backend_options=self.BACKEND_OPTS,
+                                    noise_model=noise_model).result()
+        success = getattr(result, 'success', False)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
-            self.assertRaises(AerError, get_result)
+            self.assertFalse(success)
         else:
-            result = get_result()
-            self.is_completed(result)
+            self.assertTrue(success)
             if method == 'automatic':
                 target_method = 'density_matrix'
             else:
@@ -204,18 +183,15 @@ class QasmMethodTests:
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS).result()
-
+        result = self.SIMULATOR.run(
+            qobj, backend_options=self.BACKEND_OPTS).result()
+        success = getattr(result, 'success', False)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
-            self.assertRaises(AerError, get_result)
+            self.assertFalse(success)
         else:
-            result = get_result()
-            self.is_completed(result)
+            self.assertTrue(success)
             if method == 'automatic':
                 target_method = 'statevector'
             else:
@@ -245,19 +221,17 @@ class QasmMethodTests:
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS,
-                noise_model=noise_model).result()
-
+        result = self.SIMULATOR.run(qobj,
+                                    backend_options=self.BACKEND_OPTS,
+                                    noise_model=noise_model).result()
+        success = getattr(result, 'success', False)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
-            self.assertRaises(AerError, get_result)
+            self.assertFalse(success)
         else:
-            result = get_result()
-            self.is_completed(result)
+            self.assertTrue
+            self.assertTrue(success)
             if method == 'automatic':
                 target_method = 'density_matrix'
             else:
@@ -278,19 +252,16 @@ class QasmMethodTests:
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS,
-                noise_model=noise_model).result()
-
+        result = self.SIMULATOR.run(qobj,
+                                    backend_options=self.BACKEND_OPTS,
+                                    noise_model=noise_model).result()
+        success = getattr(result, 'success', False)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
-            self.assertRaises(AerError, get_result)
+            self.assertFalse(success)
         else:
-            result = get_result()
-            self.is_completed(result)
+            self.assertTrue(success)
             if method == 'automatic':
                 target_method = 'density_matrix'
             else:
@@ -311,19 +282,16 @@ class QasmMethodTests:
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS,
-                noise_model=noise_model).result()
-
+        result = self.SIMULATOR.run(qobj,
+                                    backend_options=self.BACKEND_OPTS,
+                                    noise_model=noise_model).result()
+        success = getattr(result, 'success', False)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
-            self.assertRaises(AerError, get_result)
+            self.assertFalse(success)
         else:
-            result = get_result()
-            self.is_completed(result)
+            self.assertTrue(success)
             if method == 'automatic':
                 target_method = 'density_matrix'
             else:
@@ -345,19 +313,16 @@ class QasmMethodTests:
             final_measure=True)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
 
-        def get_result():
-            return self.SIMULATOR.run(
-                qobj,
-                backend_options=self.BACKEND_OPTS,
-                noise_model=noise_model).result()
-
+        result = self.SIMULATOR.run(qobj,
+                                    backend_options=self.BACKEND_OPTS,
+                                    noise_model=noise_model).result()
+        success = getattr(result, 'success', False)
         # Check simulation method
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method == 'stabilizer':
-            self.assertRaises(AerError, get_result)
+            self.assertFalse(success)
         else:
-            result = get_result()
-            self.is_completed(result)
+            self.assertTrue(success)
             if method == 'automatic':
                 target_method = 'density_matrix'
             else:

--- a/test/terra/backends/qasm_simulator/qasm_noise.py
+++ b/test/terra/backends/qasm_simulator/qasm_noise.py
@@ -44,7 +44,7 @@ class QasmReadoutNoiseTests:
                 qobj,
                 backend_options=self.BACKEND_OPTS,
                 noise_model=noise_model).result()
-            self.is_completed(result)
+            self.assertTrue(getattr(result, 'success', False))
             self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
 
 
@@ -68,7 +68,7 @@ class QasmPauliNoiseTests:
                 qobj,
                 backend_options=self.BACKEND_OPTS,
                 noise_model=noise_model).result()
-            self.is_completed(result)
+            self.assertTrue(getattr(result, 'success', False))
             self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
 
     def test_pauli_reset_noise(self):
@@ -85,7 +85,7 @@ class QasmPauliNoiseTests:
                 qobj,
                 backend_options=self.BACKEND_OPTS,
                 noise_model=noise_model).result()
-            self.is_completed(result)
+            self.assertTrue(getattr(result, 'success', False))
             self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
 
     def test_pauli_measure_noise(self):
@@ -102,7 +102,7 @@ class QasmPauliNoiseTests:
                 qobj,
                 backend_options=self.BACKEND_OPTS,
                 noise_model=noise_model).result()
-            self.is_completed(result)
+            self.assertTrue(getattr(result, 'success', False))
             self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
 
 
@@ -126,7 +126,7 @@ class QasmResetNoiseTests:
                 qobj,
                 backend_options=self.BACKEND_OPTS,
                 noise_model=noise_model).result()
-            self.is_completed(result)
+            self.assertTrue(getattr(result, 'success', False))
             self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
 
 
@@ -150,5 +150,5 @@ class QasmKrausNoiseTests:
                 qobj,
                 backend_options=self.BACKEND_OPTS,
                 noise_model=noise_model).result()
-            self.is_completed(result)
+            self.assertTrue(getattr(result, 'success', False))
             self.compare_counts(result, [circuit], [target], delta=0.05 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_noncliffords.py
+++ b/test/terra/backends/qasm_simulator/qasm_noncliffords.py
@@ -35,7 +35,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_t_gate_nondeterministic_default_basis_gates(self):
@@ -46,7 +46,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -60,7 +60,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_tdg_gate_nondeterministic_default_basis_gates(self):
@@ -71,7 +71,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -85,7 +85,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_ccx_gate_nondeterministic_default_basis_gates(self):
@@ -96,7 +96,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -109,7 +109,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.cswap_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cswap_gate_nondeterministic_default_basis_gates(self):
@@ -119,7 +119,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.cswap_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -133,7 +133,7 @@ class QasmNonCliffordTests:
         targets = ref_non_clifford.cu1_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
 
@@ -154,7 +154,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_t_gate_nondeterministic_waltz_basis_gates(self):
@@ -165,7 +165,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -179,7 +179,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_tdg_gate_nondeterministic_waltz_basis_gates(self):
@@ -190,7 +190,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -204,7 +204,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_ccx_gate_nondeterministic_waltz_basis_gates(self):
@@ -215,7 +215,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -229,7 +229,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.cswap_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cswap_gate_nondeterministic_waltz_basis_gates(self):
@@ -240,7 +240,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.cswap_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -254,7 +254,7 @@ class QasmNonCliffordTestsWaltzBasis:
         targets = ref_non_clifford.cu1_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
 
@@ -275,7 +275,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_t_gate_nondeterministic_minimal_basis_gates(self):
@@ -286,7 +286,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -300,7 +300,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_tdg_gate_nondeterministic_minimal_basis_gates(self):
@@ -311,7 +311,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -325,7 +325,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_ccx_gate_nondeterministic_minimal_basis_gates(self):
@@ -336,7 +336,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     # ---------------------------------------------------------------------
@@ -350,7 +350,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.cu1_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     # ---------------------------------------------------------------------
@@ -364,7 +364,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.multiplexer_ccx_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_multiplexer_cxx_gate_nondeterministic_default_basis_gates(self):
@@ -375,7 +375,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.multiplexer_ccx_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -389,7 +389,7 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.cswap_gate_counts_deterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cswap_gate_nondeterministic_minimal_basis_gates(self):
@@ -400,5 +400,5 @@ class QasmNonCliffordTestsMinimalBasis:
         targets = ref_non_clifford.cswap_gate_counts_nondeterministic(shots)
         job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_reset.py
+++ b/test/terra/backends/qasm_simulator/qasm_reset.py
@@ -37,7 +37,7 @@ class QasmResetTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_reset_nondeterministic(self):
@@ -51,7 +51,7 @@ class QasmResetTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_reset_sampling_opt(self):
@@ -62,7 +62,7 @@ class QasmResetTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_repeated_resets(self):
@@ -73,5 +73,5 @@ class QasmResetTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         result = self.SIMULATOR.run(
             qobj, backend_options=self.BACKEND_OPTS).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)

--- a/test/terra/backends/qasm_simulator/qasm_snapshot.py
+++ b/test/terra/backends/qasm_simulator/qasm_snapshot.py
@@ -70,12 +70,13 @@ class QasmSnapshotStatevectorTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         job = self.SIMULATOR.run(qobj,
                                  backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotStatevectorTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result, circuits, counts_targets, delta=0)
             # Check snapshots
             for j, circuit in enumerate(circuits):
@@ -100,13 +101,13 @@ class QasmSnapshotStatevectorTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         job = self.SIMULATOR.run(qobj,
                                  backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotStatevectorTests.SUPPORTED_QASM_METHODS:
-
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result,
                                 circuits,
                                 counts_targets,
@@ -134,13 +135,14 @@ class QasmSnapshotStatevectorTests:
         qobj = assemble(circuits, self.SIMULATOR, memory=True, shots=shots)
         job = self.SIMULATOR.run(qobj,
                                  backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotStatevectorTests.SUPPORTED_QASM_METHODS:
             logging.getLogger().setLevel(logging.CRITICAL)
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result, circuits, counts_targets, delta=0)
             # Check snapshots
             for i, circuit in enumerate(circuits):
@@ -164,12 +166,13 @@ class QasmSnapshotStatevectorTests:
         qobj = assemble(circuits, self.SIMULATOR, memory=True, shots=shots)
         job = self.SIMULATOR.run(qobj,
                                  backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotStatevectorTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result,
                                 circuits,
                                 counts_targets,
@@ -223,12 +226,13 @@ class QasmSnapshotStabilizerTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         job = self.SIMULATOR.run(qobj,
                                  backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotStabilizerTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result, circuits, counts_targets, delta=0)
             # Check snapshots
             for j, circuit in enumerate(circuits):
@@ -254,12 +258,13 @@ class QasmSnapshotStabilizerTests:
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         job = self.SIMULATOR.run(qobj,
                                  backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotStabilizerTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result,
                                 circuits,
                                 counts_targets,
@@ -288,12 +293,13 @@ class QasmSnapshotStabilizerTests:
         qobj = assemble(circuits, self.SIMULATOR, memory=True, shots=shots)
         job = self.SIMULATOR.run(qobj,
                                  backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotStabilizerTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result, circuits, counts_targets, delta=0)
             # Check snapshots
             for i, circuit in enumerate(circuits):
@@ -319,12 +325,13 @@ class QasmSnapshotStabilizerTests:
         qobj = assemble(circuits, self.SIMULATOR, memory=True, shots=shots)
         job = self.SIMULATOR.run(qobj,
                                  backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotStabilizerTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result,
                                 circuits,
                                 counts_targets,
@@ -375,12 +382,13 @@ class QasmSnapshotDensityMatrixTests:
 
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result, circuits, counts_targets, delta=0)
             # Check snapshots
             for j, circuit in enumerate(circuits):
@@ -405,12 +413,13 @@ class QasmSnapshotDensityMatrixTests:
 
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result,
                                 circuits,
                                 counts_targets,
@@ -437,12 +446,13 @@ class QasmSnapshotDensityMatrixTests:
 
         qobj = assemble(circuits, self.SIMULATOR, memory=True, shots=shots)
         job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result, circuits, counts_targets, delta=0)
             # Check snapshots
             for i, circuit in enumerate(circuits):
@@ -467,12 +477,13 @@ class QasmSnapshotDensityMatrixTests:
 
         qobj = assemble(circuits, self.SIMULATOR, memory=True, shots=shots)
         job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result,
                                 circuits,
                                 counts_targets,
@@ -519,12 +530,13 @@ class QasmSnapshotProbabilitiesTests:
 
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotProbabilitiesTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result, circuits, counts_targets, delta=0.1 * shots)
             # Check snapshots
             for j, circuit in enumerate(circuits):
@@ -548,12 +560,13 @@ class QasmSnapshotProbabilitiesTests:
 
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
         job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        success = getattr(result, 'success', False)
         method = self.BACKEND_OPTS.get('method', 'automatic')
         if method not in QasmSnapshotProbabilitiesTests.SUPPORTED_QASM_METHODS:
-            self.assertRaises(AerError, job.result)
+            self.assertFalse(success)
         else:
-            result = job.result()
-            self.is_completed(result)
+            self.assertTrue(success)
             self.compare_counts(result, circuits, counts_targets, delta=0.1 * shots)
             # Check snapshots
             for j, circuit in enumerate(circuits):

--- a/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
+++ b/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
@@ -37,5 +37,5 @@ class QasmUnitaryGateTests:
         targets = ref_unitary_gate.unitary_gate_counts_deterministic(
             shots)
         result = execute(circuits, self.SIMULATOR, shots=shots).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)

--- a/test/terra/backends/test_qasm_extended_stabilizer_simulator.py
+++ b/test/terra/backends/test_qasm_extended_stabilizer_simulator.py
@@ -57,7 +57,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_reset.reset_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_reset_nondeterministic(self):
@@ -71,7 +71,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_reset.reset_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # # ---------------------------------------------------------------------
@@ -86,7 +86,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_measure.measure_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_measure_deterministic_without_sampling(self):
@@ -98,7 +98,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_measure.measure_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_measure_nondeterministic_with_sampling(self):
@@ -110,7 +110,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_measure.measure_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_measure_nondeterministic_without_sampling(self):
@@ -122,7 +122,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_measure.measure_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # # ---------------------------------------------------------------------
@@ -137,7 +137,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         qobj = assemble(circuits, QasmSimulator(), shots=shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_measure_deterministic_multi_qubit_without_sampling(self):
@@ -149,7 +149,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         qobj = assemble(circuits, QasmSimulator(), shots=shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_measure_nondeterministic_multi_qubit_with_sampling(self):
@@ -161,7 +161,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         qobj = assemble(circuits, QasmSimulator(), shots=shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_measure_nondeterministic_multi_qubit_without_sampling(self):
@@ -173,7 +173,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         qobj = assemble(circuits, QasmSimulator(), shots=shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # # ---------------------------------------------------------------------
@@ -188,7 +188,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_conditionals.conditional_counts_1bit(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_conditional_2bit(self):
@@ -200,7 +200,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_conditionals.conditional_counts_2bit(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -215,7 +215,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_h_gate_nondeterministic_default_basis_gates(self):
@@ -227,7 +227,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -242,7 +242,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.x_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -257,7 +257,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.z_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -272,7 +272,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.y_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     # ---------------------------------------------------------------------
@@ -287,7 +287,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_s_gate_nondeterministic_default_basis_gates(self):
@@ -299,7 +299,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -314,7 +314,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_sdg_gate_nondeterministic_default_basis_gates(self):
@@ -326,7 +326,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -341,7 +341,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cx_gate_nondeterministic_default_basis_gates(self):
@@ -353,7 +353,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -368,7 +368,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_cz_gate_nondeterministic_default_basis_gates(self):
@@ -380,7 +380,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -395,7 +395,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
 
     def test_swap_gate_nondeterministic_default_basis_gates(self):
@@ -407,7 +407,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_counts_nondeterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS_SAMPLING)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     # ---------------------------------------------------------------------
@@ -422,7 +422,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     def test_t_gate_nondeterministic_default_basis_gates(self):
@@ -436,7 +436,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         opts["extended_stabilizer_mixing_time"] = 50
         job = QasmSimulator().run(qobj, backend_options=opts)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     # ---------------------------------------------------------------------
@@ -451,7 +451,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
 
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
@@ -466,7 +466,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         opts["extended_stabilizer_mixing_time"] = 50
         job = QasmSimulator().run(qobj, backend_options=opts)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     # ---------------------------------------------------------------------
@@ -483,7 +483,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         opts["extended_stabilizer_mixing_time"] = 100
         job = QasmSimulator().run(qobj, backend_options=opts)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_ccx_gate_nondeterministic_default_basis_gates(self):
@@ -497,7 +497,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         opts["extended_stabilizer_mixing_time"] = 100
         job = QasmSimulator().run(qobj, backend_options=opts)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.10 * shots)
 
     # # ---------------------------------------------------------------------
@@ -514,7 +514,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         opts["extended_stabilizer_mixing_time"] = 100
         job = QasmSimulator().run(qobj, backend_options=opts)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
 
     def test_teleport_default_basis_gates(self):
@@ -525,7 +525,7 @@ class TestQasmExtendedStabilizerSimulator(common.QiskitAerTestCase):
         targets = ref_algorithms.teleport_counts(shots)
         job = QasmSimulator().run(qobj, backend_options=self.BACKEND_OPTS)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
 

--- a/test/terra/backends/test_statevector_simulator.py
+++ b/test/terra/backends/test_statevector_simulator.py
@@ -43,7 +43,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         qobj = assemble(circuits, shots=1)
         sim_job = StatevectorSimulator().run(qobj)
         result = sim_job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_initialize_2(self):
@@ -53,7 +53,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         qobj = assemble(circuits, shots=1)
         sim_job = StatevectorSimulator().run(qobj)
         result = sim_job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -67,7 +67,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_reset.reset_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_reset_nondeterministic(self):
@@ -78,7 +78,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_reset.reset_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -90,7 +90,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_measure.measure_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -102,7 +102,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_conditionals.conditional_statevector_1bit()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_conditional_unitary_1bit(self):
@@ -112,7 +112,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_conditionals.conditional_statevector_1bit()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_conditional_gate_2bit(self):
@@ -121,7 +121,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_conditionals.conditional_statevector_2bit()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_conditional_unitary_2bit(self):
@@ -131,7 +131,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_conditionals.conditional_statevector_2bit()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -143,7 +143,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_h_gate_deterministic_waltz_basis_gates(self):
@@ -153,7 +153,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_h_gate_deterministic_minimal_basis_gates(self):
@@ -162,7 +162,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_h_gate_nondeterministic_default_basis_gates(self):
@@ -171,7 +171,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_h_gate_nondeterministic_waltz_basis_gates(self):
@@ -181,7 +181,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_h_gate_nondeterministic_minimal_basis_gates(self):
@@ -190,7 +190,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -202,7 +202,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.x_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_x_gate_deterministic_waltz_basis_gates(self):
@@ -212,7 +212,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_x_gate_deterministic_minimal_basis_gates(self):
@@ -222,7 +222,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -234,7 +234,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.z_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_z_gate_deterministic_waltz_basis_gates(self):
@@ -244,7 +244,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_z_gate_deterministic_minimal_basis_gates(self):
@@ -254,7 +254,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -266,7 +266,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.y_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_y_gate_deterministic_waltz_basis_gates(self):
@@ -276,7 +276,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_y_gate_deterministic_minimal_basis_gates(self):
@@ -286,7 +286,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -298,7 +298,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_s_gate_deterministic_waltz_basis_gates(self):
@@ -308,7 +308,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_s_gate_deterministic_minimal_basis_gates(self):
@@ -318,7 +318,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_s_gate_nondeterministic_default_basis_gates(self):
@@ -327,7 +327,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_s_gate_nondeterministic_waltz_basis_gates(self):
@@ -337,7 +337,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_s_gate_nondeterministic_minimal_basis_gates(self):
@@ -347,7 +347,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -359,7 +359,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_sdg_gate_deterministic_waltz_basis_gates(self):
@@ -369,7 +369,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_sdg_gate_deterministic_minimal_basis_gates(self):
@@ -379,7 +379,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_sdg_gate_nondeterministic_default_basis_gates(self):
@@ -388,7 +388,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_sdg_gate_nondeterministic_waltz_basis_gates(self):
@@ -398,7 +398,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_sdg_gate_nondeterministic_minimal_basis_gates(self):
@@ -408,7 +408,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -420,7 +420,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cx_gate_deterministic_waltz_basis_gates(self):
@@ -430,7 +430,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cx_gate_deterministic_minimal_basis_gates(self):
@@ -440,7 +440,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cx_gate_nondeterministic_default_basis_gates(self):
@@ -449,7 +449,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cx_gate_nondeterministic_waltz_basis_gates(self):
@@ -459,7 +459,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cx_gate_nondeterministic_minimal_basis_gates(self):
@@ -469,7 +469,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -481,7 +481,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cz_gate_deterministic_waltz_basis_gates(self):
@@ -491,7 +491,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cz_gate_deterministic_minimal_basis_gates(self):
@@ -501,7 +501,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cz_gate_nondeterministic_default_basis_gates(self):
@@ -510,7 +510,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cz_gate_nondeterministic_waltz_basis_gates(self):
@@ -520,7 +520,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cz_gate_nondeterministic_minimal_basis_gates(self):
@@ -530,7 +530,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -542,7 +542,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_swap_gate_deterministic_waltz_basis_gates(self):
@@ -552,7 +552,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_swap_gate_deterministic_minimal_basis_gates(self):
@@ -562,7 +562,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_swap_gate_nondeterministic_default_basis_gates(self):
@@ -571,7 +571,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_swap_gate_nondeterministic_waltz_basis_gates(self):
@@ -581,7 +581,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_swap_gate_nondeterministic_minimal_basis_gates(self):
@@ -591,7 +591,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -603,7 +603,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_t_gate_deterministic_waltz_basis_gates(self):
@@ -613,7 +613,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_t_gate_deterministic_minimal_basis_gates(self):
@@ -623,7 +623,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_t_gate_nondeterministic_default_basis_gates(self):
@@ -632,7 +632,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_t_gate_nondeterministic_waltz_basis_gates(self):
@@ -642,7 +642,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_t_gate_nondeterministic_minimal_basis_gates(self):
@@ -652,7 +652,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -664,7 +664,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_tdg_gate_deterministic_waltz_basis_gates(self):
@@ -674,7 +674,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_tdg_gate_deterministic_minimal_basis_gates(self):
@@ -684,7 +684,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_tdg_gate_nondeterministic_default_basis_gates(self):
@@ -693,7 +693,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_tdg_gate_nondeterministic_waltz_basis_gates(self):
@@ -703,7 +703,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_tdg_gate_nondeterministic_minimal_basis_gates(self):
@@ -713,7 +713,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -725,7 +725,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.ccx_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_ccx_gate_deterministic_waltz_basis_gates(self):
@@ -735,7 +735,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_ccx_gate_deterministic_minimal_basis_gates(self):
@@ -745,7 +745,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_ccx_gate_nondeterministic_default_basis_gates(self):
@@ -754,7 +754,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.ccx_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_ccx_gate_nondeterministic_waltz_basis_gates(self):
@@ -764,7 +764,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_ccx_gate_nondeterministic_minimal_basis_gates(self):
@@ -774,7 +774,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -786,7 +786,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_unitary_gate.unitary_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -798,7 +798,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cu1_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cu1_gate_nondeterministic_waltz_basis_gates(self):
@@ -808,7 +808,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cu1_gate_nondeterministic_minimal_basis_gates(self):
@@ -817,7 +817,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cu1_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -830,7 +830,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cswap_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cswap_gate_deterministic_minimal_basis_gates(self):
@@ -840,7 +840,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cswap_gate_statevector_deterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cswap_gate_deterministic_waltz_basis_gates(self):
@@ -850,7 +850,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cswap_gate_nondeterministic_default_basis_gates(self):
@@ -859,7 +859,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cswap_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cswap_gate_nondeterministic_minimal_basis_gates(self):
@@ -869,7 +869,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cswap_gate_statevector_nondeterministic()
         job = execute(circuits, StatevectorSimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
     def test_cswap_gate_nondeterministic_waltz_basis_gates(self):
@@ -879,7 +879,7 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         job = execute(circuits, StatevectorSimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
 

--- a/test/terra/backends/test_unitary_simulator.py
+++ b/test/terra/backends/test_unitary_simulator.py
@@ -37,7 +37,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_h_gate_deterministic_waltz_basis_gates(self):
@@ -46,7 +46,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_h_gate_deterministic_minimal_basis_gates(self):
@@ -55,7 +55,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_h_gate_nondeterministic_default_basis_gates(self):
@@ -64,7 +64,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_h_gate_nondeterministic_waltz_basis_gates(self):
@@ -73,7 +73,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_h_gate_nondeterministic_minimal_basis_gates(self):
@@ -82,7 +82,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.h_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -94,7 +94,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.x_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_x_gate_deterministic_waltz_basis_gates(self):
@@ -103,7 +103,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.x_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_x_gate_deterministic_minimal_basis_gates(self):
@@ -112,7 +112,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.x_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -124,7 +124,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.z_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_z_gate_deterministic_waltz_basis_gates(self):
@@ -133,7 +133,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.z_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_z_gate_deterministic_minimal_basis_gates(self):
@@ -142,7 +142,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.z_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -154,7 +154,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.y_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_y_gate_deterministic_waltz_basis_gates(self):
@@ -163,7 +163,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.y_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_y_gate_deterministic_minimal_basis_gates(self):
@@ -172,7 +172,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.y_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -184,7 +184,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_s_gate_deterministic_waltz_basis_gates(self):
@@ -193,7 +193,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_s_gate_deterministic_minimal_basis_gates(self):
@@ -202,7 +202,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_s_gate_nondeterministic_default_basis_gates(self):
@@ -211,7 +211,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_s_gate_nondeterministic_waltz_basis_gates(self):
@@ -220,7 +220,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_s_gate_nondeterministic_minimal_basis_gates(self):
@@ -229,7 +229,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.s_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -241,7 +241,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_sdg_gate_deterministic_waltz_basis_gates(self):
@@ -250,7 +250,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_sdg_gate_deterministic_minimal_basis_gates(self):
@@ -259,7 +259,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_sdg_gate_nondeterministic_default_basis_gates(self):
@@ -268,7 +268,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_sdg_gate_nondeterministic_waltz_basis_gates(self):
@@ -277,7 +277,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_sdg_gate_nondeterministic_minimal_basis_gates(self):
@@ -286,7 +286,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_1q_clifford.sdg_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -298,7 +298,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cx_gate_deterministic_waltz_basis_gates(self):
@@ -307,7 +307,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cx_gate_deterministic_minimal_basis_gates(self):
@@ -316,7 +316,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cx_gate_nondeterministic_default_basis_gates(self):
@@ -325,7 +325,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cx_gate_nondeterministic_waltz_basis_gates(self):
@@ -334,7 +334,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cx_gate_nondeterministic_minimal_basis_gates(self):
@@ -343,7 +343,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cx_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -355,7 +355,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cz_gate_deterministic_waltz_basis_gates(self):
@@ -364,7 +364,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cz_gate_deterministic_minimal_basis_gates(self):
@@ -373,7 +373,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cz_gate_nondeterministic_default_basis_gates(self):
@@ -382,7 +382,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cz_gate_nondeterministic_waltz_basis_gates(self):
@@ -391,7 +391,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cz_gate_nondeterministic_minimal_basis_gates(self):
@@ -400,7 +400,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.cz_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -412,7 +412,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_swap_gate_deterministic_waltz_basis_gates(self):
@@ -421,7 +421,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_swap_gate_deterministic_minimal_basis_gates(self):
@@ -430,7 +430,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_swap_gate_nondeterministic_default_basis_gates(self):
@@ -439,7 +439,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_swap_gate_nondeterministic_waltz_basis_gates(self):
@@ -448,7 +448,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_swap_gate_nondeterministic_minimal_basis_gates(self):
@@ -457,7 +457,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_2q_clifford.swap_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -469,7 +469,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_t_gate_deterministic_waltz_basis_gates(self):
@@ -478,7 +478,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_t_gate_deterministic_minimal_basis_gates(self):
@@ -487,7 +487,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_t_gate_nondeterministic_default_basis_gates(self):
@@ -496,7 +496,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_t_gate_nondeterministic_waltz_basis_gates(self):
@@ -505,7 +505,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_t_gate_nondeterministic_minimal_basis_gates(self):
@@ -514,7 +514,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.t_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -526,7 +526,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_tdg_gate_deterministic_waltz_basis_gates(self):
@@ -535,7 +535,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_tdg_gate_deterministic_minimal_basis_gates(self):
@@ -544,7 +544,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_tdg_gate_nondeterministic_default_basis_gates(self):
@@ -553,7 +553,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_tdg_gate_nondeterministic_waltz_basis_gates(self):
@@ -562,7 +562,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_tdg_gate_nondeterministic_minimal_basis_gates(self):
@@ -571,7 +571,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.tdg_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -583,7 +583,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.ccx_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_ccx_gate_deterministic_waltz_basis_gates(self):
@@ -592,7 +592,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.ccx_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_ccx_gate_deterministic_minimal_basis_gates(self):
@@ -601,7 +601,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.ccx_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_ccx_gate_nondeterministic_default_basis_gates(self):
@@ -610,7 +610,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.ccx_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_ccx_gate_nondeterministic_waltz_basis_gates(self):
@@ -619,7 +619,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.ccx_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_ccx_gate_nondeterministic_minimal_basis_gates(self):
@@ -628,7 +628,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.ccx_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -640,7 +640,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_unitary_gate.unitary_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -652,7 +652,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cswap_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     # ---------------------------------------------------------------------
@@ -664,7 +664,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cu1_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cswap_gate_deterministic_minimal_basis_gates(self):
@@ -674,7 +674,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cswap_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cu1_gate_nondeterministic_minimal_basis_gates(self):
@@ -683,7 +683,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cu1_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cswap_gate_deterministic_waltz_basis_gates(self):
@@ -693,7 +693,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         job = execute(circuits, UnitarySimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cswap_gate_nondeterministic_default_basis_gates(self):
@@ -702,7 +702,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cswap_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cu1_gate_nondeterministic_default_basis_gates(self):
@@ -711,7 +711,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cu1_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cswap_gate_nondeterministic_minimal_basis_gates(self):
@@ -721,7 +721,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         targets = ref_non_clifford.cswap_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cswap_gate_nondeterministic_waltz_basis_gates(self):
@@ -731,7 +731,7 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         job = execute(circuits, UnitarySimulator(), shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
 

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -112,10 +112,6 @@ class QiskitAerTestCase(unittest.TestCase):
         if pos is not None:
             items.pop(pos)
 
-    def is_completed(self, result):
-        """Check a Result is completed"""
-        self.assertEqual(result.status, 'COMPLETED')
-
     def compare_statevector(self, result, circuits, targets,
                             global_phase=True, places=None):
         """Compare final statevectors to targets."""

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -51,7 +51,7 @@ class TestNoise(common.QiskitAerTestCase):
         circuit = transpile(circuit, basis_gates=noise_model.basis_gates)
         qobj = assemble([circuit], backend, shots=shots)
         result = backend.run(qobj, noise_model=noise_model).result()
-        self.is_completed(result)
+        self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
 
     def test_noise_model_basis_gates(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Start of refactor of simulator result data types.  This adds C++ structs for simulator results rather than using pure json internally. The goal is that these classes can be wrapped into python using pybind or cython to directly build a python result object without going via json/str conversion for local simulation.

### Details and comments

* Adds `Result` class
* Adds `ExperimentResult` class
* Renames `OutputData` to `ExperimentData`