### PR TITLE
Fix CMakeLists.txt and FindPybind11.cmake to pass compiler options to…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ find_package(OpenMP QUIET)
 # first find_package(OpenMP) call
 if(NOT "${OpenMP_FOUND}" OR NOT "${OpenMP_CXX_FOUND}")
 	if(APPLE)
+		message(STATUS "On Mac, manually setting libomp linking")
 		set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp")
 		set(OpenMP_CXX_LIB_NAMES "omp")
 		set(OpenMP_omp_LIBRARY "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/macos/lib/libomp.dylib")
@@ -130,8 +131,8 @@ if(NOT "${OpenMP_FOUND}" OR NOT "${OpenMP_CXX_FOUND}")
 endif()
 
 if(OPENMP_FOUND)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+	set(AER_COMPILE_FLAGS "${AER_COMPILE_FLAGS} ${OpenMP_CXX_FLAGS}")
+	set(AER_LINKER_FLAGS "${AER_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 	if(APPLE)
 		# On Apple and clang, we do need to link against the library unless we are building
 		# the Terra Addon, see issue: https://github.com/Qiskit/qiskit-aer/issues/1
@@ -193,8 +194,9 @@ else() # Standalone build
 	add_executable(qasm_simulator ${AER_SIMULATOR_CPP_MAIN})
 	set_target_properties(qasm_simulator PROPERTIES
 		LINKER_LANGUAGE CXX
-		CXX_STANDARD 14)
-	set_target_properties(qasm_simulator PROPERTIES
+		CXX_STANDARD 14
+		COMPILE_FLAGS ${AER_COMPILE_FLAGS}
+		LINK_FLAGS ${AER_LINKER_FLAGS}
 		RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
 		RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
 	target_include_directories(qasm_simulator PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,6 @@ find_package(OpenMP QUIET)
 # first find_package(OpenMP) call
 if(NOT "${OpenMP_FOUND}" OR NOT "${OpenMP_CXX_FOUND}")
 	if(APPLE)
-		message(STATUS "On Mac, manually setting libomp linking")
 		set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp")
 		set(OpenMP_CXX_LIB_NAMES "omp")
 		set(OpenMP_omp_LIBRARY "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/macos/lib/libomp.dylib")

--- a/cmake/FindPybind11.cmake
+++ b/cmake/FindPybind11.cmake
@@ -1,3 +1,12 @@
+find_package(PythonExtensions REQUIRED)
+find_package(PythonLibs REQUIRED)
+
+message(STATUS ${PYTHON_INCLUDE_DIRS})
+message(STATUS "PYTHON EXECUTABLE: ${PYTHON_EXECUTABLE}")
+
+# Pybind includes are searched for through python
+# If they aren't found, we set them to the python include directories
+#   set by CMake
 set(_find_pybind_includes_command "
 import sys
 import pybind11
@@ -9,13 +18,11 @@ execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "${_find_pybind_includes_comma
 if(_py_result EQUAL "0")
     message(STATUS "PYCOMM RAW: ${_py_output}")
     set(PYBIND_INCLUDE_DIRS "${_py_output}")
-    message(STATUS "PYBIND INCLUDES FOUND: ${PYBIND_INCLUDE_DIRS}")
 else()
-    message(FATAL_ERROR "COULD NOT FIND PYBIND!")
+    message(WARNING "(NAIVE) CHECK COULD NOT FIND PYBIND!")
+    set(PYBIND_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
 endif()
-
-find_package(PythonExtensions REQUIRED)
-find_package(PythonLibs REQUIRED)
+message(STATUS "PYBIND INCLUDES: ${PYBIND_INCLUDE_DIRS}")
 
 function(basic_pybind11_add_module target_name)
     set(options MODULE SHARED EXCLUDE_FROM_ALL NO_EXTRAS SYSTEM THIN_LTO)
@@ -35,9 +42,6 @@ function(basic_pybind11_add_module target_name)
 
     add_library(${target_name} ${lib_type} ${exclude_from_all} ${ARG_UNPARSED_ARGUMENTS})
 
-    # This sets various properties (python include dirs) and links to python libs
-    #python_extension_module(${target_name}) # FORWARD_DECL_MODULES_VAR fdecl_module_list))
-    #target_link_libraries(${target_name} ${PYTHON_LIBRARIES})
     target_include_directories(${target_name} PRIVATE ${PYTHON_INCLUDE_DIRS}) 
     set_target_properties(${target_name} PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}")
     set_target_properties(${target_name} PROPERTIES SUFFIX "${PYTHON_EXTENSION_MODULE_SUFFIX}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "pybind11>2.4"]

--- a/qiskit/providers/aer/backends/wrappers/CMakeLists.txt
+++ b/qiskit/providers/aer/backends/wrappers/CMakeLists.txt
@@ -1,7 +1,4 @@
 include(Linter)
-
-find_package(PythonExtensions REQUIRED)
-find_package(PythonLibs REQUIRED)
 find_package(Pybind11 REQUIRED)
 
 # We need to remove the -static flag, because Python Extension system only supports
@@ -9,28 +6,11 @@ find_package(Pybind11 REQUIRED)
 # dependencies we can, so some of these dependencies are linked statically into our
 # shared library.
 string(REPLACE " -static " "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-if(APPLE OR LINUX) 
+if(APPLE OR LINUX)
     string(CONCAT CMAKE_CXX_FLAGS "-fvisibility=hidden")
 endif()
 
-# Set some general flags
-if(APPLE)
-    message(STATUS "On Mac, we force linking with undefined symbols for Python library, they will be
-                    solved at runtime by the loader")
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(AER_LINKER_FLAGS "-undefined dynamic_lookup")
-    else()
-        # -flat_namespace linker flag is needed otherwise dynamic symbol resolution doesn't work as expected with GCC.
-        # Symbols with the same name exist in different .so, so the loader just takes the first one it finds,
-        # which is usually the one from the first .so loaded.
-        # See: Two-Leve namespace symbol resolution
-        set(AER_LINKER_FLAGS "-undefined dynamic_lookup -flat_namespace")
-    endif()
-    unset(PYTHON_LIBRARIES)
-endif()
-
 # Controllers
-
 basic_pybind11_add_module(controller_wrappers bindings.cc)
 target_include_directories(controller_wrappers PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR}
                                                PRIVATE ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
@@ -39,6 +19,5 @@ install(TARGETS controller_wrappers LIBRARY DESTINATION qiskit/providers/aer/bac
 
 # Install redistributable dependencies
 if(APPLE)
-    set_target_properties(controller_wrappers PROPERTIES LINK_FLAGS ${AER_LINKER_FLAGS})
     install(FILES "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/macos/lib/libomp.dylib" DESTINATION qiskit/providers/aer/backends)
 endif()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,5 @@ Sphinx>=1.8.3
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11 
 sphinx-automodapi
-pybind11
 jupyter-sphinx
 stestr>=2.5.0

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,22 @@
 import os
+import subprocess
+import sys
+
 try:
     from skbuild import setup
 except ImportError:
-    import subprocess, sys
     subprocess.call([sys.executable, '-m', 'pip', 'install', 'scikit-build'])
     from skbuild import setup
+try:
+    import pybind11
+except ImportError:
+    subprocess.call([sys.executable, '-m', 'pip', 'install', 'pybind11>=2.4'])
+
 from setuptools import find_packages
 
 requirements = [
-    "numpy>=1.13"
+    "numpy>=1.13",
+    "pybind11>=2.4"
 ]
 
 VERSION_PATH = os.path.join(os.path.dirname(__file__),
@@ -52,7 +60,7 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     install_requires=requirements,
-    setup_requires=['scikit-build', 'cmake', 'Cython'],
+    setup_requires=['scikit-build', 'cmake', 'Cython', 'pybind11>2.4'],
     include_package_data=True,
     cmake_args=["-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9"],
     keywords="qiskit aer simulator quantum addon backend",


### PR DESCRIPTION
… pybind compilation

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I have improved the way compiler and linker options are passed to the compilation process and fixed the problem with not passing OpenMP and other compiler flags.


### Details and comments


