### PR TITLE
Fix missing pulse simulator dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,16 +13,22 @@ try:
 except ImportError:
     subprocess.call([sys.executable, '-m', 'pip', 'install', 'scikit-build'])
     from skbuild import setup
-try:
-    import pybind11
-except ImportError:
-    subprocess.call([sys.executable, '-m', 'pip', 'install', 'pybind11>=2.4'])
 
 from setuptools import find_packages
 
 requirements = [
-    "numpy>=1.13",
-    "pybind11>=2.4"
+    'numpy>=1.13',
+    'scipy>=1.0',
+    'cython>=0.27.1',
+    'pybind11>=2.4'  # This isn't really an install requirement,
+                     # Pybind11 is required to be pre-installed for
+                     # CMake to successfully find header files.
+                     # This should be fixed in the CMake build files.
+]
+
+setup_requirements = requirements + [
+    'scikit-build',
+    'cmake'
 ]
 
 VERSION_PATH = os.path.join(os.path.dirname(__file__),
@@ -71,7 +77,7 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     install_requires=requirements,
-    setup_requires=['scikit-build', 'cmake', 'Cython', 'pybind11>2.4'],
+    setup_requires=setup_requirements,
     include_package_data=True,
     cmake_args=["-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9"],
     keywords="qiskit aer simulator quantum addon backend",

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ try:
 except ImportError:
     subprocess.call([sys.executable, '-m', 'pip', 'install', 'scikit-build'])
     from skbuild import setup
+try:
+    import pybind11
+except ImportError:
+    subprocess.call([sys.executable, '-m', 'pip', 'install', 'pybind11>=2.4'])
 
 from setuptools import find_packages
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recently added pulse simulator adds numpy and scipy as build and install dependencies. These were missing from the setup.py causing an error if they weren't already installed on the system.

### Details and comments

Pybind is still a remaning issue. As noted in #546, if one tries to install directly in a clean environment (eg `pip install .` or `pip install git+https...`), setup will fail unless Pybind has already been pip installed.