### PR TITLE
Linear algebra operations for STL types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Added
 Changed
 -------
 - Improved pershot snapshot data container performance (\#405)
+- Add basic linear algebra functions for numeric STL classes (\#406)
 
 Removed
 -------

--- a/src/framework/linalg/almost_equal.hpp
+++ b/src/framework/linalg/almost_equal.hpp
@@ -1,0 +1,49 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_almost_equal_hpp_
+#define _aer_framework_linalg_almost_equal_hpp_
+
+#include <complex>
+#include <limits>
+#include <type_traits>
+
+#include "framework/linalg/enable_if_numeric.hpp"
+
+namespace AER {
+namespace Linalg {
+
+// No silver bullet for floating point comparison techniques.
+// With this function the user can at least specify the precision
+// If we have numbers closer to 0, then max_diff can be set to a value
+// way smaller than epsilon. For numbers larger than 1.0, epsilon will
+// scale (the bigger the number, the bigger the epsilon).
+template <typename T1, typename T2, typename = enable_if_numeric<T1>,
+          typename = enable_if_numeric<T2>>
+bool almost_equal(T1 f1, T2 f2,
+                  T1 max_diff = std::numeric_limits<T1>::epsilon(),
+                  T1 max_relative_diff = std::numeric_limits<T1>::epsilon()) {
+  T1 diff = std::abs<T1>(f1 - f2);
+  if (diff <= max_diff) return true;
+
+  return diff <=
+         max_relative_diff * std::max<T1>(std::abs<T1>(f1), std::abs<T2>(f2));
+}
+
+//------------------------------------------------------------------------------
+}  // namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/enable_if_numeric.hpp
+++ b/src/framework/linalg/enable_if_numeric.hpp
@@ -1,0 +1,38 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_enable_if_numeric_hpp_
+#define _aer_framework_linalg_enable_if_numeric_hpp_
+
+#include <complex>
+#include <type_traits>
+
+// Type check template to enable functions if type is a numeric scalar
+// (integer, float, or complex float)
+template <class T>
+struct is_numeric_scalar
+    : std::integral_constant<
+          bool, std::is_arithmetic<T>::value ||
+                    std::is_same<std::complex<float>,
+                                 typename std::remove_cv<T>::type>::value ||
+                    std::is_same<std::complex<double>,
+                                 typename std::remove_cv<T>::type>::value ||
+                    std::is_same<std::complex<long double>,
+                                 typename std::remove_cv<T>::type>::value> {};
+
+template <class T>
+using enable_if_numeric = std::enable_if_t<is_numeric_scalar<T>::value>;
+
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/linalg.hpp
+++ b/src/framework/linalg/linalg.hpp
@@ -1,0 +1,28 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_hpp_
+#define _aer_framework_linalg_hpp_
+
+#include "framework/linalg/almost_equal.hpp"
+#include "framework/linalg/linops/linops_array.hpp"
+#include "framework/linalg/linops/linops_generic.hpp"
+#include "framework/linalg/linops/linops_json.hpp"
+#include "framework/linalg/linops/linops_map.hpp"
+#include "framework/linalg/linops/linops_matrix.hpp"
+#include "framework/linalg/linops/linops_unordered_map.hpp"
+#include "framework/linalg/linops/linops_vector.hpp"
+#include "framework/linalg/square.hpp"
+
+#endif

--- a/src/framework/linalg/linops/linops_array.hpp
+++ b/src/framework/linalg/linops/linops_array.hpp
@@ -1,0 +1,130 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_linops_array_hpp_
+#define _aer_framework_linalg_linops_array_hpp_
+
+#include <array>
+#include <functional>
+
+#include "framework/linalg/almost_equal.hpp"
+#include "framework/linalg/enable_if_numeric.hpp"
+
+namespace AER {
+namespace Linalg {
+
+// This defines functions add, sub, mul, div and iadd, imul, isub, idiv
+// that work for numeric vector types
+
+//----------------------------------------------------------------------------
+// Linear operations
+//----------------------------------------------------------------------------
+template <class T, size_t N, typename = enable_if_numeric<T>>
+std::array<T, N>& iadd(std::array<T, N>& lhs, const std::array<T, N>& rhs) {
+  std::transform(lhs.begin(), lhs.end(), rhs.begin(), lhs.begin(),
+                 std::plus<T>());
+  return lhs;
+}
+
+template <class T, size_t N, typename = enable_if_numeric<T>>
+std::array<T, N> add(const std::array<T, N>& lhs, const std::array<T, N>& rhs) {
+  std::array<T, N> result = lhs;
+  return iadd(result, rhs);
+}
+
+template <class T, size_t N, typename = enable_if_numeric<T>>
+std::array<T, N>& isub(std::array<T, N>& lhs, const std::array<T, N>& rhs) {
+  std::transform(lhs.begin(), lhs.end(), rhs.begin(), lhs.begin(),
+                 std::minus<T>());
+  return lhs;
+}
+
+template <class T, size_t N, typename = enable_if_numeric<T>>
+std::array<T, N> sub(const std::array<T, N>& lhs, const std::array<T, N>& rhs) {
+  std::array<T, N> result = lhs;
+  return isub(result, rhs);
+}
+
+//----------------------------------------------------------------------------
+// Affine operations
+//----------------------------------------------------------------------------
+template <class T, size_t N, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::array<T, N>& iadd(std::array<T, N>& data, const Scalar& val) {
+  std::transform(data.begin(), data.end(), data.begin(),
+                 std::bind(std::plus<T>(), std::placeholders::_1, val));
+  return data;
+}
+
+template <class T, size_t N, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::array<T, N> add(const std::array<T, N>& data, const Scalar& val) {
+  std::array<T, N> result = data;
+  return iadd(result, val);
+}
+
+template <class T, size_t N, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::array<T, N>& isub(std::array<T, N>& data, const Scalar& val) {
+  std::transform(data.begin(), data.end(), data.begin(),
+                 std::bind(std::minus<T>(), std::placeholders::_1, val));
+  return data;
+}
+
+template <class T, size_t N, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::array<T, N> sub(const std::array<T, N>& data, const Scalar& val) {
+  std::array<T, N> result = data;
+  return isub(result, val);
+}
+
+//----------------------------------------------------------------------------
+// Scalar operations
+//----------------------------------------------------------------------------
+template <class T, size_t N, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::array<T, N>& imul(std::array<T, N>& data, const Scalar& val) {
+  std::transform(data.begin(), data.end(), data.begin(),
+                 std::bind(std::multiplies<T>(), std::placeholders::_1, val));
+  return data;
+}
+
+template <class T, size_t N, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::array<T, N> mul(const std::array<T, N>& data, const Scalar& val) {
+  std::array<T, N> result = data;
+  return imul(result, val);
+}
+
+template <class T, size_t N, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::array<T, N>& idiv(std::array<T, N>& data, const Scalar& val) {
+  std::transform(data.begin(), data.end(), data.begin(),
+                 std::bind(std::divides<T>(), std::placeholders::_1, val));
+  return data;
+}
+
+template <class T, size_t N, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::array<T, N> div(const std::array<T, N>& data, const Scalar& val) {
+  std::array<T, N> result = data;
+  return idiv(result, val);
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/linops/linops_generic.hpp
+++ b/src/framework/linalg/linops/linops_generic.hpp
@@ -1,0 +1,119 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_linops_generic_hpp_
+#define _aer_framework_linalg_linops_generic_hpp_
+
+#include <functional>
+
+#include "framework/linalg/almost_equal.hpp"
+#include "framework/linalg/enable_if_numeric.hpp"
+
+namespace AER {
+namespace Linalg {
+
+// This defines functions add, sub, mul, div and iadd, imul, isub, idiv
+// that for generic types that support +,-,*,/ and +=, -=, *=, /= overloads
+
+//----------------------------------------------------------------------------
+// Linear operations
+//----------------------------------------------------------------------------
+template <class T>
+T add(const T& lhs, const T& rhs) {
+  return std::plus<T>()(lhs, rhs);
+}
+
+template <class T>
+T& iadd(T& lhs, const T& rhs) {
+  lhs = std::plus<T>()(lhs, rhs);
+  return lhs;
+}
+
+template <class T>
+T sub(const T& lhs, const T& rhs) {
+  return std::minus<T>()(lhs, rhs);
+}
+
+template <class T>
+T& isub(T& lhs, const T& rhs) {
+  lhs = std::minus<T>()(lhs, rhs);
+  return lhs;
+}
+
+//----------------------------------------------------------------------------
+// Affine operations
+//----------------------------------------------------------------------------
+template <class T, class Scalar, typename = enable_if_numeric<Scalar>>
+T add(const T& data, const Scalar& val) {
+  return std::plus<T>()(data, val);
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<Scalar>>
+T& iadd(T& data, const Scalar& val) {
+  data = std::plus<T>()(data, val);
+  return data;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<Scalar>>
+T sub(const T& data, const Scalar& val) {
+  return std::minus<T>()(data, val);
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<Scalar>>
+T& isub(T& data, const Scalar& val) {
+  data = std::minus<T>()(data, val);
+  return data;
+}
+
+//----------------------------------------------------------------------------
+// Scalar operations
+//----------------------------------------------------------------------------
+template <class T, class Scalar, typename = enable_if_numeric<Scalar>>
+T mul(const T& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  return std::multiplies<T>()(data, val);
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<Scalar>>
+T& imul(T& data, const Scalar& val) {
+  if (!almost_equal(val, 1)) {
+    data = std::multiplies<T>()(data, val);
+  }
+  return data;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<Scalar>>
+T div(const T& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  return std::divides<T>()(data, val);
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<Scalar>>
+T& idiv(T& data, const Scalar& val) {
+  if (!almost_equal(val, 1)) {
+    data = std::divides<T>()(data, val);
+  }
+  return data;
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/linops/linops_json.hpp
+++ b/src/framework/linalg/linops/linops_json.hpp
@@ -1,0 +1,242 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_linops_json_hpp_
+#define _aer_framework_linalg_linops_json_hpp_
+
+#include "framework/json.hpp"
+#include "framework/linalg/almost_equal.hpp"
+#include "framework/linalg/enable_if_numeric.hpp"
+
+namespace AER {
+namespace Linalg {
+
+// This defines functions add, sub, mul, div and iadd, imul, isub, idiv
+// that for numeric json that support +,-,*,/ and +=, -=, *=, /= overloads
+
+//----------------------------------------------------------------------------
+// Linear operations
+//----------------------------------------------------------------------------
+json_t& iadd(json_t& lhs, const json_t& rhs) {
+  // Null case
+  if (lhs.is_null()) {
+    lhs = rhs;
+    return lhs;
+  }
+  if (rhs.is_null()) {
+    return lhs;
+  }
+  // Terminating case
+  if (lhs.is_number() && rhs.is_number()) {
+    lhs = double(lhs) + double(rhs);
+    return lhs;
+  }
+  // Recursive cases
+  if (lhs.is_array() && rhs.is_array() && lhs.size() == rhs.size()) {
+    for (size_t pos = 0; pos < lhs.size(); pos++) {
+      iadd(lhs[pos], rhs[pos]);
+    }
+  } else if (lhs.is_object() && rhs.is_object()) {
+    for (auto it = rhs.begin(); it != rhs.end(); ++it) {
+      iadd(lhs[it.key()], it.value());
+    }
+  } else {
+    throw std::invalid_argument("Input JSONs cannot be added.");
+  }
+  return lhs;
+}
+
+json_t add(const json_t& lhs, const json_t& rhs) {
+  json_t result = lhs;
+  return iadd(result, rhs);
+}
+
+json_t& isub(json_t& lhs, const json_t& rhs) {
+  // Null case
+  if (rhs.is_null()) {
+    return lhs;
+  }
+  // Terminating case
+  if (lhs.is_number() && rhs.is_number()) {
+    lhs = double(lhs) - double(rhs);
+    return lhs;
+  }
+  // Recursive cases
+  if (lhs.is_array() && rhs.is_array() && lhs.size() == rhs.size()) {
+    for (size_t pos = 0; pos < lhs.size(); pos++) {
+      isub(lhs[pos], rhs[pos]);
+    }
+  } else if (lhs.is_object() && rhs.is_object()) {
+    for (auto it = rhs.begin(); it != rhs.end(); ++it) {
+      isub(lhs[it.key()], it.value());
+    }
+  } else {
+    throw std::invalid_argument("Input JSONs cannot be subtracted.");
+  }
+  return lhs;
+}
+
+template <class T>
+json_t sub(const T& lhs, const json_t& rhs) {
+  json_t result = lhs;
+  return isub(result, rhs);
+}
+
+//----------------------------------------------------------------------------
+// Affine operations
+//----------------------------------------------------------------------------
+template <class Scalar, typename = enable_if_numeric<Scalar>>
+json_t& iadd(json_t& data, const Scalar& val) {
+  // Null case
+  if (val == 0) {
+    return data;
+  }
+  // Terminating case
+  if (data.is_number()) {
+    data = double(data) + val;
+    return data;
+  }
+  // Recursive cases
+  if (data.is_array()) {
+    for (size_t pos = 0; pos < data.size(); pos++) {
+      iadd(data[pos], val);
+    }
+  } else if (data.is_object()) {
+    for (auto it = data.begin(); it != data.end(); ++it) {
+      iadd(data[it.key()], val);
+    }
+  } else {
+    throw std::invalid_argument("Input JSON does not support affine addition.");
+  }
+  return data;
+}
+
+template <class Scalar, typename = enable_if_numeric<Scalar>>
+json_t add(const json_t& data, const Scalar& val) {
+  json_t result = data;
+  return iadd(result, val);
+}
+
+template <class Scalar, typename = enable_if_numeric<Scalar>>
+json_t& isub(json_t& data, const Scalar& val) {
+  // Null case
+  if (val == 0) {
+    return data;
+  }
+  // Terminating case
+  if (data.is_number()) {
+    data = double(data) - val;
+    return data;
+  }
+  // Recursive cases
+  if (data.is_array()) {
+    for (size_t pos = 0; pos < data.size(); pos++) {
+      isub(data[pos], val);
+    }
+  } else if (data.is_object()) {
+    for (auto it = data.begin(); it != data.end(); ++it) {
+      isub(data[it.key()], val);
+    }
+  } else {
+    throw std::invalid_argument(
+        "Input JSON does not support affine subtraction.");
+  }
+  return data;
+}
+
+template <class Scalar, typename = enable_if_numeric<Scalar>>
+json_t sub(const json_t& data, const Scalar& val) {
+  json_t result = data;
+  return isub(result, val);
+}
+
+//----------------------------------------------------------------------------
+// Scalar operations
+//----------------------------------------------------------------------------
+
+template <class Scalar, typename = enable_if_numeric<Scalar>>
+json_t& imul(json_t& data, const Scalar& val) {
+  // Trival case
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  // Terminating case
+  if (data.is_number()) {
+    data = double(data) * val;
+    return data;
+  }
+  // Recursive cases
+  if (data.is_array()) {
+    for (size_t pos = 0; pos < data.size(); pos++) {
+      imul(data[pos], val);
+    }
+    return data;
+  }
+  if (data.is_object()) {
+    for (auto it = data.begin(); it != data.end(); ++it) {
+      imul(data[it.key()], val);
+    }
+    return data;
+  }
+  throw std::invalid_argument(
+      "Input JSON does not support scalar multiplication.");
+}
+
+template <class Scalar, typename = enable_if_numeric<Scalar>>
+json_t mul(const json_t& data, const Scalar& val) {
+  // Null case
+  json_t result = data;
+  return imul(result, val);
+}
+
+template <class Scalar, typename = enable_if_numeric<Scalar>>
+json_t& idiv(json_t& data, const Scalar& val) {
+  // Trival case
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  // Terminating case
+  if (data.is_number()) {
+    data = double(data) / val;
+    return data;
+  }
+  // Recursive cases
+  if (data.is_array()) {
+    for (size_t pos = 0; pos < data.size(); pos++) {
+      idiv(data[pos], val);
+    }
+    return data;
+  }
+  if (data.is_object()) {
+    for (auto it = data.begin(); it != data.end(); ++it) {
+      idiv(data[it.key()], val);
+    }
+    return data;
+  }
+  throw std::invalid_argument("Input JSON does not support scalar division.");
+}
+
+template <class Scalar, typename = enable_if_numeric<Scalar>>
+json_t div(const json_t& data, const Scalar& val) {
+  // Null case
+  json_t result = data;
+  return idiv(result, val);
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/linops/linops_map.hpp
+++ b/src/framework/linalg/linops/linops_map.hpp
@@ -31,8 +31,8 @@ namespace Linalg {
 //----------------------------------------------------------------------------
 template <class T1, class T2, class T3, class T4,
           typename = enable_if_numeric<T2>>
-std::map<T1, T2, T3, T4> add(const std::map<T1, T2, T3, T4>& lhs,
-                             const std::map<T1, T2, T3, T4>& rhs) {
+decltype(auto) add(const std::map<T1, T2, T3, T4>& lhs,
+                   const std::map<T1, T2, T3, T4>& rhs) {
   std::map<T1, T2, T3, T4> result = lhs;
   for (const auto& pair : rhs) {
     result[pair.first] = std::plus<T2>()(result[pair.first], pair.second);
@@ -42,8 +42,8 @@ std::map<T1, T2, T3, T4> add(const std::map<T1, T2, T3, T4>& lhs,
 
 template <class T1, class T2, class T3, class T4,
           typename = enable_if_numeric<T2>>
-std::map<T1, T2, T3, T4>& iadd(std::map<T1, T2, T3, T4>& lhs,
-                               const std::map<T1, T2, T3, T4>& rhs) {
+decltype(auto) iadd(std::map<T1, T2, T3, T4>& lhs,
+                    const std::map<T1, T2, T3, T4>& rhs) {
   for (const auto& pair : rhs) {
     lhs[pair.first] = std::plus<T2>()(lhs[pair.first], pair.second);
   }
@@ -52,8 +52,8 @@ std::map<T1, T2, T3, T4>& iadd(std::map<T1, T2, T3, T4>& lhs,
 
 template <class T1, class T2, class T3, class T4,
           typename = enable_if_numeric<T2>>
-std::map<T1, T2, T3, T4> sub(const std::map<T1, T2, T3, T4>& lhs,
-                             const std::map<T1, T2, T3, T4>& rhs) {
+decltype(auto) sub(const std::map<T1, T2, T3, T4>& lhs,
+                   const std::map<T1, T2, T3, T4>& rhs) {
   std::map<T1, T2, T3, T4> result = lhs;
   for (const auto& pair : rhs) {
     result[pair.first] = std::minus<T2>()(result[pair.first], pair.second);
@@ -63,8 +63,8 @@ std::map<T1, T2, T3, T4> sub(const std::map<T1, T2, T3, T4>& lhs,
 
 template <class T1, class T2, class T3, class T4,
           typename = enable_if_numeric<T2>>
-std::map<T1, T2, T3, T4>& isub(std::map<T1, T2, T3, T4>& lhs,
-                               const std::map<T1, T2, T3, T4>& rhs) {
+decltype(auto) isub(std::map<T1, T2, T3, T4>& lhs,
+                    const std::map<T1, T2, T3, T4>& rhs) {
   for (const auto& pair : rhs) {
     lhs[pair.first] = std::minus<T2>()(lhs[pair.first], pair.second);
   }
@@ -77,8 +77,7 @@ std::map<T1, T2, T3, T4>& isub(std::map<T1, T2, T3, T4>& lhs,
 template <class T1, class T2, class T3, class T4, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::map<T1, T2, T3, T4> add(const std::map<T1, T2, T3, T4>& data,
-                             const Scalar& val) {
+decltype(auto) add(const std::map<T1, T2, T3, T4>& data, const Scalar& val) {
   std::map<T1, T2, T3, T4> result;
   for (const auto& pair : data) {
     result[pair.first] = std::plus<T2>()(pair.second, val);
@@ -89,8 +88,7 @@ std::map<T1, T2, T3, T4> add(const std::map<T1, T2, T3, T4>& data,
 template <class T1, class T2, class T3, class T4, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::map<T1, T2, T3, T4>& iadd(std::map<T1, T2, T3, T4>& data,
-                               const Scalar& val) {
+decltype(auto) iadd(std::map<T1, T2, T3, T4>& data, const Scalar& val) {
   for (const auto& pair : data) {
     data[pair.first] = std::plus<T2>()(data[pair.first], val);
   }
@@ -100,8 +98,7 @@ std::map<T1, T2, T3, T4>& iadd(std::map<T1, T2, T3, T4>& data,
 template <class T1, class T2, class T3, class T4, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::map<T1, T2, T3, T4> sub(const std::map<T1, T2, T3, T4>& data,
-                             const Scalar& val) {
+decltype(auto) sub(const std::map<T1, T2, T3, T4>& data, const Scalar& val) {
   std::map<T1, T2, T3, T4> result;
   for (const auto& pair : data) {
     result[pair.first] = std::minus<T2>()(pair.second, val);
@@ -112,8 +109,7 @@ std::map<T1, T2, T3, T4> sub(const std::map<T1, T2, T3, T4>& data,
 template <class T1, class T2, class T3, class T4, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::map<T1, T2, T3, T4>& isub(std::map<T1, T2, T3, T4>& data,
-                               const Scalar& val) {
+decltype(auto) isub(std::map<T1, T2, T3, T4>& data, const Scalar& val) {
   for (const auto& pair : data) {
     data[pair.first] = std::plus<T2>()(data[pair.first], val);
   }
@@ -127,8 +123,7 @@ std::map<T1, T2, T3, T4>& isub(std::map<T1, T2, T3, T4>& data,
 template <class T1, class T2, class T3, class T4, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::map<T1, T2, T3, T4> mul(const std::map<T1, T2, T3, T4>& data,
-                             const Scalar& val) {
+decltype(auto) mul(const std::map<T1, T2, T3, T4>& data, const Scalar& val) {
   if (almost_equal(val, 1)) {
     return data;
   }
@@ -142,8 +137,7 @@ std::map<T1, T2, T3, T4> mul(const std::map<T1, T2, T3, T4>& data,
 template <class T1, class T2, class T3, class T4, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::map<T1, T2, T3, T4>& imul(std::map<T1, T2, T3, T4>& data,
-                               const Scalar& val) {
+decltype(auto) imul(std::map<T1, T2, T3, T4>& data, const Scalar& val) {
   if (almost_equal(val, 1)) {
     return data;
   }
@@ -156,8 +150,7 @@ std::map<T1, T2, T3, T4>& imul(std::map<T1, T2, T3, T4>& data,
 template <class T1, class T2, class T3, class T4, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::map<T1, T2, T3, T4> div(const std::map<T1, T2, T3, T4>& data,
-                             const Scalar& val) {
+decltype(auto) div(const std::map<T1, T2, T3, T4>& data, const Scalar& val) {
   if (almost_equal(val, 1)) {
     return data;
   }
@@ -171,8 +164,7 @@ std::map<T1, T2, T3, T4> div(const std::map<T1, T2, T3, T4>& data,
 template <class T1, class T2, class T3, class T4, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::map<T1, T2, T3, T4>& idiv(std::map<T1, T2, T3, T4>& data,
-                               const Scalar& val) {
+decltype(auto) idiv(std::map<T1, T2, T3, T4>& data, const Scalar& val) {
   if (almost_equal(val, 1)) {
     return data;
   }

--- a/src/framework/linalg/linops/linops_map.hpp
+++ b/src/framework/linalg/linops/linops_map.hpp
@@ -1,0 +1,190 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_linops_map_hpp_
+#define _aer_framework_linalg_linops_map_hpp_
+
+#include <functional>
+#include <map>
+#include "framework/linalg/almost_equal.hpp"
+#include "framework/linalg/enable_if_numeric.hpp"
+
+namespace AER {
+namespace Linalg {
+
+// This defines functions add, sub, mul, div and iadd, imul, isub, idiv
+// that work for numeric map types
+
+//----------------------------------------------------------------------------
+// Linear operations
+//----------------------------------------------------------------------------
+template <class T1, class T2, class T3, class T4,
+          typename = enable_if_numeric<T2>>
+std::map<T1, T2, T3, T4> add(const std::map<T1, T2, T3, T4>& lhs,
+                             const std::map<T1, T2, T3, T4>& rhs) {
+  std::map<T1, T2, T3, T4> result = lhs;
+  for (const auto& pair : rhs) {
+    result[pair.first] = std::plus<T2>()(result[pair.first], pair.second);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4,
+          typename = enable_if_numeric<T2>>
+std::map<T1, T2, T3, T4>& iadd(std::map<T1, T2, T3, T4>& lhs,
+                               const std::map<T1, T2, T3, T4>& rhs) {
+  for (const auto& pair : rhs) {
+    lhs[pair.first] = std::plus<T2>()(lhs[pair.first], pair.second);
+  }
+  return lhs;
+}
+
+template <class T1, class T2, class T3, class T4,
+          typename = enable_if_numeric<T2>>
+std::map<T1, T2, T3, T4> sub(const std::map<T1, T2, T3, T4>& lhs,
+                             const std::map<T1, T2, T3, T4>& rhs) {
+  std::map<T1, T2, T3, T4> result = lhs;
+  for (const auto& pair : rhs) {
+    result[pair.first] = std::minus<T2>()(result[pair.first], pair.second);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4,
+          typename = enable_if_numeric<T2>>
+std::map<T1, T2, T3, T4>& isub(std::map<T1, T2, T3, T4>& lhs,
+                               const std::map<T1, T2, T3, T4>& rhs) {
+  for (const auto& pair : rhs) {
+    lhs[pair.first] = std::minus<T2>()(lhs[pair.first], pair.second);
+  }
+  return lhs;
+}
+
+//----------------------------------------------------------------------------
+// Affine operations
+//----------------------------------------------------------------------------
+template <class T1, class T2, class T3, class T4, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::map<T1, T2, T3, T4> add(const std::map<T1, T2, T3, T4>& data,
+                             const Scalar& val) {
+  std::map<T1, T2, T3, T4> result;
+  for (const auto& pair : data) {
+    result[pair.first] = std::plus<T2>()(pair.second, val);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::map<T1, T2, T3, T4>& iadd(std::map<T1, T2, T3, T4>& data,
+                               const Scalar& val) {
+  for (const auto& pair : data) {
+    data[pair.first] = std::plus<T2>()(data[pair.first], val);
+  }
+  return data;
+}
+
+template <class T1, class T2, class T3, class T4, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::map<T1, T2, T3, T4> sub(const std::map<T1, T2, T3, T4>& data,
+                             const Scalar& val) {
+  std::map<T1, T2, T3, T4> result;
+  for (const auto& pair : data) {
+    result[pair.first] = std::minus<T2>()(pair.second, val);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::map<T1, T2, T3, T4>& isub(std::map<T1, T2, T3, T4>& data,
+                               const Scalar& val) {
+  for (const auto& pair : data) {
+    data[pair.first] = std::plus<T2>()(data[pair.first], val);
+  }
+  return data;
+}
+
+//----------------------------------------------------------------------------
+// Scalar operations
+//----------------------------------------------------------------------------
+
+template <class T1, class T2, class T3, class T4, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::map<T1, T2, T3, T4> mul(const std::map<T1, T2, T3, T4>& data,
+                             const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  std::map<T1, T2, T3, T4> result;
+  for (const auto& pair : data) {
+    result[pair.first] = std::multiplies<T2>()(pair.second, val);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::map<T1, T2, T3, T4>& imul(std::map<T1, T2, T3, T4>& data,
+                               const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  for (const auto& pair : data) {
+    data[pair.first] = std::multiplies<T2>()(data[pair.first], val);
+  }
+  return data;
+}
+
+template <class T1, class T2, class T3, class T4, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::map<T1, T2, T3, T4> div(const std::map<T1, T2, T3, T4>& data,
+                             const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  std::map<T1, T2, T3, T4> result;
+  for (const auto& pair : data) {
+    result[pair.first] = std::divides<T2>()(pair.second, val);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::map<T1, T2, T3, T4>& idiv(std::map<T1, T2, T3, T4>& data,
+                               const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  for (const auto& pair : data) {
+    data[pair.first] = std::divides<T2>()(data[pair.first], val);
+  }
+  return data;
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/linops/linops_matrix.hpp
+++ b/src/framework/linalg/linops/linops_matrix.hpp
@@ -1,0 +1,144 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_linops_matrix_hpp_
+#define _aer_framework_linalg_linops_matrix_hpp_
+
+#include <functional>
+
+#include "framework/linalg/almost_equal.hpp"
+#include "framework/linalg/enable_if_numeric.hpp"
+#include "framework/matrix.hpp"
+
+namespace AER {
+namespace Linalg {
+
+// This defines some missing overloads for matrix class
+// It should really be added to the matrix class
+
+//----------------------------------------------------------------------------
+// Linear operations
+//----------------------------------------------------------------------------
+template <class T, typename = enable_if_numeric<T>>
+matrix<T> add(const matrix<T>& lhs, const matrix<T>& rhs) {
+  return lhs + rhs;
+}
+
+template <class T, typename = enable_if_numeric<T>>
+matrix<T>& iadd(matrix<T>& lhs, const matrix<T>& rhs) {
+  lhs = lhs + rhs;
+  return lhs;
+}
+
+template <class T, typename = enable_if_numeric<T>>
+matrix<T> sub(const matrix<T>& lhs, const matrix<T>& rhs) {
+  return lhs - rhs;
+}
+
+template <class T, typename = enable_if_numeric<T>>
+matrix<T>& isub(matrix<T>& lhs, const matrix<T>& rhs) {
+  lhs = lhs - rhs;
+  return lhs;
+}
+
+//----------------------------------------------------------------------------
+// Affine operations
+//----------------------------------------------------------------------------
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+matrix<T>& iadd(matrix<T>& data, const Scalar& val) {
+  if (val == 0) {
+    return data;
+  }
+  for (size_t j = 0; j < data.size(); j++) {
+    data[j] = std::plus<T>()(data[j], val);
+  }
+  return data;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+matrix<T> add(const matrix<T>& data, const Scalar& val) {
+  matrix<T> result(data);
+  return iadd(result, val);
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+matrix<T> sub(const matrix<T>& data, const Scalar& val) {
+  return add(data, -val);
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+matrix<T>& isub(matrix<T>& data, const Scalar& val) {
+  return iadd(data, -val);
+}
+
+//----------------------------------------------------------------------------
+// Scalar operations
+//----------------------------------------------------------------------------
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+matrix<T>& imul(matrix<T>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  for (size_t j = 0; j < data.size(); j++) {
+    data[j] = std::multiplies<T>()(data[j], val);
+  }
+  return data;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+matrix<T> mul(const matrix<T>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  matrix<T> result = data;
+  imul(result, val);
+  return result;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+matrix<T>& idiv(matrix<T>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  for (size_t j = 0; j < data.size(); j++) {
+    data[j] = std::divides<T>()(data[j], val);
+  }
+  return data;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+matrix<T> div(const matrix<T>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  matrix<T> result = data;
+  idiv(result, val);
+  return result;
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/linops/linops_unordered_map.hpp
+++ b/src/framework/linalg/linops/linops_unordered_map.hpp
@@ -31,9 +31,8 @@ namespace Linalg {
 //----------------------------------------------------------------------------
 template <class T1, class T2, class T3, class T4, class T5,
           typename = enable_if_numeric<T2>>
-std::unordered_map<T1, T2, T3, T4, T5> add(
-    const std::unordered_map<T1, T2, T3, T4, T5>& lhs,
-    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
+decltype(auto) add(const std::unordered_map<T1, T2, T3, T4, T5>& lhs,
+                   const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
   std::unordered_map<T1, T2, T3, T4, T5> result = lhs;
   for (const auto& pair : rhs) {
     result[pair.first] = std::plus<T2>()(result[pair.first], pair.second);
@@ -43,9 +42,8 @@ std::unordered_map<T1, T2, T3, T4, T5> add(
 
 template <class T1, class T2, class T3, class T4, class T5,
           typename = enable_if_numeric<T2>>
-std::unordered_map<T1, T2, T3, T4, T5>& iadd(
-    std::unordered_map<T1, T2, T3, T4, T5>& lhs,
-    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
+decltype(auto) iadd(std::unordered_map<T1, T2, T3, T4, T5>& lhs,
+                    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
   for (const auto& pair : rhs) {
     lhs[pair.first] = std::plus<T2>()(lhs[pair.first], pair.second);
   }
@@ -54,9 +52,8 @@ std::unordered_map<T1, T2, T3, T4, T5>& iadd(
 
 template <class T1, class T2, class T3, class T4, class T5,
           typename = enable_if_numeric<T2>>
-std::unordered_map<T1, T2, T3, T4, T5> sub(
-    const std::unordered_map<T1, T2, T3, T4, T5>& lhs,
-    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
+decltype(auto) sub(const std::unordered_map<T1, T2, T3, T4, T5>& lhs,
+                   const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
   std::unordered_map<T1, T2, T3, T4, T5> result = lhs;
   for (const auto& pair : rhs) {
     result[pair.first] = std::minus<T2>()(result[pair.first], pair.second);
@@ -66,9 +63,8 @@ std::unordered_map<T1, T2, T3, T4, T5> sub(
 
 template <class T1, class T2, class T3, class T4, class T5,
           typename = enable_if_numeric<T2>>
-std::unordered_map<T1, T2, T3, T4, T5>& isub(
-    std::unordered_map<T1, T2, T3, T4, T5>& lhs,
-    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
+decltype(auto) isub(std::unordered_map<T1, T2, T3, T4, T5>& lhs,
+                    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
   for (const auto& pair : rhs) {
     lhs[pair.first] = std::minus<T2>()(lhs[pair.first], pair.second);
   }
@@ -81,8 +77,8 @@ std::unordered_map<T1, T2, T3, T4, T5>& isub(
 template <class T1, class T2, class T3, class T4, class T5, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::unordered_map<T1, T2, T3, T4, T5> add(
-    const std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+decltype(auto) add(const std::unordered_map<T1, T2, T3, T4, T5>& data,
+                   const Scalar& val) {
   std::unordered_map<T1, T2, T3, T4, T5> result;
   for (const auto& pair : data) {
     result[pair.first] = std::plus<T2>()(pair.second, val);
@@ -93,8 +89,8 @@ std::unordered_map<T1, T2, T3, T4, T5> add(
 template <class T1, class T2, class T3, class T4, class T5, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::unordered_map<T1, T2, T3, T4, T5>& iadd(
-    std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+decltype(auto) iadd(std::unordered_map<T1, T2, T3, T4, T5>& data,
+                    const Scalar& val) {
   for (const auto& pair : data) {
     data[pair.first] = std::plus<T2>()(data[pair.first], val);
   }
@@ -104,8 +100,8 @@ std::unordered_map<T1, T2, T3, T4, T5>& iadd(
 template <class T1, class T2, class T3, class T4, class T5, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::unordered_map<T1, T2, T3, T4, T5> sub(
-    const std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+decltype(auto) sub(const std::unordered_map<T1, T2, T3, T4, T5>& data,
+                   const Scalar& val) {
   std::unordered_map<T1, T2, T3, T4, T5> result;
   for (const auto& pair : data) {
     result[pair.first] = std::minus<T2>()(pair.second, val);
@@ -116,8 +112,8 @@ std::unordered_map<T1, T2, T3, T4, T5> sub(
 template <class T1, class T2, class T3, class T4, class T5, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::unordered_map<T1, T2, T3, T4, T5>& isub(
-    std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+decltype(auto) isub(std::unordered_map<T1, T2, T3, T4, T5>& data,
+                    const Scalar& val) {
   for (const auto& pair : data) {
     data[pair.first] = std::plus<T2>()(data[pair.first], val);
   }
@@ -131,8 +127,8 @@ std::unordered_map<T1, T2, T3, T4, T5>& isub(
 template <class T1, class T2, class T3, class T4, class T5, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::unordered_map<T1, T2, T3, T4, T5> mul(
-    const std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+decltype(auto) mul(const std::unordered_map<T1, T2, T3, T4, T5>& data,
+                   const Scalar& val) {
   if (almost_equal(val, 1)) {
     return data;
   }
@@ -146,8 +142,8 @@ std::unordered_map<T1, T2, T3, T4, T5> mul(
 template <class T1, class T2, class T3, class T4, class T5, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::unordered_map<T1, T2, T3, T4, T5>& imul(
-    std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+decltype(auto) imul(std::unordered_map<T1, T2, T3, T4, T5>& data,
+                    const Scalar& val) {
   if (almost_equal(val, 1)) {
     return data;
   }
@@ -160,8 +156,8 @@ std::unordered_map<T1, T2, T3, T4, T5>& imul(
 template <class T1, class T2, class T3, class T4, class T5, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::unordered_map<T1, T2, T3, T4, T5> div(
-    const std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+decltype(auto) div(const std::unordered_map<T1, T2, T3, T4, T5>& data,
+                   const Scalar& val) {
   if (almost_equal(val, 1)) {
     return data;
   }
@@ -175,8 +171,8 @@ std::unordered_map<T1, T2, T3, T4, T5> div(
 template <class T1, class T2, class T3, class T4, class T5, class Scalar,
           typename = enable_if_numeric<T2>,
           typename = enable_if_numeric<Scalar>>
-std::unordered_map<T1, T2, T3, T4, T5>& idiv(
-    std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+decltype(auto) idiv(std::unordered_map<T1, T2, T3, T4, T5>& data,
+                    const Scalar& val) {
   if (almost_equal(val, 1)) {
     return data;
   }

--- a/src/framework/linalg/linops/linops_unordered_map.hpp
+++ b/src/framework/linalg/linops/linops_unordered_map.hpp
@@ -1,0 +1,194 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_linops_unordered_map_hpp_
+#define _aer_framework_linalg_linops_unordered_map_hpp_
+
+#include <functional>
+#include <unordered_map>
+
+#include "framework/linalg/almost_equal.hpp"
+#include "framework/linalg/enable_if_numeric.hpp"
+namespace AER {
+namespace Linalg {
+
+// This defines functions add, sub, mul, div and iadd, imul, isub, idiv
+// that work for numeric unordered_map types
+
+//----------------------------------------------------------------------------
+// Linear operations
+//----------------------------------------------------------------------------
+template <class T1, class T2, class T3, class T4, class T5,
+          typename = enable_if_numeric<T2>>
+std::unordered_map<T1, T2, T3, T4, T5> add(
+    const std::unordered_map<T1, T2, T3, T4, T5>& lhs,
+    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
+  std::unordered_map<T1, T2, T3, T4, T5> result = lhs;
+  for (const auto& pair : rhs) {
+    result[pair.first] = std::plus<T2>()(result[pair.first], pair.second);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class T5,
+          typename = enable_if_numeric<T2>>
+std::unordered_map<T1, T2, T3, T4, T5>& iadd(
+    std::unordered_map<T1, T2, T3, T4, T5>& lhs,
+    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
+  for (const auto& pair : rhs) {
+    lhs[pair.first] = std::plus<T2>()(lhs[pair.first], pair.second);
+  }
+  return lhs;
+}
+
+template <class T1, class T2, class T3, class T4, class T5,
+          typename = enable_if_numeric<T2>>
+std::unordered_map<T1, T2, T3, T4, T5> sub(
+    const std::unordered_map<T1, T2, T3, T4, T5>& lhs,
+    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
+  std::unordered_map<T1, T2, T3, T4, T5> result = lhs;
+  for (const auto& pair : rhs) {
+    result[pair.first] = std::minus<T2>()(result[pair.first], pair.second);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class T5,
+          typename = enable_if_numeric<T2>>
+std::unordered_map<T1, T2, T3, T4, T5>& isub(
+    std::unordered_map<T1, T2, T3, T4, T5>& lhs,
+    const std::unordered_map<T1, T2, T3, T4, T5>& rhs) {
+  for (const auto& pair : rhs) {
+    lhs[pair.first] = std::minus<T2>()(lhs[pair.first], pair.second);
+  }
+  return lhs;
+}
+
+//----------------------------------------------------------------------------
+// Affine operations
+//----------------------------------------------------------------------------
+template <class T1, class T2, class T3, class T4, class T5, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::unordered_map<T1, T2, T3, T4, T5> add(
+    const std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+  std::unordered_map<T1, T2, T3, T4, T5> result;
+  for (const auto& pair : data) {
+    result[pair.first] = std::plus<T2>()(pair.second, val);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class T5, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::unordered_map<T1, T2, T3, T4, T5>& iadd(
+    std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+  for (const auto& pair : data) {
+    data[pair.first] = std::plus<T2>()(data[pair.first], val);
+  }
+  return data;
+}
+
+template <class T1, class T2, class T3, class T4, class T5, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::unordered_map<T1, T2, T3, T4, T5> sub(
+    const std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+  std::unordered_map<T1, T2, T3, T4, T5> result;
+  for (const auto& pair : data) {
+    result[pair.first] = std::minus<T2>()(pair.second, val);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class T5, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::unordered_map<T1, T2, T3, T4, T5>& isub(
+    std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+  for (const auto& pair : data) {
+    data[pair.first] = std::plus<T2>()(data[pair.first], val);
+  }
+  return data;
+}
+
+//----------------------------------------------------------------------------
+// Scalar operations
+//----------------------------------------------------------------------------
+
+template <class T1, class T2, class T3, class T4, class T5, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::unordered_map<T1, T2, T3, T4, T5> mul(
+    const std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  std::unordered_map<T1, T2, T3, T4, T5> result;
+  for (const auto& pair : data) {
+    result[pair.first] = std::multiplies<T2>()(pair.second, val);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class T5, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::unordered_map<T1, T2, T3, T4, T5>& imul(
+    std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  for (const auto& pair : data) {
+    data[pair.first] = std::multiplies<T2>()(data[pair.first], val);
+  }
+  return data;
+}
+
+template <class T1, class T2, class T3, class T4, class T5, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::unordered_map<T1, T2, T3, T4, T5> div(
+    const std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  std::unordered_map<T1, T2, T3, T4, T5> result;
+  for (const auto& pair : data) {
+    result[pair.first] = std::divides<T2>()(pair.second, val);
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, class T4, class T5, class Scalar,
+          typename = enable_if_numeric<T2>,
+          typename = enable_if_numeric<Scalar>>
+std::unordered_map<T1, T2, T3, T4, T5>& idiv(
+    std::unordered_map<T1, T2, T3, T4, T5>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  for (const auto& pair : data) {
+    data[pair.first] = std::divides<T2>()(data[pair.first], val);
+  }
+  return data;
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/linops/linops_vector.hpp
+++ b/src/framework/linalg/linops/linops_vector.hpp
@@ -1,0 +1,172 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_linops_vector_hpp_
+#define _aer_framework_linalg_linops_vector_hpp_
+
+#include <functional>
+#include <vector>
+
+#include "framework/linalg/almost_equal.hpp"
+#include "framework/linalg/enable_if_numeric.hpp"
+
+namespace AER {
+namespace Linalg {
+
+// This defines functions add, sub, mul, div and iadd, imul, isub, idiv
+// that work for numeric vector types
+
+//----------------------------------------------------------------------------
+// Linear operations
+//----------------------------------------------------------------------------
+template <class T, typename = enable_if_numeric<T>>
+std::vector<T> add(const std::vector<T>& lhs, const std::vector<T>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    throw std::runtime_error("Cannot add two vectors of different sizes.");
+  }
+  std::vector<T> result;
+  result.reserve(lhs.size());
+  std::transform(lhs.begin(), lhs.end(), rhs.begin(),
+                 std::back_inserter(result), std::plus<T>());
+  return result;
+}
+
+template <class T, typename = enable_if_numeric<T>>
+std::vector<T>& iadd(std::vector<T>& lhs, const std::vector<T>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    throw std::runtime_error("Cannot add two vectors of different sizes.");
+  }
+  std::transform(lhs.begin(), lhs.end(), rhs.begin(), lhs.begin(),
+                 std::plus<T>());
+  return lhs;
+}
+
+template <class T, typename = enable_if_numeric<T>>
+std::vector<T> sub(const std::vector<T>& lhs, const std::vector<T>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    throw std::runtime_error("Cannot add two vectors of different sizes.");
+  }
+  std::vector<T> result;
+  result.reserve(lhs.size());
+  std::transform(lhs.begin(), lhs.end(), rhs.begin(),
+                 std::back_inserter(result), std::minus<T>());
+  return result;
+}
+
+template <class T, typename = enable_if_numeric<T>>
+std::vector<T>& isub(std::vector<T>& lhs, const std::vector<T>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    throw std::runtime_error("Cannot add two vectors of different sizes.");
+  }
+  std::transform(lhs.begin(), lhs.end(), rhs.begin(), lhs.begin(),
+                 std::minus<T>());
+  return lhs;
+}
+
+//----------------------------------------------------------------------------
+// Affine operations
+//----------------------------------------------------------------------------
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::vector<T> add(const std::vector<T>& data, const Scalar& val) {
+  std::vector<T> result;
+  result.reserve(data.size());
+  std::transform(data.begin(), data.end(), std::back_inserter(result),
+                 std::bind(std::plus<T>(), std::placeholders::_1, val));
+  return result;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::vector<T>& iadd(std::vector<T>& data, const Scalar& val) {
+  std::transform(data.begin(), data.end(), data.begin(),
+                 std::bind(std::plus<T>(), std::placeholders::_1, val));
+  return data;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::vector<T> sub(const std::vector<T>& data, const Scalar& val) {
+  std::vector<T> result;
+  result.reserve(data.size());
+  std::transform(data.begin(), data.end(), std::back_inserter(result),
+                 std::bind(std::minus<T>(), std::placeholders::_1, val));
+  return result;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::vector<T>& isub(std::vector<T>& data, const Scalar& val) {
+  std::transform(data.begin(), data.end(), data.begin(),
+                 std::bind(std::minus<T>(), std::placeholders::_1, val));
+  return data;
+}
+
+//----------------------------------------------------------------------------
+// Scalar operations
+//----------------------------------------------------------------------------
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::vector<T> mul(const std::vector<T>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  std::vector<T> result;
+  result.reserve(data.size());
+  std::transform(data.begin(), data.end(), std::back_inserter(result),
+                 std::bind(std::multiplies<T>(), std::placeholders::_1, val));
+  return result;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::vector<T>& imul(std::vector<T>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  std::transform(data.begin(), data.end(), data.begin(),
+                 std::bind(std::multiplies<T>(), std::placeholders::_1, val));
+  return data;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::vector<T> div(const std::vector<T>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  std::vector<T> result;
+  result.reserve(data.size());
+  std::transform(data.begin(), data.end(), std::back_inserter(result),
+                 std::bind(std::divides<T>(), std::placeholders::_1, val));
+  return result;
+}
+
+template <class T, class Scalar, typename = enable_if_numeric<T>,
+          typename = enable_if_numeric<Scalar>>
+std::vector<T>& idiv(std::vector<T>& data, const Scalar& val) {
+  if (almost_equal(val, 1)) {
+    return data;
+  }
+  std::transform(data.begin(), data.end(), data.begin(),
+                 std::bind(std::divides<T>(), std::placeholders::_1, val));
+  return data;
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/linalg/square.hpp
+++ b/src/framework/linalg/square.hpp
@@ -47,6 +47,7 @@ template <class T, size_t N, typename = enable_if_numeric<T>>
 std::array<T, N>& isquare(std::array<T, N>& data) {
   std::transform(data.begin(), data.end(), data.begin(), data.begin(),
                  std::multiplies<T>());
+  return data;
 }
 
 //----------------------------------------------------------------------------
@@ -68,6 +69,7 @@ template <class T, typename = enable_if_numeric<T>>
 std::vector<T>& isquare(std::vector<T>& data) {
   std::transform(data.begin(), data.end(), data.begin(), data.begin(),
                  std::multiplies<T>());
+  return data;
 }
 
 //----------------------------------------------------------------------------
@@ -148,15 +150,14 @@ json_t& isquare(json_t& data) {
       isquare(data[pos]);
     }
     return data;
-  } else if (data.is_object()) {
+  } 
+  if (data.is_object()) {
     for (auto it = data.begin(); it != data.end(); ++it) {
       isquare(data[it.key()]);
     }
     return data;
-  } else {
-    throw std::invalid_argument("Input JSONs cannot be squared.");
   }
-  return data;
+  throw std::invalid_argument("Input JSONs cannot be squared.");
 }
 
 json_t square(const json_t& data) {

--- a/src/framework/linalg/square.hpp
+++ b/src/framework/linalg/square.hpp
@@ -1,0 +1,187 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_linalg_square_hpp_
+#define _aer_framework_linalg_square_hpp_
+
+#include <array>
+#include <functional>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "framework/json.hpp"
+#include "framework/matrix.hpp"
+#include "framework/types.hpp"
+
+namespace AER {
+namespace Linalg {
+
+// This defines functions 'square' for entrywise square of
+// numeric types, and 'isquare' for inplace entywise square.
+
+//----------------------------------------------------------------------------
+// Entrywise square of std::array
+//----------------------------------------------------------------------------
+
+// Return entrywise square of a vector
+template <class T, size_t N, typename = enable_if_numeric<T>>
+std::array<T, N> square(const std::array<T, N>& data) {
+  std::array<T, N> result = data;
+  return isquare(result);
+}
+
+// Return inplace entrywise square of a vector
+template <class T, size_t N, typename = enable_if_numeric<T>>
+std::array<T, N>& isquare(std::array<T, N>& data) {
+  std::transform(data.begin(), data.end(), data.begin(), data.begin(),
+                 std::multiplies<T>());
+}
+
+//----------------------------------------------------------------------------
+// Entrywise square of std::vector
+//----------------------------------------------------------------------------
+
+// Return entrywise square of a vector
+template <class T, typename = enable_if_numeric<T>>
+std::vector<T> square(const std::vector<T>& data) {
+  std::vector<T> result;
+  result.reserve(data.size());
+  std::transform(data.begin(), data.end(), data.begin(), std::back_inserter(result),
+                 std::multiplies<T>());
+  return result;
+}
+
+// Return inplace entrywise square of a vector
+template <class T, typename = enable_if_numeric<T>>
+std::vector<T>& isquare(std::vector<T>& data) {
+  std::transform(data.begin(), data.end(), data.begin(), data.begin(),
+                 std::multiplies<T>());
+}
+
+//----------------------------------------------------------------------------
+// Entrywise square of std::map
+//----------------------------------------------------------------------------
+
+template <class T1, class T2, class T3, typename = enable_if_numeric<T2>>
+std::map<T1, T2, T3> square(const std::map<T1, T2, T3>& data) {
+  std::map<T1, T2, T3> result;
+  for (const auto& pair : data) {
+    result[pair.first] = pair.second * pair.second;
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, typename = enable_if_numeric<T2>>
+std::map<T1, T2, T3>& isquare(std::map<T1, T2, T3>& data) {
+  for (auto& pair : data) {
+    pair.second *= pair.second;
+  }
+  return data;
+}
+
+//----------------------------------------------------------------------------
+// Entrywise square of std::unordered_map
+//----------------------------------------------------------------------------
+
+template <class T1, class T2, class T3, typename = enable_if_numeric<T2>>
+std::unordered_map<T1, T2, T3> square(
+    const std::unordered_map<T1, T2, T3>& data) {
+  std::unordered_map<T1, T2, T3> result;
+  for (const auto& pair : data) {
+    result[pair.first] = pair.second * pair.second;
+  }
+  return result;
+}
+
+template <class T1, class T2, class T3, typename = enable_if_numeric<T2>>
+std::unordered_map<T1, T2, T3>& isquare(std::unordered_map<T1, T2, T3>& data) {
+  for (auto& pair : data) {
+    pair.second *= pair.second;
+  }
+  return data;
+}
+
+//----------------------------------------------------------------------------
+// Entrywise square of matrix
+//----------------------------------------------------------------------------
+
+template <class T, typename = enable_if_numeric<T>>
+matrix<T>& isquare(matrix<T>& data) {
+  for (size_t j = 0; j < data.size(); j++) {
+    data[j] *= data[j];
+  }
+  return data;
+}
+
+template <class T, typename = enable_if_numeric<T>>
+matrix<T> square(const matrix<T>& data) {
+  matrix<T> result = data;
+  return isquare(result);
+}
+
+//----------------------------------------------------------------------------
+// Entrywise square of JSON
+//----------------------------------------------------------------------------
+
+json_t& isquare(json_t& data) {
+  // Terminating case
+  if (data.is_number()) {
+    double val = data;
+    data = val * val;
+    return data;
+  }
+  // Recursive cases
+  if (data.is_array()) {
+    for (size_t pos = 0; pos < data.size(); pos++) {
+      isquare(data[pos]);
+    }
+    return data;
+  } else if (data.is_object()) {
+    for (auto it = data.begin(); it != data.end(); ++it) {
+      isquare(data[it.key()]);
+    }
+    return data;
+  } else {
+    throw std::invalid_argument("Input JSONs cannot be squared.");
+  }
+  return data;
+}
+
+json_t square(const json_t& data) {
+  json_t result = data;
+  return isquare(result);
+}
+
+//----------------------------------------------------------------------------
+// Square of general type
+//----------------------------------------------------------------------------
+
+template <class T>
+T square(const T& data) {
+  return data * data;
+}
+
+template <class T>
+T& isquare(T& data) {
+  data *= data;
+  return data;
+}
+
+//------------------------------------------------------------------------------
+}  // end namespace Linalg
+//------------------------------------------------------------------------------
+}  // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -1540,21 +1540,6 @@ std::string int2string(uint_t n, uint_t base, uint_t minlen) {
   return padleft_inplace(tmp, '0', minlen);
 }
 
-// No silver bullet for floating point comparison techniques.
-// With this function the user can at least specify the precision
-// If we have numbers closer to 0, then max_diff can be set to a value
-// way smaller than epsilon. For numbers larger than 1.0, epsilon will
-// scale (the bigger the number, the bigger the epsilon).
-template<typename T>
-typename std::enable_if<!std::numeric_limits<T>::is_integer, bool>::type
-    almost_equal(T f1, T f2, T max_diff = std::numeric_limits<T>::epsilon(), T max_relative_diff = std::numeric_limits<T>::epsilon())
-{
-  T diff = std::abs(f1 - f2);
-  if(diff <= max_diff)
-    return true;
-
-  return diff <= max_relative_diff * std::max(std::abs(f1), std::abs(f2));
-}
 
 //------------------------------------------------------------------------------
 } // end namespace Utils

--- a/test/src/test_utils.cpp
+++ b/test/src/test_utils.cpp
@@ -3,7 +3,7 @@
 #include <catch.hpp>
 #include <cmath>
 #include <limits>
-#include "framework/utils.hpp"
+#include "framework/linalg/almost_equal.hpp"
 #include "utils.hpp"
 
 namespace AER{
@@ -15,14 +15,14 @@ TEST_CASE( "Framework Utilities", "[almost_equal]" ) {
         double first = 1.0 + std::numeric_limits<double>::epsilon();
         double actual = 1.0;
         // Because the max_diff param is bigger than epsilon, this should be almost equal
-        REQUIRE(Utils::almost_equal<decltype(first)>(first, actual, 1e-15, 1e-15));
+        REQUIRE(Linalg::almost_equal<decltype(first)>(first, actual, 1e-15, 1e-15));
         
     }
 
     SECTION( "The difference between two numbers really close to 0 should say are almost equal" ) {
         double first = 5e-323; // Really close to the min magnitude of double
         double actual = 6e-323;
-        REQUIRE(Utils::almost_equal<decltype(first)>(first, actual, 1e-323, 1e-323));
+        REQUIRE(Linalg::almost_equal<decltype(first)>(first, actual, 1e-323, 1e-323));
         
     }
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds utility functions for `add`, `iadd`, `sub`, `isub`, `mul`, `imul`, `div`, `idiv`, `square` for generic types that support these functions, and specialized functions for `std::array`, `std::vector` `std::map`, `std::unordered_map`, `matrix` and `json` types.

### Details and comments

This is needed as a first step for adding improved average snapshot containers with non-JSON data storage types in #407 