### PR TITLE
Meas level 1 comment in pulse sim tests

### DIFF
--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -433,6 +433,9 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
     # ---------------------------------------------------------------------
     # Test meas level 1 (using square drive)
+    # Note: the simulator generates approximate IQ data with the proper
+    # data structure; it should not, however, be compared with an actual
+    # device.
     # ---------------------------------------------------------------------
 
     def test_meas_level_1(self):


### PR DESCRIPTION
### Summary

Add comment on IQ data for meas level 1.
