### PR TITLE
Add pybind as a requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "pybind11>2.4"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,5 @@ Sphinx>=1.8.3
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11 
 sphinx-automodapi
-pybind11
 jupyter-sphinx
 stestr>=2.5.0

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
 import os
+import subprocess
+import sys
+
 try:
     from skbuild import setup
 except ImportError:
-    import subprocess, sys
     subprocess.call([sys.executable, '-m', 'pip', 'install', 'scikit-build'])
     from skbuild import setup
+try:
+    import pybind11
+except ImportError:
+    subprocess.call([sys.executable, '-m', 'pip', 'install', 'pybind11>=2.4'])
+
 from setuptools import find_packages
 
 requirements = [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ except ImportError:
 from setuptools import find_packages
 
 requirements = [
-    "numpy>=1.13"
+    "numpy>=1.13",
+    "pybind11>=2.4"
 ]
 
 VERSION_PATH = os.path.join(os.path.dirname(__file__),
@@ -52,7 +53,7 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     install_requires=requirements,
-    setup_requires=['scikit-build', 'cmake', 'Cython'],
+    setup_requires=['scikit-build', 'cmake', 'Cython', 'pybind11>2.4'],
     include_package_data=True,
     cmake_args=["-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9"],
     keywords="qiskit aer simulator quantum addon backend",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since commit 0e184e09c6e1c6f28d4e4b199e9182d262b81520 we've required
pybind to build the python extension for aer. However this was expected
to outside of the install by users and was only listed as a dev requirement
via the requirements-dev.txt file. However, pybind is a build dependency
and will always need to be installed to build and install aer. This
commit updates the install_requires and setup_requires list to make sure
we always have pybind11 installed when installing aer from source or
sdist.


### Details and comments