### PR TITLE
Switch to running tests in parallel with stestr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ contrib/standalone/version.hpp
 test/.asv
 
 .tox/
+.stestr/
 
 docs/_build/
 docs/stubs/

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,3 +1,3 @@
 [DEFAULT]
 test_path=./test/terra
-group_regex=(test.terra.backends.test_qasm_matrix_product_state|test.terra.backends.test_qasm_mps_simulator)
+parallel_class=True

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=./test/terra
+group_regex=(test.terra.backends.test_qasm_matrix_product_state|test.terra.backends.test_qasm_mps_simulator)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@
 notifications:
   email: false
 
-cache: pip
+cache:
+  pip: true
+  directories:
+    - .stestr
 sudo: false
 
 ###############################################################################
@@ -42,10 +45,15 @@ stage_linux: &stage_linux
     - sudo apt-get -y update
     - sudo apt-get -y install g++-7
     - sudo apt-get -y install libopenblas-dev
+  before_script:
+    - |
+      if [ ! "$(ls -A .stestr)" ]; then
+        rm -rf .stestr
+      fi
   script:
     - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
     - pip install dist/qiskit_aer*whl
-    - python -m unittest discover -s test -v
+    - stestr run
 
 stage_osx: &stage_osx
   <<: *stage_generic
@@ -56,6 +64,7 @@ stage_osx: &stage_osx
     pip: true
     directories:
       - ~/python-interpreters/
+      - .stestr
   before_install:
     # Travis does not provide support for Python 3 under osx - it needs to be
     # installed manually.
@@ -71,10 +80,16 @@ stage_osx: &stage_osx
         virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
         source venv/bin/activate
       fi
+  before_script:
+    - |
+      if [ ! "$(ls -A .stestr)" ]; then
+        rm -rf .stestr
+      fi
+
   script:
     - python setup.py bdist_wheel -- -- -j4
     - pip install dist/qiskit_aer*whl
-    - python -m unittest discover -s test -v
+    - stestr run
 
 ###############################################################################
 # Stage-related definitions

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ stage_linux: &stage_linux
   script:
     - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
     - pip install dist/qiskit_aer*whl
-    - stestr run
+    - stestr run --slowest
 
 stage_osx: &stage_osx
   <<: *stage_generic
@@ -89,7 +89,7 @@ stage_osx: &stage_osx
   script:
     - python setup.py bdist_wheel -- -- -j4
     - pip install dist/qiskit_aer*whl
-    - stestr run
+    - stestr run --slowest
 
 ###############################################################################
 # Stage-related definitions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,5 +75,5 @@ jobs:
           set -e
           source activate qiskit-aer-$(Build.BuildNumber)
           pip install dist/qiskit_aer*.whl
-          python -m unittest discover -s test/terra -v
+          stestr run
         displayName: 'Install Aer and Run Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,5 +75,5 @@ jobs:
           set -e
           source activate qiskit-aer-$(Build.BuildNumber)
           pip install dist/qiskit_aer*.whl
-          stestr run
+          stestr run --slowest
         displayName: 'Install Aer and Run Tests'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ Sphinx>=1.8.3
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 jupyter-sphinx
+stestr>=2.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,17 @@ deps =
 commands =
     python setup.py bdist_wheel -- -- -j4
     pip install --find-links={toxinidir}/dist qiskit_aer
-    python -m unittest discover -s test -v
+    stestr run {posargs}
+
+[testenv:coverage]
+basepython = python3
+setenv =
+  {[testenv]setenv}
+  PYTHON=coverage3 run --source qiskit --parallel-mode
+commands =
+  stestr run {posargs}
+  coverage3 combine
+  coverage3 report
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit switches the test runner for running the aer tests to
stestr. stestr is a unittest compatible test runner that executes tests
in parallel by default. This can provide significant speeds ups for
running a test suite. It also provides a rich set of scheduling [1] and
test selection [2] features which we can use to fine tune how we execute
tests. Based on local testing 2 classes of tests run in parallel already, to
optimize the run time thees need to be scheduled serially so that they don't
compete for resources. This is done using a group_regex [3] which is used
to provide a scheduler hint to keep these tests together.

### Details and comments

[1] https://stestr.readthedocs.io/en/stable/MANUAL.html#test-scheduling
[2] https://stestr.readthedocs.io/en/stable/MANUAL.html#test-selection
[3] https://stestr.readthedocs.io/en/stable/MANUAL.html#grouping-tests