### PR TITLE
Issue 478 pulsesim test errors

### DIFF
--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -80,7 +80,7 @@ def digest_pulse_obj(qobj):
         out.global_data['meas_return'] = config_dict['meas_return']
 
     out.global_data['seed'] = None
-    if 'seed' in config_keys:
+    if 'seed' in config_keys_sim:
         out.global_data['seed'] = int(config_dict_sim['seed'])
 
     if 'memory_slots' in config_keys:

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -81,7 +81,7 @@ def digest_pulse_obj(qobj):
 
     out.global_data['seed'] = None
     if 'seed' in config_keys:
-        out.global_data['seed'] = int(config_dict['seed'])
+        out.global_data['seed'] = int(config_dict_sim['seed'])
 
     if 'memory_slots' in config_keys:
         out.global_data['memory_slots'] = config_dict['memory_slots']

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -263,6 +263,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         backend_options['qubit_list'] = [self.qubit_0]
         backend_options['dt'] = 1.0  # makes time = self.drive_samples
         backend_options['ode_options'] = {}  # optionally set ode settings
+        backend_options['seed'] = 90841
         return backend_options
 
     def backend_options_2q(self, omega_0, omega_a, omega_i, qub_dim=2):
@@ -283,6 +284,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         backend_options['qubit_list'] = [self.qubit_0, self.qubit_1]
         backend_options['dt'] = 1.0  # makes time = self.drive_samples
         backend_options['ode_options'] = {}  # optionally set ode settings
+        backend_options['seed'] = 12387
         return backend_options
 
     def qobj_params_1q(self, omega_d0):
@@ -684,6 +686,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         exp_prop_shift = self._analytic_prop_fc(np.pi / 4 - np.pi / 8)
         self.assertDictAlmostEqual(prop_shift, exp_prop_shift, delta=0.01)
 
+    '''
+    Commented out as PersistentValue pulses currently not supported.
     def test_persistent_value(self):
         """Test persistent value command. """
 
@@ -710,7 +714,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         exp_result = {'1': shots}
 
         self.assertDictAlmostEqual(counts, exp_result)
-
+    '''
     # ---------------------------------------------------------------------
     # Test higher energy levels (take 3 level system for simplicity,
     # use square drive)

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -686,8 +686,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         exp_prop_shift = self._analytic_prop_fc(np.pi / 4 - np.pi / 8)
         self.assertDictAlmostEqual(prop_shift, exp_prop_shift, delta=0.01)
 
-    '''
-    Commented out as PersistentValue pulses currently not supported.
+    @unittest.skip("PerisitentValue pulses are currently not supported.")
     def test_persistent_value(self):
         """Test persistent value command. """
 
@@ -714,7 +713,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         exp_result = {'1': shots}
 
         self.assertDictAlmostEqual(counts, exp_result)
-    '''
+
     # ---------------------------------------------------------------------
     # Test higher energy levels (take 3 level system for simplicity,
     # use square drive)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Addresses issue #478 by implementing the suggested changes.

### Details and comments

1. The test case `test_persistent_value` was commented out.
2. `digest_pulse_obj` was modified to look for key `'seed'` in `backend_options` and pass this to the pulse simulator. (Code for this already existed, but it was looking in the standard 
pulse `qobj` configuration. I think `backend_options` is a more natural place for this as it is an option for how simulation is done.) The helper functions, `backend_options_1q` and `backend_options_2q`, were updated to include a seed.

