### PR TITLE
Update travis xcode build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,6 @@ stage_osx: &stage_osx
         virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
         source venv/bin/activate
       fi
-    - travis_wait brew install libomp
-    - travis_wait brew install openblas
   script:
     - python setup.py bdist_wheel -- -- -j4
     - pip install dist/qiskit_aer*whl


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Remove `libomp` and `openblas` dependencies from MacOS travis builds

### Details and comments

The brew bottle for GCC is no longer supplied for MacOS 10.12 (xcode 9.2) this was causing all travis mac builds to timeout because gcc was being built from source (as a dependency for openblas) which can take an hour.

