### PR TITLE
Pulse simulator doc strings and changing naming of `qubit_list`

### DIFF
--- a/qiskit/providers/aer/__init__.py
+++ b/qiskit/providers/aer/__init__.py
@@ -34,6 +34,7 @@ Simulator Backends
     QasmSimulator
     StatevectorSimulator
     UnitarySimulator
+    PulseSimulator
 
 Job Class
 =========

--- a/qiskit/providers/aer/__init__.py
+++ b/qiskit/providers/aer/__init__.py
@@ -43,6 +43,15 @@ Job Class
 
    AerJob
 
+OpenPulse
+=========
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    PulseSystemModel
+    duffing_system_model
+
 Exceptions
 ==========
 .. autosummary::
@@ -65,6 +74,7 @@ from .aerprovider import AerProvider
 from .aerjob import AerJob
 from .aererror import AerError
 from .backends import *
+from .openpulse import *
 from . import noise
 from . import utils
 from .version import __version__

--- a/qiskit/providers/aer/backends/__init__.py
+++ b/qiskit/providers/aer/backends/__init__.py
@@ -17,3 +17,4 @@ Aer Provider Simulator Backends
 from .qasm_simulator import QasmSimulator
 from .statevector_simulator import StatevectorSimulator
 from .unitary_simulator import UnitarySimulator
+from .pulse_simulator import PulseSimulator

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -46,8 +46,7 @@ class PulseSimulator(AerBackend):
 
     To use the simulator, first :meth:`assemble` a :class:`PulseQobj` object from a list of pulse
     :class:`Schedule` objects, using ``backend=PulseSimulator()``. Call the simulator with the
-    :class:`PulseQobj` and a :class:`PulseSystemModel` object representing the properties of the
-    physical system.
+    :class:`PulseQobj` and a :class:`PulseSystemModel` object representing the physical system.
 
     .. code-block:: python
 
@@ -59,43 +58,30 @@ class PulseSimulator(AerBackend):
         # Run simulation on a PulseSystemModel object
         results = backend_sim.run(pulse_qobj, system_model)
 
-    **Important parameters**
+    **Supported PulseQobj parameters**
 
-    * `qubit_lo_freq`: The local oscillator frequency for each `DriveChannel`. This can be drawn
-                       from several places, listed in order of importance:
-           * passed as an argument to `assemble`
-           * determined from PulseSystemModel attribute `_qubit_freq_est`, if not passed to assemble
-           * computed from the dressed energy gaps of the drift Hamiltonian
+    * ``qubit_lo_freq``: Local oscillator frequencies for each :class:`DriveChannel`.
+      Defaults to either the value given in the :class:`PulseSystemModel`, or
+      is calculated directly from the Hamiltonian.
+    * ``meas_level``: Type of desired measurement output, in ``[1, 2]``.
+      ``1`` gives complex numbers (IQ values), and ``2`` gives discriminated states ``|0>`` and
+      ``|1>``.
+    * ``meas_return``: Measurement type, ``'single'`` or ``'avg'``. Defaults to ``'avg'``.
+    * ``shots``: Number of shots per experiment. Defaults to ``1024``.
 
-    **Measurement and output**
-
-    The measurement results are from projections of the state vector in dressed energy basis of
-    the drift Hamiltonian.
-
-    There are three measurement levels that return the data, specified when using assemble.
-    Measurement level `0` gives the raw data.
-    Measurement level `1` gives complex numbers (IQ values).
-    Measurement level `2` gives the discriminated states, `|0>` and `|1>`.
 
     **Simulation method**
 
-    The simulator uses the `zvode` differential equation solver method through `scipy`.
+    The simulator uses the ``zvode`` differential equation solver method through ``scipy``.
 
     **Other options**
 
