### PR TITLE
Removed `noise_model` and `sim_config` as an argument in the pulse simulator

### DIFF
--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -24,7 +24,6 @@ from qiskit.result import Result
 from qiskit.providers.models import BackendConfiguration, PulseDefaults
 from .aerbackend import AerBackend
 from ..aerjob import AerJob
-from ..aererror import AerError
 from ..version import __version__
 from ..openpulse.qobj.digest import digest_pulse_obj
 from ..openpulse.solver.opsolve import opsolve
@@ -103,12 +102,6 @@ class PulseSimulator(AerBackend):
         output["backend_version"] = self.configuration().backend_version
         output["time_taken"] = time_taken
         return Result.from_dict(output)
-
-    def _validate(self, qobj, backend_options, noise_model):
-        """Validate the pulse object. Make sure a
-        config has been attached in the proper location"""
-
-        super()._validate(qobj, backend_options, noise_model)
 
     def defaults(self):
         """Return defaults.

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -67,27 +67,25 @@ class PulseSimulator(AerBackend):
     def run(self, qobj,
             system_model,
             backend_options=None,
-            noise_model=None,
             validate=False):
         """Run a qobj on the backend."""
         # Submit job
         job_id = str(uuid.uuid4())
         aer_job = AerJob(self, job_id, self._run_job, qobj, system_model,
-                         backend_options, noise_model, validate)
+                         backend_options, validate)
         aer_job.submit()
         return aer_job
 
     def _run_job(self, job_id, qobj,
                  system_model,
                  backend_options,
-                 noise_model,
                  validate):
         """Run a qobj job"""
         start = time.time()
         if validate:
             self._validate(qobj, backend_options, noise_model)
         # Send to solver
-        openpulse_system = digest_pulse_obj(qobj, system_model, backend_options, noise_model)
+        openpulse_system = digest_pulse_obj(qobj, system_model, backend_options)
         results = opsolve(openpulse_system)
         end = time.time()
         return self._format_results(job_id, results, end - start, qobj.qobj_id)

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -70,7 +70,6 @@ class PulseSimulator(AerBackend):
             validate=False):
         """Run a qobj on the backend."""
         # Submit job
-        print('you are here')
         job_id = str(uuid.uuid4())
         aer_job = AerJob(self, job_id, self._run_job, qobj, system_model,
                          backend_options, validate)

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -70,6 +70,7 @@ class PulseSimulator(AerBackend):
             validate=False):
         """Run a qobj on the backend."""
         # Submit job
+        print('you are here')
         job_id = str(uuid.uuid4())
         aer_job = AerJob(self, job_id, self._run_job, qobj, system_model,
                          backend_options, validate)
@@ -83,7 +84,7 @@ class PulseSimulator(AerBackend):
         """Run a qobj job"""
         start = time.time()
         if validate:
-            self._validate(qobj, backend_options, noise_model)
+            self._validate(qobj, backend_options, noise_model=None)
         # Send to solver
         openpulse_system = digest_pulse_obj(qobj, system_model, backend_options)
         results = opsolve(openpulse_system)
@@ -107,11 +108,6 @@ class PulseSimulator(AerBackend):
     def _validate(self, qobj, backend_options, noise_model):
         """Validate the pulse object. Make sure a
         config has been attached in the proper location"""
-
-        # Check to make sure a sim_config has been added
-        if not hasattr(qobj.config, 'sim_config'):
-            raise AerError('The pulse simulator qobj must have a sim_config '
-                           'entry to configure the simulator')
 
         super()._validate(qobj, backend_options, noise_model)
 

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -29,7 +29,7 @@ from ..cy.utils import oplist_to_array
 from . import op_qobj as op
 
 
-def digest_pulse_obj(qobj, system_model, backend_options=None, noise_model=None):
+def digest_pulse_obj(qobj, system_model, backend_options=None):
     """Convert specification of a simulation in the pulse language into the format accepted
     by the simulator.
 
@@ -53,11 +53,7 @@ def digest_pulse_obj(qobj, system_model, backend_options=None, noise_model=None)
     if backend_options is None:
         backend_options = {}
 
-    # Temp backwards compatibility
-    if 'sim_config' in qobj_config:
-        for key, val in qobj_config['sim_config'].items():
-            backend_options[key] = val
-        qobj_config.pop('sim_config')
+    noise_model = backend_options.get('noise_model', None)
 
     # post warnings for unsupported features
     _unsupported_warnings(qobj_dict, noise_model)

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -72,7 +72,7 @@ def digest_pulse_obj(qobj, system_model, backend_options=None):
     if 'qubit_lo_freq' not in qobj_config:
         raise ValueError('qubit_lo_freq must be specified in qobj.')
     # qobj frequencies are divided by 1e9, so multiply back
