### PR TITLE
Travis CI: Add Python 3.8 and flake8 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
   pip: true
   directories:
     - .stestr
-sudo: false
 
 ###############################################################################
 # Anchored and aliased definitions.
@@ -35,11 +34,8 @@ stage_generic: &stage_generic
 
 stage_linux: &stage_linux
   <<: *stage_generic
-  os: linux
-  dist: xenial
   language: python
-  python: 3.7
-  sudo: true
+  python: 3.8
   before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get -y update
@@ -112,6 +108,8 @@ jobs:
       name: Python Style and Linter
       <<: *stage_linux
       script:
+        - pip install flake8
+        - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         - pycodestyle --ignore=E402,W504 --max-line-length=100 qiskit/providers/aer
         - pylint -j 2 -rn qiskit/providers/aer
 
@@ -119,6 +117,13 @@ jobs:
     ###########################################################################
     # GNU/Linux, Python 3.7
     - stage: test
+      name: Python 3.8 Tests Linux
+      <<: *stage_linux
+      python: 3.8
+
+    # GNU/Linux, Python 3.7
+    - stage: test
+      if: type = cron
       name: Python 3.7 Tests Linux
       <<: *stage_linux
       python: 3.7
@@ -162,4 +167,3 @@ jobs:
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.5.6
-

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
         "Programming Language :: C++",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering",
     ],
     install_requires=requirements,

--- a/test/terra/utils/mock.py
+++ b/test/terra/utils/mock.py
@@ -245,7 +245,7 @@ class FakeJob(BaseJob):
 
 def new_fake_qobj():
     """Create fake `Qobj` and backend instances."""
-    backend = FakeQasmSimulator()
+    backend = FakeQasmSimulator()  # noqa: F821
     return QasmQobj(
         qobj_id='test-id',
         config=QasmQobjConfig(shots=1024, memory_slots=1, max_credits=100),


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