-    The `run` function additionally takes an argument `backend_options` for additional
-    customization. It accepts keys:
+    :meth:`PulseSimulator.run` takes an additional ``dict`` argument ``backend_options` for
+    customization. Accepted keys:
 
-    * `'ode_options'`: a dictionary containing options to pass to the `zvode` solver. Accepted keys
-      for this option are `'atol'`, `'rtol'`, `'nsteps'`, `'max_step'`, `'num_cpus'`, `'norm_tol'`,
-      and `'norm_steps'`
-
-    **Default behaviors**
-
-    Defaults filled in for `assemble` parameters if not specified:
-    * `meas_level`: `2`
-    * `meas_return`: `'avg'`
-    * `shots`: `1024`
+    * ``'ode_options'``: A ``dict`` for ``zvode`` solver options. Accepted keys
+      are ``'atol'``, ``'rtol'``, ``'nsteps'``, ``'max_step'``, ``'num_cpus'``, ``'norm_tol'``,
+      and ``'norm_steps'``.
     """
 
     DEFAULT_CONFIGURATION = {

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2019, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -37,10 +37,8 @@ class PulseSimulator(AerBackend):
 
     The ``PulseSimulator`` simulates continuous time Hamiltonian dynamics of a quantum system,
     with controls specified by pulse :class:`Schedule` objects, and the model of the physical
-    system specified by :class:`PulseSystemModel` objects. Simulation is performed in the
-    rotating frame of the drift Hamiltonian in the :class:`PulseSystemModel`.
-
-    Results are returned in the same format as when jobs are submitted to actual devices.
+    system specified by :class:`PulseSystemModel` objects. Results are returned in the same format
+    as when jobs are submitted to actual devices.
 
     **Example**
 
@@ -70,9 +68,12 @@ class PulseSimulator(AerBackend):
     * ``shots``: Number of shots per experiment. Defaults to ``1024``.
 
 
-    **Simulation method**
+    **Simulation details**
 
     The simulator uses the ``zvode`` differential equation solver method through ``scipy``.
+    Simulation is performed in the rotating frame of the diagonal of the drift Hamiltonian
+    contained in the :class:`PulseSystemModel`. Measurements are performed in the `dressed basis`
+    of the drift Hamiltonian.
 
     **Other options**
 

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -42,13 +42,12 @@ class PulseSimulator(AerBackend):
 
     Results are returned in the same format as when jobs are submitted to actual devices.
 
-    **Example of usage**
+    **Example**
 
-    To use the simulator, `assemble` a `PulseQobj` object from a list of pulse `Schedules`, using
-    `backend=PulseSimulator()`.
-
-    In the following, `schedules` is a list of pulse `Schedule` objects, and `system_model` is a
-    `PulseSystemModel` object.
+    To use the simulator, first :meth:`assemble` a :class:`PulseQobj` object from a list of pulse
+    :class:`Schedule` objects, using ``backend=PulseSimulator()``. Call the simulator with the
+    :class:`PulseQobj` and a :class:`PulseSystemModel` object representing the properties of the
+    physical system.
 
     .. code-block:: python
 
@@ -130,7 +129,17 @@ class PulseSimulator(AerBackend):
                          provider=provider)
 
     def run(self, qobj, system_model, backend_options=None, validate=False):
-        """Run a qobj on the backend."""
+        """Run a qobj on system_model.
+
+        Args:
+            qobj (PulseQobj): Qobj for pulse Schedules to run
+            system_model (PulseSystemModel): Physical model to run simulation on
+            backend_options (dict): Other options
+            validate (bool): Flag for validation checks
+
+        Returns:
+            Result: results of simulation
+        """
         # Submit job
         job_id = str(uuid.uuid4())
         aer_job = AerJob(self, job_id, self._run_job, qobj, system_model,

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -48,7 +48,7 @@ class PulseSimulator(AerBackend):
 
     .. code-block:: python
 
-        backend_sim = qiskit.providers.aer.PulseSimulator
+        backend_sim = qiskit.providers.aer.PulseSimulator()
 
         # Assemble schedules using PulseSimulator as the backend
         pulse_qobj = assemble(schedules, backend=backend_sim)

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -63,7 +63,7 @@ class PulseSimulator(AerBackend):
       is calculated directly from the Hamiltonian.
     * ``meas_level``: Type of desired measurement output, in ``[1, 2]``.
       ``1`` gives complex numbers (IQ values), and ``2`` gives discriminated states ``|0>`` and
-      ``|1>``.
+      ``|1>``. Defaults to ``2``.
     * ``meas_return``: Measurement type, ``'single'`` or ``'avg'``. Defaults to ``'avg'``.
     * ``shots``: Number of shots per experiment. Defaults to ``1024``.
 

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -35,13 +35,10 @@ class PulseSimulator(AerBackend):
     """
     Aer OpenPulse simulator
 
-    The `PulseSimulator` simulates pulse `Schedules` on a model of a quantum system, where a model
-    is specified by a `PulseSystemModel` object, which stores Hamiltonian and control channel
-    information. Simulation is performed in the rotating frame of the drift Hamiltonian in the
-    `PulseSystemModel`.
-
-    `PulseSystemModel` objects can be constructed from backends with a hamiltonian description, or
-    from the `transmon_system_model` function.
+    The ``PulseSimulator`` simulates continuous time Hamiltonian dynamics of a quantum system,
+    with controls specified by pulse :class:`Schedule` objects, and the model of the physical
+    system specified by :class:`PulseSystemModel` objects. Simulation is performed in the
+    rotating frame of the drift Hamiltonian in the :class:`PulseSystemModel`.
 
     Results are returned in the same format as when jobs are submitted to actual devices.
 
@@ -55,12 +52,12 @@ class PulseSimulator(AerBackend):
 
     .. code-block:: python
 
-        backend_sim = qiskit.Aer.get_backend('pulse_simulator')
+        backend_sim = qiskit.providers.aer.PulseSimulator
 
-        # assemble pulse_qobj with backend=backend_sim
+        # Assemble schedules using PulseSimulator as the backend
         pulse_qobj = assemble(schedules, backend=backend_sim)
 
-        # Run simulation
+        # Run simulation on a PulseSystemModel object
         results = backend_sim.run(pulse_qobj, system_model)
 
     **Important parameters**

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -32,8 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class PulseSimulator(AerBackend):
-    """
-    Aer OpenPulse simulator
+    r"""Aer OpenPulse simulator.
 
     The ``PulseSimulator`` simulates continuous time Hamiltonian dynamics of a quantum system,
     with controls specified by pulse :class:`Schedule` objects, and the model of the physical
@@ -42,9 +41,10 @@ class PulseSimulator(AerBackend):
 
     **Example**
 
-    To use the simulator, first :meth:`assemble` a :class:`PulseQobj` object from a list of pulse
-    :class:`Schedule` objects, using ``backend=PulseSimulator()``. Call the simulator with the
-    :class:`PulseQobj` and a :class:`PulseSystemModel` object representing the physical system.
+    To use the simulator, first :meth:`assemble` a :class:`PulseQobj` object
+    from a list of pulse :class:`Schedule` objects, using ``backend=PulseSimulator()``.
+    Call the simulator with the :class:`PulseQobj` and a :class:`PulseSystemModel`
+    object representing the physical system.
 
     .. code-block:: python
 
@@ -77,7 +77,7 @@ class PulseSimulator(AerBackend):
 
     **Other options**
 
-    :meth:`PulseSimulator.run` takes an additional ``dict`` argument ``backend_options` for
+    :meth:`PulseSimulator.run` takes an additional ``dict`` argument ``backend_options`` for
     customization. Accepted keys:
 
     * ``'ode_options'``: A ``dict`` for ``zvode`` solver options. Accepted keys

