### PR TITLE
Pulse simulator control channel labels from backend

### DIFF
--- a/qiskit/providers/aer/openpulse/duffing_model_generators.py
+++ b/qiskit/providers/aer/openpulse/duffing_model_generators.py
@@ -126,7 +126,7 @@ def duffing_system_model(dim_oscillators,
     # construct and return the PulseSystemModel
     return PulseSystemModel(hamiltonian=hamiltonian_model,
                             u_channel_lo=u_channel_lo,
-                            control_channel_dict=cr_idx_dict,
+                            control_channel_labels=coupling_graph.sorted_two_way_graph,
                             qubit_list=oscillators,
                             dt=dt)
 

--- a/qiskit/providers/aer/openpulse/pulse_system_model.py
+++ b/qiskit/providers/aer/openpulse/pulse_system_model.py
@@ -117,7 +117,7 @@ class PulseSystemModel():
                         q_idx = u_term_dict.get('q')
                         if len(u_string) > 0:
                             u_string += ' + '
-                        u_string += str(scale[0] + scale[1]*1j) + 'q' + str(q_idx)
+                        u_string += str(scale[0] + scale[1] * 1j) + 'q' + str(q_idx)
                     control_channel_labels[u_idx] = {'driven_q': drive_idx, 'freq': u_string}
 
         return cls(hamiltonian=hamiltonian,

--- a/qiskit/providers/aer/openpulse/pulse_system_model.py
+++ b/qiskit/providers/aer/openpulse/pulse_system_model.py
@@ -30,7 +30,7 @@ class PulseSystemModel():
                  qubit_freq_est=None,
                  meas_freq_est=None,
                  u_channel_lo=None,
-                 control_channel_dict=None,
+                 control_channel_labels=None,
                  qubit_list=None,
                  dt=None):
         """Basic constructor.
@@ -48,7 +48,7 @@ class PulseSystemModel():
             raise AerError("hamiltonian must be a HamiltonianModel object")
         self.hamiltonian = hamiltonian
         self.u_channel_lo = u_channel_lo
-        self.control_channel_dict = control_channel_dict or {}
+        self.control_channel_labels = control_channel_labels or []
         self.qubit_list = qubit_list
         self.dt = dt
 
@@ -84,31 +84,64 @@ class PulseSystemModel():
         # draw from configuration
         # if no qubit_list, use all for device
         qubit_list = qubit_list or list(range(config['n_qubits']))
-        hamiltonian = HamiltonianModel.from_dict(config['hamiltonian'], qubit_list)
+        ham_string = config['hamiltonian']
+        hamiltonian = HamiltonianModel.from_dict(ham_string, qubit_list)
         u_channel_lo = config.get('u_channel_lo', None)
         dt = config.get('dt', None)
+
+        control_channel_labels = [None] * len(u_channel_lo)
+        # populate control_channel_dict
+        # for now it assumes the u channel drives a single qubit, and we return the index
+        # of the driven qubit, along with the frequency description
+        if u_channel_lo is not None:
+            for u_idx, u_lo in enumerate(u_channel_lo):
+                # find drive index
+                drive_idx = None
+                while drive_idx is None:
+                    u_str_label = 'U{0}'.format(str(u_idx))
+                    for h_term_str in ham_string['h_str']:
+                        # check if this string corresponds to this u channel
+                        if u_str_label in h_term_str:
+                            # get index of X operator drive term
+                            x_idx = h_term_str.find('X')
+                            # if 'X' is found, and is not at the end of the string, drive_idx
+                            # is the subsequent character
+                            if x_idx != -1 and x_idx + 1 < len(h_term_str):
+                                drive_idx = int(h_term_str[x_idx + 1])
+
+                if drive_idx is not None:
+                    # construct string for u channel
+                    u_string = ''
+                    for u_term_dict in u_lo:
+                        scale = u_term_dict.get('scale', [1.0, 0])
+                        q_idx = u_term_dict.get('q')
+                        if len(u_string) > 0:
+                            u_string += ' + '
+                        u_string += str(scale[0] + scale[1]*1j) + 'q' + str(q_idx)
+                    control_channel_labels[u_idx] = {'driven_q': drive_idx, 'freq': u_string}
 
         return cls(hamiltonian=hamiltonian,
                    qubit_freq_est=qubit_freq_est,
                    meas_freq_est=meas_freq_est,
                    u_channel_lo=u_channel_lo,
+                   control_channel_labels=control_channel_labels,
                    qubit_list=qubit_list,
                    dt=dt)
 
-    def control_channel_index(self, key):
-        """Return the index of the control channel with identifying key.
+    def control_channel_index(self, label):
+        """Return the index of the control channel with identifying label.
 
         Args:
-            key (Any): key that identifies a control channel
+            label (Any): label that identifies a control channel
 
         Returns:
-            int or None: index of the control channel
+            int or None: index of the ControlChannel
         """
-        if key not in self.control_channel_dict:
-            warn('There is no listed ControlChannel matching the provided key.')
+        if label not in self.control_channel_labels:
+            warn('There is no listed ControlChannel matching the provided label.')
             return None
         else:
-            return self.control_channel_dict.get(key)
+            return self.control_channel_labels.index(label)
 
     def calculate_channel_frequencies(self, qubit_lo_freq=None):
         """Calculate frequencies for each channel.

--- a/test/terra/openpulse/test_duffing_model_generators.py
+++ b/test/terra/openpulse/test_duffing_model_generators.py
@@ -43,7 +43,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
                                                       drive_strengths,
                                                       coupling_dict,
                                                       dt)
-        cr_idx_dict = system_model.control_channel_dict
+        cr_idx_dict = {label: idx for idx, label in enumerate(system_model.control_channel_labels)}
 
         # check basic parameters
         self.assertEqual(system_model.qubit_list, [0, 1])
@@ -124,7 +124,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
                                                       drive_strengths,
                                                       coupling_dict,
                                                       dt)
-        cr_idx_dict = system_model.control_channel_dict
+        cr_idx_dict = {label: idx for idx, label in enumerate(system_model.control_channel_labels)}
 
         # check basic parameters
         self.assertEqual(system_model.qubit_list, [0, 1, 2])
@@ -218,7 +218,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
                                                       drive_strengths,
                                                       coupling_dict,
                                                       dt)
-        cr_idx_dict = system_model.control_channel_dict
+        cr_idx_dict = {label: idx for idx, label in enumerate(system_model.control_channel_labels)}
 
         # check basic parameters
         self.assertEqual(system_model.qubit_list, [0, 1, 2, 3])

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -17,6 +17,7 @@ import unittest
 import warnings
 from test.terra.common import QiskitAerTestCase
 import qiskit
+from qiskit.test.mock import FakeOpenPulse2Q
 import qiskit.pulse as pulse
 from qiskit.pulse import pulse_lib
 from qiskit.compiler import assemble
@@ -96,8 +97,17 @@ class TestPulseSystemModel(BaseTestPulseSystemModel):
             self.assertEqual(len(w), 1)
             self.assertTrue('ControlChannel' in str(w[-1].message))
 
+    def test_control_channel_labels_from_backend(self):
+        """Test correct importing of backend control channel description."""
+        backend = FakeOpenPulse2Q()
 
-    def test_qubit_lo_default_from_backend(self):
+        system_model = PulseSystemModel.from_backend(backend)
+        expected = [{'driven_q': 1, 'freq': '(1+0j)q0'},
+                    {'driven_q': 0, 'freq': '(-1+0j)q0 + (1+0j)q1'}]
+
+        self.assertEqual(system_model.control_channel_labels, expected)
+
+    def test_qubit_lo_default(self):
         """Test drawing of defaults form a backend."""
         test_model = self._simple_system_model()
         default_qubit_lo_freq = self._default_qubit_lo_freq

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -81,8 +81,8 @@ class TestPulseSystemModel(BaseTestPulseSystemModel):
             self.assertEqual(len(w), 1)
             self.assertTrue('ControlChannel' in str(w[-1].message))
 
-        # add a control channel dict
-        test_model.control_channel_dict = {(0,1): 0}
+        # control channel labels
+        test_model.control_channel_labels = [(0,1)]
 
         self.assertEqual(test_model.control_channel_index((0,1)), 0)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In `PulseSystemModel` changed `control_channel_dict` to a list called `control_channel_labels` and created an automatic construction of this list in the `from_backend` constructor.

### Details and comments

1. Had to change `control_channel_dict` to a list as elements of a dict need to be hashable (and therefore can't be anything, as was originally intended). Now the function `control_channel_index` takes an argument called `label`, and is implemented by finding the index in the list. Had to change the duffing model generators, as well as associated tests to correspond to this change.
2. Added a piece to `from_backend` to automatically construct labels for u channels. The format for the auto generated labels is currently cumbersome, but there isn't really a way around it. Given a u channel, it automatically finds which qubit is being driven by that u channel (which is an assumption), and creates a string representation of the frequency combination for the u channel lo.
