### PR TITLE
README > Fix broken tutorials links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ We use [GitHub issues](https://github.com/Qiskit/qiskit-aer/issues) for tracking
 ## Next Steps
 
 Now you're set up and ready to check out some of the other examples from our
-[Qiskit Tutorials](https://github.com/Qiskit/qiskit-tutorials/tree/master/qiskit/aer) repository.
+[Qiskit IQX Tutorials](https://github.com/Qiskit/qiskit-iqx-tutorials/tree/master/qiskit/advanced/aer) or [Qiskit Community Tutorials](https://github.com/Qiskit/qiskit-community-tutorials/tree/master/aer) repositories.
 
 ## Authors and Citation
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The README had a broken link to tutorials for Aer.


### Details and comments
I replaced the single broken link with links to the IQX tutorials and the Community tutorials. Please let me know if only one of those is preferred.

Does this change need to be documented in the CHANGELOG or have an issue opened? The CHANGELOG appears to only be used for code changes. 

This is my first (very small) contribution to Qiskit so please forgive me if I have done something incorrectly.