--- a/qiskit/providers/aer/openpulse/__init__.py
+++ b/qiskit/providers/aer/openpulse/__init__.py
@@ -13,6 +13,9 @@
 # that they have been altered from the originals.
 """Init for openpulse"""
 
+from .duffing_model_generators import duffing_system_model
+from .pulse_system_model import PulseSystemModel
+
 # pylint: disable=import-error
 import distutils.sysconfig  # noqa
 import numpy as np

--- a/qiskit/providers/aer/openpulse/__init__.py
+++ b/qiskit/providers/aer/openpulse/__init__.py
@@ -13,13 +13,13 @@
 # that they have been altered from the originals.
 """Init for openpulse"""
 
-from .duffing_model_generators import duffing_system_model
-from .pulse_system_model import PulseSystemModel
-
 # pylint: disable=import-error
 import distutils.sysconfig  # noqa
 import numpy as np
 from .qutip_lite.cy import pyxbuilder as pbldr
+
+from .duffing_model_generators import duffing_system_model
+from .pulse_system_model import PulseSystemModel
 
 # Remove -Wstrict-prototypes from cflags
 CFG_VARS = distutils.sysconfig.get_config_vars()

--- a/qiskit/providers/aer/openpulse/duffing_model_generators.py
+++ b/qiskit/providers/aer/openpulse/duffing_model_generators.py
@@ -169,7 +169,7 @@ def duffing_system_model(dim_oscillators,
     return PulseSystemModel(hamiltonian=hamiltonian_model,
                             u_channel_lo=u_channel_lo,
                             control_channel_labels=coupling_graph.sorted_two_way_graph,
-                            qubit_list=oscillators,
+                            subsystem_list=oscillators,
                             dt=dt)
 
 

--- a/qiskit/providers/aer/openpulse/duffing_model_generators.py
+++ b/qiskit/providers/aer/openpulse/duffing_model_generators.py
@@ -27,22 +27,22 @@ def duffing_system_model(dim_oscillators,
                          drive_strengths,
                          coupling_dict,
                          dt):
-    """Returns a :class:`PulseSystemModel` representing a physical model for a
+    r"""Returns a :class:`PulseSystemModel` representing a physical model for a
     collection of Duffing oscillators.
 
     In the model, each individual oscillator is specified by the parameters:
 
-        * Frequency: :math:`\\nu`, specified in the list ``oscillator_freqs``
-        * Anharmonicity: :math:`\\alpha`, specified in the list ``anharm_freqs``, and
+        * Frequency: :math:`\nu`, specified in the list ``oscillator_freqs``
+        * Anharmonicity: :math:`\alpha`, specified in the list ``anharm_freqs``, and
         * Drive strength: :math:`r`, specified in the list ``drive_strengths``.
 
     For each oscillator, the above parameters enter into the Hamiltonian via the terms:
 
     .. math::
-        \\pi(2 \\nu - \\alpha)a^\\dagger a +
-        \\pi \\alpha (a^\\dagger a)^2 + 2 \\pi r D(t) (a + a^\\dagger),
+        \pi(2 \nu - \alpha)a^\dagger a +
+        \pi \alpha (a^\dagger a)^2 + 2 \pi r D(t) (a + a^\dagger),
 
-    where :math:`a^\\dagger` and :math:`a` are, respectively, the creation and annihilation
+    where :math:`a^\dagger` and :math:`a` are, respectively, the creation and annihilation
     operators for the oscillator, and :math:`D(t)` is the drive signal for the oscillator.
 
     Each coupling term between a pair of oscillators is specified by:
@@ -55,7 +55,7 @@ def duffing_system_model(dim_oscillators,
     results in the Hamiltonian term:
 
     .. math::
-        2 \\pi j (a_i^\\dagger a_k + a_i a_k^\\dagger).
+        2 \pi j (a_i^\dagger a_k + a_i a_k^\dagger).
 
     Finally, the returned :class:`PulseSystemModel` is setup for performing cross-resonance
     drives between coupled qubits. The index for the :class:`ControlChannel` corresponding

--- a/qiskit/providers/aer/openpulse/hamiltonian_model.py
+++ b/qiskit/providers/aer/openpulse/hamiltonian_model.py
@@ -15,7 +15,6 @@
 
 "HamiltonianModel class for system specification for the PulseSimulator"
 
-from warnings import warn
 from collections import OrderedDict
 import numpy as np
 import numpy.linalg as la

--- a/qiskit/providers/aer/openpulse/hamiltonian_model.py
+++ b/qiskit/providers/aer/openpulse/hamiltonian_model.py
@@ -223,12 +223,6 @@ class HamiltonianModel():
             evals_mapped[pos] = evals[i]
             estates_mapped[:, pos] = estate
 
-        overlap_threshold = 0.6
-        if min_overlap < overlap_threshold:
-            warn('Warning: The minimum overlap of an eigenstate of the drift to an element of '
-                 'the computational basis is below ' +
-                 '{0}, and may result in unexpected behavior.'.format(str(overlap_threshold)))
-
         self._evals = evals_mapped
         self._estates = estates_mapped
         self._h_diag = np.ascontiguousarray(np.diag(ham_full).real)

--- a/qiskit/providers/aer/openpulse/hamiltonian_model.py
+++ b/qiskit/providers/aer/openpulse/hamiltonian_model.py
@@ -28,15 +28,13 @@ class HamiltonianModel():
     def __init__(self,
                  system=None,
                  variables=None,
-                 qubit_dims=None,
-                 oscillator_dims=None):
+                 subsystem_dims=None):
         """Initialize a Hamiltonian model.
 
         Args:
             system (list): List of Qobj objects representing operator form of the Hamiltonian.
             variables (OrderedDict): Ordered dict for parameter values in Hamiltonian.
-            qubit_dims (dict): dict of qubit dimensions.
-            oscillator_dims (dict): dict of oscillator dimensions.
+            subsystem_dims (dict): dict of subsystem dimensions.
 
         Raises:
             ValueError: if arguments are invalid.
@@ -49,9 +47,7 @@ class HamiltonianModel():
         self._variables = variables
         # Channels in the Hamiltonian string
         # Qubit subspace dimensinos
-        self._qubit_dims = qubit_dims or {}
-        # Oscillator subspace dimensions
-        self._oscillator_dims = oscillator_dims or {}
+        self._subsystem_dims = subsystem_dims or {}
 
         # The rest are computed from the previous
 
@@ -72,12 +68,12 @@ class HamiltonianModel():
         self._compute_drift_data()
 
     @classmethod
-    def from_dict(cls, hamiltonian, qubit_list=None):
+    def from_dict(cls, hamiltonian, subsystem_list=None):
         """Initialize from a Hamiltonian string specification.
 
         Args:
             hamiltonian (dict): dictionary representing Hamiltonian in string specification.
-            qubit_list (list or None): List of qubits to extract from the hamiltonian.
+            subsystem_list (list or None): List of subsystems to extract from the hamiltonian.
 
         Returns:
             HamiltonianModel: instantiated from hamiltonian dictionary
@@ -93,15 +89,15 @@ class HamiltonianModel():
 
         # Get qubit subspace dimensions
         if 'qub' in hamiltonian:
-            if qubit_list is None:
-                qubit_list = [int(qubit) for qubit in hamiltonian['qub']]
+            if subsystem_list is None:
+                subsystem_list = [int(qubit) for qubit in hamiltonian['qub']]
 
-            qubit_dims = {
+            subsystem_dims = {
                 int(key): val
                 for key, val in hamiltonian['qub'].items()
             }
         else:
-            qubit_dims = {}
+            subsystem_dims = {}
 
         # Get oscillator subspace dimensions
         if 'osc' in hamiltonian:
@@ -115,11 +111,11 @@ class HamiltonianModel():
         # Parse the Hamiltonian
         system = HamiltonianParser(h_str=hamiltonian['h_str'],
                                    dim_osc=oscillator_dims,
-                                   dim_qub=qubit_dims)
-        system.parse(qubit_list)
+                                   dim_qub=subsystem_dims)
+        system.parse(subsystem_list)
         system = system.compiled
 
-        return cls(system, variables, qubit_dims, oscillator_dims)
+        return cls(system, variables, subsystem_dims)
 
     def get_qubit_lo_from_drift(self):
         """ Computes a list of qubit frequencies corresponding to the exact energy
@@ -128,13 +124,13 @@ class HamiltonianModel():
         Returns:
             qubit_lo_freq (list): the list of frequencies
         """
-        qubit_lo_freq = [0] * len(self._qubit_dims)
+        qubit_lo_freq = [0] * len(self._subsystem_dims)
 
         # compute difference between first excited state of each qubit and
         # the ground energy
         min_eval = np.min(self._evals)
-        for q_idx in range(len(self._qubit_dims)):
-            single_excite = _first_excited_state(q_idx, self._qubit_dims)
+        for q_idx in range(len(self._subsystem_dims)):
+            single_excite = _first_excited_state(q_idx, self._subsystem_dims)
             dressed_eval = _eval_for_max_espace_overlap(
                 single_excite, self._evals, self._estates)
             qubit_lo_freq[q_idx] = (dressed_eval - min_eval) / (2 * np.pi)
@@ -240,7 +236,7 @@ def _hamiltonian_parse_exceptions(hamiltonian):
         raise AerError('Oscillator-type systems are not supported.')
 
 
-def _first_excited_state(qubit_idx, qubit_dims):
+def _first_excited_state(qubit_idx, subsystem_dims):
     """
     Returns the vector corresponding to all qubits in the 0 state, except for
     qubit_idx in the 1 state.
@@ -252,18 +248,18 @@ def _first_excited_state(qubit_idx, qubit_dims):
     Parameters:
         qubit_idx (int): the qubit to be in the 1 state
 
-        qubit_dims (dict): a dictionary with keys being qubit index, and
-                        value being the dimension of the qubit
+        subsystem_dims (dict): a dictionary with keys being subsystem index, and
+                        value being the dimension of the subsystem
 
     Returns:
         vector: the state with qubit_idx in state 1, and the rest in state 0
     """
     vector = np.array([1.])
     # iterate through qubits, tensoring on the state
-    qubit_indices = [int(qubit) for qubit in qubit_dims]
+    qubit_indices = [int(qubit) for qubit in subsystem_dims]
     qubit_indices.sort()
     for idx in qubit_indices:
-        new_vec = np.zeros(qubit_dims[idx])
+        new_vec = np.zeros(subsystem_dims[idx])
         if idx == qubit_idx:
             new_vec[1] = 1
         else:

--- a/qiskit/providers/aer/openpulse/pulse_system_model.py
+++ b/qiskit/providers/aer/openpulse/pulse_system_model.py
@@ -35,7 +35,7 @@ class PulseSystemModel():
           frequencies in terms of qubit local oscillator frequencies.
         * ``"control_channel_labels"``: Optional list of identifying information for
           each :class:`ControlChannel` that the model supports.
-        * ``"qubit_list"``: List of qubits in the model.
+        * ``"subsystem_list"``: List of subsystems in the model.
         * ``"dt"``: Sample width size for OpenPulse instructions.
 
     A :class:`PulseSystemModel` object can be instantiated from the
@@ -59,7 +59,7 @@ class PulseSystemModel():
                  meas_freq_est=None,
                  u_channel_lo=None,
                  control_channel_labels=None,
-                 qubit_list=None,
+                 subsystem_list=None,
                  dt=None):
         """Initialize a PulseSystemModel.
 
@@ -72,7 +72,7 @@ class PulseSystemModel():
             u_channel_lo (list): list of ControlChannel frequency specifications.
             control_channel_labels (list): list of labels for control channels, which can be of
                                            any type.
-            qubit_list (list): list of valid qubit indicies for the model.
+            subsystem_list (list): list of valid qubit indicies for the model.
             dt (float): pixel size for pulse Instructions.
         Raises:
             AerError: if hamiltonian is not None or a HamiltonianModel
@@ -88,16 +88,16 @@ class PulseSystemModel():
         self.hamiltonian = hamiltonian
         self.u_channel_lo = u_channel_lo
         self.control_channel_labels = control_channel_labels or []
-        self.qubit_list = qubit_list
+        self.subsystem_list = subsystem_list
         self.dt = dt
 
     @classmethod
-    def from_backend(cls, backend, qubit_list=None):
+    def from_backend(cls, backend, subsystem_list=None):
         """Returns a PulseSystemModel constructed from an OpenPulse enabled backend object.
 
         Args:
             backend (Backend): backend object to draw information from.
