### PR TITLE
Add compile stage to travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ stage_generic: &stage_generic
     - pip install cython
     # Installing qiskit-terra master branch...
     - pip install https://github.com/Qiskit/qiskit-terra/archive/master.zip
+    # Installing qiskit-ibmq-provider stable branch
+    # This is only needed to suppress warnings when importing Qiskit
+    - pip install https://github.com/Qiskit/qiskit-ibmq-provider/archive/stable.zip
     # Installing qiskit-aer...
     - pip install -U -c constraints.txt -r requirements-dev.txt
 
@@ -51,9 +54,10 @@ stage_linux: &stage_linux
       if [ ! "$(ls -A .stestr)" ]; then
         rm -rf .stestr
       fi
-  script:
+    # Build and install qiskit-aer package
     - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
     - pip install dist/qiskit_aer*whl
+  script:
     - stestr run --slowest
 
 stage_osx: &stage_osx
@@ -61,6 +65,10 @@ stage_osx: &stage_osx
   os: osx
   osx_image: xcode9.2
   language: generic
+  python: 3.7
+  env:
+        - MPLBACKEND=ps
+        - PYTHON_VERSION=3.7.2
   cache:
     pip: true
     directories:
@@ -86,10 +94,10 @@ stage_osx: &stage_osx
       if [ ! "$(ls -A .stestr)" ]; then
         rm -rf .stestr
       fi
-
-  script:
-    - python setup.py bdist_wheel -- -- -j4
+    # Build and install qiskit-aer package
+    - python setup.py bdist_wheel -- -DAER_THRUST_BACKEND=OMP -- -j4
     - pip install dist/qiskit_aer*whl
+  script:
     - stestr run --slowest
 
 ###############################################################################
@@ -99,6 +107,7 @@ stage_osx: &stage_osx
 # Define the order of the stages.
 stages:
   - lint
+  - compile
   - test
 
 # Define the job matrix explicitly, as matrix expansion causes issues when
@@ -112,9 +121,26 @@ jobs:
     - stage: lint
       name: Python Style and Linter
       <<: *stage_linux
+      before_script: true
       script:
         - pycodestyle --ignore=E402,W504 --max-line-length=100 qiskit/providers/aer
         - pylint -j 2 -rn qiskit/providers/aer
+
+    # "compile" stage
+    ###########################################################################
+    - stage: compile
+      name: Test Build Linux
+      <<: *stage_linux
+      before_script: true
+      script:
+        - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
+  
+    - stage: compile
+      name: Test Build MacOS
+      <<: *stage_osx
+      before_script: true
+      script:
+        - python setup.py bdist_wheel -- -- -j4
 
     # "test" stage
     ###########################################################################
@@ -144,36 +170,40 @@ jobs:
       <<: *stage_linux
       python: 3.5
 
+    # MacOS, Python 3.8 (via pyenv)
     - stage: test
-      name: Python 3.8 Tests OSX
+      if: type = cron
+      name: Python 3.8 Tests MacOS
       <<: *stage_osx
       python: 3.8
       env:
         - PYTHON_VERSION=3.8.1
 
-    # OSX, Python 3.7.2 (via pyenv)
+    # MacOS, Python 3.7 (via pyenv)
     - stage: test
-      name: Python 3.7 Tests OSX
+      name: Python 3.7 Tests MacOS
       <<: *stage_osx
+      python: 3.7
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.7.2
 
-    # OSX, Python 3.6.5 (via pyenv)
+    # MacOS, Python 3.6 (via pyenv)
     - stage: test
       if: type = cron
-      name: Python 3.6 Tests OSX
+      name: Python 3.6 Tests MacOS
       <<: *stage_osx
+      python: 3.6
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.6.5
 
-    # OSX, Python 3.5.6 (via pyenv)
+    # MacOS, Python 3.5 (via pyenv)
     - stage: test
       if: type = cron
+      name: Python 3.5 Tests MacOS
       <<: *stage_osx
-      name: Python 3.5 Tests OSX
+      python: 3.5
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.5.6
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ stage_osx: &stage_osx
         rm -rf .stestr
       fi
     # Build and install qiskit-aer package
-    - python setup.py bdist_wheel -- -DAER_THRUST_BACKEND=OMP -- -j4
+    - python setup.py bdist_wheel -- -- -j4
     - pip install dist/qiskit_aer*whl
   script:
     - stestr run --slowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,13 +128,14 @@ jobs:
 
     # "compile" stage
     ###########################################################################
+    # Linux on Intel
     - stage: compile
       name: Test Build Linux
       <<: *stage_linux
       before_script: true
       script:
         - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
