### PR TITLE
Improve additional data containers in ExperimentData

### DIFF
--- a/src/base/controller.hpp
+++ b/src/base/controller.hpp
@@ -657,8 +657,8 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
     exp_result.seed = circ.seed;
     // Move any metadata from the subclass run_circuit data
     // to the experiment resultmetadata field
-    for(auto& metadatum: exp_result.data.metadata().items()) {
-      exp_result.add_metadata(metadatum.key(), metadatum.value());
+    for(const auto& pair: exp_result.data.metadata()) {
+      exp_result.add_metadata(pair.first, pair.second);
     }
     // Remove the metatdata field from data
     exp_result.data.metadata().clear();

--- a/src/base/state.hpp
+++ b/src/base/state.hpp
@@ -282,7 +282,7 @@ void State<state_t>::snapshot_state(const Operations::Op &op,
                                     ExperimentData &data,
                                     std::string name) const {
   name = (name.empty()) ? op.name : name;
-  data.add_singleshot_snapshot(name, op.string_params[0], qreg_);
+  data.add_pershot_snapshot(name, op.string_params[0], qreg_);
 }
 
 
@@ -290,7 +290,7 @@ template <class state_t>
 void State<state_t>::snapshot_creg_memory(const Operations::Op &op,
                                           ExperimentData &data,
                                           std::string name) const {
-  data.add_singleshot_snapshot(name,
+  data.add_pershot_snapshot(name,
                                op.string_params[0],
                                creg_.memory_hex());
 }
@@ -300,7 +300,7 @@ template <class state_t>
 void State<state_t>::snapshot_creg_register(const Operations::Op &op,
                                             ExperimentData &data,
                                             std::string name) const {
-  data.add_singleshot_snapshot(name,
+  data.add_pershot_snapshot(name,
                                op.string_params[0],
                                creg_.register_hex());
 }
@@ -311,11 +311,11 @@ void State<state_t>::add_creg_to_data(ExperimentData &data) const {
   if (creg_.memory_size() > 0) {
     std::string memory_hex = creg_.memory_hex();
     data.add_memory_count(memory_hex);
-    data.add_memory_singleshot(memory_hex);
+    data. add_pershot_memory(memory_hex);
   }
   // Register bits value
   if (creg_.register_size() > 0) {
-    data.add_register_singleshot(creg_.register_hex());
+    data. add_pershot_register(creg_.register_hex());
   }
 }
 //-------------------------------------------------------------------------

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -80,18 +80,30 @@ class ExperimentData {
 
   // Add new data at the specified key.
   // If they key already exists this will override the stored data
+  // This will use the json conversion method `to_json` for data type T
+  // if it isn't a natively supported data type.
+  // Current native types are: cvector_t, cmatrix_t.
   template <typename T>
-  void add_additional_data(const std::string &key, const T &data);
+  void add_additional_data(const std::string &key, T &&data);
+
+  // Erase additional data stored at the provided key.
+  // This will erase from all additional data containers
+  void erase_additional_data(const std::string &key);
 
   //----------------------------------------------------------------
   // Metadata
   //----------------------------------------------------------------
 
+  // Access metadata map
   stringmap_t<json_t> &metadata() { return metadata_; }
   const stringmap_t<json_t> &metadata() const { return metadata_; }
 
+  // Add new data to metadata at the specified key.
+  // This will use the json conversion method `to_json` for data type T.
+  // If they key already exists this will update the current data
+  // with the new data.
   template <typename T>
-  void add_metadata(const std::string &key, const T &data);
+  void add_metadata(const std::string &key, T &&data);
 
   //----------------------------------------------------------------
   // Config
@@ -161,6 +173,15 @@ class ExperimentData {
   // Miscelaneous data
   stringmap_t<json_t> additional_json_data_;
 
+  // Complex vector data
+  stringmap_t<cvector_t> additional_cvector_data_;
+
+  // Complex matrix data
+  stringmap_t<cmatrix_t> additional_cmatrix_data_;
+
+  // Check if key name is reserved and if so throw an exception
+  void check_reserved_key(const std::string &key);
+
   //----------------------------------------------------------------
   // Metadata
   //----------------------------------------------------------------
@@ -190,6 +211,10 @@ void ExperimentData::set_config(const json_t &config) {
   JSON::get_value(return_register_, "register", config);
   JSON::get_value(return_snapshots_, "snapshots", config);
 }
+
+//------------------------------------------------------------------
+// Classical data
+//------------------------------------------------------------------
 
 void ExperimentData::add_memory_count(const std::string &memory) {
   // Memory bits value
@@ -245,48 +270,101 @@ void ExperimentData::add_average_snapshot(const std::string &type,
 // Additional Data
 //------------------------------------------------------------------
 
-const stringset_t ExperimentData::reserved_keys_ = {
-    "counts", "memory", "register", "snapshots"};
+const stringset_t ExperimentData::reserved_keys_ = {"counts", "memory",
+                                                    "register", "snapshots"};
 
-template <typename T>
-void ExperimentData::add_additional_data(const std::string &key,
-                                         const T &data) {
-  // Check key isn't one of the reserved keys
+void ExperimentData::check_reserved_key(const std::string &key) {
   if (reserved_keys_.find(key) != reserved_keys_.end()) {
     throw std::invalid_argument(
         "Cannot add additional data with reserved key name \"" + key + "\".");
   }
-  if (return_additional_data_) {
-    // Use implicit to_json conversion function for T
-    json_t jdata = data;
-    additional_json_data_[key] = std::move(jdata);
-  }
+}
+
+void ExperimentData::erase_additional_data(const std::string &key) {
+  additional_json_data_.erase(key);
+  additional_cvector_data_.erase(key);
+  additional_cmatrix_data_.erase(key);
 }
 
 template <typename T>
-void ExperimentData::add_metadata(const std::string &key, const T &data) {
-  // Use implicit to_json conversion function for T
-  json_t jdata = data;
-  auto elt = metadata_.find("key");
-  if (elt == metadata_.end()) {
-    // If key doesn't already exist add new data
-    metadata_[key] = std::move(jdata);
-  } else {
-    // If key already exists append with additional data
-    elt->second.update(jdata.begin(), jdata.end());
+void ExperimentData::add_additional_data(const std::string &key, T &&data) {
+  check_reserved_key(key);
+  if (return_additional_data_) {
+    json_t jdata = data;
+    add_additional_data(key, std::move(jdata));
   }
 }
 
+template <>
+void ExperimentData::add_additional_data(const std::string &key, json_t &&data) {
+  check_reserved_key(key);
+  if (return_additional_data_) {
+    erase_additional_data(key);
+    additional_json_data_[key] = data;
+  }
+}
+
+template <>
+void ExperimentData::add_additional_data(const std::string &key,
+                                         cvector_t &&data) {
+  check_reserved_key(key);
+  if (return_additional_data_) {
+    erase_additional_data(key);
+    additional_cvector_data_[key] = data;
+  }
+}
+
+template <>
+void ExperimentData::add_additional_data(const std::string &key,
+                                         cmatrix_t &&data) {
+  check_reserved_key(key);
+  if (return_additional_data_) {
+    erase_additional_data(key);
+    additional_cmatrix_data_[key] = data;
+  }
+}
+
+//------------------------------------------------------------------
+// Metadata
+//------------------------------------------------------------------
+
+template <typename T>
+void ExperimentData::add_metadata(const std::string &key, T &&data) {
+  // Use implicit to_json conversion function for T
+  json_t jdata = data;
+  add_metadata(key, std::move(jdata));
+}
+
+template<>
+void ExperimentData::add_metadata(const std::string &key, json_t &&data) {
+  auto elt = metadata_.find("key");
+  if (elt == metadata_.end()) {
+    // If key doesn't already exist add new data
+    metadata_[key] = data;
+  } else {
+    // If key already exists append with additional data
+    elt->second.update(data.begin(), data.end());
+  }
+}
+
+//------------------------------------------------------------------
+// Clear and combine
+//------------------------------------------------------------------
+
 void ExperimentData::clear() {
-  // Clear measure and counts
+  // Clear measurement data
   counts_.clear();
   memory_.clear();
   register_.clear();
-  // Clear snapshots
+  // Clear pershot snapshots
   pershot_json_snapshots_.clear();
+  // Clear average snapshots
   average_json_snapshots_.clear();
   // Clear additional data
   additional_json_data_.clear();
+  additional_cvector_data_.clear();
+  additional_cmatrix_data_.clear();
+  // Clear metadata
   metadata_.clear();
 }
 
@@ -315,27 +393,53 @@ ExperimentData &ExperimentData::combine(ExperimentData &data) {
   // Combine additional data
   for (auto &pair : data.additional_json_data_) {
     const auto &key = pair.first;
-    // erase_duplicate_data_keys(key, "json");
-    additional_json_data_[key] = pair.second;
+    erase_additional_data(key);
+    additional_json_data_[key] = std::move(pair.second);
   }
-
+  for (auto &pair : data.additional_cvector_data_) {
+    const auto &key = pair.first;
+    erase_additional_data(key);
+    additional_cvector_data_[key] = std::move(pair.second);
+  }
+  for (auto &pair : data.additional_cmatrix_data_) {
+    const auto &key = pair.first;
+    erase_additional_data(key);
+    additional_cmatrix_data_[key] = std::move(pair.second);
+  }
   // Clear any remaining data from other container
   data.clear();
 
   return *this;
 }
 
+//------------------------------------------------------------------------------
+// JSON serialization
+//------------------------------------------------------------------------------
+
 json_t ExperimentData::json() const {
   // Initialize output as additional data JSON
-  json_t tmp = additional_json_data_;
+  json_t tmp;
 
   // Measure data
   if (return_counts_ && counts_.empty() == false) tmp["counts"] = counts_;
   if (return_memory_ && memory_.empty() == false) tmp["memory"] = memory_;
   if (return_register_ && register_.empty() == false)
     tmp["register"] = register_;
-  // Average snapshot data
+
+  // Add additional data
+  for (const auto &pair : additional_json_data_) {
+    tmp[pair.first] = pair.second;
+  }
+  for (const auto &pair : additional_cvector_data_) {
+    tmp[pair.first] = pair.second;
+  }
+  for (const auto &pair : additional_cmatrix_data_) {
+    tmp[pair.first] = pair.second;
+  }
+
+  // Snapshot data
   if (return_snapshots_) {
+    // Average snapshots
     for (auto &pair : average_json_snapshots_) {
       tmp["snapshots"][pair.first] = pair.second;
     }
@@ -351,9 +455,6 @@ json_t ExperimentData::json() const {
   return tmp;
 }
 
-//------------------------------------------------------------------------------
-// Implicit JSON conversion function
-//------------------------------------------------------------------------------
 inline void to_json(json_t &js, const ExperimentData &data) {
   js = data.json();
 }

--- a/src/framework/results/experiment_result.hpp
+++ b/src/framework/results/experiment_result.hpp
@@ -41,10 +41,7 @@ public:
 
   // Metadata
   json_t header;
-  json_t metadata;
-
-  // Clear all metadata for given key
-  void clear_metadata(const std::string &key);
+  stringmap_t<json_t> metadata;
   
   // Append metadata for a given key.
   // This assumes the metadata value is a dictionary and appends
@@ -62,15 +59,16 @@ public:
 //------------------------------------------------------------------------------
 template <typename T>
 void ExperimentResult::add_metadata(const std::string &key, const T &meta) {
-  json_t js = meta; // use implicit to_json conversion function for T
-  if (JSON::check_key(key, metadata))
-    metadata[key].update(js.begin(), js.end());
-  else
-    metadata[key] = js;
-}
-
-void ExperimentResult::clear_metadata(const std::string &key) {
-  metadata.erase(key);
+  // Use implicit to_json conversion function for T
+  json_t jdata = meta;
+  auto elt = metadata.find("key");
+  if (elt == metadata.end()) {
+    // If key doesn't already exist add new data
+    metadata[key] = std::move(jdata);
+  } else {
+    // If key already exists append with additional data
+    elt->second.update(jdata.begin(), jdata.end());
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/framework/results/snapshot.hpp
+++ b/src/framework/results/snapshot.hpp
@@ -316,6 +316,18 @@ void AverageData::accum_helper(json_t &lhs, json_t &rhs, bool subtract) {
 }
 
 //------------------------------------------------------------------------------
+// JSON serialization
+//------------------------------------------------------------------------------
+
+void to_json(json_t &js, const AverageSnapshot &snapshot) {
+  js = snapshot.json();
+}
+
+void to_json(json_t &js, const SingleShotSnapshot &snapshot) {
+  js = snapshot.json();
+}
+
+//------------------------------------------------------------------------------
 } // end namespace AER
 //------------------------------------------------------------------------------
 #endif

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -672,7 +672,7 @@ void State::statevector_snapshot(const Operations::Op &op, ExperimentData &data,
   {
     sum += std::pow(std::abs(statevector[i]), 2);
   }
-  data.add_singleshot_snapshot("statevector", op.string_params[0], statevector);
+  data.add_pershot_snapshot("statevector", op.string_params[0], statevector);
 }
 
 void State::probabilities_snapshot(const Operations::Op &op, ExperimentData &data, RngEngine &rng)

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -477,7 +477,7 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
     one_expval = qreg_.expectation_value(op.qubits, pauli_matrices);
     expval += coeff * one_expval;;
   }
-  data.add_singleshot_snapshot("expectation_value", op.string_params[0], expval);
+  data.add_pershot_snapshot("expectation_value", op.string_params[0], expval);
 }
 
 void State::snapshot_matrix_expval(const Operations::Op &op,
@@ -497,7 +497,7 @@ void State::snapshot_matrix_expval(const Operations::Op &op,
       const cmatrix_t &mat = pair.second;
       one_expval = qreg_.expectation_value(qubits, mat);
       expval += coeff * one_expval;
-      data.add_singleshot_snapshot("expectation_value", op.string_params[0], expval);
+      data.add_pershot_snapshot("expectation_value", op.string_params[0], expval);
     }
   }
 }
@@ -508,7 +508,7 @@ void State::snapshot_state(const Operations::Op &op,
   cvector_t statevector;
   qreg_.full_state_vector(statevector);
 
-  data.add_singleshot_snapshot("statevector", op.string_params[0], statevector);
+  data.add_pershot_snapshot("statevector", op.string_params[0], statevector);
 }
 
 void State::snapshot_probabilities(const Operations::Op &op,
@@ -517,7 +517,7 @@ void State::snapshot_probabilities(const Operations::Op &op,
   MatrixProductState::MPS_Tensor full_tensor = qreg_.state_vec(0, qreg_.num_qubits()-1);
   rvector_t prob_vector;
   qreg_.probabilities_vector(prob_vector);
-  data.add_singleshot_snapshot("probabilities", op.string_params[0], prob_vector);
+  data.add_pershot_snapshot("probabilities", op.string_params[0], prob_vector);
 }
 
 void State::apply_gate(const Operations::Op &op) {

--- a/src/simulators/qasm/qasm_controller.hpp
+++ b/src/simulators/qasm/qasm_controller.hpp
@@ -888,9 +888,9 @@ void QasmController::measure_sampler(const std::vector<Operations::Op> &meas_roe
 
     auto memory = creg.memory_hex();
     data.add_memory_count(memory);
-    data.add_memory_singleshot(memory);
+    data. add_pershot_memory(memory);
 
-    data.add_register_singleshot(creg.register_hex());
+    data. add_pershot_register(creg.register_hex());
 
     // pop off processed sample
     all_samples.pop_back();

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -455,7 +455,7 @@ void State::snapshot_stabilizer(const Operations::Op &op, ExperimentData &data) 
   // stabilizer part. First Convert simulator clifford table to JSON
   json_t clifford = BaseState::qreg_;
   // Then extract the stabilizer generator list
-  data.add_singleshot_snapshot("stabilizer",
+  data.add_pershot_snapshot("stabilizer",
                                op.string_params[0],
                                clifford["stabilizers"]);
 }

--- a/src/simulators/statevector/statevector_controller.hpp
+++ b/src/simulators/statevector/statevector_controller.hpp
@@ -184,7 +184,7 @@ ExperimentData StatevectorController::run_circuit(const Circuit &circ,
   state.add_creg_to_data(data);
   
   // Add final state to the data
-  data.add_additional_data("statevector", state.qreg());
+  data.add_additional_data("statevector", state.qreg().vector());
 
   return data;
 }

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -605,7 +605,7 @@ void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
                             BaseState::creg_.memory_hex(), expval, true);
       break;
     case SnapshotDataType::single_shot:
-      data.add_singleshot_snapshot("expectation_values", op.string_params[0], expval);
+      data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);
       break;
   }
   // Revert to original state
@@ -665,7 +665,7 @@ void State<statevec_t>::snapshot_matrix_expval(const Operations::Op &op,
                             BaseState::creg_.memory_hex(), expval, true);
       break;
     case SnapshotDataType::single_shot:
-      data.add_singleshot_snapshot("expectation_values", op.string_params[0], expval);
+      data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);
       break;
   }
   // Revert to original state

--- a/src/simulators/unitary/unitary_controller.hpp
+++ b/src/simulators/unitary/unitary_controller.hpp
@@ -183,7 +183,7 @@ ExperimentData UnitaryController::run_circuit(const Circuit &circ,
   state.add_creg_to_data(data);
 
   // Add final state unitary to the data
-  data.add_additional_data("unitary", state.qreg());
+  data.add_additional_data("unitary", state.qreg().matrix());
 
   return data;
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds complex vector and complex matrix additional data containers to the `ExperimentData` class.
* Updates JSON data containers to be `unordered_map<string, json>` so that JSON is only used for the inner data type.

### Details and comments

This is a first step for speeding up the statevector and unitary simulators by only converting to JSON at the very end of simulation. Follow up work is to bypass this conversion step entirely and copy the vector and matrix data directly into a numpy array in python for local simulation.