-            qubit_list (list): a list of ints for which qubits to include in the model.
+            subsystem_list (list): a list of ints for which qubits to include in the model.
 
         Returns:
             PulseSystemModel: the PulseSystemModel constructed from the backend.
@@ -121,10 +121,10 @@ class PulseSystemModel():
         meas_freq_est = defaults.get('meas_freq_est', None)
 
         # draw from configuration
-        # if no qubit_list, use all for device
-        qubit_list = qubit_list or list(range(config['n_qubits']))
+        # if no subsystem_list, use all for device
+        subsystem_list = subsystem_list or list(range(config['n_qubits']))
         ham_string = config['hamiltonian']
-        hamiltonian = HamiltonianModel.from_dict(ham_string, qubit_list)
+        hamiltonian = HamiltonianModel.from_dict(ham_string, subsystem_list)
         u_channel_lo = config.get('u_channel_lo', None)
         dt = config.get('dt', None)
 
@@ -164,7 +164,7 @@ class PulseSystemModel():
                    meas_freq_est=meas_freq_est,
                    u_channel_lo=u_channel_lo,
                    control_channel_labels=control_channel_labels,
-                   qubit_list=qubit_list,
+                   subsystem_list=subsystem_list,
                    dt=dt)
 
     def control_channel_index(self, label):

