### PR TITLE
Fix bugs in parallelization thread management and improve testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ Added
 - Added tests for probabilities snapshot (\#380)
 - Added support for reset() in MPS simulation method (\#393)
 - Added tests for matrix and Pauli expectation value snapshot (\#386)
+- Added test decorators for tests that require OpenMP and multi-threading(\#551)
+- Added tests for automatic and custom parallel thread configuration (\#511)
 
 Changed
 -------
@@ -138,6 +140,8 @@ Removed
 
 Fixed
 -----
+- Fixed bug in parallel thread configuration where total threads could exceed
+  the "max_parallel_threads" config settings (\#551)
 
 
 [0.3.0](https://github.com/Qiskit/qiskit-aer/compare/0.2.3...0.3.0) - 2019-08-21

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -120,7 +120,7 @@ class QasmSimulator(AerBackend):
       parallel shot execution will be disabled. If set to 0 the
       maximum will be automatically set to max_parallel_threads.
       Note that this cannot be enabled at the same time as parallel
-      experiment execution (Default: 1).
+      experiment execution (Default: 0).
 
     * ``"max_memory_mb"`` (int): Sets the maximum size of memory
       to store a state vector. If a state vector needs more, an error

--- a/test/terra/decorators.py
+++ b/test/terra/decorators.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Decorator for using with Qiskit Aer unit tests."""
+
+import unittest
+import multiprocessing
+
+from qiskit import QuantumCircuit, assemble, execute
+from qiskit.providers.aer import QasmSimulator
+from qiskit.providers.aer import AerError
+
+
+def is_qasm_method_available(method):
+    """Check if input method is available for the qasm simulator."""
+    # Simple test circuit that should work on all simulators.
+    dummy_circ = QuantumCircuit(1)
+    dummy_circ.iden(0)
+    qobj = assemble(dummy_circ, optimization_level=0)
+    backend_options = {"method": method}
+    try:
+        job = QasmSimulator().run(qobj, backend_options=backend_options)
+        result = job.result()
+        return result.success
+    except AerError:
+        return False
+    return True
+
+
+def requires_omp(test_item):
+    """Decorator that skips test if OpenMP is not available.
+
+    Args:
+        test_item (callable): function or class to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+    # Run dummy circuit to check OpenMP status
+    result = execute(QuantumCircuit(1), QasmSimulator()).result()
+    omp_enabled = result.metadata.get('omp_enabled', False)
+    skip = not omp_enabled
+    reason = 'OpenMP not available, skipping test'
+    return unittest.skipIf(skip, reason)(test_item)
+
+
+def requires_multiprocessing(test_item):
+    """Decorator that skips test if run on single-core CPU.
+
+    Args:
+        test_item (callable): function or class to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+    skip = multiprocessing.cpu_count() <= 1
+    reason = 'Multicore CPU not available, skipping test'
+    return unittest.skipIf(skip, reason)(test_item)
+
+
+def requires_gpu(test_item):
+    """Decorator that skips test if GPU statevector method is not available.
+
+    Args:
+        test_item (callable): function or class to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+    reason = 'GPU not available, skipping test'
+    skip = not is_qasm_method_available("statevector_gpu")
+    return unittest.skipIf(skip, reason)(test_item)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Custom OpenMP parallelization settings were being set correctly with respect to maximum number of threads. This PR corrects the setting and adds several additional integration tests for testing that the default and custom thread setting behavior works as expected.

This PR also adds test decorators for tests that require OpenMP or a multicore CPU so that they will be skipped if run on a system without these.

### Details and comments

* By default all available threads will be used for parallel shots and state update, subject to available memory, noise, and measure sampling.
* Parallel experiments will only ever be run if this option is explicitly configured.
* Adds test decorator `requires_omp` which will skip tests if simulator is build without OpenMP
* Adds test decorator `requires_multiprocessing` which will skip tests if the number of cpus reported by pythons multiprocessing module is not > 1.