### PR TITLE
Issue 490 - cvxpy needed for noise transformations

### DIFF
--- a/qiskit/providers/aer/noise/utils/noise_transformation.py
+++ b/qiskit/providers/aer/noise/utils/noise_transformation.py
@@ -29,6 +29,7 @@ used in a Clifford simulator.
 """
 
 import itertools
+import logging
 import numpy
 
 from qiskit.providers.aer.noise.errors import QuantumError
@@ -37,6 +38,8 @@ from qiskit.providers.aer.noise.noiseerror import NoiseError
 from qiskit.providers.aer.noise.errors.errorutils import single_qubit_clifford_instructions
 from qiskit.quantum_info.operators.channel import Kraus
 from qiskit.quantum_info.operators.channel import SuperOp
+
+logger = logging.getLogger(__name__)
 
 
 def approximate_quantum_error(error, *,
@@ -728,7 +731,10 @@ class NoiseTransformer:
             This method is the only place in the code where we rely on the cvxpy library
             should we consider another library, only this method needs to change.
         """
-        import cvxpy
+        try:
+            import cvxpy
+        except ImportError:
+            logger.error("cvxpy module needs to be installed to use this feature.")
 
         P = numpy.array(P).astype(float)
         q = numpy.array(q).astype(float).T


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Some noise transformations requires cvxpy library to operate.
As cvxpy is a heavy dependency, we send a message to the user if it's needed but not installed.


### Details and comments