--- a/qiskit/providers/aer/openpulse/pulse_system_model.py
+++ b/qiskit/providers/aer/openpulse/pulse_system_model.py
@@ -23,9 +23,35 @@ from ..aererror import AerError
 
 
 class PulseSystemModel():
-    """Contains all model parameters necessary for :class:`PulseSimulator`.
+    """Physical model object for use in :class:`PulseSimulator`.
 
-    
+    This class contains model information required by :class:`PulseSimulator`. It contains:
+
+        * ``"hamiltonian"``: a :class:`HamiltonianModel` object representing the
+          Hamiltonian of the system.
+        * ``"qubit_freq_est"`` and ``"meas_freq_est"``: optional default values for
+          qubit and measurement frequencies.
+        * ``"u_channel_lo"``: A description of :class:`ControlChannel` local oscillator
+          frequencies in terms of qubit local oscillator frequencies.
+        * ``"control_channel_labels"``: Optional list of identifying information for
+          each :class:`ControlChannel` that the model supports.
+        * ``"qubit_list"``: List of qubits in the model.
+        * ``"dt"``: Sample width size for OpenPulse instructions.
+
+    A :class:`PulseSystemModel` object can be instantiated from the
+    helper function :meth:`duffing_system_model`, or using the
+    :meth:`PulseSystemModel.from_backend` constructor.
+
+    **Example**
+
+    Constructing from a backend:
+
+    .. code-block: python
+
+        provider = IBMQ.load_account()
+        armonk_backend = provider.get_backend('ibmq_armonk')
+
+        system_model = PulseSystemModel.from_backend(armonk_backend)
     """
     def __init__(self,
                  hamiltonian=None,
@@ -157,7 +183,7 @@ class PulseSystemModel():
             return self.control_channel_labels.index(label)
 
     def calculate_channel_frequencies(self, qubit_lo_freq=None):
-        """Calculate frequencies for each channel.
+        """Calculate frequencies for each channel given qubit_lo_freq.
 
         Args:
             qubit_lo_freq (list or None): list of qubit linear

--- a/qiskit/providers/aer/openpulse/pulse_system_model.py
+++ b/qiskit/providers/aer/openpulse/pulse_system_model.py
@@ -23,7 +23,7 @@ from ..aererror import AerError
 
 
 class PulseSystemModel():
-    """Physical model object for use in :class:`PulseSimulator`.
+    r"""Physical model object for use in :class:`PulseSimulator`.
 
     This class contains model information required by :class:`PulseSimulator`. It contains:
 

--- a/qiskit/providers/aer/openpulse/pulse_system_model.py
+++ b/qiskit/providers/aer/openpulse/pulse_system_model.py
@@ -23,7 +23,9 @@ from ..aererror import AerError
 
 
 class PulseSystemModel():
-    """PulseSystemModel containing all model parameters necessary for simulation.
+    """Contains all model parameters necessary for :class:`PulseSimulator`.
+
+    
     """
     def __init__(self,
                  hamiltonian=None,
@@ -65,7 +67,7 @@ class PulseSystemModel():
 
     @classmethod
     def from_backend(cls, backend, qubit_list=None):
-        """Returns a PulseSystemModel constructed from a backend object.
+        """Returns a PulseSystemModel constructed from an OpenPulse enabled backend object.
 
         Args:
             backend (Backend): backend object to draw information from.

--- a/qiskit/providers/aer/openpulse/qobj/digest.py
+++ b/qiskit/providers/aer/openpulse/qobj/digest.py
@@ -106,7 +106,7 @@ def digest_pulse_obj(qobj, system_model, backend_options=None):
     # ###############################
 
     # Get qubit list and number
-    qubit_list = system_model.qubit_list
+    qubit_list = system_model.subsystem_list
     if qubit_list is None:
         raise ValueError('Model must have a qubit list to simulate.')
     n_qubits = len(qubit_list)
@@ -123,8 +123,8 @@ def digest_pulse_obj(qobj, system_model, backend_options=None):
     out.h_diag = ham_model._h_diag
     out.evals = ham_model._evals
     out.estates = ham_model._estates
-    dim_qub = ham_model._qubit_dims
-    dim_osc = ham_model._oscillator_dims
+    dim_qub = ham_model._subsystem_dims
+    dim_osc = {}
     out.freqs = system_model.calculate_channel_frequencies(qubit_lo_freq=qubit_lo_freq)
     # convert estates into a Qutip qobj
     estates = [op.state(state) for state in ham_model._estates.T[:]]

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -641,12 +641,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         ham_model = HamiltonianModel.from_dict(hamiltonian)
 
         u_channel_lo = []
-        qubit_list = [0]
+        subsystem_list = [0]
         dt = 1.
 
         return PulseSystemModel(hamiltonian=ham_model,
                                 u_channel_lo=u_channel_lo,
-                                qubit_list=qubit_list,
+                                subsystem_list=subsystem_list,
                                 dt=dt)
 
     def _system_model_2Q(self, omega_0, omega_a, omega_i, qubit_dim=2):
@@ -678,12 +678,12 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         u_channel_lo = [[{'q': 0, 'scale': [1.0, 0.0]}],
                         [{'q': 0, 'scale': [-1.0, 0.0]}, {'q': 1, 'scale': [1.0, 0.0]}]]
-        qubit_list = [0, 1]
+        subsystem_list = [0, 1]
         dt = 1.
 
         return PulseSystemModel(hamiltonian=ham_model,
                                 u_channel_lo=u_channel_lo,
-                                qubit_list=qubit_list,
+                                subsystem_list=subsystem_list,
                                 dt=dt)
 
     def _simple_1Q_schedule(self, phi, total_samples, shape="square", gauss_sigma=0):

--- a/test/terra/openpulse/test_duffing_model_generators.py
+++ b/test/terra/openpulse/test_duffing_model_generators.py
@@ -46,7 +46,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
         cr_idx_dict = {label: idx for idx, label in enumerate(system_model.control_channel_labels)}
 
         # check basic parameters
-        self.assertEqual(system_model.qubit_list, [0, 1])
+        self.assertEqual(system_model.subsystem_list, [0, 1])
         self.assertEqual(system_model.dt, 1.3)
 
         # check that cr_idx_dict is correct
@@ -70,7 +70,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
                          'r0': 1.1, 'r1': 1.2,
                          'j01': 0.02}
         self.assertEqual(ham_model._variables, expected_vars)
