### PR TITLE
Add missing basis gates to backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 
 Added
 -----
+- Added controlled gates (``cu1``, ``cu2``, ``cu3``) to simulator basis_gates (\#417)
+- Added multi-controlled gates (``mcx``, ``mcy``, ``mcz``, ``mcu1``, ``mcu2``, ``mcu3``)
+  to simulator basis gates (\#417)
+- Added gate definitions to simulator backend configurations (\#417)
 
 Changed
 -------

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -210,22 +210,221 @@ class QasmSimulator(AerBackend):
         'description': 'A C++ simulator with realistic noise for qobj files',
         'coupling_map': None,
         'basis_gates': [
-            'u1', 'u2', 'u3', 'cx', 'cz', 'cu1', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
-            't', 'tdg', 'ccx', 'swap', 'multiplexer', 'snapshot', 'unitary', 'reset',
-            'initialize', 'kraus', 'roerror'
+            'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
+            't', 'tdg', 'swap', 'ccx', 'unitary', 'initialize', 'cu1', 'cu2',
+            'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcu1', 'mcu2', 'mcu3',
+            'mcswap', 'multiplexer', 'kraus', 'roerror'
         ],
         'gates': [{
-            'name': 'TODO',
+            'name': 'u1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'Single-qubit gate [[1, 0], [0, exp(1j*lam)]]',
+            'qasm_def': 'gate u1(lam) q { U(0,0,lam) q; }'
+        }, {
+            'name': 'u2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description':
+            'Single-qubit gate [[1, -exp(1j*lam)], [exp(1j*phi), exp(1j*(phi+lam))]]/sqrt(2)',
+            'qasm_def': 'gate u2(phi,lam) q { U(pi/2,phi,lam) q; }'
+        }, {
+            'name':
+            'u3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional':
+            True,
+            'description':
+            'Single-qubit gate with three rotation angles',
+            'qasm_def':
+            'gate u3(theta,phi,lam) q { U(theta,phi,lam) q; }'
+        }, {
+            'name': 'cx',
             'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-NOT gate',
+            'qasm_def': 'gate cx c,t { CX c,t; }'
+        }, {
+            'name': 'cz',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-Z gate',
+            'qasm_def': 'gate cz a,b { h b; cx a,b; h b; }'
+        }, {
+            'name': 'id',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit identity gate',
+            'qasm_def': 'gate id a { U(0,0,0) a; }'
+        }, {
+            'name': 'x',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-X gate',
+            'qasm_def': 'gate x a { U(pi,0,pi) a; }'
+        }, {
+            'name': 'y',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-Y gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'z',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-Z gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'h',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Hadamard gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 's',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit phase gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'sdg',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit adjoint phase gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 't',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit T gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'tdg',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit adjoint T gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'swap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit SWAP gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'ccx',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Three-qubit Toffoli gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cswap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Three-qubit Fredkin (controlled-SWAP) gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'unitary',
+            'parameters': ['matrix'],
+            'conditional': True,
+            'description': 'N-qubit arbitrary unitary gate. '
+                           'The parameter is the N-qubit matrix to apply.',
+            'qasm_def': 'unitary(matrix) q1, q2,...'
+        }, {
+            'name': 'initialize',
+            'parameters': ['vector'],
+            'conditional': False,
+            'description': 'N-qubit state initialize. '
+                           'Resets qubits then sets statevector to the parameter vector.',
+            'qasm_def': 'initialize(vector) q1, q2,...'
+        }, {
+            'name': 'cu1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u1 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cu2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u2 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cu3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u3 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcx',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-X gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcy',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-Y gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcz',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-Z gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u1 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u2 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u3 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcswap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-SWAP gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'multiplexer',
+            'parameters': ['mat1', 'mat2', '...'],
+            'conditional': True,
+            'description': 'N-qubit multi-plexer gate. '
+                           'The input parameters are the gates for each value.',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'kraus',
+            'parameters': ['mat1', 'mat2', '...'],
+            'conditional': True,
+            'description': 'N-qubit Kraus error instruction. '
+                           'The input parameters are the Kraus matrices.',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'roerror',
+            'parameters': ['matrix'],
+            'conditional': False,
+            'description': 'N-bit classical readout error instruction. '
+                           'The input parameter is the readout error probability matrix.',
             'qasm_def': 'TODO'
         }]
     }
 
     def __init__(self, configuration=None, provider=None):
-        super().__init__(
-            qasm_controller_execute,
-            QasmBackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION),
-            provider=provider)
+        super().__init__(qasm_controller_execute,
+                         QasmBackendConfiguration.from_dict(
+                             self.DEFAULT_CONFIGURATION),
+                         provider=provider)
 
     def _validate(self, qobj, backend_options, noise_model):
         """Semantic validations of the qobj which cannot be done via schemas.

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -85,16 +85,201 @@ class StatevectorSimulator(AerBackend):
         'max_shots': 1,
         'description': 'A C++ statevector simulator for qobj files',
         'coupling_map': None,
-        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'cu1', 'id', 'x', 'y', 'z',
-                        'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
-                        'multiplexer', 'snapshot', 'unitary', 'reset', 'initialize'],
-        'gates': [
-            {
-                'name': 'TODO',
-                'parameters': [],
-                'qasm_def': 'TODO'
-            }
-        ]
+        'basis_gates': [
+            'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
+            't', 'tdg', 'swap', 'ccx', 'unitary', 'initialize', 'cu1', 'cu2',
+            'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcu1', 'mcu2', 'mcu3',
+            'mcswap', 'multiplexer',
+        ],
+        'gates': [{
+            'name': 'u1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'Single-qubit gate [[1, 0], [0, exp(1j*lam)]]',
+            'qasm_def': 'gate u1(lam) q { U(0,0,lam) q; }'
+        }, {
+            'name': 'u2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description':
+            'Single-qubit gate [[1, -exp(1j*lam)], [exp(1j*phi), exp(1j*(phi+lam))]]/sqrt(2)',
+            'qasm_def': 'gate u2(phi,lam) q { U(pi/2,phi,lam) q; }'
+        }, {
+            'name':
+            'u3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional':
+            True,
+            'description':
+            'Single-qubit gate with three rotation angles',
+            'qasm_def':
+            'gate u3(theta,phi,lam) q { U(theta,phi,lam) q; }'
+        }, {
+            'name': 'cx',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-NOT gate',
+            'qasm_def': 'gate cx c,t { CX c,t; }'
+        }, {
+            'name': 'cz',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-Z gate',
+            'qasm_def': 'gate cz a,b { h b; cx a,b; h b; }'
+        }, {
+            'name': 'id',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit identity gate',
+            'qasm_def': 'gate id a { U(0,0,0) a; }'
+        }, {
+            'name': 'x',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-X gate',
+            'qasm_def': 'gate x a { U(pi,0,pi) a; }'
+        }, {
+            'name': 'y',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-Y gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'z',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-Z gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'h',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Hadamard gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 's',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit phase gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'sdg',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit adjoint phase gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 't',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit T gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'tdg',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit adjoint T gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'swap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit SWAP gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'ccx',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Three-qubit Toffoli gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cswap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Three-qubit Fredkin (controlled-SWAP) gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'unitary',
+            'parameters': ['matrix'],
+            'conditional': True,
+            'description': 'N-qubit arbitrary unitary gate. '
+                           'The parameter is the N-qubit matrix to apply.',
+            'qasm_def': 'unitary(matrix) q1, q2,...'
+        }, {
+            'name': 'initialize',
+            'parameters': ['vector'],
+            'conditional': False,
+            'description': 'N-qubit state initialize. '
+                           'Resets qubits then sets statevector to the parameter vector.',
+            'qasm_def': 'initialize(vector) q1, q2,...'
+        }, {
+            'name': 'cu1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u1 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cu2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u2 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cu3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u3 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcx',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-X gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcy',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-Y gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcz',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-Z gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u1 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u2 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u3 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcswap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-SWAP gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'multiplexer',
+            'parameters': ['mat1', 'mat2', '...'],
+            'conditional': True,
+            'description': 'N-qubit multi-plexer gate. '
+                           'The input parameters are the gates for each value.',
+            'qasm_def': 'TODO'
+        }]
     }
 
     def __init__(self, configuration=None, provider=None):

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -91,16 +91,201 @@ class UnitarySimulator(AerBackend):
         'description': 'A Python simulator for computing the unitary'
                        'matrix for experiments in qobj files',
         'coupling_map': None,
-        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'cz', 'cu1', 'id', 'x', 'y', 'z',
-                        'h', 's', 'sdg', 't', 'tdg', 'ccx', 'swap',
-                        'multiplexer', 'snapshot', 'unitary'],
-        'gates': [
-            {
-                'name': 'TODO',
-                'parameters': [],
-                'qasm_def': 'TODO'
-            }
-        ]
+        'basis_gates': [
+            'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
+            't', 'tdg', 'swap', 'ccx', 'unitary', 'initialize', 'cu1', 'cu2',
+            'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcu1', 'mcu2', 'mcu3',
+            'mcswap', 'multiplexer',
+        ],
+        'gates': [{
+            'name': 'u1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'Single-qubit gate [[1, 0], [0, exp(1j*lam)]]',
+            'qasm_def': 'gate u1(lam) q { U(0,0,lam) q; }'
+        }, {
+            'name': 'u2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description':
+            'Single-qubit gate [[1, -exp(1j*lam)], [exp(1j*phi), exp(1j*(phi+lam))]]/sqrt(2)',
+            'qasm_def': 'gate u2(phi,lam) q { U(pi/2,phi,lam) q; }'
+        }, {
+            'name':
+            'u3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional':
+            True,
+            'description':
+            'Single-qubit gate with three rotation angles',
+            'qasm_def':
+            'gate u3(theta,phi,lam) q { U(theta,phi,lam) q; }'
+        }, {
+            'name': 'cx',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-NOT gate',
+            'qasm_def': 'gate cx c,t { CX c,t; }'
+        }, {
+            'name': 'cz',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-Z gate',
+            'qasm_def': 'gate cz a,b { h b; cx a,b; h b; }'
+        }, {
+            'name': 'id',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit identity gate',
+            'qasm_def': 'gate id a { U(0,0,0) a; }'
+        }, {
+            'name': 'x',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-X gate',
+            'qasm_def': 'gate x a { U(pi,0,pi) a; }'
+        }, {
+            'name': 'y',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-Y gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'z',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Pauli-Z gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'h',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit Hadamard gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 's',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit phase gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'sdg',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit adjoint phase gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 't',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit T gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'tdg',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Single-qubit adjoint T gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'swap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Two-qubit SWAP gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'ccx',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Three-qubit Toffoli gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cswap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'Three-qubit Fredkin (controlled-SWAP) gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'unitary',
+            'parameters': ['matrix'],
+            'conditional': True,
+            'description': 'N-qubit arbitrary unitary gate. '
+                           'The parameter is the N-qubit matrix to apply.',
+            'qasm_def': 'unitary(matrix) q1, q2,...'
+        }, {
+            'name': 'initialize',
+            'parameters': ['vector'],
+            'conditional': False,
+            'description': 'N-qubit state initialize. '
+                           'Resets qubits then sets statevector to the parameter vector.',
+            'qasm_def': 'initialize(vector) q1, q2,...'
+        }, {
+            'name': 'cu1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u1 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cu2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u2 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'cu3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional': True,
+            'description': 'Two-qubit Controlled-u3 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcx',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-X gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcy',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-Y gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcz',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-Z gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu1',
+            'parameters': ['lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u1 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu2',
+            'parameters': ['phi', 'lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u2 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcu3',
+            'parameters': ['theta', 'phi', 'lam'],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-u3 gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'mcswap',
+            'parameters': [],
+            'conditional': True,
+            'description': 'N-qubit multi-controlled-SWAP gate',
+            'qasm_def': 'TODO'
+        }, {
+            'name': 'multiplexer',
+            'parameters': ['mat1', 'mat2', '...'],
+            'conditional': True,
+            'description': 'N-qubit multi-plexer gate. '
+                           'The input parameters are the gates for each value.',
+            'qasm_def': 'TODO'
+        }]
     }
 
     def __init__(self, configuration=None, provider=None):

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -84,9 +84,9 @@ public:
 
   // Return the set of qobj gate instruction names supported by the State
   virtual stringset_t allowed_gates() const override {
-    return {"u1", "u2", "u3", "cx", "cz", "cy", "cu1", "swap",
-            "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx",
-            "mcx", "mcz", "mcy", "mcz", "mcu1", "mcu2", "mcu3", "mcswap"};
+    return {"u1", "u2", "u3", "cx", "cz", "cy", "cu1", "cu2", "cu3", "swap", 
+            "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx", "cswap",
+            "mcx", "mcy", "mcz", "mcu1", "mcu2", "mcu3", "mcswap"};
   }
 
   // Return the set of qobj snapshot types supported by the State
@@ -316,16 +316,20 @@ const stringmap_t<Gates> State<statevec_t>::gateset_({
   {"cy", Gates::mcy},        // Controlled-Y gate
   {"cz", Gates::mcz},        // Controlled-Z gate
   {"cu1", Gates::mcu1},      // Controlled-u1 gate
+  {"cu2", Gates::mcu2},      // Controlled-u2 gate
+  {"cu3", Gates::mcu3},      // Controlled-u3 gate
   {"swap", Gates::mcswap},   // SWAP gate
-  {"mcswap", Gates::mcswap}, // Multi-controlled SWAP gate
+  // 3-qubit gates
+  {"ccx", Gates::mcx},       // Controlled-CX gate (Toffoli)
+  {"cswap", Gates::mcswap},  // Controlled SWAP gate (Fredkin)
   // Multi-qubit controlled gates
-  {"ccx", Gates::mcx},   // Controlled-CX gate (Toffoli)
-  {"mcx", Gates::mcx},   // Multi-controlled-X gate
-  {"mcy", Gates::mcy},   // Multi-controlled-Y gate
-  {"mcz", Gates::mcz},   // Multi-controlled-Z gate
-  {"mcu1", Gates::mcu1}, // Multi-controlled-u1
-  {"mcu2", Gates::mcu2}, // Multi-controlled-u2
-  {"mcu3", Gates::mcu3}  // Multi-controlled-u3
+  {"mcx", Gates::mcx},      // Multi-controlled-X gate
+  {"mcy", Gates::mcy},      // Multi-controlled-Y gate
+  {"mcz", Gates::mcz},      // Multi-controlled-Z gate
+  {"mcu1", Gates::mcu1},    // Multi-controlled-u1
+  {"mcu2", Gates::mcu2},    // Multi-controlled-u2
+  {"mcu3", Gates::mcu3},    // Multi-controlled-u3
+  {"mcswap", Gates::mcswap} // Multi-controlled SWAP gate
 
 });
 

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -67,9 +67,9 @@ public:
 
   // Return the set of qobj gate instruction names supported by the State
   virtual stringset_t allowed_gates() const override {
-    return {"u1", "u2", "u3", "cx", "cz", "cy", "cu1", "swap",
-            "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx",
-            "mcx", "mcz", "mcy", "mcu1", "mcu2", "mcu3", "mcswap"};
+    return {"u1", "u2", "u3", "cx", "cz", "cy", "cu1", "cu2", "cu3", "swap",
+            "id", "x", "y", "z", "h", "s", "sdg", "t", "tdg", "ccx", "cswap",
+            "mcx", "mcy", "mcz", "mcu1", "mcu2", "mcu3", "mcswap"};
   }
 
   // Return the set of qobj snapshot types supported by the State
@@ -188,19 +188,23 @@ const stringmap_t<Gates> State<data_t>::gateset_({
   {"u2", Gates::mcu2},  // single-X90 pulse waltz gate
   {"u3", Gates::mcu3},  // two X90 pulse waltz gate
   // Two-qubit gates
-  {"cx", Gates::mcx},   // Controlled-X gate (CNOT)
-  {"cy", Gates::mcy},   // Controlled-Z gate
-  {"cz", Gates::mcz},   // Controlled-Z gate
-  {"cu1", Gates::mcu1}, // Controlled-u1 gate
-  {"swap", Gates::mcswap}, // SWAP gate
+  {"cx", Gates::mcx},       // Controlled-X gate (CNOT)
+  {"cy", Gates::mcy},       // Controlled-Z gate
+  {"cz", Gates::mcz},       // Controlled-Z gate
+  {"cu1", Gates::mcu1},     // Controlled-u1 gate
+  {"cu2", Gates::mcu2},    // Controlled-u2
+  {"cu3", Gates::mcu1},     // Controlled-u3 gate
+  {"swap", Gates::mcswap},  // SWAP gate
   // Three-qubit gates
-  {"ccx", Gates::mcx},   // Controlled-CX gate (Toffoli)
-  {"mcx", Gates::mcx},   // Multi-controlled-X gate
-  {"mcy", Gates::mcy},   // Multi-controlled-Y gate
-  {"mcz", Gates::mcz},    // Multi-controlled-Z gate
-  {"mcu1", Gates::mcu1}, // Multi-controlled-u1
-  {"mcu2", Gates::mcu2}, // Multi-controlled-u2
-  {"mcu3", Gates::mcu3},  // Multi-controlled-u3
+  {"ccx", Gates::mcx},      // Controlled-CX gate (Toffoli)
+  {"cswap", Gates::mcswap}, // Controlled-SWAP gate (Fredkin)
+  // Multi-qubit controlled gates
+  {"mcx", Gates::mcx},      // Multi-controlled-X gate
+  {"mcy", Gates::mcy},      // Multi-controlled-Y gate
+  {"mcz", Gates::mcz},      // Multi-controlled-Z gate
+  {"mcu1", Gates::mcu1},    // Multi-controlled-u1
+  {"mcu2", Gates::mcu2},    // Multi-controlled-u2
+  {"mcu3", Gates::mcu3},    // Multi-controlled-u3
   {"mcswap", Gates::mcswap} // Multi-controlled-SWAP gate
 });
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds missing supported basis gates to the backend "basis_gates".
* Adds missing "gates" fields information to Aer backend configuration.

### Details and comments

Added basis gates that were already supported by simulators include:

* Controlled-u1 gate (name `"cu1"`)
* Controlled-u2 gate (name `"cu2"`)
* Controlled-u3 gate (name `"cu3"`)
* Controlled Swap (fredkin) gate (name `"cswap"`)
* Multi-controlled X gate (name `"mcx"`)
* Multi-controlled Y gate (name `"mcy"`)
* Multi-controlled Z gate (name `"mcz"`)
* Multi-controlled u1 gate (name `"mcu1"`)
* Multi-controlled u2 gate (name `"mcu2"`)
* Multi-controlled u3 gate (name `"mcu3"`)