### PR TITLE
Add travis wait to brew installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,8 @@ stage_osx: &stage_osx
         virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
         source venv/bin/activate
       fi
-    - brew install libomp
-    - brew install openblas
+    - travis_wait brew install libomp
+    - travis_wait brew install openblas
   script:
     - python setup.py bdist_wheel -- -- -j4
     - pip install dist/qiskit_aer*whl


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The brew installation of openblas is sometimes taking over 10min to
build and install in the osx travis jobs. To avoid the job timing out
waiting for brew to emit output this commit adds a travis_wait call to
all the brew calls to make the timeout independent from output from the
command.

### Details and comments