-        self.assertEqual(ham_model._qubit_dims, {0: 2, 1: 2})
+        self.assertEqual(ham_model._subsystem_dims, {0: 2, 1: 2})
         self._compare_str_lists(list(ham_model._channels), ['D0', 'D1', 'U0', 'U1'])
 
         # check that Hamiltonian terms have been imported correctly
@@ -127,7 +127,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
         cr_idx_dict = {label: idx for idx, label in enumerate(system_model.control_channel_labels)}
 
         # check basic parameters
-        self.assertEqual(system_model.qubit_list, [0, 1, 2])
+        self.assertEqual(system_model.subsystem_list, [0, 1, 2])
         self.assertEqual(system_model.dt, 1.3)
 
         # check that cr_idx_dict is correct
@@ -154,7 +154,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
                          'r0': 1.1, 'r1': 1.2, 'r2': 1.3,
                          'j01': 0.02, 'j12': 0.03}
         self.assertEqual(ham_model._variables, expected_vars)
-        self.assertEqual(ham_model._qubit_dims, {0: 3, 1: 3, 2: 3})
+        self.assertEqual(ham_model._subsystem_dims, {0: 3, 1: 3, 2: 3})
         self._compare_str_lists(list(ham_model._channels), ['D0', 'D1', 'D3', 'U0', 'U1', 'U2', 'U3'])
 
         # check that Hamiltonian terms have been imported correctly
