### PR TITLE
Fixing pulse simulator eigenstate ordering bug

### DIFF
--- a/qiskit/providers/aer/openpulse/hamiltonian_model.py
+++ b/qiskit/providers/aer/openpulse/hamiltonian_model.py
@@ -15,6 +15,7 @@
 
 "HamiltonianModel class for system specification for the PulseSimulator"
 
+from warnings import warn
 from collections import OrderedDict
 import numpy as np
 import numpy.linalg as la
@@ -207,7 +208,7 @@ class HamiltonianModel():
         evals_mapped = np.zeros(evals.shape, dtype=evals.dtype)
         estates_mapped = np.zeros(estates.shape, dtype=estates.dtype)
 
-        #order the eigenvalues and eigenstates according to overlap with computational basis
+        # order the eigenvalues and eigenstates according to overlap with computational basis
         pos_list = []
         min_overlap = 1
         for i, estate in enumerate(estates.T):

--- a/qiskit/providers/aer/openpulse/hamiltonian_model.py
+++ b/qiskit/providers/aer/openpulse/hamiltonian_model.py
@@ -212,18 +212,14 @@ class HamiltonianModel():
         pos_list = []
         min_overlap = 1
         for i, estate in enumerate(estates.T):
-            pos = -1
+            # make a copy and set entries with indices in pos_list to 0
             estate_copy = estate.copy()
-            while pos == -1:
-                # find the index with max overlap, excluding indices that have already been filled
-                idx = np.argmax(np.abs(estate_copy))
-                if idx in pos_list:
-                    estate_copy[idx] = 0
-                else:
-                    pos = idx
+            estate_copy[pos_list] = 0
 
-            min_overlap = min(np.abs(estate_copy)[pos]**2, min_overlap)
+            pos = np.argmax(np.abs(estate_copy))
             pos_list.append(pos)
+            min_overlap = min(np.abs(estate_copy)[pos]**2, min_overlap)
+
             evals_mapped[pos] = evals[i]
             estates_mapped[:, pos] = estate
 

--- a/qiskit/providers/aer/openpulse/hamiltonian_model.py
+++ b/qiskit/providers/aer/openpulse/hamiltonian_model.py
@@ -229,7 +229,8 @@ class HamiltonianModel():
 
         overlap_threshold = 0.6
         if min_overlap < overlap_threshold:
-            warn('Warning: The minimum overlap of an eigenstate of the drift is below ' +
+            warn('Warning: The minimum overlap of an eigenstate of the drift to an element of '
+                 'the computational basis is below ' +
                  '{0}, and may result in unexpected behavior.'.format(str(overlap_threshold)))
 
         self._evals = evals_mapped

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -90,8 +90,8 @@ def digest_pulse_obj(qobj, system_model, backend_options=None):
     # if still None draw from the Hamiltonian
     if qubit_lo_freq is None:
         qubit_lo_freq = system_model.hamiltonian.get_qubit_lo_from_drift()
-        warn('Warning: qubit_lo_freq was not specified in PulseQobj or in PulseSystemModel, \
-             so it is beign automatically determined from the drift Hamiltonian.')
+        warn('Warning: qubit_lo_freq was not specified in PulseQobj or in PulseSystemModel, ' +
+             'so it is beign automatically determined from the drift Hamiltonian.')
 
     # Build pulse arrays ***************************************************************
     pulses, pulses_idx, pulse_dict = build_pulse_arrays(qobj_dict['experiments'],

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -15,6 +15,8 @@ Tests for PulseSystemModel and HamiltonianModel functionality
 
 import unittest
 import warnings
+from numpy import array
+from numpy.linalg import norm
 from test.terra.common import QiskitAerTestCase
 import qiskit
 from qiskit.test.mock import FakeOpenPulse2Q
@@ -161,6 +163,48 @@ class TestPulseSystemModel(BaseTestPulseSystemModel):
                 u_lo_freq += qfreq * qscale
             u_lo_freqs.append(u_lo_freq)
         return u_lo_freqs
+
+class TestHamiltonianModel(QiskitAerTestCase):
+    """Tests for HamiltonianModel"""
+
+    def test_eigen_sorting(self):
+        """Test estate mappings"""
+
+        X = array([[0,1],[1,0]])
+        Y = array([[0,-1j], [1j, 0]])
+        Z = array([[1,0], [0, -1]])
+
+        simple_ham = {'h_str': ['a*X0','b*Y0', 'c*Z0'],
+                      'vars': {'a': 0.1, 'b': 1, 'c' : 0.2},
+                      'qub': {'0': 2}}
+
+        ham_model = HamiltonianModel.from_dict(simple_ham)
+
+        # check norm
+        for estate in ham_model._estates:
+            self.assertAlmostEqual(norm(estate), 1)
+
+        # check actually an eigenstate
+        mat = 0.1 * X + 1 * Y + 0.2 * Z
+        for idx, eval in enumerate(ham_model._evals):
+            diff = mat @ ham_model._estates[:, idx] - eval * ham_model._estates[:, idx]
+            self.assertAlmostEqual(norm(diff), 0)
+
+        simple_ham = {'h_str': ['a*X0','b*Y0', 'c*Z0'],
+                      'vars': {'a': 100, 'b': 32.1, 'c' : 0.12},
+                      'qub': {'0': 2}}
+
+        ham_model = HamiltonianModel.from_dict(simple_ham)
+
+        # check norm
+        for estate in ham_model._estates:
+            self.assertAlmostEqual(norm(estate), 1)
+
+        # check actually an eigenstate
+        mat = 100 * X + 32.1 * Y + 0.12 * Z
+        for idx, eval in enumerate(ham_model._evals):
+            diff = mat @ ham_model._estates[:, idx] - eval * ham_model._estates[:, idx]
+            self.assertAlmostEqual(norm(diff), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes the following issue:

The pulse simulator implicitly assumes in various places that the drift Hamiltonian is nearly diagonal. One place is (currently) in `HamiltonianModel`, when the drift data is being computed: the eigenstates are being ordered according to their overlap with the computational basis. If two eigenstates have max overlap occurring on the *same* computational basis vector (e.g. a single qubit, with the drift being Pauli X), the current ordering routine will overwrite the first one with the second one, resulting in some eigenvectors not being counted, and ultimately leads to the ordered eigenvalue list containing at least one instance of the 0 vector. This led to situations in which simulator would 'think' the ground state of the hamiltonian is the 0 vector, leading to non-sensical outputs.

### Details and comments

- In `HamiltonianModel._compute_drift_data`, where the ordering is being done, modified the ordering routine so that eigenvectors are never overwritten. (It now looks for the computational basis vector with max overlap, *excluding* ones that are already accounted for.)
- In the same function, if the minimum overlap to the assigned computational basis vector for each eigenstate is below some threshold (which I've set to `0.6`), a warning is issued to the user that this is the case, and that it may produce unexpected behavior. (Exactly what this behavior is I don't know, but at least now it will run.)
- A test has been added for this functionality.
- Unrelated to this issue, but fixed a problem in `digest` where a warning message had an unnecessary line break.