### PR TITLE
from qiskit import QiskitError for lines 55 and 110

### DIFF
--- a/test/benchmark/fusion_benchmarks.py
+++ b/test/benchmark/fusion_benchmarks.py
@@ -1,6 +1,6 @@
 import numpy as np
 import math
-from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, QiskitError
 from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
 from qiskit.quantum_info.random import random_unitary


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

from qiskit import QiskitError for lines 55 and 110

### Details and comments

Lines 55 and 110 have the potential to raise NameError instead of the intended QiskitError because they refer to QiskitError which has not been defined or imported into this file.