@@ -221,7 +221,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
         cr_idx_dict = {label: idx for idx, label in enumerate(system_model.control_channel_labels)}
 
         # check basic parameters
-        self.assertEqual(system_model.qubit_list, [0, 1, 2, 3])
+        self.assertEqual(system_model.subsystem_list, [0, 1, 2, 3])
         self.assertEqual(system_model.dt, 1.3)
 
         # check that cr_idx_dict is correct
@@ -253,7 +253,7 @@ class TestDuffingModelGenerators(QiskitAerTestCase):
                          'r0': 1.1, 'r1': 1.2, 'r2': 1.3, 'r3': 1.4,
                          'j01': 0.02, 'j02': 0.03, 'j03': 0.14, 'j12': 0.33, 'j13': 0.18}
         self.assertEqual(ham_model._variables, expected_vars)
-        self.assertEqual(ham_model._qubit_dims, {0: 2, 1: 2, 2: 2, 3: 2})
+        self.assertEqual(ham_model._subsystem_dims, {0: 2, 1: 2, 2: 2, 3: 2})
         self._compare_str_lists(list(ham_model._channels), ['D0', 'D1', 'D3', 'D4',
                                                             'U0', 'U1', 'U2', 'U3', 'U4',
                                                             'U5', 'U6', 'U7', 'U8', 'U9'])

