### PR TITLE
Fixed get_backend selection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ from qiskit import Aer, IBMQ  # import the Aer and IBMQ providers
 from qiskit.providers.aer import noise  # import Aer noise models
 
 # Choose a real device to simulate
-IBMQ.save_account(token)
 provider = IBMQ.load_account()
 device = provider.get_backend('ibmq_16_melbourne')
 properties = device.properties()

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ from qiskit import Aer, IBMQ  # import the Aer and IBMQ providers
 from qiskit.providers.aer import noise  # import Aer noise models
 
 # Choose a real device to simulate
-IBMQ.load_accounts()
-device = IBMQ.get_backend('ibmq_16_melbourne')
+token = 'your-ibm-account-token-here'
+IBMQ.save_account(token)
+provider = IBMQ.load_account()
+device = provider.get_backend('ibmq_16_melbourne')
 properties = device.properties()
 coupling_map = device.configuration().coupling_map
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ from qiskit import Aer, IBMQ  # import the Aer and IBMQ providers
 from qiskit.providers.aer import noise  # import Aer noise models
 
 # Choose a real device to simulate
-token = 'your-ibm-account-token-here'
 IBMQ.save_account(token)
 provider = IBMQ.load_account()
 device = provider.get_backend('ibmq_16_melbourne')


### PR DESCRIPTION
IBMQ.get_backend('ibmq_16_melbourne') function should be called by the provider object as per the new update.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


