### PR TITLE
Improve pershot snapshot data container and performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Added
 
 Changed
 -------
+- Improved pershot snapshot data container performance (\#405)
 
 Removed
 -------

--- a/src/framework/results/data/pershot_data.hpp
+++ b/src/framework/results/data/pershot_data.hpp
@@ -32,7 +32,7 @@ class PershotData {
 
   // Add a new shot of data by appending to data vector
   // Uses move semantics
-  void add_data(T&& datum) { data_.push_back(std::move(datum)); }
+  void add_data(T&& datum) noexcept { data_.push_back(std::move(datum)); }
 
   // Combine with another pershot data by concatinating
   // Uses copy semantics
@@ -40,7 +40,7 @@ class PershotData {
 
   // Combine with another pershot data by concatinating
   // Uses move semantics
-  void combine(PershotData<T>&& other);
+  void combine(PershotData<T>&& other) noexcept;
 
   // Access data
   std::vector<T>& data() { return data_; }
@@ -76,12 +76,10 @@ void PershotData<T>::combine(const PershotData<T>& other) {
 }
 
 template <typename T>
-void PershotData<T>::combine(PershotData<T>&& other) {
+void PershotData<T>::combine(PershotData<T>&& other) noexcept {
   // Move data from other container
   data_.insert(data_.end(), std::make_move_iterator(other.data_.begin()),
                std::make_move_iterator(other.data_.end()));
-  // Since we have moved contents of other container we clear it
-  other.clear();
 }
 
 //------------------------------------------------------------------------------

--- a/src/framework/results/data/pershot_data.hpp
+++ b/src/framework/results/data/pershot_data.hpp
@@ -1,0 +1,98 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_results_data_pershot_data_hpp_
+#define _aer_framework_results_data_pershot_data_hpp_
+
+#include "framework/json.hpp"
+#include "framework/types.hpp"
+
+namespace AER {
+
+template <typename T>
+class PershotData {
+ public:
+  // Constructor
+  PershotData(size_t num_shots = 0) { data_.reserve(num_shots); }
+
+  // Add a new shot of data by appending to data vector
+  // Uses copy semantics
+  void add_data(const T& datum) { data_.push_back(datum); }
+
+  // Add a new shot of data by appending to data vector
+  // Uses move semantics
+  void add_data(T&& datum) { data_.push_back(std::move(datum)); }
+
+  // Combine with another pershot data by concatinating
+  // Uses copy semantics
+  void combine(const PershotData<T>& other);
+
+  // Combine with another pershot data by concatinating
+  // Uses move semantics
+  void combine(PershotData<T>&& other);
+
+  // Access data
+  std::vector<T>& data() { return data_; }
+
+  // Const access data
+  const std::vector<T>& data() const { return data_; }
+
+  // Get number of datum accumulated
+  size_t size() const { return data_.size(); }
+
+  void reserve(size_t sz) { data_.reserve(sz); }
+
+  // Clear all stored data
+  void clear() { data_.clear(); }
+
+  // Return true if data is empty
+  bool empty() const { return data_.empty(); }
+
+ protected:
+  // Internal Storage
+  std::vector<T> data_;
+};
+
+//------------------------------------------------------------------------------
+// Implementation
+//------------------------------------------------------------------------------
+
+template <typename T>
+void PershotData<T>::combine(const PershotData<T>& other) {
+  // Copy data from other container
+  data_.reserve(data_.size() + other.data_.size());
+  data_.insert(data_.end(), other.data_.begin(), other.data_.end());
+}
+
+template <typename T>
+void PershotData<T>::combine(PershotData<T>&& other) {
+  // Move data from other container
+  data_.insert(data_.end(), std::make_move_iterator(other.data_.begin()),
+               std::make_move_iterator(other.data_.end()));
+  // Since we have moved contents of other container we clear it
+  other.clear();
+}
+
+//------------------------------------------------------------------------------
+// JSON serialization
+//------------------------------------------------------------------------------
+template <typename T>
+void to_json(json_t& js, const PershotData<T>& data) {
+  js = data.data();
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/results/data/pershot_snapshot.hpp
+++ b/src/framework/results/data/pershot_snapshot.hpp
@@ -1,0 +1,114 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_results_data_pershot_snapshot_hpp_
+#define _aer_framework_results_data_pershot_snapshot_hpp_
+
+#include "framework/json.hpp"
+#include "framework/results/data/pershot_data.hpp"
+#include "framework/types.hpp"
+
+namespace AER {
+
+//------------------------------------------------------------------------------
+// Pershot Snapshot data storage class
+//------------------------------------------------------------------------------
+
+template <typename T>
+class PershotSnapshot {
+  // Inner snapshot data map type
+
+ public:
+  // Add a new datum to the snapshot at the specified key
+  // Uses copy semantics
+  void add_data(const std::string &key, const T &datum);
+
+  // Add a new datum to the snapshot at the specified key
+  // Uses move semantics
+  void add_data(const std::string &key, T &&datum);
+
+  // Combine with another pershot snapshot container
+  // Uses copy semantics
+  void combine(const PershotSnapshot<T> &other);
+
+  // Combine with another pershot snapshot container
+  // Uses move semantics
+  void combine(PershotSnapshot<T> &&other);
+
+  // Clear all data from current snapshot container
+  void clear() { data_.clear(); }
+
+  // Clear all snapshot data for a given label
+  void erase(const std::string &label) { data_.erase(label); }
+
+  // Return true if snapshot container is empty
+  bool empty() const { return data_.empty(); }
+
+  // Return data reference
+  stringmap_t<PershotData<T>> data() { return data_; }
+
+  // Return const data reference
+  const stringmap_t<PershotData<T>> &data() const { return data_; }
+
+ private:
+  // Internal Storage
+  // Map key is the snapshot label string
+  stringmap_t<PershotData<T>> data_;
+};
+
+//------------------------------------------------------------------------------
+// Implementation: PershotSnapshot class methods
+//------------------------------------------------------------------------------
+
+template <typename T>
+void PershotSnapshot<T>::add_data(const std::string &key, const T &datum) {
+  data_[key].add_data(datum);
+}
+
+template <typename T>
+void PershotSnapshot<T>::add_data(const std::string &key, T &&datum) {
+  data_[key].add_data(std::move(datum));
+}
+
+template <typename T>
+void PershotSnapshot<T>::combine(const PershotSnapshot<T> &other) {
+  for (const auto &pair : other.data_) {
+    data_[pair.first].combine(pair.second);
+  }
+}
+
+template <typename T>
+void PershotSnapshot<T>::combine(PershotSnapshot<T> &&other) {
+  for (auto &pair : other.data_) {
+    data_[pair.first].combine(std::move(pair.second));
+  }
+  // Clear added snapshot
+  other.clear();
+}
+
+//------------------------------------------------------------------------------
+// JSON serialization
+//------------------------------------------------------------------------------
+template <typename T>
+void to_json(json_t &js, const PershotSnapshot<T> &snapshot) {
+  js = json_t::object();
+  for (const auto &pair : snapshot.data()) {
+    js[pair.first] = pair.second;
+  }
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/results/data/pershot_snapshot.hpp
+++ b/src/framework/results/data/pershot_snapshot.hpp
@@ -36,7 +36,7 @@ class PershotSnapshot {
 
   // Add a new datum to the snapshot at the specified key
   // Uses move semantics
-  void add_data(const std::string &key, T &&datum);
+  void add_data(const std::string &key, T &&datum) noexcept;
 
   // Combine with another pershot snapshot container
   // Uses copy semantics
@@ -44,7 +44,7 @@ class PershotSnapshot {
 
   // Combine with another pershot snapshot container
   // Uses move semantics
-  void combine(PershotSnapshot<T> &&other);
+  void combine(PershotSnapshot<T> &&other) noexcept;
 
   // Clear all data from current snapshot container
   void clear() { data_.clear(); }
@@ -77,7 +77,7 @@ void PershotSnapshot<T>::add_data(const std::string &key, const T &datum) {
 }
 
 template <typename T>
-void PershotSnapshot<T>::add_data(const std::string &key, T &&datum) {
+void PershotSnapshot<T>::add_data(const std::string &key, T &&datum) noexcept {
   data_[key].add_data(std::move(datum));
 }
 
@@ -89,7 +89,7 @@ void PershotSnapshot<T>::combine(const PershotSnapshot<T> &other) {
 }
 
 template <typename T>
-void PershotSnapshot<T>::combine(PershotSnapshot<T> &&other) {
+void PershotSnapshot<T>::combine(PershotSnapshot<T> &&other) noexcept {
   for (auto &pair : other.data_) {
     data_[pair.first].combine(std::move(pair.second));
   }

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -279,14 +279,35 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           json_t &&datum) {
   if (return_snapshots_) {
     // use implicit to_json conversion function for T
-    pershot_json_snapshots_[type].add_data(label, datum);
+    pershot_json_snapshots_[type].add_data(label, std::move(datum));
   }
 }
 
 template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
+                                          const json_t &datum) {
+  if (return_snapshots_) {
+    // use implicit to_json conversion function for T
+    pershot_json_snapshots_[type].add_data(label, datum);
+  }
+}
+
+
+template <>
+void ExperimentData::add_pershot_snapshot(const std::string &type,
+                                          const std::string &label,
                                           complex_t &&datum) {
+  if (return_snapshots_) {
+    // use implicit to_json conversion function for T
+    pershot_complex_snapshots_[type].add_data(label, std::move(datum));
+  }
+}
+
+template <>
+void ExperimentData::add_pershot_snapshot(const std::string &type,
+                                          const std::string &label,
+                                          const complex_t &datum) {
   if (return_snapshots_) {
     // use implicit to_json conversion function for T
     pershot_complex_snapshots_[type].add_data(label, datum);
@@ -298,6 +319,15 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           cvector_t &&datum) {
   if (return_snapshots_) {
+    pershot_cvector_snapshots_[type].add_data(label, std::move(datum));
+  }
+}
+
+template <>
+void ExperimentData::add_pershot_snapshot(const std::string &type,
+                                          const std::string &label,
+                                          const cvector_t &datum) {
+  if (return_snapshots_) {
     pershot_cvector_snapshots_[type].add_data(label, datum);
   }
 }
@@ -306,6 +336,15 @@ template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           cmatrix_t &&datum) {
+  if (return_snapshots_) {
+    pershot_cmatrix_snapshots_[type].add_data(label, std::move(datum));
+  }
+}
+
+template <>
+void ExperimentData::add_pershot_snapshot(const std::string &type,
+                                          const std::string &label,
+                                          const cmatrix_t &datum) {
   if (return_snapshots_) {
     pershot_cmatrix_snapshots_[type].add_data(label, datum);
   }
@@ -316,6 +355,15 @@ void ExperimentData::add_pershot_snapshot(
     const std::string &type, const std::string &label,
     std::map<std::string, complex_t> &&datum) {
   if (return_snapshots_) {
+    pershot_cmap_snapshots_[type].add_data(label, std::move(datum));
+  }
+}
+
+template <>
+void ExperimentData::add_pershot_snapshot(
+    const std::string &type, const std::string &label,
+    const std::map<std::string, complex_t> &datum) {
+  if (return_snapshots_) {
     pershot_cmap_snapshots_[type].add_data(label, datum);
   }
 }
@@ -324,6 +372,15 @@ template <>
 void ExperimentData::add_pershot_snapshot(
     const std::string &type, const std::string &label,
     std::map<std::string, double> &&datum) {
+  if (return_snapshots_) {
+    pershot_rmap_snapshots_[type].add_data(label, std::move(datum));
+  }
+}
+
+template <>
+void ExperimentData::add_pershot_snapshot(
+    const std::string &type, const std::string &label,
+    const std::map<std::string, double> &datum) {
   if (return_snapshots_) {
     pershot_rmap_snapshots_[type].add_data(label, datum);
   }

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -263,6 +263,7 @@ void ExperimentData::add_pershot_register(const std::string &reg) {
 // Pershot Snapshots
 //------------------------------------------------------------------
 
+// Generic
 template <typename T>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label, T &&datum) {
@@ -273,6 +274,7 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
   }
 }
 
+// JSON
 template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
@@ -293,7 +295,15 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
   }
 }
 
+template <>
+void ExperimentData::add_pershot_snapshot(const std::string &type,
+                                          const std::string &label,
+                                          json_t &datum) {
+  const json_t &const_datum = datum;
+  add_pershot_snapshot(type, label, const_datum);
+}
 
+// Complex
 template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
@@ -317,6 +327,15 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
 template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
+                                          complex_t &datum) {
+  const complex_t &const_datum = datum;
+  add_pershot_snapshot(type, label, const_datum);
+}
+
+// Complex vector
+template <>
+void ExperimentData::add_pershot_snapshot(const std::string &type,
+                                          const std::string &label,
                                           cvector_t &&datum) {
   if (return_snapshots_) {
     pershot_cvector_snapshots_[type].add_data(label, std::move(datum));
@@ -335,6 +354,15 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
 template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
+                                          cvector_t &datum) {
+  const cvector_t &const_datum = datum;
+  add_pershot_snapshot(type, label, const_datum);
+}
+
+// Complex matrix
+template <>
+void ExperimentData::add_pershot_snapshot(const std::string &type,
+                                          const std::string &label,
                                           cmatrix_t &&datum) {
   if (return_snapshots_) {
     pershot_cmatrix_snapshots_[type].add_data(label, std::move(datum));
@@ -350,6 +378,15 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
   }
 }
 
+template <>
+void ExperimentData::add_pershot_snapshot(const std::string &type,
+                                          const std::string &label,
+                                          cmatrix_t &datum) {
+  const cmatrix_t &const_datum = datum;
+  add_pershot_snapshot(type, label, const_datum);
+}
+
+// Complex map
 template <>
 void ExperimentData::add_pershot_snapshot(
     const std::string &type, const std::string &label,
@@ -371,6 +408,15 @@ void ExperimentData::add_pershot_snapshot(
 template <>
 void ExperimentData::add_pershot_snapshot(
     const std::string &type, const std::string &label,
+    std::map<std::string, complex_t> &datum) {
+  const std::map<std::string, complex_t> &const_datum = datum;
+  add_pershot_snapshot(type, label, const_datum);
+}
+
+// Real map
+template <>
+void ExperimentData::add_pershot_snapshot(
+    const std::string &type, const std::string &label,
     std::map<std::string, double> &&datum) {
   if (return_snapshots_) {
     pershot_rmap_snapshots_[type].add_data(label, std::move(datum));
@@ -384,6 +430,14 @@ void ExperimentData::add_pershot_snapshot(
   if (return_snapshots_) {
     pershot_rmap_snapshots_[type].add_data(label, datum);
   }
+}
+
+template <>
+void ExperimentData::add_pershot_snapshot(
+    const std::string &type, const std::string &label,
+    std::map<std::string, double> &datum) {
+  const std::map<std::string, double> &const_datum = datum;
+  add_pershot_snapshot(type, label, const_datum);
 }
 
 //------------------------------------------------------------------
@@ -461,6 +515,12 @@ void ExperimentData::add_additional_data(const std::string &key,
 }
 
 template <>
+void ExperimentData::add_additional_data(const std::string &key, json_t &data) {
+  const json_t &const_data = data;
+  add_additional_data(key, const_data);
+}
+
+template <>
 void ExperimentData::add_additional_data(const std::string &key,
                                          cvector_t &&data) {
   check_reserved_key(key);
@@ -482,6 +542,13 @@ void ExperimentData::add_additional_data(const std::string &key,
 
 template <>
 void ExperimentData::add_additional_data(const std::string &key,
+                                         cvector_t &data) {
+  const cvector_t &const_data = data;
+  add_additional_data(key, const_data);
+}
+
+template <>
+void ExperimentData::add_additional_data(const std::string &key,
                                          cmatrix_t &&data) {
   check_reserved_key(key);
   if (return_additional_data_) {
@@ -498,6 +565,13 @@ void ExperimentData::add_additional_data(const std::string &key,
     erase_additional_data(key);
     additional_cmatrix_data_[key] = data;
   }
+}
+
+template <>
+void ExperimentData::add_additional_data(const std::string &key,
+                                         cmatrix_t &data) {
+  const cmatrix_t &const_data = data;
+  add_additional_data(key, const_data);
 }
 
 //------------------------------------------------------------------
@@ -535,12 +609,17 @@ void ExperimentData::add_metadata(const std::string &key, const json_t &data) {
   }
 }
 
+template <>
+void ExperimentData::add_metadata(const std::string &key, json_t &data) {
+  const json_t &const_data = data;
+  add_metadata(key, const_data);
+}
+
 //------------------------------------------------------------------
 // Clear and combine
 //------------------------------------------------------------------
 
 void ExperimentData::clear() {
-
   // Clear measurement data
   counts_.clear();
   memory_.clear();

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -560,14 +560,14 @@ json_t ExperimentData::json() const {
   // Snapshot data
   if (return_snapshots_) {
     // Average snapshots
-    for (auto &pair : average_json_snapshots_) {
+    for (const auto &pair : average_json_snapshots_) {
       tmp["snapshots"][pair.first] = pair.second;
     }
 
     // Singleshot snapshot data
     // Note these will override the average snapshots
     // if they share the same type string
-    for (auto &pair : pershot_json_snapshots_) {
+    for (const auto &pair : pershot_json_snapshots_) {
       tmp["snapshots"][pair.first] = pair.second;
     }
     for (auto &pair : pershot_complex_snapshots_) {

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -580,22 +580,22 @@ ExperimentData &ExperimentData::combine(ExperimentData &other) {
 
   // Combine pershot snapshots
   for (auto &pair : other.pershot_json_snapshots_) {
-    pershot_json_snapshots_[pair.first].combine(pair.second);
+    pershot_json_snapshots_[pair.first].combine(std::move(pair.second));
   }
   for (auto &pair : other.pershot_complex_snapshots_) {
-    pershot_complex_snapshots_[pair.first].combine(pair.second);
+    pershot_complex_snapshots_[pair.first].combine(std::move(pair.second));
   }
   for (auto &pair : other.pershot_cvector_snapshots_) {
-    pershot_cvector_snapshots_[pair.first].combine(pair.second);
+    pershot_cvector_snapshots_[pair.first].combine(std::move(pair.second));
   }
   for (auto &pair : other.pershot_cmatrix_snapshots_) {
-    pershot_cmatrix_snapshots_[pair.first].combine(pair.second);
+    pershot_cmatrix_snapshots_[pair.first].combine(std::move(pair.second));
   }
   for (auto &pair : other.pershot_cmap_snapshots_) {
-    pershot_cmap_snapshots_[pair.first].combine(pair.second);
+    pershot_cmap_snapshots_[pair.first].combine(std::move(pair.second));
   }
   for (auto &pair : other.pershot_rmap_snapshots_) {
-    pershot_rmap_snapshots_[pair.first].combine(pair.second);
+    pershot_rmap_snapshots_[pair.first].combine(std::move(pair.second));
   }
 
   // Combine average snapshots
@@ -605,7 +605,7 @@ ExperimentData &ExperimentData::combine(ExperimentData &other) {
 
   // Combine metadata
   for (auto &pair : other.metadata_) {
-    metadata_[pair.first] = pair.second;
+    metadata_[pair.first] = std::move(pair.second);
   }
 
   // Combine additional data

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -446,6 +446,16 @@ void ExperimentData::add_additional_data(const std::string &key,
   check_reserved_key(key);
   if (return_additional_data_) {
     erase_additional_data(key);
+    additional_json_data_[key] = std::move(data);
+  }
+}
+
+template <>
+void ExperimentData::add_additional_data(const std::string &key,
+                                         const json_t &data) {
+  check_reserved_key(key);
+  if (return_additional_data_) {
+    erase_additional_data(key);
     additional_json_data_[key] = data;
   }
 }
@@ -456,6 +466,16 @@ void ExperimentData::add_additional_data(const std::string &key,
   check_reserved_key(key);
   if (return_additional_data_) {
     erase_additional_data(key);
+    additional_cvector_data_[key] = std::move(data);
+  }
+}
+
+template <>
+void ExperimentData::add_additional_data(const std::string &key,
+                                         const cvector_t &data) {
+  check_reserved_key(key);
+  if (return_additional_data_) {
+    erase_additional_data(key);
     additional_cvector_data_[key] = data;
   }
 }
@@ -463,6 +483,16 @@ void ExperimentData::add_additional_data(const std::string &key,
 template <>
 void ExperimentData::add_additional_data(const std::string &key,
                                          cmatrix_t &&data) {
+  check_reserved_key(key);
+  if (return_additional_data_) {
+    erase_additional_data(key);
+    additional_cmatrix_data_[key] = std::move(data);
+  }
+}
+
+template <>
+void ExperimentData::add_additional_data(const std::string &key,
+                                         const cmatrix_t &data) {
   check_reserved_key(key);
   if (return_additional_data_) {
     erase_additional_data(key);
@@ -483,6 +513,18 @@ void ExperimentData::add_metadata(const std::string &key, T &&data) {
 
 template <>
 void ExperimentData::add_metadata(const std::string &key, json_t &&data) {
+  auto elt = metadata_.find("key");
+  if (elt == metadata_.end()) {
+    // If key doesn't already exist add new data
+    metadata_[key] = std::move(data);
+  } else {
+    // If key already exists append with additional data
+    elt->second.update(data.begin(), data.end());
+  }
+}
+
+template <>
+void ExperimentData::add_metadata(const std::string &key, const json_t &data) {
   auto elt = metadata_.find("key");
   if (elt == metadata_.end()) {
     // If key doesn't already exist add new data

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -280,7 +280,6 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           json_t &&datum) {
   if (return_snapshots_) {
-    // use implicit to_json conversion function for T
     pershot_json_snapshots_[type].add_data(label, std::move(datum));
   }
 }
@@ -290,7 +289,6 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           const json_t &datum) {
   if (return_snapshots_) {
-    // use implicit to_json conversion function for T
     pershot_json_snapshots_[type].add_data(label, datum);
   }
 }
@@ -299,8 +297,9 @@ template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           json_t &datum) {
-  const json_t &const_datum = datum;
-  add_pershot_snapshot(type, label, const_datum);
+  if (return_snapshots_) {
+    pershot_json_snapshots_[type].add_data(label, datum);
+  }
 }
 
 // Complex
@@ -309,7 +308,6 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           complex_t &&datum) {
   if (return_snapshots_) {
-    // use implicit to_json conversion function for T
     pershot_complex_snapshots_[type].add_data(label, std::move(datum));
   }
 }
@@ -319,7 +317,6 @@ void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           const complex_t &datum) {
   if (return_snapshots_) {
-    // use implicit to_json conversion function for T
     pershot_complex_snapshots_[type].add_data(label, datum);
   }
 }
@@ -328,8 +325,9 @@ template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           complex_t &datum) {
-  const complex_t &const_datum = datum;
-  add_pershot_snapshot(type, label, const_datum);
+  if (return_snapshots_) {
+    pershot_complex_snapshots_[type].add_data(label, datum);
+  }
 }
 
 // Complex vector
@@ -355,8 +353,9 @@ template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           cvector_t &datum) {
-  const cvector_t &const_datum = datum;
-  add_pershot_snapshot(type, label, const_datum);
+  if (return_snapshots_) {
+    pershot_cvector_snapshots_[type].add_data(label, datum);
+  }
 }
 
 // Complex matrix
@@ -382,8 +381,9 @@ template <>
 void ExperimentData::add_pershot_snapshot(const std::string &type,
                                           const std::string &label,
                                           cmatrix_t &datum) {
-  const cmatrix_t &const_datum = datum;
-  add_pershot_snapshot(type, label, const_datum);
+  if (return_snapshots_) {
+    pershot_cmatrix_snapshots_[type].add_data(label, datum);
+  }
 }
 
 // Complex map
@@ -409,8 +409,9 @@ template <>
 void ExperimentData::add_pershot_snapshot(
     const std::string &type, const std::string &label,
     std::map<std::string, complex_t> &datum) {
-  const std::map<std::string, complex_t> &const_datum = datum;
-  add_pershot_snapshot(type, label, const_datum);
+  if (return_snapshots_) {
+    pershot_cmap_snapshots_[type].add_data(label, datum);
+  }
 }
 
 // Real map
@@ -436,8 +437,9 @@ template <>
 void ExperimentData::add_pershot_snapshot(
     const std::string &type, const std::string &label,
     std::map<std::string, double> &datum) {
-  const std::map<std::string, double> &const_datum = datum;
-  add_pershot_snapshot(type, label, const_datum);
+  if (return_snapshots_) {
+    pershot_rmap_snapshots_[type].add_data(label, datum);
+  }
 }
 
 //------------------------------------------------------------------

--- a/src/framework/results/snapshot.hpp
+++ b/src/framework/results/snapshot.hpp
@@ -20,48 +20,6 @@
 namespace AER {
 
 //------------------------------------------------------------------------------
-// Snapshot data storage class
-//------------------------------------------------------------------------------
-
-class SingleShotSnapshot {
-
-// Inner snapshot data map type
-
-public:
-
-  // Add a new datum to the snapshot at the specified key
-  // This uses the `to_json` function for convertion
-  template <typename T>
-  inline void add_data(const std::string &key, T &datum) {
-    json_t tmp = datum;
-    data_[key].push_back(tmp);
-  }
-
-  // Combine with another snapshot object clearing each inner map
-  // as it is copied, and then clearing the resulting object.
-  void combine(SingleShotSnapshot &snapshot);
-
-  // Clear all data from current snapshot
-  inline void clear() {data_.clear();}
-
-  // Clear all snapshot data for a given label
-  inline void erase(const std::string &label) {data_.erase(label);}
-
-  // Dump all snapshots to JSON;
-  json_t json() const;
-
-  // Return true if snapshot container is empty
-  inline bool empty() const {return data_.empty();}
-
-private:
-
-  // Internal Storage
-  // Map key is the snapshot label string
-  stringmap_t<std::vector<json_t>> data_;
-};
-
-
-//------------------------------------------------------------------------------
 // AverageData class for storage of averaged quantities
 //------------------------------------------------------------------------------
 
@@ -154,31 +112,6 @@ protected:
   // Inner map key is the memory value string
   stringmap_t<stringmap_t<AverageData>> data_;
 };
-
-
-//------------------------------------------------------------------------------
-// Implementation: SingleShotSnapshot class methods
-//------------------------------------------------------------------------------
-
-void SingleShotSnapshot::combine(SingleShotSnapshot &snapshot) {
-  for (auto &data : snapshot.data_) {
-    auto &slot = data_[data.first];
-    auto &new_data = data.second;
-    slot.insert(slot.end(), std::make_move_iterator(new_data.begin()), 
-                            std::make_move_iterator(new_data.end()));
-    new_data.clear();
-  }
-  snapshot.clear(); // clear added snapshot
-}
-
-
-json_t SingleShotSnapshot::json() const {
-  json_t result;
-  for (const auto &pair : data_) {
-    result[pair.first] = pair.second;
-  }
-  return result;
-}
 
 
 //------------------------------------------------------------------------------
@@ -320,10 +253,6 @@ void AverageData::accum_helper(json_t &lhs, json_t &rhs, bool subtract) {
 //------------------------------------------------------------------------------
 
 void to_json(json_t &js, const AverageSnapshot &snapshot) {
-  js = snapshot.json();
-}
-
-void to_json(json_t &js, const SingleShotSnapshot &snapshot) {
   js = snapshot.json();
 }
 

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -44,7 +44,7 @@ enum class Snapshots {
 };
 
 // Enum class for different types of expectation values
-enum class SnapshotDataType {average, average_var, single_shot};
+enum class SnapshotDataType {average, average_var, pershot};
 
 //=========================================================================
 // QubitVector State subclass
@@ -229,6 +229,11 @@ protected:
   // during snapshot, but after the snapshot is applied the simulator
   // should be left in the pre-snapshot state.
   //-----------------------------------------------------------------------
+
+  // Snapshot current qubit probabilities for a measurement (average)
+  void snapshot_statevector(const Operations::Op &op,
+                            ExperimentData &data,
+                            SnapshotDataType type);
 
   // Snapshot current qubit probabilities for a measurement (average)
   void snapshot_probabilities(const Operations::Op &op,
@@ -487,7 +492,7 @@ void State<statevec_t>::apply_snapshot(const Operations::Op &op,
                                 op.name + "\'.");
   switch (it -> second) {
     case Snapshots::statevector:
-      BaseState::snapshot_state(op, data, "statevector");
+      data.add_pershot_snapshot("statevector", op.string_params[0], BaseState::qreg_.vector());
       break;
     case Snapshots::cmemory:
       BaseState::snapshot_creg_memory(op, data);
@@ -516,10 +521,10 @@ void State<statevec_t>::apply_snapshot(const Operations::Op &op,
       snapshot_matrix_expval(op, data, SnapshotDataType::average_var);
     }  break;
     case Snapshots::expval_pauli_shot: {
-      snapshot_pauli_expval(op, data, SnapshotDataType::single_shot);
+      snapshot_pauli_expval(op, data, SnapshotDataType::pershot);
     } break;
     case Snapshots::expval_matrix_shot: {
-      snapshot_matrix_expval(op, data, SnapshotDataType::single_shot);
+      snapshot_matrix_expval(op, data, SnapshotDataType::pershot);
     }  break;
     default:
       // We shouldn't get here unless there is a bug in the snapshotset
@@ -604,7 +609,7 @@ void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
       data.add_average_snapshot("expectation_value", op.string_params[0],
                             BaseState::creg_.memory_hex(), expval, true);
       break;
-    case SnapshotDataType::single_shot:
+    case SnapshotDataType::pershot:
       data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);
       break;
   }
@@ -664,7 +669,7 @@ void State<statevec_t>::snapshot_matrix_expval(const Operations::Op &op,
       data.add_average_snapshot("expectation_value", op.string_params[0],
                             BaseState::creg_.memory_hex(), expval, true);
       break;
-    case SnapshotDataType::single_shot:
+    case SnapshotDataType::pershot:
       data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);
       break;
   }

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -417,6 +417,7 @@ void State<data_t>::apply_snapshot(const Operations::Op &op,
                                    ExperimentData &data) {
   // Look for snapshot type in snapshotset
   if (op.name == "unitary" || op.name == "state") {
+    data.add_pershot_snapshot("unitary", op.string_params[0], BaseState::qreg_.matrix());
     BaseState::snapshot_state(op, data);
   } else {
     throw std::invalid_argument("Unitary::State::invalid snapshot instruction \'" +


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Reworks pershot snapshot data containers to have templated data types. Adds standard pershot snapshot containers to `ExpeirmentData` for complex numbers, complex vectors, complex matrices, complex string-maps, and double string-maps, and json.

* Partially fixes #269 
* Depends on #404*
* Will add similar fix for average snapshots in follow up PR

### Details and comments

Using fixed datatypes for snapshot storage greatly reduces memory usage and improves simulation time when snapshots are used since they are only converted to JSON during final serialization of the Result object. Eventually this serialization should be bypassed for local simulation and the objects should directly be copied to python objects.

Example of memory usage reduction for 14-qubit statevector snapshot on a noisy simulation with 1024 shots:

**Old memory usage and run-time:**
![mem_usage_old](https://user-images.githubusercontent.com/2235104/67231150-c3023f00-f40c-11e9-9ead-1539249afdad.png)

**New memory usage and run-time:**
![mem_usage_new](https://user-images.githubusercontent.com/2235104/67231161-c72e5c80-f40c-11e9-8b67-dde351175bf0.png)
