### PR TITLE
Updating pulse simulator to new way of specifying Acquire commands

### DIFF
--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -196,6 +196,8 @@ def digest_pulse_obj(qobj, system_model, backend_options=None):
 
         # Add in measurement operators
         # Not sure if this will work for multiple measurements
+        # Note: the extraction of multiple measurements works, but the simulator itself
+        # implicitly assumes there is only one measurement at the end
         if any(exp_struct['acquire']):
             for acq in exp_struct['acquire']:
                 for jj in acq[1]:
@@ -492,7 +494,7 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds,
 
     structs['tlist'] = np.asarray([0] + structs['tlist'], dtype=float)
 
-    if len(structs['acquire']) > 1 or structs['tlist'][-1] > structs['acquire'][-1][0]:
+    if structs['tlist'][-1] > structs['acquire'][-1][0]:
         structs['can_sample'] = False
 
     return structs

--- a/qiskit/providers/aer/openpulse/solver/unitary.py
+++ b/qiskit/providers/aer/openpulse/solver/unitary.py
@@ -99,11 +99,18 @@ def unitary_evolution(exp, op_system):
 
         # set channel and frame change indexing arrays
 
-    # Do final measurement at end
+    # Do final measurement at end, only take acquire channels at the end
     psi_rot = np.exp(-1j * global_data['h_diag_elems'] * ODE.t)
     psi *= psi_rot
-    qubits = exp['acquire'][0][1]
-    memory_slots = exp['acquire'][0][2]
+    qubits = []
+    memory_slots = []
+    for acq in exp['acquire']:
+        if acq[0] == tlist[-1]:
+            qubits += list(acq[1])
+            memory_slots += list(acq[2])
+    qubits = np.array(qubits, dtype='uint32')
+    memory_slots = np.array(memory_slots, dtype='uint32')
+
     probs = occ_probabilities(qubits, psi, global_data['measurement_ops'])
     rand_vals = rng.rand(memory_slots.shape[0] * shots)
     write_shots_memory(memory, memory_slots, probs, rand_vals)

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -824,8 +824,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         schedule += const_pulse(ControlChannel(uchannel)) << schedule.duration  # u chan pulse
 
         acq_cmd = pulse.Acquire(duration=total_samples)
-        schedule |= acq_cmd([AcquireChannel(0), AcquireChannel(1)],
-                            [MemorySlot(0), MemorySlot(1)]) << schedule.duration
+        acq_sched = acq_cmd(AcquireChannel(0), MemorySlot(0))
+        acq_sched += acq_cmd(AcquireChannel(1), MemorySlot(1))
+
+        schedule |= acq_sched << schedule.duration
 
         return schedule
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updated pulse sim to use new way of specifying `Acquire` commands to eliminate deprecation warnings in tests. Note, at the time of writing, the tests still generate many warnings, but these warnings are a bug in `terra` as described by @lcapelluto, so should go away.



### Details and comments

Old way of specifying `Acquire` commands was to specify a single command with a list of `AcquireChannel` objects and a list of `MemorySlot` objects. New way is to specify an acquire command for each qubit individually.

1. Updated digest to not set `can_sample` to `False` if there is more than one acquire command. (Now it only does so if any acquire commands occur before the final time.)
2. Updated `unitary.py` to handle a list of acquire commands occurring at the end of simulation. (It compiles them back into a single list.)
3. Updated tests to use the new method for specifying `Acquire` commands.
