### PR TITLE
Fixed a typo in quantum_error.py

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -248,7 +248,7 @@ class QuantumError:
         return False
 
     def to_quantumchannel(self):
-        """Convet the QuantumError to a SuperOp quantum channel."""
+        """Convert the QuantumError to a SuperOp quantum channel."""
         # Initialize as an empty superoperator of the correct size
         dim = 2**self.number_of_qubits
         channel = SuperOp(np.zeros([dim * dim, dim * dim]))
@@ -259,7 +259,7 @@ class QuantumError:
         return channel
 
     def to_instruction(self):
-        """Convet the QuantumError to a circuit Instruction."""
+        """Convert the QuantumError to a circuit Instruction."""
         return self.to_quantumchannel().to_instruction()
 
     def error_term(self, position):


### PR DESCRIPTION
Fixed a typo in "to_instruction" and in "to_quantumchannel".

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


