### PR TITLE
Remove pip pin in azure jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
           set -e
           source activate qiskit-aer-$(Build.BuildNumber)
           git clean -fdX
-          python -m pip install --disable-pip-version-check pip==18
+          python -m pip install -U pip virtualenv setuptools
           pip install cython
           pip install git+https://github.com/Qiskit/qiskit-terra.git
           pip install --ignore-installed -r requirements-dev.txt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the past we needed to pin the pip version we used in the ci jobs to
avoid a pip regression introduced in pip 19.0. But that has since been
fixed so pinning is no longer necessary. This commit updates the azure
pipelines configuration to remove the pip pinning so we can use the
latest version.

### Details and comments


