### PR TITLE
Fix bug in unitary simulator cu3 and add cu3 tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Removed
 
 Fixed
 -----
+- Fixes bug where cu3 was being applied as cu1 for unitary_simulator (\#483)
 
 [0.3.3](https://github.com/Qiskit/qiskit-aer/compare/0.3.2...0.3.3) - 2019-11-14
 ====================================================================================

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -192,8 +192,8 @@ const stringmap_t<Gates> State<data_t>::gateset_({
   {"cy", Gates::mcy},       // Controlled-Z gate
   {"cz", Gates::mcz},       // Controlled-Z gate
   {"cu1", Gates::mcu1},     // Controlled-u1 gate
-  {"cu2", Gates::mcu2},    // Controlled-u2
-  {"cu3", Gates::mcu1},     // Controlled-u3 gate
+  {"cu2", Gates::mcu2},     // Controlled-u2
+  {"cu3", Gates::mcu3},     // Controlled-u3 gate
   {"swap", Gates::mcswap},  // SWAP gate
   // Three-qubit gates
   {"ccx", Gates::mcx},      // Controlled-CX gate (Toffoli)

--- a/test/terra/backends/qasm_simulator/qasm_noncliffords.py
+++ b/test/terra/backends/qasm_simulator/qasm_noncliffords.py
@@ -136,6 +136,20 @@ class QasmNonCliffordTests:
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
+    # ---------------------------------------------------------------------
+    # Test cu3 gate
+    # ---------------------------------------------------------------------
+    def test_cu3_gate_deterministic_default_basis_gates(self):
+        """Test cu3-gate gate circuits compiling to default basis."""
+        shots = 100
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(
+            final_measure=True)
+        targets = ref_non_clifford.cu3_gate_counts_deterministic(shots)
+        job = execute(circuits, self.SIMULATOR, shots=shots)
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_counts(result, circuits, targets, delta=0)
+
 
 class QasmNonCliffordTestsWaltzBasis:
     """QasmSimulator non-Clifford gate tests in minimal u1,u2,u3,cx basis."""
@@ -152,7 +166,10 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.t_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
@@ -163,7 +180,10 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -177,7 +197,10 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
@@ -188,7 +211,10 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -202,7 +228,10 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
@@ -213,7 +242,10 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -227,7 +259,10 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.cswap_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.cswap_gate_counts_deterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
@@ -238,7 +273,10 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.cswap_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.cswap_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -252,10 +290,30 @@ class QasmNonCliffordTestsWaltzBasis:
         circuits = ref_non_clifford.cu1_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.cu1_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+
+    # ---------------------------------------------------------------------
+    # Test cu3 gate
+    # ---------------------------------------------------------------------
+    def test_cu3_gate_deterministic_default_basis_gates(self):
+        """Test cu3-gate gate circuits compiling to u1,u2,u3,cx."""
+        shots = 100
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(
+            final_measure=True)
+        targets = ref_non_clifford.cu3_gate_counts_deterministic(shots)
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_counts(result, circuits, targets, delta=0)
 
 
 class QasmNonCliffordTestsMinimalBasis:
@@ -273,7 +331,10 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.t_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_deterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
@@ -284,7 +345,10 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.t_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -298,7 +362,10 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_deterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
@@ -309,7 +376,10 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.tdg_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
@@ -323,7 +393,10 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_deterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
@@ -334,7 +407,10 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.ccx_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
@@ -348,7 +424,10 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.cu1_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.cu1_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
@@ -361,7 +440,8 @@ class QasmNonCliffordTestsMinimalBasis:
         shots = 100
         circuits = ref_non_clifford.multiplexer_ccx_gate_circuits_deterministic(
             final_measure=True)
-        targets = ref_non_clifford.multiplexer_ccx_gate_counts_deterministic(shots)
+        targets = ref_non_clifford.multiplexer_ccx_gate_counts_deterministic(
+            shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
@@ -372,7 +452,8 @@ class QasmNonCliffordTestsMinimalBasis:
         shots = 2000
         circuits = ref_non_clifford.multiplexer_ccx_gate_circuits_nondeterministic(
             final_measure=True)
-        targets = ref_non_clifford.multiplexer_ccx_gate_counts_nondeterministic(shots)
+        targets = ref_non_clifford.multiplexer_ccx_gate_counts_nondeterministic(
+            shots)
         job = execute(circuits, self.SIMULATOR, shots=shots)
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
@@ -387,7 +468,10 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.cswap_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_non_clifford.cswap_gate_counts_deterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0)
@@ -398,7 +482,27 @@ class QasmNonCliffordTestsMinimalBasis:
         circuits = ref_non_clifford.cswap_gate_circuits_nondeterministic(
             final_measure=True)
         targets = ref_non_clifford.cswap_gate_counts_nondeterministic(shots)
-        job = execute(circuits, self.SIMULATOR, shots=shots, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.1 * shots)
+
+    # ---------------------------------------------------------------------
+    # Test cu3 gate
+    # ---------------------------------------------------------------------
+    def test_cu3_gate_deterministic_default_basis_gates(self):
+        """Test cu3-gate gate circuits compiling to u3, cx."""
+        shots = 100
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(
+            final_measure=True)
+        targets = ref_non_clifford.cu3_gate_counts_deterministic(shots)
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=shots,
+                      basis_gates=['u3', 'cx'])
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_counts(result, circuits, targets, delta=0)

--- a/test/terra/backends/test_statevector_simulator.py
+++ b/test/terra/backends/test_statevector_simulator.py
@@ -882,6 +882,39 @@ class TestStatevectorSimulator(common.QiskitAerTestCase):
         self.assertTrue(getattr(result, 'success', False))
         self.compare_statevector(result, circuits, targets)
 
+    # ---------------------------------------------------------------------
+    # Test cu3-gate (Fredkin)
+    # ---------------------------------------------------------------------
+
+    def test_cu3_gate_deterministic_default_basis_gates(self):
+        """Test cu3-gate circuits compiling to backend default basis_gates."""
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(final_measure=False)
+        targets = ref_non_clifford.cu3_gate_statevector_deterministic()
+        job = execute(circuits, StatevectorSimulator(), shots=1)
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_statevector(result, circuits, targets)
+
+    def test_cu3_gate_deterministic_minimal_basis_gates(self):
+        """Test cu3-gate gate circuits compiling to u3,cx"""
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(
+            final_measure=True)
+        targets = ref_non_clifford.cu3_gate_statevector_deterministic()
+        job = execute(circuits, StatevectorSimulator(), shots=1, basis_gates=['u3', 'cx'])
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_statevector(result, circuits, targets)
+
+    def test_cu3_gate_deterministic_waltz_basis_gates(self):
+        """Test cu3-gate gate circuits compiling to u1,u2,u3,cx"""
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(final_measure=False)
+        targets = ref_non_clifford.cu3_gate_statevector_deterministic()
+        job = execute(circuits, StatevectorSimulator(), shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_statevector(result, circuits, targets)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/backends/test_unitary_simulator.py
+++ b/test/terra/backends/test_unitary_simulator.py
@@ -9,7 +9,6 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-
 """
 UnitarySimulator Integration Tests
 """
@@ -33,7 +32,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_h_gate_deterministic_default_basis_gates(self):
         """Test h-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.h_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.h_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.h_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -42,25 +42,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_h_gate_deterministic_waltz_basis_gates(self):
         """Test h-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_1q_clifford.h_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.h_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.h_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_h_gate_deterministic_minimal_basis_gates(self):
         """Test h-gate gate circuits compiling to u3,cx"""
-        circuits = ref_1q_clifford.h_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.h_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.h_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_h_gate_nondeterministic_default_basis_gates(self):
         """Test h-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.h_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -69,18 +78,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_h_gate_nondeterministic_waltz_basis_gates(self):
         """Test h-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.h_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_h_gate_nondeterministic_minimal_basis_gates(self):
         """Test h-gate gate circuits compiling to u3,cx"""
-        circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.h_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.h_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -90,7 +107,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_x_gate_deterministic_default_basis_gates(self):
         """Test x-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.x_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.x_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.x_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -99,18 +117,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_x_gate_deterministic_waltz_basis_gates(self):
         """Test x-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_1q_clifford.x_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.x_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.x_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_x_gate_deterministic_minimal_basis_gates(self):
         """Test x-gate gate circuits compiling to u3,cx"""
-        circuits = ref_1q_clifford.x_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.x_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.x_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -120,7 +146,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_z_gate_deterministic_default_basis_gates(self):
         """Test z-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.z_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.z_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.z_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -129,18 +156,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_z_gate_deterministic_waltz_basis_gates(self):
         """Test z-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_1q_clifford.z_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.z_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.z_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_z_gate_deterministic_minimal_basis_gates(self):
         """Test z-gate gate circuits compiling to u3,cx"""
-        circuits = ref_1q_clifford.z_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.z_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.z_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -150,7 +185,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_y_gate_deterministic_default_basis_gates(self):
         """Test y-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.y_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.y_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.y_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -159,18 +195,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_y_gate_deterministic_waltz_basis_gates(self):
         """Test y-gate gate circuits compiling to u1,u2,u3,cx."""
-        circuits = ref_1q_clifford.y_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.y_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.y_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_y_gate_deterministic_minimal_basis_gates(self):
         """Test y-gate gate circuits compiling to u3, cx."""
-        circuits = ref_1q_clifford.y_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.y_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.y_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -180,7 +224,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_s_gate_deterministic_default_basis_gates(self):
         """Test s-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.s_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.s_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.s_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -189,25 +234,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_s_gate_deterministic_waltz_basis_gates(self):
         """Test s-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_1q_clifford.s_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.s_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.s_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_s_gate_deterministic_minimal_basis_gates(self):
         """Test s-gate gate circuits compiling to u3,cx"""
-        circuits = ref_1q_clifford.s_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.s_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.s_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_s_gate_nondeterministic_default_basis_gates(self):
         """Test s-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.s_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -216,18 +270,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_s_gate_nondeterministic_waltz_basis_gates(self):
         """Test s-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.s_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_s_gate_nondeterministic_minimal_basis_gates(self):
         """Test s-gate gate circuits compiling to u3,cx"""
-        circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.s_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.s_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -237,7 +299,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_sdg_gate_deterministic_default_basis_gates(self):
         """Test sdg-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.sdg_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -246,25 +309,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_sdg_gate_deterministic_waltz_basis_gates(self):
         """Test sdg-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.sdg_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_sdg_gate_deterministic_minimal_basis_gates(self):
         """Test sdg-gate gate circuits compiling to u3,cx"""
-        circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_1q_clifford.sdg_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_1q_clifford.sdg_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_sdg_gate_nondeterministic_default_basis_gates(self):
         """Test sdg-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.sdg_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -273,18 +345,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_sdg_gate_nondeterministic_waltz_basis_gates(self):
         """Test sdg-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.sdg_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_sdg_gate_nondeterministic_minimal_basis_gates(self):
         """Test sdg-gate gate circuits compiling to u3,cx"""
-        circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_1q_clifford.sdg_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_1q_clifford.sdg_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -294,7 +374,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_cx_gate_deterministic_default_basis_gates(self):
         """Test cx-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cx_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -303,25 +384,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_cx_gate_deterministic_waltz_basis_gates(self):
         """Test cx-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cx_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cx_gate_deterministic_minimal_basis_gates(self):
         """Test cx-gate gate circuits compiling to u3,cx"""
-        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.cx_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cx_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cx_gate_nondeterministic_default_basis_gates(self):
         """Test cx-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cx_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -330,18 +420,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_cx_gate_nondeterministic_waltz_basis_gates(self):
         """Test cx-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cx_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cx_gate_nondeterministic_minimal_basis_gates(self):
         """Test cx-gate gate circuits compiling to u3,cx"""
-        circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.cx_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cx_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -351,7 +449,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_cz_gate_deterministic_default_basis_gates(self):
         """Test cz-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_2q_clifford.cz_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cz_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -360,25 +459,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_cz_gate_deterministic_waltz_basis_gates(self):
         """Test cz-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_2q_clifford.cz_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cz_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cz_gate_deterministic_minimal_basis_gates(self):
         """Test cz-gate gate circuits compiling to u3,cx"""
-        circuits = ref_2q_clifford.cz_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.cz_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cz_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cz_gate_nondeterministic_default_basis_gates(self):
         """Test cz-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cz_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -387,18 +495,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_cz_gate_nondeterministic_waltz_basis_gates(self):
         """Test cz-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cz_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cz_gate_nondeterministic_minimal_basis_gates(self):
         """Test cz-gate gate circuits compiling to u3,cx"""
-        circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.cz_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.cz_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -408,7 +524,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_swap_gate_deterministic_default_basis_gates(self):
         """Test swap-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_2q_clifford.swap_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.swap_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.swap_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -417,25 +534,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_swap_gate_deterministic_waltz_basis_gates(self):
         """Test swap-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_2q_clifford.swap_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.swap_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.swap_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_swap_gate_deterministic_minimal_basis_gates(self):
         """Test swap-gate gate circuits compiling to u3,cx"""
-        circuits = ref_2q_clifford.swap_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_2q_clifford.swap_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_2q_clifford.swap_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_swap_gate_nondeterministic_default_basis_gates(self):
         """Test swap-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.swap_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -444,18 +570,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_swap_gate_nondeterministic_waltz_basis_gates(self):
         """Test swap-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.swap_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_swap_gate_nondeterministic_minimal_basis_gates(self):
         """Test swap-gate gate circuits compiling to u3,cx"""
-        circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_2q_clifford.swap_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_2q_clifford.swap_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -465,7 +599,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_t_gate_deterministic_default_basis_gates(self):
         """Test t-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_non_clifford.t_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.t_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.t_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -474,25 +609,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_t_gate_deterministic_waltz_basis_gates(self):
         """Test t-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.t_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.t_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.t_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_t_gate_deterministic_minimal_basis_gates(self):
         """Test t-gate gate circuits compiling to u3,cx"""
-        circuits = ref_non_clifford.t_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.t_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.t_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_t_gate_nondeterministic_default_basis_gates(self):
         """Test t-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_non_clifford.t_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.t_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -501,18 +645,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_t_gate_nondeterministic_waltz_basis_gates(self):
         """Test t-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.t_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.t_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_t_gate_nondeterministic_minimal_basis_gates(self):
         """Test t-gate gate circuits compiling to u3,cx"""
-        circuits = ref_non_clifford.t_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.t_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.t_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -522,7 +674,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_tdg_gate_deterministic_default_basis_gates(self):
         """Test tdg-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_non_clifford.tdg_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.tdg_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -531,25 +684,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_tdg_gate_deterministic_waltz_basis_gates(self):
         """Test tdg-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.tdg_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.tdg_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_tdg_gate_deterministic_minimal_basis_gates(self):
         """Test tdg-gate gate circuits compiling to u3,cx"""
-        circuits = ref_non_clifford.tdg_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.tdg_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.tdg_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_tdg_gate_nondeterministic_default_basis_gates(self):
         """Test tdg-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.tdg_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -558,18 +720,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_tdg_gate_nondeterministic_waltz_basis_gates(self):
         """Test tdg-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.tdg_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_tdg_gate_nondeterministic_minimal_basis_gates(self):
         """Test tdg-gate gate circuits compiling to u3,cx"""
-        circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.tdg_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.tdg_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -579,7 +749,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_ccx_gate_deterministic_default_basis_gates(self):
         """Test ccx-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_non_clifford.ccx_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.ccx_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -588,25 +759,34 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_ccx_gate_deterministic_waltz_basis_gates(self):
         """Test ccx-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.ccx_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.ccx_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_ccx_gate_deterministic_minimal_basis_gates(self):
         """Test ccx-gate gate circuits compiling to u3,cx"""
-        circuits = ref_non_clifford.ccx_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.ccx_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.ccx_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_ccx_gate_nondeterministic_default_basis_gates(self):
         """Test ccx-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.ccx_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
@@ -615,18 +795,26 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_ccx_gate_nondeterministic_waltz_basis_gates(self):
         """Test ccx-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.ccx_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_ccx_gate_nondeterministic_minimal_basis_gates(self):
         """Test ccx-gate gate circuits compiling to u3,cx"""
-        circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.ccx_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.ccx_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -636,20 +824,9 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     def test_unitary_gate(self):
         """Test simulation with unitary gate circuit instructions."""
-        circuits = ref_unitary_gate.unitary_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_unitary_gate.unitary_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_unitary_gate.unitary_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1)
-        result = job.result()
-        self.assertTrue(getattr(result, 'success', False))
-        self.compare_unitary(result, circuits, targets)
-
-    # ---------------------------------------------------------------------
-    # Test cswap-gate (Fredkin)
-    # ---------------------------------------------------------------------
-    def test_cswap_gate_deterministic_default_basis_gates(self):
-        """Test cswap-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_non_clifford.cswap_gate_circuits_deterministic(final_measure=False)
-        targets = ref_non_clifford.cswap_gate_unitary_deterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
@@ -658,11 +835,90 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
     # ---------------------------------------------------------------------
     # Test cu1 gate
     # ---------------------------------------------------------------------
+    def test_cu1_gate_nondeterministic_default_basis_gates(self):
+        """Test cu1-gate gate circuits compiling to default basis"""
+        circuits = ref_non_clifford.cu1_gate_circuits_nondeterministic(
+            final_measure=False)
+        targets = ref_non_clifford.cu1_gate_unitary_nondeterministic()
+        job = execute(circuits, UnitarySimulator(), shots=1)
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_unitary(result, circuits, targets)
+
     def test_cu1_gate_nondeterministic_waltz_basis_gates(self):
         """Test cu1-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.cu1_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.cu1_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.cu1_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_unitary(result, circuits, targets)
+
+    def test_cu1_gate_nondeterministic_minimal_basis_gates(self):
+        """"Test cu1-gate gate circuits compiling to u3,cx"""
+        circuits = ref_non_clifford.cu1_gate_circuits_nondeterministic(
+            final_measure=False)
+        targets = ref_non_clifford.cu1_gate_unitary_nondeterministic()
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_unitary(result, circuits, targets)
+
+    # ---------------------------------------------------------------------
+    # Test cu3 gate
+    # ---------------------------------------------------------------------
+    def test_cu3_gate_deterministic_default_basis_gates(self):
+        """Test cu3-gate gate circuits compiling to default basis"""
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(
+            final_measure=False)
+        targets = ref_non_clifford.cu3_gate_unitary_deterministic()
+        job = execute(circuits, UnitarySimulator(), shots=1)
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_unitary(result, circuits, targets)
+
+    def test_cu3_gate_deterministic_waltz_basis_gates(self):
+        """Test cu3-gate gate circuits compiling to u1,u2,u3,cx"""
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(
+            final_measure=False)
+        targets = ref_non_clifford.cu3_gate_unitary_deterministic()
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u1', 'u2', 'u3', 'cx'])
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_unitary(result, circuits, targets)
+
+    def test_cu3_gate_deterministic_minimal_basis_gates(self):
+        """"Test cu3-gate gate circuits compiling to u3,cx"""
+        circuits = ref_non_clifford.cu3_gate_circuits_deterministic(
+            final_measure=False)
+        targets = ref_non_clifford.cu3_gate_unitary_deterministic()
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_unitary(result, circuits, targets)
+
+    # ---------------------------------------------------------------------
+    # Test cswap gate
+    # ---------------------------------------------------------------------
+    def test_cswap_gate_deterministic_default_basis_gates(self):
+        """Test cswap-gate circuits compiling to backend default basis_gates."""
+        circuits = ref_non_clifford.cswap_gate_circuits_deterministic(
+            final_measure=False)
+        targets = ref_non_clifford.cswap_gate_unitary_deterministic()
+        job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
@@ -672,25 +928,22 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         circuits = ref_non_clifford.cswap_gate_circuits_deterministic(
             final_measure=False)
         targets = ref_non_clifford.cswap_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
-        result = job.result()
-        self.assertTrue(getattr(result, 'success', False))
-        self.compare_unitary(result, circuits, targets)
-
-    def test_cu1_gate_nondeterministic_minimal_basis_gates(self):
-        """"Test cu1-gate gate circuits compiling to u3,cx"""
-        circuits = ref_non_clifford.cu1_gate_circuits_nondeterministic(final_measure=False)
-        targets = ref_non_clifford.cu1_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cswap_gate_deterministic_waltz_basis_gates(self):
         """Test cswap-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.cswap_gate_circuits_deterministic(final_measure=False)
+        circuits = ref_non_clifford.cswap_gate_circuits_deterministic(
+            final_measure=False)
         targets = ref_non_clifford.cswap_gate_unitary_deterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1,
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
@@ -698,17 +951,9 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
 
     def test_cswap_gate_nondeterministic_default_basis_gates(self):
         """Test cswap-gate circuits compiling to backend default basis_gates."""
-        circuits = ref_non_clifford.cswap_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.cswap_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.cswap_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1)
-        result = job.result()
-        self.assertTrue(getattr(result, 'success', False))
-        self.compare_unitary(result, circuits, targets)
-
-    def test_cu1_gate_nondeterministic_default_basis_gates(self):
-        """Test cu1-gate gate circuits compiling to default basis"""
-        circuits = ref_non_clifford.cu1_gate_circuits_nondeterministic(final_measure=False)
-        targets = ref_non_clifford.cu1_gate_unitary_nondeterministic()
         job = execute(circuits, UnitarySimulator(), shots=1)
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
@@ -719,16 +964,22 @@ class TestUnitarySimulator(common.QiskitAerTestCase):
         circuits = ref_non_clifford.cswap_gate_circuits_nondeterministic(
             final_measure=False)
         targets = ref_non_clifford.cswap_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1, basis_gates=['u3', 'cx'])
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
+                      basis_gates=['u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_unitary(result, circuits, targets)
 
     def test_cswap_gate_nondeterministic_waltz_basis_gates(self):
         """Test cswap-gate gate circuits compiling to u1,u2,u3,cx"""
-        circuits = ref_non_clifford.cswap_gate_circuits_nondeterministic(final_measure=False)
+        circuits = ref_non_clifford.cswap_gate_circuits_nondeterministic(
+            final_measure=False)
         targets = ref_non_clifford.cswap_gate_unitary_nondeterministic()
-        job = execute(circuits, UnitarySimulator(), shots=1,
+        job = execute(circuits,
+                      UnitarySimulator(),
+                      shots=1,
                       basis_gates=['u1', 'u2', 'u3', 'cx'])
         result = job.result()
         self.assertTrue(getattr(result, 'success', False))

--- a/test/terra/reference/ref_non_clifford.py
+++ b/test/terra/reference/ref_non_clifford.py
@@ -9,22 +9,18 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-
 """
 Test circuits and reference outputs for non-Clifford gate instructions.
 """
 
 import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.extensions import Cu1Gate
-from qiskit.quantum_info.synthesis import two_qubit_cnot_decompose
-
 from test.terra.utils.multiplexer import multiplexer_multi_controlled_x
-
 
 # ==========================================================================
 # T-gate
 # ==========================================================================
+
 
 def t_gate_circuits_deterministic(final_measure=True):
     """T-gate test circuits with deterministic counts."""
@@ -221,20 +217,22 @@ def t_gate_unitary_nondeterministic():
     """T-gate circuits reference unitaries."""
     targets = []
     # T.H
-    targets.append(np.array([[1 / np.sqrt(2), 1 / np.sqrt(2)],
-                             [0.5 + 0.5j, -0.5 - 0.5j]]))
+    targets.append(
+        np.array([[1 / np.sqrt(2), 1 / np.sqrt(2)], [0.5 + 0.5j,
+                                                     -0.5 - 0.5j]]))
     # X.T.H
-    targets.append(np.array([[0.5 + 0.5j, -0.5 - 0.5j],
-                             [1 / np.sqrt(2), 1 / np.sqrt(2)]]))
+    targets.append(
+        np.array([[0.5 + 0.5j, -0.5 - 0.5j], [1 / np.sqrt(2),
+                                              1 / np.sqrt(2)]]))
     # H.T.T.H = H.S.H
-    targets.append(np.array([[1 + 1j, 1 - 1j],
-                             [1 - 1j, 1 + 1j]]) / 2)
+    targets.append(np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]]) / 2)
     return targets
 
 
 # ==========================================================================
 # T^dagger-gate
 # ==========================================================================
+
 
 def tdg_gate_circuits_deterministic(final_measure=True):
     """Tdg-gate test circuits with deterministic counts."""
@@ -417,20 +415,22 @@ def tdg_gate_unitary_nondeterministic():
     """Tdg-gate circuits reference unitaries."""
     targets = []
     # Tdg.H
-    targets.append(np.array([[1 / np.sqrt(2), 1 / np.sqrt(2)],
-                             [0.5 - 0.5j, -0.5 + 0.5j]]))
+    targets.append(
+        np.array([[1 / np.sqrt(2), 1 / np.sqrt(2)], [0.5 - 0.5j,
+                                                     -0.5 + 0.5j]]))
     # X.Tdg.H
-    targets.append(np.array([[0.5 - 0.5j, -0.5 + 0.5j],
-                             [1 / np.sqrt(2), 1 / np.sqrt(2)]]))
+    targets.append(
+        np.array([[0.5 - 0.5j, -0.5 + 0.5j], [1 / np.sqrt(2),
+                                              1 / np.sqrt(2)]]))
     # H.Tdg.Tdg.H = H.Sdg.H
-    targets.append(np.array([[1 - 1j, 1 + 1j],
-                             [1 + 1j, 1 - 1j]]) / 2)
+    targets.append(np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]]) / 2)
     return targets
 
 
 # ==========================================================================
 # CCX-gate
 # ==========================================================================
+
 
 def ccx_gate_circuits_deterministic(final_measure=True):
     """CCX-gate test circuits with deterministic counts."""
@@ -625,77 +625,53 @@ def ccx_gate_unitary_deterministic():
     targets = []
 
     # CCX(0,1,2)
-    targets.append(np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0]]))
+    targets.append(
+        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0, 0, 0]]))
     # (I^X^X).CCX(0,1,2).(I^X^X) -> |100>
-    targets.append(np.array([[0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1]]))
+    targets.append(
+        np.array([[0, 0, 0, 0, 1, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [1, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     # (X^I^X).CCX(0,1,2).(X^I^X) -> |000>
-    targets.append(np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1]]))
+    targets.append(
+        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     # (X^X^I).CCX(0,1,2).(X^X^I) -> |000>
-    targets.append(np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1]]))
+    targets.append(
+        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     # CCX(2,1,0)
-    targets.append(np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 0, 0, 0, 0, 1, 0]]))
+    targets.append(
+        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 1, 0]]))
     # (I^X^X).CCX(2,1,0).(I^X^X) -> |000>
-    targets.append(np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1]]))
+    targets.append(
+        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     # (X^I^X).CCX(2,1,0).(X^I^X) -> |000>
-    targets.append(np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1]]))
+    targets.append(
+        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     # (X^X^I).CCX(2,1,0).(X^X^I) -> |001>
-    targets.append(np.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1]]))
+    targets.append(
+        np.array([[0, 1, 0, 0, 0, 0, 0, 0], [1, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     return targets
 
 
@@ -810,42 +786,35 @@ def ccx_gate_unitary_nondeterministic():
     """CCX-gate circuits reference unitaries."""
     targets = []
     # (I^X^I).CCX(0,1,2).(I^X^H) -> |000> + |101>
-    targets.append(np.array([[1, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, -1, 0, 0],
-                             [0, 0, 1, 1, 0, 0, 0, 0],
-                             [0, 0, 1, -1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 1, 0, 0],
-                             [1, -1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 1],
-                             [0, 0, 0, 0, 0, 0, 1, -1]]) / np.sqrt(2))
+    targets.append(
+        np.array([[1, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 1, -1, 0, 0],
+                  [0, 0, 1, 1, 0, 0, 0, 0], [0, 0, 1, -1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 1, 0, 0], [1, -1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 0, 0, 1, -1]]) /
+        np.sqrt(2))
     # (I^I^X).CCX(0,1,2).(I^H^X) -> |000> + |110>
-    targets.append(np.array([[1, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, -1, 0],
-                             [0, 1, 0, -1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 1],
-                             [1, 0, -1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, -1]]) / np.sqrt(2))
+    targets.append(
+        np.array([[1, 0, 1, 0, 0, 0, 0, 0], [0, 1, 0, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, -1, 0], [0, 1, 0, -1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 1, 0], [0, 0, 0, 0, 0, 1, 0, 1],
+                  [1, 0, -1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, -1]]) /
+        np.sqrt(2))
     # (I^X^I).CCX(2,1,0).(H^X^I) -> |000> + |101>
-    targets.append(np.array([[1, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 1],
-                             [0, 1, 0, 0, 0, -1, 0, 0],
-                             [1, 0, 0, 0, -1, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, -1, 0],
-                             [0, 0, 0, 1, 0, 0, 0, -1]]) / np.sqrt(2))
+    targets.append(
+        np.array([[1, 0, 0, 0, 1, 0, 0, 0], [0, 1, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0, 0, 1],
+                  [0, 1, 0, 0, 0, -1, 0, 0], [1, 0, 0, 0, -1, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, -1, 0], [0, 0, 0, 1, 0, 0, 0, -1]]) /
+        np.sqrt(2))
     # (X^I^I).CCX(2,1,0).(X^H^I) -> |000> + |011>
-    targets.append(np.array([[1, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 1, 0, 0, 0, 0],
-                             [0, 1, 0, -1, 0, 0, 0, 0],
-                             [1, 0, -1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 1],
-                             [0, 0, 0, 0, 1, 0, -1, 0],
-                             [0, 0, 0, 0, 0, 1, 0, -1]]) / np.sqrt(2))
+    targets.append(
+        np.array([[1, 0, 1, 0, 0, 0, 0, 0], [0, 1, 0, 1, 0, 0, 0, 0],
+                  [0, 1, 0, -1, 0, 0, 0, 0], [1, 0, -1, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 1, 0], [0, 0, 0, 0, 0, 1, 0, 1],
+                  [0, 0, 0, 0, 1, 0, -1, 0], [0, 0, 0, 0, 0, 1, 0, -1]]) /
+        np.sqrt(2))
     return targets
+
 
 # ==========================================================================
 # Multiplexer-gate (CCX-like)
@@ -866,7 +835,8 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
 
     # CCX(0,1,2)
     circuit = QuantumCircuit(*regs)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[0], qr[1], qr[2]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[0], qr[1], qr[2]])
     if final_measure:
         circuit.barrier(qr)
         circuit.measure(qr, cr)
@@ -878,7 +848,8 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[1])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[0], qr[1], qr[2]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[0], qr[1], qr[2]])
     circuit.barrier(qr)
     circuit.x(qr[0])
     circuit.barrier(qr)
@@ -894,7 +865,8 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[2])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[0], qr[1], qr[2]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[0], qr[1], qr[2]])
     circuit.barrier(qr)
     circuit.x(qr[0])
     circuit.barrier(qr)
@@ -910,7 +882,8 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[2])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[0], qr[1], qr[2]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[0], qr[1], qr[2]])
     circuit.barrier(qr)
     circuit.x(qr[1])
     circuit.barrier(qr)
@@ -922,7 +895,8 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
 
     # CCX(2,1,0)
     circuit = QuantumCircuit(*regs)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[2], qr[1], qr[0]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[2], qr[1], qr[0]])
     if final_measure:
         circuit.barrier(qr)
         circuit.measure(qr, cr)
@@ -934,7 +908,8 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[1])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[2], qr[1], qr[0]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[2], qr[1], qr[0]])
     circuit.barrier(qr)
     circuit.x(qr[0])
     circuit.barrier(qr)
@@ -950,7 +925,8 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[2])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[2], qr[1], qr[0]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[2], qr[1], qr[0]])
     circuit.barrier(qr)
     circuit.x(qr[0])
     circuit.barrier(qr)
@@ -966,7 +942,8 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[2])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[2], qr[1], qr[0]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[2], qr[1], qr[0]])
     circuit.barrier(qr)
     circuit.x(qr[1])
     circuit.barrier(qr)
@@ -977,6 +954,7 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
     circuits.append(circuit)
 
     return circuits
+
 
 def multiplexer_ccx_gate_circuits_nondeterministic(final_measure=True):
     """mukltiplexer CCX-like gate test circuits with non-deterministic counts."""
@@ -997,7 +975,8 @@ def multiplexer_ccx_gate_circuits_nondeterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[1])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[0], qr[1], qr[2]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[0], qr[1], qr[2]])
     circuit.barrier(qr)
     circuit.x(qr[1])
     if final_measure:
@@ -1011,7 +990,8 @@ def multiplexer_ccx_gate_circuits_nondeterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[0])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[0], qr[1], qr[2]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[0], qr[1], qr[2]])
     circuit.barrier(qr)
     circuit.x(qr[0])
     if final_measure:
@@ -1025,7 +1005,8 @@ def multiplexer_ccx_gate_circuits_nondeterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[1])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[2], qr[1], qr[0]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[2], qr[1], qr[0]])
     circuit.barrier(qr)
     circuit.x(qr[1])
     if final_measure:
@@ -1039,7 +1020,8 @@ def multiplexer_ccx_gate_circuits_nondeterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.x(qr[2])
     circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits), [qr[2], qr[1], qr[0]])
+    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
+                   [qr[2], qr[1], qr[0]])
     circuit.barrier(qr)
     circuit.x(qr[2])
     if final_measure:
@@ -1049,15 +1031,17 @@ def multiplexer_ccx_gate_circuits_nondeterministic(final_measure=True):
 
     return circuits
 
+
 def multiplexer_ccx_gate_counts_deterministic(shots, hex_counts=True):
     """ The counts are exactly the same as the ccx gate """
     return ccx_gate_counts_deterministic(shots, hex_counts)
+
 
 def multiplexer_ccx_gate_counts_nondeterministic(shots, hex_counts=True):
     """ The counts are exactly the same as the ccx gate """
     return ccx_gate_counts_nondeterministic(shots, hex_counts)
 
-  
+
 # ==========================================================================
 # CSWAP-gate (Fredkin)
 # ==========================================================================
@@ -1069,7 +1053,7 @@ def cswap_gate_circuits_deterministic(final_measure):
         cr = ClassicalRegister(3)
         regs = (qr, cr)
     else:
-        regs = (qr,)
+        regs = (qr, )
 
     # CSWAP(0,1,2) # -> |000>
     circuit = QuantumCircuit(*regs)
@@ -1100,7 +1084,7 @@ def cswap_gate_circuits_deterministic(final_measure):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
-    
+
     # CSWAP(0,1,2).(X^X^I) -> |110>
     circuit = QuantumCircuit(*regs)
     circuit.x(qr[1])
@@ -1112,7 +1096,7 @@ def cswap_gate_circuits_deterministic(final_measure):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
-    
+
     # CSWAP(0,1,2).(I^I^X) -> |001>
     circuit = QuantumCircuit(*regs)
     circuit.x(qr[0])
@@ -1135,7 +1119,7 @@ def cswap_gate_circuits_deterministic(final_measure):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
-    
+
     # CSWAP(0,1,2).(X^I^X) -> |011>
     circuit = QuantumCircuit(*regs)
     circuit.x(qr[0])
@@ -1160,7 +1144,7 @@ def cswap_gate_circuits_deterministic(final_measure):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
-    
+
     # CSWAP(1,0,2).(I^X^X) -> |110>
     circuit = QuantumCircuit(*regs)
     circuit.x(qr[0])
@@ -1184,118 +1168,6 @@ def cswap_gate_circuits_deterministic(final_measure):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
-    return circuits
-  
-  
-# ==========================================================================
-# CU1
-# ==========================================================================
-def cu1_gate_circuits_nondeterministic(final_measure):
-    circuits = []
-    qr = QuantumRegister(2)
-    if final_measure:
-        cr = ClassicalRegister(2)
-        regs = (qr, cr)
-    else:
-        regs = (qr,)
-
-    #H^X.CU1(0,0,1).H^X
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.x(qr[0])
-    circuit.cu1(0, qr[0], qr[1])
-    circuit.x(qr[0])
-    circuit.h(qr[1])
-
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    #H^I.CU1(pi,0,1).H^I
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.cu1(np.pi, qr[0], qr[1])
-    circuit.h(qr[1])
-    
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    #H^X.CU1(pi/4,0,1).H^X
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.x(qr[0])
-    circuit.cu1(np.pi/4, qr[0], qr[1])
-    circuit.x(qr[0])
-    circuit.h(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # H^X.CU1(pi/2,0,1).H^X
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.x(qr[0])
-    circuit.cu1(np.pi/2, qr[0], qr[1])
-    circuit.x(qr[0])
-    circuit.h(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # H^X.CU1(pi,0,1).H^X
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.x(qr[0])
-    circuit.cu1(np.pi, qr[0], qr[1])
-    circuit.x(qr[0])
-    circuit.h(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-        
-    # H^H.CU1(0,0,1).H^H
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.h(qr[0])
-    circuit.cu1(0, qr[0], qr[1])
-    circuit.h(qr[0])
-    circuit.h(qr[1])
-
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-    
-    # H^H.CU1(pi/2,0,1).H^H
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.h(qr[0])
-    circuit.cu1(np.pi/2, qr[0], qr[1])
-    circuit.h(qr[0])
-    circuit.h(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # H^H.CU1(pi,0,1).H^H
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.h(qr[0])
-    circuit.cu1(np.pi, qr[0], qr[1])
-    circuit.h(qr[0])
-    circuit.h(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-    
     return circuits
 
 
@@ -1368,7 +1240,7 @@ def cswap_gate_circuits_nondeterministic(final_measure=True):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
-   
+
     # CSWAP(0,1,2).(X^I^H). -> |100> + |011>
     circuit = QuantumCircuit(*regs)
     circuit.h(qr[0])
@@ -1397,7 +1269,7 @@ def cswap_gate_circuits_nondeterministic(final_measure=True):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
-    
+
     # CSWAP(0,1,2).(H^I^I)  -> |100>+|000>
     circuit = QuantumCircuit(*regs)
     circuit.h(qr[2])
@@ -1414,7 +1286,7 @@ def cswap_gate_circuits_nondeterministic(final_measure=True):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
-    
+
     # CSWAP(0,1,2).(X^X^H)  -> |110> + |111>
     circuit = QuantumCircuit(*regs)
     circuit.h(qr[0])
@@ -1424,85 +1296,63 @@ def cswap_gate_circuits_nondeterministic(final_measure=True):
     if final_measure:
         circuit.barrier(qr)
         circuit.measure(qr, cr)
-    circuits.append(circuit)    
+    circuits.append(circuit)
 
     return circuits
 
-  
+
 def cswap_gate_counts_nondeterministic(shots, hex_counts=True):
     targets = []
 
     if hex_counts:
         # CSWAP(0,1,2).(H^H^H)  -> |--->
-        targets.append({'0x0': shots / 8,
-                        '0x1': shots / 8,
-                        '0x2': shots / 8,
-                        '0x3': shots / 8,
-                        '0x4': shots / 8,
-                        '0x5': shots / 8,
-                        '0x6': shots / 8,
-                        '0x7': shots / 8,
-                        })
+        targets.append({
+            '0x0': shots / 8,
+            '0x1': shots / 8,
+            '0x2': shots / 8,
+            '0x3': shots / 8,
+            '0x4': shots / 8,
+            '0x5': shots / 8,
+            '0x6': shots / 8,
+            '0x7': shots / 8,
+        })
         # CSWAP(0,1,2).(X^I^H). -> |100> + |011>
-        targets.append({'0x3': shots / 2,
-                        '0x4': shots / 2
-                        })
+        targets.append({'0x3': shots / 2, '0x4': shots / 2})
         # CSWAP(0,1,2).(I^X^H). -> |010> + |101>
-        targets.append({'0x2': shots / 2,
-                        '0x5': shots / 2
-                        })
+        targets.append({'0x2': shots / 2, '0x5': shots / 2})
         # CSWAP(0,1,2).(I^H^I)  -> |0-0>
-        targets.append({'0x2': shots / 2,
-                        '0x0': shots / 2
-                        })
+        targets.append({'0x2': shots / 2, '0x0': shots / 2})
         # CSWAP(0,1,2).(H^I^I)  -> |-00>
-        targets.append({'0x4': shots / 2,
-                        '0x0': shots / 2
-                        })
+        targets.append({'0x4': shots / 2, '0x0': shots / 2})
         # CSWAP(0,1,2).(I^I^H)  -> |00->
-        targets.append({'0x0': shots / 2,
-                        '0x1': shots / 2
-                        })
+        targets.append({'0x0': shots / 2, '0x1': shots / 2})
         # CSWAP(0,1,2).(X^X^H)  -> |110> + |111>
-        targets.append({'0x6': shots / 2,
-                        '0x7': shots / 2
-                        })
+        targets.append({'0x6': shots / 2, '0x7': shots / 2})
 
     else:
         # CSWAP(0,1,2).(H^H^H)  -> |--->
-        targets.append({'000': shots / 8,
-                        '001': shots / 8,
-                        '010': shots / 8,
-                        '011': shots / 8,
-                        '100': shots / 8,
-                        '101': shots / 8,
-                        '110': shots / 8,
-                        '111': shots / 8,
-                        })
+        targets.append({
+            '000': shots / 8,
+            '001': shots / 8,
+            '010': shots / 8,
+            '011': shots / 8,
+            '100': shots / 8,
+            '101': shots / 8,
+            '110': shots / 8,
+            '111': shots / 8,
+        })
         # CSWAP(0,1,2).(X^I^H). -> |100> + |011>
-        targets.append({'011': shots / 2,
-                        '100': shots / 2
-                        })
+        targets.append({'011': shots / 2, '100': shots / 2})
         # CSWAP(0,1,2).(I^X^H). -> |010> + |101>
-        targets.append({'010': shots / 2,
-                        '101': shots / 2
-                        })
+        targets.append({'010': shots / 2, '101': shots / 2})
         # CSWAP(0,1,2).(I^H^I)  -> |0-0>
-        targets.append({'010': shots / 2,
-                        '000': shots / 2
-                        })
+        targets.append({'010': shots / 2, '000': shots / 2})
         # CSWAP(0,1,2).(H^I^I)  -> |-00>
-        targets.append({'100': shots / 2,
-                        '000': shots / 2
-                        })
+        targets.append({'100': shots / 2, '000': shots / 2})
         # CSWAP(0,1,2).(I^I^H)  -> |00->
-        targets.append({'001': shots / 2,
-                        '000': shots / 2
-                        })
+        targets.append({'001': shots / 2, '000': shots / 2})
         # CSWAP(0,1,2).(X^X^H)  -> |110> + |111>
-        targets.append({'110': shots / 2,
-                        '111': shots / 2
-                        })
+        targets.append({'110': shots / 2, '111': shots / 2})
 
     return targets
 
@@ -1556,95 +1406,65 @@ def cswap_gate_unitary_deterministic():
     targets = []
 
     # CSWAP(0,1,2) # -> |000>
-    targets.append(np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1]]))
+    targets.append(
+        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     # CSWAP(0,1,2).(X^I^I) -> |100>
-    targets.append(np.array([[0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0]]))
+    targets.append(
+        np.array([[0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [1, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0]]))
     # CSWAP(0,1,2).(I^X^I) -> |010>
-    targets.append(np.array([[0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0]]))
+    targets.append(
+        np.array([[0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [1, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1],
+                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0]]))
     # CSWAP(0,1,2).(X^X^I) -> |110>
-    targets.append(np.array([[0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0]]))
+    targets.append(
+        np.array([[0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1],
+                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0]]))
     # CSWAP(0,1,2).(I^I^X) -> |001>
-    targets.append(np.array([[0, 1, 0, 0, 0, 0, 0, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 0, 0, 0, 0, 1, 0]]))
+    targets.append(
+        np.array([[0, 1, 0, 0, 0, 0, 0, 0], [1, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 1, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 1, 0]]))
     # CSWAP(0,1,2).(I^X^X) -> |101>
-    targets.append(np.array([[0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0]]))
+    targets.append(
+        np.array([[0, 0, 0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 1, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 1], [1, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0]]))
     # CSWAP(0,1,2).(X^I^X) -> |011>
-    targets.append(np.array([[0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0]]))
+    targets.append(
+        np.array([[0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 1], [1, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 1, 0],
+                  [0, 0, 0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0]]))
     # CSWAP(0,1,2).(X^X^X) -> |111>
-    targets.append(np.array([[0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0]]))
+    targets.append(
+        np.array([[0, 0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 1, 0],
+                  [0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 1, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0],
+                  [0, 1, 0, 0, 0, 0, 0, 0], [1, 0, 0, 0, 0, 0, 0, 0]]))
     # CSWAP(1,0,2).(I^X^X) -> |110>
-    targets.append(np.array([[0, 0, 0, 1, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0]]))
+    targets.append(
+        np.array([[0, 0, 0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 1, 0],
+                  [1, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0]]))
     # CSWAP(2,1,0).(X^I^X) -> |110>
-    targets.append(np.array([[0, 0, 0, 0, 0, 1, 0, 0],
-                             [0, 0, 0, 0, 1, 0, 0, 0],
-                             [0, 0, 0, 0, 0, 0, 0, 1],
-                             [0, 0, 0, 0, 0, 0, 1, 0],
-                             [0, 1, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 0, 1, 0, 0, 0, 0],
-                             [1, 0, 0, 0, 0, 0, 0, 0],
-                             [0, 0, 1, 0, 0, 0, 0, 0]]))
+    targets.append(
+        np.array([[0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 1, 0],
+                  [0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                  [1, 0, 0, 0, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0]]))
     return targets
 
 
@@ -1652,126 +1472,214 @@ def cswap_gate_unitary_nondeterministic():
     """cswap-gate circuits reference unitaries."""
     targets = []
 
-    targets.append(np.array([ [0.35355339,  0.35355339,  0.35355339,  0.35355339,
-                               0.35355339,  0.35355339,  0.35355339,  0.35355339],
-                              [0.35355339, -0.35355339,  0.35355339, -0.35355339,
-                               0.35355339, -0.35355339,  0.35355339, -0.35355339],
-                              [0.35355339,  0.35355339, -0.35355339, -0.35355339,
-                               0.35355339,  0.35355339, -0.35355339, -0.35355339],
-                              [0.35355339, -0.35355339,  0.35355339, -0.35355339,
-                              -0.35355339,  0.35355339, -0.35355339,  0.35355339],
-                              [0.35355339,  0.35355339,  0.35355339,  0.35355339,
-                              -0.35355339, -0.35355339, -0.35355339, -0.35355339],
-                              [0.35355339, -0.35355339, -0.35355339,  0.35355339,
-                               0.35355339, -0.35355339, -0.35355339,  0.35355339],
-                              [0.35355339,  0.35355339, -0.35355339, -0.35355339,
-                              -0.35355339, -0.35355339,  0.35355339,  0.35355339],
-                              [0.35355339, -0.35355339, -0.35355339,  0.35355339,
-                              -0.35355339,  0.35355339,  0.35355339, -0.35355339]]))
+    targets.append(
+        np.array([[
+            0.35355339, 0.35355339, 0.35355339, 0.35355339, 0.35355339,
+            0.35355339, 0.35355339, 0.35355339
+        ],
+                  [
+                      0.35355339, -0.35355339, 0.35355339, -0.35355339,
+                      0.35355339, -0.35355339, 0.35355339, -0.35355339
+                  ],
+                  [
+                      0.35355339, 0.35355339, -0.35355339, -0.35355339,
+                      0.35355339, 0.35355339, -0.35355339, -0.35355339
+                  ],
+                  [
+                      0.35355339, -0.35355339, 0.35355339, -0.35355339,
+                      -0.35355339, 0.35355339, -0.35355339, 0.35355339
+                  ],
+                  [
+                      0.35355339, 0.35355339, 0.35355339, 0.35355339,
+                      -0.35355339, -0.35355339, -0.35355339, -0.35355339
+                  ],
+                  [
+                      0.35355339, -0.35355339, -0.35355339, 0.35355339,
+                      0.35355339, -0.35355339, -0.35355339, 0.35355339
+                  ],
+                  [
+                      0.35355339, 0.35355339, -0.35355339, -0.35355339,
+                      -0.35355339, -0.35355339, 0.35355339, 0.35355339
+                  ],
+                  [
+                      0.35355339, -0.35355339, -0.35355339, 0.35355339,
+                      -0.35355339, 0.35355339, 0.35355339, -0.35355339
+                  ]]))
 
-    targets.append(np.array([ [0,           0,           0,           0,
-                               0.70710678,  0.70710678,  0,           0],
-                              [0,           0,           0,           0,
-                               0.70710678, -0.70710678,  0,           0],
-                              [0,           0,           0,           0,
-                               0,           0,           0.70710678,  0.70710678],
-                              [0.70710678, -0.70710678,  0,           0,
-                               0,           0,           0,           0],
-                              [0.70710678,  0.70710678,  0,           0,
-                               0,           0,           0,           0],
-                              [0,           0,           0,           0,
-                               0,           0,           0.70710678, -0.70710678],
-                              [0,           0,           0.70710678,  0.70710678,
-                               0,           0,           0,           0],
-                              [0,           0,           0.70710678, -0.70710678,
-                               0,           0,           0,           0]]))
+    targets.append(
+        np.array([[0, 0, 0, 0, 0.70710678, 0.70710678, 0, 0],
+                  [0, 0, 0, 0, 0.70710678, -0.70710678, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0.70710678, 0.70710678],
+                  [0.70710678, -0.70710678, 0, 0, 0, 0, 0, 0],
+                  [0.70710678, 0.70710678, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0.70710678, -0.70710678],
+                  [0, 0, 0.70710678, 0.70710678, 0, 0, 0, 0],
+                  [0, 0, 0.70710678, -0.70710678, 0, 0, 0, 0]]))
 
-    targets.append(np.array([ [0,           0,           0.70710678,  0.70710678,
-                               0,           0,           0,           0],
-                              [0,           0,           0.70710678, -0.70710678,
-                               0,           0,           0,           0],
-                              [0.70710678,  0.70710678,  0,           0,
-                               0,           0,           0,           0],
-                              [0,           0,           0,           0,
-                               0,           0,           0.70710678, -0.70710678],
-                              [0,           0,           0,           0,
-                               0,           0,           0.70710678,  0.70710678],
-                              [0.70710678, -0.70710678,  0,           0,
-                               0,           0,           0,           0],
-                              [0,           0,           0,           0,
-                               0.70710678,  0.70710678,  0,           0],
-                              [0,           0,           0,           0,
-                               0.70710678, -0.70710678,  0,           0]]))
+    targets.append(
+        np.array([[0, 0, 0.70710678, 0.70710678, 0, 0, 0, 0],
+                  [0, 0, 0.70710678, -0.70710678, 0, 0, 0, 0],
+                  [0.70710678, 0.70710678, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0.70710678, -0.70710678],
+                  [0, 0, 0, 0, 0, 0, 0.70710678, 0.70710678],
+                  [0.70710678, -0.70710678, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0.70710678, 0.70710678, 0, 0],
+                  [0, 0, 0, 0, 0.70710678, -0.70710678, 0, 0]]))
 
-    targets.append(np.array([ [0.70710678,  0,           0.70710678,  0,
-                               0,           0,           0,           0],
-                              [0,           0.70710678,  0,           0.70710678,
-                               0,           0,           0,           0],
-                              [0.70710678,  0,          -0.70710678,  0,
-                               0,           0,           0,           0],
-                              [0,           0,           0,           0,
-                               0,           0.70710678,  0,           0.70710678],
-                              [0,           0,           0,           0,
-                               0.70710678,  0,           0.70710678,  0],
-                              [0,           0.70710678,  0,          -0.70710678,
-                               0,           0,           0,           0],
-                              [0,           0,           0,           0,
-                               0.70710678,  0,          -0.70710678,  0],
-                              [0,           0,           0,           0,
-                               0,           0.70710678,  0,          -0.70710678]]))
+    targets.append(
+        np.array([[0.70710678, 0, 0.70710678, 0, 0, 0, 0, 0],
+                  [0, 0.70710678, 0, 0.70710678, 0, 0, 0, 0],
+                  [0.70710678, 0, -0.70710678, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0.70710678, 0, 0.70710678],
+                  [0, 0, 0, 0, 0.70710678, 0, 0.70710678, 0],
+                  [0, 0.70710678, 0, -0.70710678, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0.70710678, 0, -0.70710678, 0],
+                  [0, 0, 0, 0, 0, 0.70710678, 0, -0.70710678]]))
 
-    targets.append(np.array([ [0.70710678,  0,           0,           0,
-                               0.70710678,  0,           0,           0],
-                              [0,           0.70710678,  0,           0,
-                               0,           0.70710678,  0,           0],
-                              [0,           0,           0.70710678,  0,
-                               0,           0,           0.70710678,  0],
-                              [0,           0.70710678,  0,           0,
-                               0,          -0.70710678,  0,           0],
-                              [0.70710678,  0,           0,           0,
-                              -0.70710678,  0,           0,           0],
-                              [0,           0,           0,           0.70710678,
-                               0,           0,           0,           0.70710678],
-                              [0,           0,           0.70710678,  0,
-                               0,           0,          -0.70710678,  0],
-                              [0,           0,           0,           0.70710678,
-                               0,           0,           0,          -0.70710678]]))
+    targets.append(
+        np.array([[0.70710678, 0, 0, 0, 0.70710678, 0, 0, 0],
+                  [0, 0.70710678, 0, 0, 0, 0.70710678, 0, 0],
+                  [0, 0, 0.70710678, 0, 0, 0, 0.70710678, 0],
+                  [0, 0.70710678, 0, 0, 0, -0.70710678, 0, 0],
+                  [0.70710678, 0, 0, 0, -0.70710678, 0, 0, 0],
+                  [0, 0, 0, 0.70710678, 0, 0, 0, 0.70710678],
+                  [0, 0, 0.70710678, 0, 0, 0, -0.70710678, 0],
+                  [0, 0, 0, 0.70710678, 0, 0, 0, -0.70710678]]))
 
-    targets.append(np.array([ [0.70710678,  0.70710678,  0,           0,
-                               0,           0,           0,           0],
-                              [0.70710678, -0.70710678,  0,           0,
-                               0,           0,           0,           0],
-                              [0,           0,           0.70710678,  0.70710678,
-                               0,           0,           0,           0],
-                              [0,           0,           0,           0,
-                               0.70710678, -0.70710678,  0,           0],
-                              [0,           0,           0,           0,
-                               0.70710678,  0.70710678,  0,           0],
-                              [0,           0,           0.70710678, -0.70710678,
-                               0,           0,           0,           0],
-                              [0,           0,           0,           0,
-                               0,           0,           0.70710678,  0.70710678],
-                              [0,           0,           0,           0,
-                               0,           0,           0.70710678, -0.70710678]]))
+    targets.append(
+        np.array([[0.70710678, 0.70710678, 0, 0, 0, 0, 0, 0],
+                  [0.70710678, -0.70710678, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0.70710678, 0.70710678, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0.70710678, -0.70710678, 0, 0],
+                  [0, 0, 0, 0, 0.70710678, 0.70710678, 0, 0],
+                  [0, 0, 0.70710678, -0.70710678, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0.70710678, 0.70710678],
+                  [0, 0, 0, 0, 0, 0, 0.70710678, -0.70710678]]))
 
-    targets.append(np.array([ [0,           0,           0,           0,
-                               0,           0,           0.70710678,  0.70710678],
-                              [0,           0,           0,           0,
-                               0,           0,           0.70710678, -0.70710678],
-                              [0,           0,           0,           0,
-                               0.70710678,  0.70710678,  0,           0],
-                              [0,           0,           0.70710678, -0.70710678,
-                               0,           0,           0,           0],
-                              [0,           0,           0.70710678,  0.70710678,
-                               0,           0,           0,           0],
-                              [0,           0,           0,           0,
-                               0.70710678, -0.70710678,  0,           0],
-                              [0.70710678,  0.70710678,  0,           0,
-                               0,           0,           0,           0],
-                              [0.70710678, -0.70710678,  0,           0,
-                               0,           0,           0,           0]]))
+    targets.append(
+        np.array([[0, 0, 0, 0, 0, 0, 0.70710678, 0.70710678],
+                  [0, 0, 0, 0, 0, 0, 0.70710678, -0.70710678],
+                  [0, 0, 0, 0, 0.70710678, 0.70710678, 0, 0],
+                  [0, 0, 0.70710678, -0.70710678, 0, 0, 0, 0],
+                  [0, 0, 0.70710678, 0.70710678, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0.70710678, -0.70710678, 0, 0],
+                  [0.70710678, 0.70710678, 0, 0, 0, 0, 0, 0],
+                  [0.70710678, -0.70710678, 0, 0, 0, 0, 0, 0]]))
     return targets
-  
+
+
+# ==========================================================================
+# CU1
+# ==========================================================================
+def cu1_gate_circuits_nondeterministic(final_measure):
+    circuits = []
+    qr = QuantumRegister(2)
+    if final_measure:
+        cr = ClassicalRegister(2)
+        regs = (qr, cr)
+    else:
+        regs = (qr, )
+
+    # H^X.CU1(0,0,1).H^X
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[1])
+    circuit.x(qr[0])
+    circuit.cu1(0, qr[0], qr[1])
+    circuit.x(qr[0])
+    circuit.h(qr[1])
+
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # H^I.CU1(pi,0,1).H^I
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[1])
+    circuit.cu1(np.pi, qr[0], qr[1])
+    circuit.h(qr[1])
+
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # H^X.CU1(pi/4,0,1).H^X
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[1])
+    circuit.x(qr[0])
+    circuit.cu1(np.pi / 4, qr[0], qr[1])
+    circuit.x(qr[0])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # H^X.CU1(pi/2,0,1).H^X
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[1])
+    circuit.x(qr[0])
+    circuit.cu1(np.pi / 2, qr[0], qr[1])
+    circuit.x(qr[0])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # H^X.CU1(pi,0,1).H^X
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[1])
+    circuit.x(qr[0])
+    circuit.cu1(np.pi, qr[0], qr[1])
+    circuit.x(qr[0])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # H^H.CU1(0,0,1).H^H
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[1])
+    circuit.h(qr[0])
+    circuit.cu1(0, qr[0], qr[1])
+    circuit.h(qr[0])
+    circuit.h(qr[1])
+
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # H^H.CU1(pi/2,0,1).H^H
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[1])
+    circuit.h(qr[0])
+    circuit.cu1(np.pi / 2, qr[0], qr[1])
+    circuit.h(qr[0])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # H^H.CU1(pi,0,1).H^H
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[1])
+    circuit.h(qr[0])
+    circuit.cu1(np.pi, qr[0], qr[1])
+    circuit.h(qr[0])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
 def cu1_gate_counts_nondeterministic(shots, hex_counts=True):
     """CU1-gate circuits reference counts."""
     targets = []
@@ -1781,7 +1689,10 @@ def cu1_gate_counts_nondeterministic(shots, hex_counts=True):
         # H^I.CU1(pi,0,1).H^I
         targets.append({'0x0': shots})
         # H^X.CU1(pi/4,0,1).H^X
-        targets.append({'0x0': shots * (0.25 * (2 + np.sqrt(2))), '0x2': shots * (0.25 * (2 - np.sqrt(2)))})
+        targets.append({
+            '0x0': shots * (0.25 * (2 + np.sqrt(2))),
+            '0x2': shots * (0.25 * (2 - np.sqrt(2)))
+        })
         # H^X.CU1(pi/2,0,1).H^X
         targets.append({'0x0': shots * 0.5, '0x2': shots * 0.5})
         # H^X.CU1(pi,0,1).H^X
@@ -1789,9 +1700,19 @@ def cu1_gate_counts_nondeterministic(shots, hex_counts=True):
         # H^H.CU1(0,0,1).H^H
         targets.append({'0x0': shots})
         # H^H.CU1(pi/2,0,1).H^H
-        targets.append({'0x0': shots * 0.625, '0x1': shots * 0.125, '0x2': shots * 0.125, '0x3': shots * 0.125})
+        targets.append({
+            '0x0': shots * 0.625,
+            '0x1': shots * 0.125,
+            '0x2': shots * 0.125,
+            '0x3': shots * 0.125
+        })
         # H^H.CU1(pi,0,1).H^H
-        targets.append({'0x0': shots * 0.25, '0x1': shots * 0.25, '0x2': shots * 0.25, '0x3': shots * 0.25})
+        targets.append({
+            '0x0': shots * 0.25,
+            '0x1': shots * 0.25,
+            '0x2': shots * 0.25,
+            '0x3': shots * 0.25
+        })
     else:
         # H^X.CU1(0,0,1).H^X
         targets.append({'00': shots})
@@ -1806,9 +1727,19 @@ def cu1_gate_counts_nondeterministic(shots, hex_counts=True):
         # H^H.CU1(0,0,1).H^H
         targets.append({'00': shots})
         # H^H.CU1(pi/2,0,1).H^H
-        targets.append({'00': shots * 0.5125, '01': shots * 0.125, '10': shots * 0.125, '11': shots * 0.125})
+        targets.append({
+            '00': shots * 0.5125,
+            '01': shots * 0.125,
+            '10': shots * 0.125,
+            '11': shots * 0.125
+        })
         # H^H.CU1(pi,0,1).H^H
-        targets.append({'00': shots * 0.25, '01': shots * 0.25, '10': shots * 0.25, '11': shots * 0.25})
+        targets.append({
+            '00': shots * 0.25,
+            '01': shots * 0.25,
+            '10': shots * 0.25,
+            '11': shots * 0.25
+        })
     return targets
 
 
@@ -1819,16 +1750,18 @@ def cu1_gate_statevector_nondeterministic():
     # H^I.CU1(pi,0,1).H^I
     targets.append(np.array([1, 0, 0, 0]))
     # H^X.CU1(pi/4,0,1).H^X
-    targets.append(np.array(
-        [(0.25 * (2 + np.sqrt(2))) + (1 / (2 * np.sqrt(2)))*1j, 0, (0.25 * (2 - np.sqrt(2))) - (1 / (2 * np.sqrt(2)))*1j, 0]))
+    targets.append(
+        np.array([(0.25 * (2 + np.sqrt(2))) + (1 / (2 * np.sqrt(2))) * 1j, 0,
+                  (0.25 * (2 - np.sqrt(2))) - (1 / (2 * np.sqrt(2))) * 1j, 0]))
     # H^X.CU1(pi/2,0,1).H^X
-    targets.append(np.array([0.5+0.5j, 0, 0.5-0.5j, 0]))
+    targets.append(np.array([0.5 + 0.5j, 0, 0.5 - 0.5j, 0]))
     # H^X.CU1(pi,0,1).H^X
     targets.append(np.array([0, 0, 1, 0]))
     # H^H.CU1(0,0,1).H^H
     targets.append(np.array([1, 0, 0, 0]))
     # H^H.CU1(pi/2,0,1).H^H
-    targets.append(np.array([0.75+0.25j, 0.25-0.25j, 0.25-0.25j, -0.25+0.25j]))
+    targets.append(
+        np.array([0.75 + 0.25j, 0.25 - 0.25j, 0.25 - 0.25j, -0.25 + 0.25j]))
     # H^H.CU1(pi,0,1).H^H
     targets.append(np.array([0.5, 0.5, 0.5, -0.5]))
     return targets
@@ -1839,32 +1772,160 @@ def cu1_gate_unitary_nondeterministic():
     # H^X.CU1(0,0,1).H^X
     targets.append(np.eye(4))
     # H^I.CU1(pi,0,1).H^I
-    targets.append(np.array([[1, 0, 0, 0],
-                             [0, 0, 0, 1],
-                             [0, 0, 1, 0],
-                             [0, 1, 0, 0]]))
+    targets.append(
+        np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]]))
     # H^X.CU1(pi/4,0,1).H^X
-    targets.append(np.array([[(0.25 * (2 + np.sqrt(2))) + (1 / (2 * np.sqrt(2)))*1j, 0,
-                              (0.25 * (2 - np.sqrt(2))) - (1 / (2 * np.sqrt(2)))*1j, 0],
-                             [0, 1, 0, 0],
-                             [(0.25 * (2 - np.sqrt(2))) - (1 / (2 * np.sqrt(2)))*1j, 0,
-                              (0.25 * (2 + np.sqrt(2))) + (1 / (2 * np.sqrt(2)))*1j, 0],
-                             [0, 0, 0, 1]]))
+    targets.append(
+        np.array([[(0.25 * (2 + np.sqrt(2))) + (1 / (2 * np.sqrt(2))) * 1j, 0,
+                   (0.25 * (2 - np.sqrt(2))) - (1 / (2 * np.sqrt(2))) * 1j, 0],
+                  [0, 1, 0, 0],
+                  [(0.25 * (2 - np.sqrt(2))) - (1 / (2 * np.sqrt(2))) * 1j, 0,
+                   (0.25 * (2 + np.sqrt(2))) + (1 / (2 * np.sqrt(2))) * 1j, 0],
+                  [0, 0, 0, 1]]))
     # H^X.CU1(pi/2,0,1).H^X
-    targets.append(np.array([[0.5+0.5j, 0, 0.5-0.5j, 0],
-                             [0, 1, 0, 0],
-                             [0.5-0.5j, 0, 0.5+0.5j, 0],
-                             [0, 0, 0, 1]]))
+    targets.append(
+        np.array([[0.5 + 0.5j, 0, 0.5 - 0.5j, 0], [0, 1, 0, 0],
+                  [0.5 - 0.5j, 0, 0.5 + 0.5j, 0], [0, 0, 0, 1]]))
     # H^X.CU1(pi,0,1).H^X
-    targets.append(np.array([[0, 0, 1, 0],
-                             [0, 1, 0, 0],
-                             [1, 0, 0, 0],
-                             [0, 0, 0, 1]]))
+    targets.append(
+        np.array([[0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]]))
     # H^H.CU1(0,0,1).H^H
     targets.append(np.eye(4))
     # H^H.CU1(pi/2,0,1).H^H
-    targets.append((0.75 + 0.25j) * np.eye(4) + (0.25 - 0.25j) * np.array(
-        [[0, 1, 1, -1], [1, 0, -1, 1], [1, -1, 0, 1], [-1, 1, 1, 0]]))
+    targets.append(
+        (0.75 + 0.25j) * np.eye(4) + (0.25 - 0.25j) *
+        np.array([[0, 1, 1, -1], [1, 0, -1, 1], [1, -1, 0, 1], [-1, 1, 1, 0]]))
     # H^H.CU1(pi,0,1).H^H
-    targets.append(0.5 * np.array([[1, 1, 1, -1], [1, 1, -1, 1], [1, -1, 1, 1], [-1, 1, 1, 1]]))
+    targets.append(
+        0.5 *
+        np.array([[1, 1, 1, -1], [1, 1, -1, 1], [1, -1, 1, 1], [-1, 1, 1, 1]]))
+    return targets
+
+
+# ==========================================================================
+# CU3
+# ==========================================================================
+def cu3_gate_circuits_deterministic(final_measure):
+    circuits = []
+    qr = QuantumRegister(2)
+    if final_measure:
+        cr = ClassicalRegister(2)
+        regs = (qr, cr)
+    else:
+        regs = (qr, )
+
+    # I^X.CI.I^X
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr[0])
+    circuit.cu3(0, 0, 0, qr[0], qr[1])
+    circuit.x(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # CX
+    circuit = QuantumCircuit(*regs)
+    circuit.cu3(np.pi, 0, np.pi, qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # I^X.CX.I^X
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr[0])
+    circuit.cu3(np.pi, 0, np.pi, qr[0], qr[1])
+    circuit.x(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # H^X.CH.I^X
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr[0])
+    circuit.cu3(np.pi / 2, 0, np.pi, qr[0], qr[1])
+    circuit.x(qr[0])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # I^X.CRX(pi).I^X
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr[0])
+    circuit.cu3(np.pi, -np.pi / 2, np.pi / 2, qr[0], qr[1])
+    circuit.x(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # I^X.CRY(pi).I^X
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr[0])
+    circuit.cu3(np.pi, 0, 0, qr[0], qr[1])
+    circuit.x(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
+def cu3_gate_unitary_deterministic():
+    targets = []
+
+    # I^X.CI.I^X
+    targets.append(np.eye(4))
+
+    # CX
+    targets.append(
+        np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]]))
+
+    # I^X.CX.I^X
+    targets.append(
+        np.array([[0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]]))
+
+    # H^X.CH.I^X
+    targets.append(
+        np.array([[1, 0, 0, 0], [0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)],
+                  [0, 0, 1, 0], [0, 1 / np.sqrt(2), 0, -1 / np.sqrt(2)]]))
+
+    # I^X.CRX(pi).I^X
+    targets.append(
+        np.array([[0, 0, -1j, 0], [0, 1, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, 1]]))
+
+    # I^X.CRY(pi).I^X
+    targets.append(
+        np.array([[0, 0, -1, 0], [0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]]))
+
+    return targets
+
+
+def cu3_gate_statevector_deterministic():
+
+    init_state = np.array([1, 0, 0, 0])
+    targets = [mat.dot(init_state) for mat in cu3_gate_unitary_deterministic()]
+
+    return targets
+
+
+def cu3_gate_counts_deterministic(shots, hex_counts=True):
+    """CU2-gate circuits reference counts."""
+    probs = [np.abs(vec)**2 for vec in cu3_gate_statevector_deterministic()]
+    targets = []
+    for prob in probs:
+        if hex_counts:
+            targets.append({hex(i): shots * p for i, p in enumerate(prob)})
+        else:
+            counts = {}
+            for i, p in enumerate(prob):
+                key = bin(i)[2:]
+                key = (2 - len(key)) * '0' + key
+                counts[key] = shots * p
+            targets.append(counts)
     return targets


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Fixes bug in unitary simulator where `cu3` gate was being applied as a `cu1` gate.
* Adds integration tests for cu3 gate for qasm, unitary, and statevector simulators

Closes #275 

### Details and comments


