### PR TITLE
Bump pin to unify lint job versions across elements

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,2 @@
-pylint==2.4.1
-astroid==2.3.0
+pylint==2.4.4
+astroid==2.3.3

--- a/qiskit/providers/aer/noise/utils/noise_transformation.py
+++ b/qiskit/providers/aer/noise/utils/noise_transformation.py
@@ -92,7 +92,7 @@ def approximate_quantum_error(error, *,
                 no_info_error + " for {} qubits".format(error.number_of_qubits))
         operator_dict = operator_lists[error.number_of_qubits - 1]
     if operator_dict is not None:
-        names, operator_list = zip(*operator_dict.items())
+        _, operator_list = zip(*operator_dict.items())
     if operator_list is not None:
         op_matrix_list = [
             transformer.operator_matrix(operator) for operator in operator_list


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In an effort to unify the versions of pylint run across all the elements
this commit bumps the pinned versions of pylint and astroid to be the
latest and what we are syncing all the elements to use. This should make
working between all the elements easier to do.

### Details and comments

Related To: Qiskit/qiskit-terra#3629