-    qubit_lo_freq = [freq*1e9 for freq in qobj_config['qubit_lo_freq']]
+    qubit_lo_freq = [freq * 1e9 for freq in qobj_config['qubit_lo_freq']]
 
     # Build pulse arrays ***************************************************************
     pulses, pulses_idx, pulse_dict = build_pulse_arrays(qobj_dict['experiments'],

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -17,7 +17,6 @@
 into something we can actually use.
 """
 
-from warnings import warn
 from collections import OrderedDict
 import numpy as np
 from .op_system import OPSystem
@@ -27,6 +26,7 @@ from ..solver.options import OPoptions
 # pylint: disable=no-name-in-module,import-error
 from ..cy.utils import oplist_to_array
 from . import op_qobj as op
+from ..aererror import AerError
 
 
 def digest_pulse_obj(qobj, system_model, backend_options=None):
@@ -213,9 +213,9 @@ def _unsupported_warnings(qobj_dict, noise_model):
     # Warnings that don't stop execution
     warning_str = '{} are an untested feature, and therefore may not behave as expected.'
     if noise_model is not None:
-        warn(warning_str.format('Noise models'))
+        raise AerError(warning_str.format('Noise models'))
     if _contains_pv_instruction(qobj_dict['experiments']):
-        warn(warning_str.format('PersistentValue instructions'))
+        raise AerError(warning_str.format('PersistentValue instructions'))
 
 
 def _contains_pv_instruction(experiments):

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -17,6 +17,7 @@
 into something we can actually use.
 """
 
+from warnings import warn
 from collections import OrderedDict
 import numpy as np
 from qiskit.providers.aer.aererror import AerError
@@ -214,7 +215,7 @@ def _unsupported_warnings(qobj_dict, noise_model):
     # Warnings that don't stop execution
     warning_str = '{} are an untested feature, and therefore may not behave as expected.'
     if noise_model is not None:
-        raise AerError(warning_str.format('Noise models'))
+        warn(warning_str.format('Noise models'))
     if _contains_pv_instruction(qobj_dict['experiments']):
         raise AerError(warning_str.format('PersistentValue instructions'))
 

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -37,7 +37,6 @@ def digest_pulse_obj(qobj, system_model, backend_options=None):
         qobj (PulseQobj): experiment specification
         system_model (PulseSystemModel): object representing system model
         backend_options (dict): dictionary of simulation options
-        noise_model (dict): noise model specification
     Returns:
         out (OPSystem): object understandable by the pulse simulator
     Raises:
@@ -208,6 +207,7 @@ def _unsupported_warnings(qobj_dict, noise_model):
         noise_model (dict): backend_options for simulation
     Returns:
     Raises:
+        AerError: for unsupported features
     """
 
     # Warnings that don't stop execution

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -19,6 +19,7 @@ into something we can actually use.
 
 from collections import OrderedDict
 import numpy as np
+from qiskit.providers.aer.aererror import AerError
 from .op_system import OPSystem
 from .opparse import NoiseParser
 from .operators import qubit_occ_oper_dressed
@@ -26,7 +27,6 @@ from ..solver.options import OPoptions
 # pylint: disable=no-name-in-module,import-error
 from ..cy.utils import oplist_to_array
 from . import op_qobj as op
-from qiskit.providers.aer.aererror import AerError
 
 
 def digest_pulse_obj(qobj, system_model, backend_options=None):

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -26,7 +26,7 @@ from ..solver.options import OPoptions
 # pylint: disable=no-name-in-module,import-error
 from ..cy.utils import oplist_to_array
 from . import op_qobj as op
-from ..aererror import AerError
+from qiskit.providers.aer.aererror import AerError
 
 
 def digest_pulse_obj(qobj, system_model, backend_options=None):

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -71,7 +71,8 @@ def digest_pulse_obj(qobj, system_model, backend_options=None):
 
     if 'qubit_lo_freq' not in qobj_config:
         raise ValueError('qubit_lo_freq must be specified in qobj.')
-    qubit_lo_freq = qobj_config['qubit_lo_freq']
+    # qobj frequencies are divided by 1e9, so multiply back
+    qubit_lo_freq = [freq*1e9 for freq in qobj_config['qubit_lo_freq']]
 
     # Build pulse arrays ***************************************************************
     pulses, pulses_idx, pulse_dict = build_pulse_arrays(qobj_dict['experiments'],


### PR DESCRIPTION
### Summary
As it won't be supported, removed `noise_model` argument from the pulse simulator backend, as well as the `digest` file. It can still be passed and detected through `backend_options`, but an `AerError` will now be raised.

In addition: 

- all reference to `sim_config` has been removed; any options should be passed through `backend_options`
- The warning for PersistentValue pulses has also been changed to an `AerError`

