### PR TITLE
corrected typo in readout_error.py

### DIFF
--- a/qiskit/providers/aer/noise/errors/readout_error.py
+++ b/qiskit/providers/aer/noise/errors/readout_error.py
@@ -52,8 +52,8 @@ class ReadoutError:
             representations of bitstrings.
 
             Example: 1-qubit
-                probabilities[0] = [P("0"|"0"), P("1"|"0")
-                probabilities[1] = [P("0"|"1"), P("1"|"1")
+                probabilities[0] = [P("0"|"0"), P("1"|"0")]
+                probabilities[1] = [P("0"|"1"), P("1"|"1")]
 
             Example: 2-qubit
                 probabilities[0] = [P("00"|"00"), P("01"|"00"), P("10"|"00"), P("11"|"00")]


### PR DESCRIPTION
Put the missing brackets at the end of "Example: 1- qubit" for the probabilities[0] and [1].

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


