### PR TITLE
Rewrite stabilizer snapshot_probabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 
 Added
 -----
+- Added support for probabilities snapshot and Pauli expectation value snapshot in the stabilizer simulator (\#423)
 
 Changed
 -------

--- a/src/simulators/stabilizer/clifford.hpp
+++ b/src/simulators/stabilizer/clifford.hpp
@@ -99,7 +99,7 @@ public:
 
   // If we perform a single qubit Z measurement, 
   // will the outcome be random or deterministic.
-  bool is_deterministic_outcome(const uint64_t qubit) const;
+  bool is_deterministic_outcome(const uint64_t& qubit) const;
 
   // Return the outcome (0 or 1) of a single qubit Z measurement, and
   // update the stabilizer to the conditional (post measurement) state if
@@ -289,7 +289,7 @@ std::pair<bool, uint64_t> Clifford::x_anticommuting(const uint64_t qubit) const 
 // Measurement
 //------------------------------------------------------------------------------
 
-bool Clifford::is_deterministic_outcome(const uint64_t qubit) {
+bool Clifford::is_deterministic_outcome(const uint64_t& qubit) const {
   // Clifford state measurements only have three probabilities:
   // (p0, p1) = (0.5, 0.5), (1, 0), or (0, 1)
   // The random case happens if there is a row anti-commuting with Z[qubit]

--- a/src/simulators/stabilizer/clifford.hpp
+++ b/src/simulators/stabilizer/clifford.hpp
@@ -97,6 +97,10 @@ public:
   // Measurement
   //-----------------------------------------------------------------------
 
+  // If we perform a single qubit Z measurement, 
+  // will the outcome be random or deterministic.
+  bool is_deterministic_outcome(const uint64_t qubit) const;
+
   // Return the outcome (0 or 1) of a single qubit Z measurement, and
   // update the stabilizer to the conditional (post measurement) state if
   // the outcome was random.
@@ -284,6 +288,13 @@ std::pair<bool, uint64_t> Clifford::x_anticommuting(const uint64_t qubit) const 
 //------------------------------------------------------------------------------
 // Measurement
 //------------------------------------------------------------------------------
+
+bool Clifford::is_deterministic_outcome(const uint64_t qubit) {
+  // Clifford state measurements only have three probabilities:
+  // (p0, p1) = (0.5, 0.5), (1, 0), or (0, 1)
+  // The random case happens if there is a row anti-commuting with Z[qubit]
+  return !z_anticommuting(qubit).first;
+}
 
 bool Clifford::measure_and_update(const uint64_t qubit, const uint64_t randint) {
   // Clifford state measurements only have three probabilities:

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -499,10 +499,11 @@ void State::snapshot_probabilities_auxiliary(const reg_t& qubits,
 					     double outcome_prob,
 					     stringmap_t<double>& probs) {
   uint_t qubit_for_branching = -1;
-  for(uint_t i=qubits.size()-1; i>=0; --i) {
+  for(uint_t i=0; i<qubits.size(); ++i) {
+    uint_t qubit = qubits[qubits.size()-i-1];
     if(outcome[i] == 'X') {
-      if(BaseState::qreg_.is_deterministic_outcome(qubits[i])) {
-	bool single_qubit_outcome = BaseState::qreg_.measure_and_update(qubits[i], 0);
+      if(BaseState::qreg_.is_deterministic_outcome(qubit)) {
+	bool single_qubit_outcome = BaseState::qreg_.measure_and_update(qubit, 0);
 	if(single_qubit_outcome) {
 	  outcome[i] = '1';
 	}
@@ -517,7 +518,7 @@ void State::snapshot_probabilities_auxiliary(const reg_t& qubits,
   }
 
   if(qubit_for_branching == -1) {
-    probs[outcome] = outcome_prob;
+    probs[Utils::bin2hex(outcome)] = outcome_prob;
     return;
   }
 
@@ -529,11 +530,11 @@ void State::snapshot_probabilities_auxiliary(const reg_t& qubits,
     else {
       new_outcome[qubit_for_branching] = '0';
     }
+    auto copy_of_qreg = BaseState::qreg_;
+    BaseState::qreg_.measure_and_update(qubits[qubits.size()-qubit_for_branching-1], single_qubit_outcome);
     snapshot_probabilities_auxiliary(qubits, new_outcome, 0.5*outcome_prob, probs);
+    BaseState::qreg_ = copy_of_qreg;
   }
-
-  auto copy_of_qreg = BaseState::qreg_;
-  
 }
 
 

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -499,19 +499,19 @@ void State::snapshot_probabilities_auxiliary(const reg_t& qubits,
 					     double outcome_prob,
 					     stringmap_t<double>& probs) {
   uint_t qubit_for_branching = -1;
-  for(const auto& qubit : qubits) {
-    if(outcome[qubits.size()-qubit-1] == 'X') {
-      if(BaseState::qreg_.is_deterministic_outcome(qubit)) {
-	bool single_qubit_outcome = BaseState::qreg_.measure_and_update(qubit, 0);
+  for(uint_t i=qubits.size()-1; i>=0; --i) {
+    if(outcome[i] == 'X') {
+      if(BaseState::qreg_.is_deterministic_outcome(qubits[i])) {
+	bool single_qubit_outcome = BaseState::qreg_.measure_and_update(qubits[i], 0);
 	if(single_qubit_outcome) {
-	  outcome[qubits.size()-qubit-1] = '1';
+	  outcome[i] = '1';
 	}
 	else {
-	  outcome[qubits.size()-qubit-1] = '0';
+	  outcome[i] = '0';
 	}
       }
       else {
-	qubit_for_branching = qubit;
+	qubit_for_branching = i;
       }
     }
   }
@@ -524,10 +524,10 @@ void State::snapshot_probabilities_auxiliary(const reg_t& qubits,
   for(uint_t single_qubit_outcome = 0; single_qubit_outcome<2; ++single_qubit_outcome) {
     std::string new_outcome = outcome;
     if(single_qubit_outcome) {
-      new_outcome[qubits.size()-qubit_for_branching-1] = '1';
+      new_outcome[qubit_for_branching] = '1';
     }
     else {
-      new_outcome[qubits.size()-qubit_for_branching-1] = '0';
+      new_outcome[qubit_for_branching] = '0';
     }
     snapshot_probabilities_auxiliary(qubits, new_outcome, 0.5*outcome_prob, probs);
   }

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -76,7 +76,7 @@ public:
 
   // Return the set of qobj snapshot types supported by the State
   virtual stringset_t allowed_snapshots() const override {
-    return {"stabilizer", "memory", "register", "probabilities"};
+    return {"stabilizer", "memory", "register", "probabilities", "probabilities_with_variance"};
   }
 
   // Apply a sequence of operations by looping over list

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -118,7 +118,7 @@ protected:
   void apply_gate(const Operations::Op &op);
 
   // Measure qubits and return a list of outcomes [q0, q1, ...]
-  // If a state subclass supports this function it then "measure"
+  // If a state subclass supports this function then "measure"
   // should be contained in the set returned by the 'allowed_ops'
   // method.
   virtual void apply_measure(const reg_t &qubits,

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -103,7 +103,7 @@ public:
   }
 
   // Apply a sequence of operations by looping over list
-  // If the input is not in allowed_ops an exeption will be raised.
+  // If the input is not in allowed_ops an exception will be raised.
   virtual void apply_ops(const std::vector<Operations::Op> &ops,
                          ExperimentData &data,
                          RngEngine &rng) override;

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -230,7 +230,7 @@ protected:
   // should be left in the pre-snapshot state.
   //-----------------------------------------------------------------------
 
-  // Snapshot current qubit probabilities for a measurement (average)
+  // Snapshot current amplitudes
   void snapshot_statevector(const Operations::Op &op,
                             ExperimentData &data,
                             SnapshotDataType type);

--- a/test/terra/backends/qasm_simulator/qasm_snapshot.py
+++ b/test/terra/backends/qasm_simulator/qasm_snapshot.py
@@ -590,7 +590,7 @@ class QasmSnapshotExpValPauliTests:
 
     SIMULATOR = QasmSimulator()
     SUPPORTED_QASM_METHODS = [
-        'automatic', 'statevector', 'matrix_product_state'
+        'automatic', 'statevector', 'stabilizer', 'matrix_product_state'
     ]
     BACKEND_OPTS = {}
 

--- a/test/terra/backends/qasm_simulator/qasm_snapshot.py
+++ b/test/terra/backends/qasm_simulator/qasm_snapshot.py
@@ -640,7 +640,7 @@ class QasmSnapshotExpValPauliTests:
                         self.assertAlmostEqual(value, target, delta=1e-7)
 
     def test_snapshot_expval_pauli_post_measure(self):
-        """Test snapshot expectation value (pauli) before final measurement"""
+        """Test snapshot expectation value (pauli) after final measurement"""
         shots = 1000
         labels = snapshot_expval_labels()
         counts_targets = snapshot_expval_counts(shots)
@@ -723,7 +723,7 @@ class QasmSnapshotExpValMatrixTests:
                         self.assertAlmostEqual(value, target, delta=1e-7)
 
     def test_snapshot_expval_matrix_post_measure(self):
-        """Test snapshot expectation value (matrix) before final measurement"""
+        """Test snapshot expectation value (matrix) after final measurement"""
         shots = 1000
         labels = snapshot_expval_labels()
         counts_targets = snapshot_expval_counts(shots)

--- a/test/terra/backends/qasm_simulator/qasm_snapshot.py
+++ b/test/terra/backends/qasm_simulator/qasm_snapshot.py
@@ -510,12 +510,12 @@ class QasmSnapshotProbabilitiesTests:
 
     SIMULATOR = QasmSimulator()
     SUPPORTED_QASM_METHODS = [
-        'automatic', 'statevector', 'density_matrix', 'matrix_product_state'
+        'automatic', 'statevector', 'stabilizer', 'density_matrix', 'matrix_product_state'
     ]
     BACKEND_OPTS = {}
 
     @staticmethod
-    def probabilitiy_snapshots(data, labels):
+    def probability_snapshots(data, labels):
         """Format snapshots as nested dicts"""
         # Check snapshot entry exists in data
         output = {}
@@ -547,7 +547,7 @@ class QasmSnapshotProbabilitiesTests:
             # Check snapshots
             for j, circuit in enumerate(circuits):
                 data = result.data(circuit)
-                all_snapshots = self.probabilitiy_snapshots(data, labels)
+                all_snapshots = self.probability_snapshots(data, labels)
                 for label in labels:
                     snaps = all_snapshots.get(label, {})
                     self.assertTrue(len(snaps), 1)
@@ -577,7 +577,7 @@ class QasmSnapshotProbabilitiesTests:
             # Check snapshots
             for j, circuit in enumerate(circuits):
                 data = result.data(circuit)
-                all_snapshots = self.probabilitiy_snapshots(data, labels)
+                all_snapshots = self.probability_snapshots(data, labels)
                 for label in labels:
                     snaps = all_snapshots.get(label, {})
                     for memory, value in snaps.items():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The code for the stabilizer probabilities snapshot does not work properly for subsets of qubits. This pull request fixes this.

### Details and comments

More details can be found in https://github.com/Qiskit/qiskit-aer/issues/389
