### PR TITLE
Pin pip<20.0.0 and bump osx python 3.8 to 3.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ sudo: false
 #   * stage_osx
 stage_generic: &stage_generic
   install:
+    - pip install -U 'pip<20.0.0'
     - pip install cython
     # Installing qiskit-terra master branch...
     - pip install https://github.com/Qiskit/qiskit-terra/archive/master.zip
@@ -148,7 +149,7 @@ jobs:
       <<: *stage_osx
       python: 3.8
       env:
-        - PYTHON_VERSION=3.8.0
+        - PYTHON_VERSION=3.8.1
 
     # OSX, Python 3.7.2 (via pyenv)
     - stage: test


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the recent release of pip 20.0.0 and 20.0.1 some packages fail to
pip install correctly (20.0.0 didn't even work at all). Until these
issues are resolved we should just cap the pip we use in CI to avoid
issues. This commit adds a cap to use pip < 20.0.0 until the upstream
issues are resolved. At the same time this commit updates the osx
version we use in CI for the 3.8 job to use 3.8.1 which contains bug
fixes on top of the previous version 3.8.0 we were using prior.

### Details and comments