### PR TITLE
Fix sdist to always attempt to build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,10 @@
 import os
 try:
     from skbuild import setup
-    dummy_install = False
-except:
-    print(""" WARNING
-              =======
-              scikit-build package is needed to build Aer sources.
-              Please, install scikit-build and reinstall Aer:
-              pip install -I qiskit-aer """)
-    from setuptools import setup
-    dummy_install = True
+except ImportError:
+    import subprocess
+    subprocess.call([sys.executable, '-m', 'pip', 'install', 'scikit-build'])
+    from skbuild import setup
 from setuptools import find_packages
 
 requirements = [
@@ -36,7 +31,7 @@ def find_qiskit_aer_packages():
 setup(
     name='qiskit-aer',
     version=VERSION,
-    packages=find_qiskit_aer_packages() if not dummy_install else [],
+    packages=find_qiskit_aer_packages(),
     cmake_source_dir='.',
     description="Qiskit Aer - High performance simulators for Qiskit",
     url="https://github.com/Qiskit/qiskit-aer",
@@ -57,6 +52,7 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     install_requires=requirements,
+    setup_requires=['scikit-build', 'cmake', 'ninja', 'Cython'],
     include_package_data=True,
     cmake_args=["-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9"],
     keywords="qiskit aer simulator quantum addon backend",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     install_requires=requirements,
-    setup_requires=['scikit-build', 'cmake', 'ninja', 'Cython'],
+    setup_requires=['scikit-build', 'cmake', 'Cython'],
     include_package_data=True,
     cmake_args=["-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9"],
     keywords="qiskit aer simulator quantum addon backend",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with the sdist if you ran in an environment
where scikit-build was not installed. scikit-build is a build time
dependency for installing aer from source, however the sdist treated
the lack of scikit-build as not fatal. Instead it would silently build a
dummy package which would just build an empty package with only
metadata. This leave users attempting to build from sdist very confused
because if they were missing scikit-build for any reason there is no
output regarding that or any errors. But instead when they go to use aer
it's not found because it was not actually installed.

### Details and comments