### PR TITLE
Disable warnings when compiling Cython generated CPPs

### DIFF
--- a/cmake/cython_utils.cmake
+++ b/cmake/cython_utils.cmake
@@ -28,6 +28,15 @@ function(add_cython_module module)
         LINKER_LANGUAGE CXX
         CXX_STANDARD 14)
 
+    # Avoid warnings in cython cpp generated code
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set_source_files_properties(${module}.cxx PROPERTIES COMPILE_FLAGS -Wno-everything)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        set_source_files_properties(${module}.cxx PROPERTIES COMPILE_FLAGS -w)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        set_source_files_properties(${module}.cxx PROPERTIES COMPILE_FLAGS /w)
+    endif()
+
     if(APPLE)
         set_target_properties(${module} PROPERTIES
             LINK_FLAGS ${AER_LINKER_FLAGS})


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Disable all warnings when compiling Cython generated cpp files


### Details and comments
Disable all warnings only for Cython generated cpp files. Other files not automatically generated will still emit warnings. This is related to issue #548.