-  
+    # MacOS
     - stage: compile
       name: Test Build MacOS
       <<: *stage_osx
@@ -207,3 +208,21 @@ jobs:
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.5.6
+  
+  # POWER tests
+  allow_failures:
+    # Power Build
+    - stage: compile
+      name: Test Build Linux (Power)
+      arch: ppc64le
+      <<: *stage_linux
+      before_script: true
+      script:
+        - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
+    # Power Tests
+    - stage: test
+      arch: ppc64le
+      name: Python 3.7 Tests Linux (Power)
+      <<: *stage_linux
+      python: 3.7
+      

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,6 +142,14 @@ jobs:
       before_script: true
       script:
         - python setup.py bdist_wheel -- -- -j4
+    # Power Build
+    - stage: compile
+      name: Test Build Linux (Power)
+      arch: ppc64le
+      <<: *stage_linux
+      before_script: true
+      script:
+        - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
 
     # "test" stage
     ###########################################################################
@@ -209,20 +217,9 @@ jobs:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.5.6
   
-  # POWER tests
-  allow_failures:
-    # Power Build
-    - stage: compile
-      name: Test Build Linux (Power)
-      arch: ppc64le
-      <<: *stage_linux
-      before_script: true
-      script:
-        - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
-    # Power Tests
+    # Power/Linux, Python 3.7
     - stage: test
       arch: ppc64le
       name: Python 3.7 Tests Linux (Power)
       <<: *stage_linux
       python: 3.7
-      

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,21 +128,30 @@ jobs:
 
     # "compile" stage
     ###########################################################################
-    # Linux on Intel
+    # Linux Wheel
     - stage: compile
-      name: Test Build Linux
+      name: Python Wheel Build Linux
       <<: *stage_linux
       before_script: true
       script:
         - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
-    # MacOS
+    # MacOS Wheel
     - stage: compile
-      name: Test Build MacOS
+      name: Python Wheel Build MacOS
       <<: *stage_osx
       before_script: true
       script:
         - python setup.py bdist_wheel -- -- -j4
-    
+    # Linux Standalone
+    - stage: compile
+      name: Standalone Build Linux
+      <<: *stage_linux
+      language: cpp
+      install: true
+      before_script: true
+      script:
+        - mkdir out; cd out; cmake ..
+        - make
 
     # "test" stage
     ###########################################################################
@@ -212,16 +221,25 @@ jobs:
 
   # Power tests (currently failing)
   allow_failures:
-      # Power Build test
+    # Power Build test
     - stage: compile
-      name: Test Build Linux (Power)
+      name: Python Wheel Build Linux (Power)
       arch: ppc64le
       <<: *stage_linux
       before_script: true
       script:
         - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
-
-      # Power/Linux, Python 3.7
+    # Linux Standalone
+    - stage: compile
+      name: Standalone Build Linux (Power)
+      arch: ppc64le
+      <<: *stage_linux
+      install: true
+      before_script: true
+      script:
+        - mkdir out; cd out; cmake ..
+        - make
+    # Power/Linux, Python 3.7
     - stage: test
       arch: ppc64le
       name: Python 3.7 Tests Linux (Power)

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,14 +142,7 @@ jobs:
       before_script: true
       script:
         - python setup.py bdist_wheel -- -- -j4
-    # Power Build
-    - stage: compile
-      name: Test Build Linux (Power)
-      arch: ppc64le
-      <<: *stage_linux
-      before_script: true
-      script:
-        - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
+    
 
     # "test" stage
     ###########################################################################
@@ -216,8 +209,19 @@ jobs:
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.5.6
-  
-    # Power/Linux, Python 3.7
+
+  # Power tests (currently failing)
+  allow_failures:
+      # Power Build test
+    - stage: compile
+      name: Test Build Linux (Power)
+      arch: ppc64le
+      <<: *stage_linux
+      before_script: true
+      script:
+        - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -- -j4
+
+      # Power/Linux, Python 3.7
     - stage: test
       arch: ppc64le
       name: Python 3.7 Tests Linux (Power)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Following on from #553, this PR helps clean up travis build logs and test by adding an extra `compile` stage to the travis tests.
* The compile stage tests building the Python wheels on Linux and MacOS
* The test stage is modified to only run the python unittest scripts so that the full CMake build log isn't returned in the output script.
* Move Python 3.8 MacOS tests to kron job since they are taking too long to run (3-4 x slower than 3.7 tests)

This helps fix issue #548 as we add more build files and more tests files leading to longer and longer logs.

### Details and comments