--- a/test/terra/openpulse/test_pulse_digest.py
+++ b/test/terra/openpulse/test_pulse_digest.py
@@ -134,12 +134,12 @@ class TestDigest(QiskitAerTestCase):
         # set up u channel freqs,
         u_channel_lo = [[{'q': 1, 'scale': [1.0, 0.0]}],
                         [{'q': 0, 'scale': [1.0, 0.0]}]]
-        qubit_list = [0, 1]
+        subsystem_list = [0, 1]
         dt = 1.
 
         return PulseSystemModel(hamiltonian=ham_model,
                                 u_channel_lo=u_channel_lo,
-                                qubit_list=qubit_list,
+                                subsystem_list=subsystem_list,
                                 dt=dt)
 
 

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -55,13 +55,13 @@ class BaseTestPulseSystemModel(QiskitAerTestCase):
                                'alpha1': alpha1}
         ham_model = HamiltonianModel.from_dict(hamiltonian)
 
-        qubit_list =[0, 1]
+        subsystem_list =[0, 1]
         dt = 1.
 
         return PulseSystemModel(hamiltonian=ham_model,
                                 qubit_freq_est=self._default_qubit_lo_freq,
                                 u_channel_lo=self._u_channel_lo,
-                                qubit_list=qubit_list,
+                                subsystem_list=subsystem_list,
                                 dt=dt)
 
 

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -195,16 +195,7 @@ class TestHamiltonianModel(QiskitAerTestCase):
                       'vars': {'a': 100, 'b': 32.1, 'c' : 0.12},
                       'qub': {'0': 2}}
 
-        # construc the model, verify the off-diagonal warning is thrown
-        # test that it gives a warning when a key has no corresponding control channel
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            ham_model = HamiltonianModel.from_dict(simple_ham)
-
-            self.assertEqual(len(w), 1)
-            self.assertTrue('minimum overlap' in str(w[-1].message))
+        ham_model = HamiltonianModel.from_dict(simple_ham)
 
         # check norm
         for estate in ham_model._estates:


### PR DESCRIPTION
### Summary

Closes #433
Closes #500

Adding doc strings for for pulse simulator files `pulse_simulator.py`, `pulse_system_model.py`, `duffing_model_generators.py`.

Changed `qubit_list` to `subsystem_list` in `hamiltonian_model`, `pulse_system_model`, and `digest`, and updated all relevant tests.

### Details and comments

Changes are:

1. Added doc strings for relevant classes/functions in above mentioned files.
2. Updated aer `__init__.py` file to put relevant classes/methods in API doc generations: added `PulseSimulator` to the list of backends, and added a section called `OpenPulse` to have `PulseSystemModel` and `duffing_model_generators`.
3. Updated backends `__init__.py` file to import `PulseSimulator`.
4. Updated openpulse `__init__.py` file to import `duffing_system_model` and `PulseSystemModel`.
5. Removed warning for off-diagonal pieces of Hamiltonian from eigenvector re-ordering code in `HamiltonianModel` as it was going off in situations that it shouldn't, and updated related test to not check for the warning.
6. Changed `qubit_list` to `subsystem_list` and `qubit_dims` to `subsystem_dims` in all relevant places, and removed `oscillator_dims` from `HamiltonianModel`.