### PR TITLE
Remove cvxopt from requirements

### DIFF
--- a/qiskit/providers/aer/noise/utils/noise_transformation.py
+++ b/qiskit/providers/aer/noise/utils/noise_transformation.py
@@ -694,10 +694,9 @@ class NoiseTransformer:
         Raises:
             ImportError: If cvxopt external module is not installed
 
-        Additional information
-        ======================
-        This method is the only place in the code where we rely on the cvxopt library
-        should we consider another library, only this method needs to change
+        Additional information:
+            This method requires the `cvxopt` library which must be
+            installed separately.
         """
         try:
             import cvxopt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ cmake
 scikit-build
 cython
 asv
-cvxopt
 pylint
 pycodestyle
 Sphinx>=1.8.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Removes cvxopt package from requirements. It must be installed separately by the user due to its software license.

### Details and comments


