### PR TITLE
- Adding missing symbols for libomp hack on MacOS, with older version…

### DIFF
--- a/src/misc/clang_omp_symbols.hpp
+++ b/src/misc/clang_omp_symbols.hpp
@@ -185,6 +185,18 @@ extern "C" {
         return _hook__kmpc_end_critical(id, global_tid, lck);
     }
 
+    using __kmpc_master_t = kmp_int32(*)(ident_t *, kmp_int32);
+    __kmpc_master_t _hook__kmpc_master;
+    kmp_int32 __kmpc_master(ident_t *id, kmp_int32 global_tid){
+        return _hook__kmpc_master(id, global_tid);
+    }
+
+    using __kmpc_end_master_t = void(*)(ident_t *, kmp_int32);
+    __kmpc_end_master_t _hook__kmpc_end_master;
+    void __kmpc_end_master(ident_t *id, kmp_int32 global_tid){
+        return _hook__kmpc_end_master(id, global_tid);
+    }
+
     #define __KAI_KMPC_CONVENTION
     using omp_get_max_threads_t = int(*)(void);
     omp_get_max_threads_t _hook_omp_get_max_threads;
@@ -292,6 +304,8 @@ void populate_hooks(void * handle){
     _hook__kmpc_global_thread_num = reinterpret_cast<decltype(&__kmpc_global_thread_num)>(dlsym(handle, "__kmpc_global_thread_num"));
     _hook__kmpc_critical = reinterpret_cast<decltype(&__kmpc_critical)>(dlsym(handle, "__kmpc_critical"));
     _hook__kmpc_end_critical = reinterpret_cast<decltype(&__kmpc_end_critical)>(dlsym(handle, "__kmpc_end_critical"));
+    _hook__kmpc_master = reinterpret_cast<decltype(&__kmpc_master)>(dlsym(handle, "__kmpc_master"));
+    _hook__kmpc_end_master = reinterpret_cast<decltype(&__kmpc_end_master)>(dlsym(handle, "__kmpc_end_master"));
     _hook_omp_get_max_threads = reinterpret_cast<decltype(&omp_get_max_threads)>(dlsym(handle, "omp_get_max_threads"));
     _hook_omp_set_nested = reinterpret_cast<decltype(&omp_set_nested)>(dlsym(handle, "omp_set_nested"));
 }


### PR DESCRIPTION
…s of clang (9)

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Travis is using an old version of clang with MacOS (AppleClang 9.0.0.9000039), so the hack we have for libomp in this platform needs to be updated for supporting other symbols being used by OMP version of Thrust.


### Details and comments
Thrust has an OMP backend, so it must be using libomp on MacOS, therefore we might need to add some new symbols to our libomp dynamically load hack.


