### PR TITLE
Update QuantumError and ReadoutError to match new Terra Operator API

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -308,12 +308,11 @@ class QuantumError:
         return error
 
     def compose(self, other, front=False):
-        """Return the composition error channel self∘other.
+        """Return the composition error channel other * self.
 
         Args:
             other (QuantumError): a quantum error channel.
-            front (bool): If False compose in standard order other(self(input))
-                          otherwise compose in reverse order self(other(input))
+            front (bool): DEPRECATED If True return self * other instead.
                           [default: False]
 
         Returns:
@@ -323,58 +322,27 @@ class QuantumError:
             NoiseError: if other cannot be converted into a QuantumError,
             or has incompatible dimensions.
         """
-        # Convert other into a quantum error
-        if not isinstance(other, QuantumError):
-            other = QuantumError(other)
-        # Error checking
-        if self.number_of_qubits != other.number_of_qubits:
-            raise NoiseError(
-                "QuantumErrors are not defined on same number of qubits.")
-
-        combined_noise_circuits = []
-        combined_noise_probabilities = []
-
-        # Combine subcircuits and probabilities
         if front:
-            noise_ops0 = list(
-                zip(other._noise_circuits, other._noise_probabilities))
-            noise_ops1 = list(
-                zip(self._noise_circuits, self._noise_probabilities))
-        else:
-            noise_ops0 = list(
-                zip(self._noise_circuits, self._noise_probabilities))
-            noise_ops1 = list(
-                zip(other._noise_circuits, other._noise_probabilities))
+            # DEPRECATED kwarg `front`
+            warnings.warn('`compose(other, front=True)` is deprecated, use `dot(other)` instead.',
+                          DeprecationWarning)
+            return self._matmul(other, left_multiply=False)
+        return self._matmul(other, left_multiply=True)
 
-        # Combine subcircuits and probabilities
-        for circuit0, prob0 in noise_ops0:
-            for circuit1, prob1 in noise_ops1:
-                combined_noise_probabilities.append(prob0 * prob1)
-                tmp_combined = circuit0 + circuit1
+    def dot(self, other):
+        """Return the composition error channel self * other.
 
-                # Fuse compatible ops to reduce noise operations:
-                combined_circuit = [tmp_combined[0]]
-                for instr in tmp_combined[1:]:
-                    last_instr = combined_circuit[-1]
-                    last_name = last_instr['name']
-                    name = instr['name']
-                    can_combine = (last_name in ['id', 'kraus', 'unitary'] or
-                                   name in ['id', 'kraus', 'unitary'])
-                    if (can_combine and self._check_instr(last_name) and
-                            self._check_instr(name)):
-                        combined_circuit[-1] = self._compose_instr(
-                            last_instr, instr, self.number_of_qubits)
-                    else:
-                        # If they cannot be combined append the operation
-                        combined_circuit.append(instr)
-                # Check if circuit is empty and add identity
-                if not combined_circuit:
-                    combined_circuit.append({'name': 'id', 'qubits': [0]})
-                # Add circuit
-                combined_noise_circuits.append(combined_circuit)
-        noise_ops = self._combine_kraus(
-            zip(combined_noise_circuits, combined_noise_probabilities))
-        return QuantumError(noise_ops)
+        Args:
+            other (QuantumError): a quantum error channel.
+
+        Returns:
+            QuantumError: The composition error channel.
+
+        Raises:
+            NoiseError: if other cannot be converted into a QuantumError,
+            or has incompatible dimensions.
+        """
+        return self._matmul(other, left_multiply=False)
 
     def power(self, n):
         """Return the compose of a error channel with itself n times.
@@ -423,23 +391,71 @@ class QuantumError:
         """
         return self._tensor_product(other, reverse=True)
 
-    def kron(self, other):
-        """
-        Return the tensor product quantum error channel self ⊗ other (DEPRECATED).
-
-        DEPRECATED: use :meth:`tensor` instead.
+    def _matmul(self, other, left_multiply=False):
+        """Return the composition quantum error.
 
         Args:
-            other (QuantumError): a quantum error or channel.
-
+            other (QuantumError): a quantum error.
+            left_multiply (bool): If True return other * self
+                                  If False return self * other [Default:False]
         Returns:
-            QuantumError: the tensor product channel self ⊗ other.
+            QuantumError: The composition quantum error.
+
+        Raises:
+            NoiseError: if other cannot be converted into a QuantumError,
+            or has incompatible dimensions.
         """
-        warnings.warn(
-            'The kron() method is deprecated and will be removed '
-            'in a future release. Use QuantumError.tensor instead.',
-            DeprecationWarning)
-        return self.tensor(other)
+        # Convert other into a quantum error
+        if not isinstance(other, QuantumError):
+            other = QuantumError(other)
+        # Error checking
+        if self.number_of_qubits != other.number_of_qubits:
+            raise NoiseError(
+                "QuantumErrors are not defined on same number of qubits.")
+
+        combined_noise_circuits = []
+        combined_noise_probabilities = []
+
+        # Combine subcircuits and probabilities
+        if left_multiply:
+            noise_ops0 = list(
+                zip(self._noise_circuits, self._noise_probabilities))
+            noise_ops1 = list(
+                zip(other._noise_circuits, other._noise_probabilities))
+        else:
+            noise_ops0 = list(
+                zip(other._noise_circuits, other._noise_probabilities))
+            noise_ops1 = list(
+                zip(self._noise_circuits, self._noise_probabilities))
+        # Combine subcircuits and probabilities
+        for circuit0, prob0 in noise_ops0:
+            for circuit1, prob1 in noise_ops1:
+                combined_noise_probabilities.append(prob0 * prob1)
+                tmp_combined = circuit0 + circuit1
+
+                # Fuse compatible ops to reduce noise operations:
+                combined_circuit = [tmp_combined[0]]
+                for instr in tmp_combined[1:]:
+                    last_instr = combined_circuit[-1]
+                    last_name = last_instr['name']
+                    name = instr['name']
+                    can_combine = (last_name in ['id', 'kraus', 'unitary'] or
+                                   name in ['id', 'kraus', 'unitary'])
+                    if (can_combine and self._check_instr(last_name) and
+                            self._check_instr(name)):
+                        combined_circuit[-1] = self._compose_instr(
+                            last_instr, instr, self.number_of_qubits)
+                    else:
+                        # If they cannot be combined append the operation
+                        combined_circuit.append(instr)
+                # Check if circuit is empty and add identity
+                if not combined_circuit:
+                    combined_circuit.append({'name': 'id', 'qubits': [0]})
+                # Add circuit
+                combined_noise_circuits.append(combined_circuit)
+        noise_ops = self._combine_kraus(
+            zip(combined_noise_circuits, combined_noise_probabilities))
+        return QuantumError(noise_ops)
 
     def _tensor_product(self, other, reverse=False):
         """Return the tensor product error channel.
@@ -628,3 +644,33 @@ class QuantumError:
         else:
             params = [composed.data]
         return {'name': name, 'qubits': qubits, 'params': params}
+
+    # Overloads
+    def __matmul__(self, other):
+        return self.compose(other)
+
+    def __mul__(self, other):
+        return self.dot(other)
+
+    def __pow__(self, n):
+        return self.power(n)
+
+    def __xor__(self, other):
+        return self.tensor(other)
+
+    def __rmul__(self, other):
+        raise NotImplementedError(
+            "'QuantumError' does not support scalar multiplication.")
+
+    def __truediv__(self, other):
+        raise NotImplementedError("'QuantumError' does not support division.")
+
+    def __add__(self, other):
+        raise NotImplementedError("'QuantumError' does not support addition.")
+
+    def __sub__(self, other):
+        raise NotImplementedError(
+            "'QuantumError' does not support subtraction.")
+
+    def __neg__(self):
+        raise NotImplementedError("'QuantumError' does not support negation.")

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -26,83 +26,67 @@ from qiskit.providers.aer.noise.errors.errorutils import standard_gate_unitary
 
 class TestQuantumError(common.QiskitAerTestCase):
     """Testing QuantumError class"""
-
     def test_standard_gate_unitary(self):
         """Test standard gates are correct"""
+        def norm(op_a, op_b):
+            return round(np.linalg.norm(op_a - op_b), 15)
 
-        def norm(a, b):
-            return round(np.linalg.norm(a - b), 15)
-
-        self.assertEqual(
-            norm(standard_gate_unitary('id'), np.eye(2)),
-            0,
-            msg="identity matrix")
-        self.assertEqual(
-            norm(standard_gate_unitary('x'), np.array([[0, 1], [1, 0]])),
-            0,
-            msg="Pauli-X matrix")
-        self.assertEqual(
-            norm(standard_gate_unitary('y'), np.array([[0, -1j], [1j, 0]])),
-            0,
-            msg="Pauli-Y matrix")
-        self.assertEqual(
-            norm(standard_gate_unitary('z'), np.diag([1, -1])),
-            0,
-            msg="Pauli-Z matrix")
-        self.assertEqual(
-            norm(
-                standard_gate_unitary('h'),
-                np.array([[1, 1], [1, -1]]) / np.sqrt(2)),
-            0,
-            msg="Hadamard gate matrix")
-        self.assertEqual(
-            norm(standard_gate_unitary('s'), np.diag([1, 1j])),
-            0,
-            msg="Phase gate matrix")
-        self.assertEqual(
-            norm(standard_gate_unitary('sdg'), np.diag([1, -1j])),
-            0,
-            msg="Adjoint phase gate matrix")
-        self.assertEqual(
-            norm(
-                standard_gate_unitary('t'), np.diag([1,
-                                                     (1 + 1j) / np.sqrt(2)])),
-            0,
-            msg="T gate matrix")
-        self.assertEqual(
-            norm(
-                standard_gate_unitary('tdg'),
-                np.diag([1, (1 - 1j) / np.sqrt(2)])),
-            0,
-            msg="Adjoint T gate matrix")
-        self.assertEqual(
-            norm(
-                standard_gate_unitary('cx'),
-                np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0],
-                          [0, 1, 0, 0]])),
-            0,
-            msg="Controlled-NOT gate matrix")
-        self.assertEqual(
-            norm(standard_gate_unitary('cz'), np.diag([1, 1, 1, -1])),
-            0,
-            msg="Controlled-Z gate matrix")
-        self.assertEqual(
-            norm(
-                standard_gate_unitary('swap'),
-                np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0],
-                          [0, 0, 0, 1]])),
-            0,
-            msg="SWAP matrix")
-        self.assertEqual(
-            norm(
-                standard_gate_unitary('ccx'),
-                np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
-                          [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1],
-                          [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
-                          [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0, 0,
-                                                     0]])),
-            0,
-            msg="Toffoli gate matrix")
+        self.assertEqual(norm(standard_gate_unitary('id'), np.eye(2)),
+                         0,
+                         msg="identity matrix")
+        self.assertEqual(norm(standard_gate_unitary('x'),
+                              np.array([[0, 1], [1, 0]])),
+                         0,
+                         msg="Pauli-X matrix")
+        self.assertEqual(norm(standard_gate_unitary('y'),
+                              np.array([[0, -1j], [1j, 0]])),
+                         0,
+                         msg="Pauli-Y matrix")
+        self.assertEqual(norm(standard_gate_unitary('z'), np.diag([1, -1])),
+                         0,
+                         msg="Pauli-Z matrix")
+        self.assertEqual(norm(standard_gate_unitary('h'),
+                              np.array([[1, 1], [1, -1]]) / np.sqrt(2)),
+                         0,
+                         msg="Hadamard gate matrix")
+        self.assertEqual(norm(standard_gate_unitary('s'), np.diag([1, 1j])),
+                         0,
+                         msg="Phase gate matrix")
+        self.assertEqual(norm(standard_gate_unitary('sdg'), np.diag([1, -1j])),
+                         0,
+                         msg="Adjoint phase gate matrix")
+        self.assertEqual(norm(standard_gate_unitary('t'),
+                              np.diag([1, (1 + 1j) / np.sqrt(2)])),
+                         0,
+                         msg="T gate matrix")
+        self.assertEqual(norm(standard_gate_unitary('tdg'),
+                              np.diag([1, (1 - 1j) / np.sqrt(2)])),
+                         0,
+                         msg="Adjoint T gate matrix")
+        self.assertEqual(norm(
+            standard_gate_unitary('cx'),
+            np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0,
+                                                                 0]])),
+                         0,
+                         msg="Controlled-NOT gate matrix")
+        self.assertEqual(norm(standard_gate_unitary('cz'),
+                              np.diag([1, 1, 1, -1])),
+                         0,
+                         msg="Controlled-Z gate matrix")
+        self.assertEqual(norm(
+            standard_gate_unitary('swap'),
+            np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0,
+                                                                 1]])),
+                         0,
+                         msg="SWAP matrix")
+        self.assertEqual(norm(
+            standard_gate_unitary('ccx'),
+            np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
+                      [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1],
+                      [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
+                      [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0, 0, 0]])),
+                         0,
+                         msg="Toffoli gate matrix")
 
     def test_raise_probabilities_negative(self):
         """Test exception is raised for negative probabilities."""
@@ -128,38 +112,38 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_raise_probabilities_normalized_unitary_kraus(self):
         """Test exception is raised for unitary kraus probs greater than 1."""
-        A0 = np.sqrt(0.9) * np.eye(2)
-        A1 = np.sqrt(0.2) * np.diag([1, -1])
-        self.assertRaises(NoiseError, lambda: QuantumError([A0, A1]))
+        a_0 = np.sqrt(0.9) * np.eye(2)
+        a_1 = np.sqrt(0.2) * np.diag([1, -1])
+        self.assertRaises(NoiseError, lambda: QuantumError([a_0, a_1]))
 
     def test_raise_probabilities_normalized_nonunitary_kraus(self):
         """Test exception is raised for non-unitary kraus probs greater than 1."""
-        A0 = np.sqrt(0.9) * np.array([[1, 0], [0, np.sqrt(1 - 0.3)]],
-                                     dtype=complex)
-        A1 = np.sqrt(0.2) * np.array([[0, np.sqrt(0.3)], [0, 0]],
-                                     dtype=complex)
-        self.assertRaises(NoiseError, lambda: QuantumError([A0, A1]))
+        a_0 = np.sqrt(0.9) * np.array([[1, 0], [0, np.sqrt(1 - 0.3)]],
+                                      dtype=complex)
+        a_1 = np.sqrt(0.2) * np.array([[0, np.sqrt(0.3)], [0, 0]],
+                                      dtype=complex)
+        self.assertRaises(NoiseError, lambda: QuantumError([a_0, a_1]))
 
     def test_raise_non_cptp_kraus(self):
         """Test exception is raised for non-CPTP input."""
-        A0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        A1 = np.array([[0, 0], [np.sqrt(0.3), 0]], dtype=complex)
-        self.assertRaises(NoiseError, lambda: QuantumError([A0, A1]))
-        self.assertRaises(NoiseError, lambda: QuantumError([A0]))
+        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
+        a_1 = np.array([[0, 0], [np.sqrt(0.3), 0]], dtype=complex)
+        self.assertRaises(NoiseError, lambda: QuantumError([a_0, a_1]))
+        self.assertRaises(NoiseError, lambda: QuantumError([a_0]))
 
     def test_raise_non_multiqubit_kraus(self):
         """Test exception is raised for non-multiqubit input."""
-        A0 = np.sqrt(0.5) * np.diag([1, 1, 1])
-        A1 = np.sqrt(0.5) * np.diag([1, 1, -1])
-        self.assertRaises(NoiseError, lambda: QuantumError([A0, A1]))
+        a_0 = np.sqrt(0.5) * np.diag([1, 1, 1])
+        a_1 = np.sqrt(0.5) * np.diag([1, 1, -1])
+        self.assertRaises(NoiseError, lambda: QuantumError([a_0, a_1]))
 
     def test_pauli_conversion_standard_gates(self):
         """Test conversion of Pauli channel kraus to gates"""
-        Ai = np.sqrt(0.25) * standard_gate_unitary('id')
-        Ax = np.sqrt(0.25) * standard_gate_unitary('x')
-        Ay = np.sqrt(0.25) * standard_gate_unitary('y')
-        Az = np.sqrt(0.25) * standard_gate_unitary('z')
-        error_dict = QuantumError([Ai, Ax, Ay, Az],
+        a_i = np.sqrt(0.25) * standard_gate_unitary('id')
+        a_x = np.sqrt(0.25) * standard_gate_unitary('x')
+        a_y = np.sqrt(0.25) * standard_gate_unitary('y')
+        a_z = np.sqrt(0.25) * standard_gate_unitary('z')
+        error_dict = QuantumError([a_i, a_x, a_y, a_z],
                                   standard_gates=True).to_dict()
         self.assertEqual(error_dict['type'], 'qerror')
         self.assertAlmostEqual(
@@ -173,11 +157,11 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_pauli_conversion_unitary(self):
         """Test conversion of Pauli channel kraus to unitary qobj"""
-        Ai = np.sqrt(0.25) * standard_gate_unitary('id')
-        Ax = np.sqrt(0.25) * standard_gate_unitary('x')
-        Ay = np.sqrt(0.25) * standard_gate_unitary('y')
-        Az = np.sqrt(0.25) * standard_gate_unitary('z')
-        error_dict = QuantumError([Ai, Ax, Ay, Az],
+        a_i = np.sqrt(0.25) * standard_gate_unitary('id')
+        a_x = np.sqrt(0.25) * standard_gate_unitary('x')
+        a_y = np.sqrt(0.25) * standard_gate_unitary('y')
+        a_z = np.sqrt(0.25) * standard_gate_unitary('z')
+        error_dict = QuantumError([a_i, a_x, a_y, a_z],
                                   standard_gates=False).to_dict()
         self.assertEqual(error_dict['type'], 'qerror')
         self.assertAlmostEqual(
@@ -191,15 +175,15 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_tensor_both_kraus(self):
         """Test tensor of two kraus errors"""
-        A0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
+        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
+        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
+        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
+        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
         # Use quantum channels for reference
-        target = SuperOp(Kraus([A0, A1]).tensor(Kraus([B0, B1])))
-        error = QuantumError([A0, A1]).tensor(QuantumError([B0, B1]))
-        kraus, p = error.error_term(0)
-        self.assertEqual(p, 1)
+        target = SuperOp(Kraus([a_0, a_1]).tensor(Kraus([b_0, b_1])))
+        error = QuantumError([a_0, a_1]).tensor(QuantumError([b_0, b_1]))
+        kraus, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0, 1])
         error_superop = SuperOp(Kraus(kraus[0]['params']))
@@ -236,23 +220,23 @@ class TestQuantumError(common.QiskitAerTestCase):
         ]
 
         for j in range(4):
-            circ, p = error.error_term(j)
+            circ, prob = error.error_term(j)
             unitary = circ[0]['params'][0]
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0, 1])
             # Remove prob from target if it is found
             # later we will check that target_probs is empty so all
             # the required ones have been removed
-            self.remove_if_found(p, target_probs)
+            self.remove_if_found(prob, target_probs)
             self.remove_if_found(unitary, target_unitaries)
         # Check we had all the correct target probs and unitaries
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(
-            target_probs, [], msg="Incorrect tensor probabilities")
-        self.assertEqual(
-            target_unitaries, [], msg="Incorrect tensor unitaries")
+        self.assertEqual(target_probs, [],
+                         msg="Incorrect tensor probabilities")
+        self.assertEqual(target_unitaries, [],
+                         msg="Incorrect tensor unitaries")
 
     def test_tensor_both_unitary_standard_gates(self):
         """Test tensor of two unitary standard gate errors"""
@@ -297,31 +281,31 @@ class TestQuantumError(common.QiskitAerTestCase):
             'qubits': [1]
         }]]
         for j in range(4):
-            circ, p = error.error_term(j)
+            circ, prob = error.error_term(j)
             # Remove prob from target if it is found
             # later we will check that target_probs is empty so all
             # the required ones have been removed
-            self.remove_if_found(p, target_probs)
+            self.remove_if_found(prob, target_probs)
             self.remove_if_found(circ, target_circs)
         # Check we had all the correct target probs and unitaries
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(
-            target_probs, [], msg="Incorrect tensor probabilities")
+        self.assertEqual(target_probs, [],
+                         msg="Incorrect tensor probabilities")
         self.assertEqual(target_circs, [], msg="Incorrect tensor circuits")
 
     def test_expand_both_kraus(self):
         """Test expand of two kraus errors"""
-        A0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
+        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
+        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
+        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
+        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
         # Use quantum channels for reference
-        target = SuperOp(Kraus([A0, A1]).expand(Kraus([B0, B1])))
-        error = QuantumError([A0, A1]).expand(QuantumError([B0, B1]))
-        kraus, p = error.error_term(0)
-        self.assertEqual(p, 1)
+        target = SuperOp(Kraus([a_0, a_1]).expand(Kraus([b_0, b_1])))
+        error = QuantumError([a_0, a_1]).expand(QuantumError([b_0, b_1]))
+        kraus, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0, 1])
         error_superop = SuperOp(Kraus(kraus[0]['params']))
@@ -358,23 +342,23 @@ class TestQuantumError(common.QiskitAerTestCase):
         ]
 
         for j in range(4):
-            circ, p = error.error_term(j)
+            circ, prob = error.error_term(j)
             unitary = circ[0]['params'][0]
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0, 1])
             # Remove prob from target if it is found
             # later we will check that target_probs is empty so all
             # the required ones have been removed
-            self.remove_if_found(p, target_probs)
+            self.remove_if_found(prob, target_probs)
             self.remove_if_found(unitary, target_unitaries)
         # Check we had all the correct target probs and unitaries
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(
-            target_probs, [], msg="Incorrect expand probabilities")
-        self.assertEqual(
-            target_unitaries, [], msg="Incorrect expand unitaries")
+        self.assertEqual(target_probs, [],
+                         msg="Incorrect expand probabilities")
+        self.assertEqual(target_unitaries, [],
+                         msg="Incorrect expand unitaries")
 
     def test_expand_both_unitary_standard_gates(self):
         """Test expand of two unitary standard gate errors"""
@@ -419,18 +403,18 @@ class TestQuantumError(common.QiskitAerTestCase):
             'qubits': [1]
         }]]
         for j in range(4):
-            circ, p = error.error_term(j)
+            circ, prob = error.error_term(j)
             # Remove prob from target if it is found
             # later we will check that target_probs is empty so all
             # the required ones have been removed
-            self.remove_if_found(p, target_probs)
+            self.remove_if_found(prob, target_probs)
             self.remove_if_found(circ, target_circs)
         # Check we had all the correct target probs and unitaries
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(
-            target_probs, [], msg="Incorrect expand probabilities")
+        self.assertEqual(target_probs, [],
+                         msg="Incorrect expand probabilities")
         self.assertEqual(target_circs, [], msg="Incorrect expand circuits")
 
     def test_raise_compose_different_dim(self):
@@ -443,15 +427,24 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_compose_both_kraus(self):
         """Test composition of two kraus errors"""
-        A0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
+        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
+        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
+        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
+        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
         # Use quantum channels for reference
-        target = SuperOp(Kraus([A0, A1]).compose(Kraus([B0, B1])))
-        error = QuantumError([A0, A1]).compose(QuantumError([B0, B1]))
-        kraus, p = error.error_term(0)
-        self.assertEqual(p, 1)
+        target = SuperOp(Kraus([a_0, a_1]).compose(Kraus([b_0, b_1])))
+        # Compose method
+        error = QuantumError([a_0, a_1]).compose(QuantumError([b_0, b_1]))
+        kraus, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(kraus[0]['name'], 'kraus')
+        self.assertEqual(kraus[0]['qubits'], [0])
+        error_superop = SuperOp(Kraus(kraus[0]['params']))
+        self.assertEqual(target, error_superop, msg="Incorrect compose kraus")
+        # @ method
+        error = QuantumError([a_0, a_1]) @ QuantumError([b_0, b_1])
+        kraus, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0])
         error_superop = SuperOp(Kraus(kraus[0]['params']))
@@ -466,11 +459,13 @@ class TestQuantumError(common.QiskitAerTestCase):
         error0 = QuantumError([
             np.sqrt(probs0[0]) * unitaries0[0],
             np.sqrt(probs0[1]) * unitaries0[1]
-        ], standard_gates=False)
+        ],
+                              standard_gates=False)
         error1 = QuantumError([
             np.sqrt(probs1[0]) * unitaries1[0],
             np.sqrt(probs1[1]) * unitaries1[1]
-        ], standard_gates=False)
+        ],
+                              standard_gates=False)
         error = error0.compose(error1)
         # Kronecker product unitaries
         target_unitaries = [
@@ -486,23 +481,23 @@ class TestQuantumError(common.QiskitAerTestCase):
         ]
 
         for j in range(4):
-            circ, p = error.error_term(j)
+            circ, prob = error.error_term(j)
             unitary = circ[0]['params'][0]
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0])
             # Remove prob from target if it is found
             # later we will check that target_probs is empty so all
             # the required ones have been removed
-            self.remove_if_found(p, target_probs)
+            self.remove_if_found(prob, target_probs)
             self.remove_if_found(unitary, target_unitaries)
         # Check we had all the correct target probs and unitaries
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(
-            target_probs, [], msg="Incorrect compose probabilities")
-        self.assertEqual(
-            target_unitaries, [], msg="Incorrect compose unitaries")
+        self.assertEqual(target_probs, [],
+                         msg="Incorrect compose probabilities")
+        self.assertEqual(target_unitaries, [],
+                         msg="Incorrect compose unitaries")
 
     def test_compose_both_qobj(self):
         """Test composition of two circuit errors"""
@@ -513,11 +508,13 @@ class TestQuantumError(common.QiskitAerTestCase):
         error0 = QuantumError([
             np.sqrt(probs0[0]) * unitaries0[0],
             np.sqrt(probs0[1]) * unitaries0[1]
-        ], standard_gates=True)
+        ],
+                              standard_gates=True)
         error1 = QuantumError([
             np.sqrt(probs1[0]) * unitaries1[0],
             np.sqrt(probs1[1]) * unitaries1[1]
-        ], standard_gates=True)
+        ],
+                              standard_gates=True)
         error = error0.compose(error1)
         # Kronecker product probabilities
         target_probs = [
@@ -545,38 +542,51 @@ class TestQuantumError(common.QiskitAerTestCase):
             'qubits': [0]
         }]]
         for j in range(4):
-            circ, p = error.error_term(j)
+            circ, prob = error.error_term(j)
             # Remove prob from target if it is found
             # later we will check that target_probs is empty so all
             # the required ones have been removed
-            self.remove_if_found(p, target_probs)
+            self.remove_if_found(prob, target_probs)
             self.remove_if_found(circ, target_circs)
         # Check we had all the correct target probs and unitaries
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(
-            target_probs, [], msg="Incorrect compose probabilities")
+        self.assertEqual(target_probs, [],
+                         msg="Incorrect compose probabilities")
         self.assertEqual(target_circs, [], msg="Incorrect compose circuits")
 
-    def test_compose_front_both_kraus(self):
-        """Test front composition of two kraus errors"""
-        A0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
+    def test_dot_both_kraus(self):
+        """Test dot of two kraus errors"""
+        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
+        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
+        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
+        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
         # Use quantum channels for reference
-        target = SuperOp(Kraus([A0, A1]).compose(Kraus([B0, B1]), front=True))
-        error = QuantumError([A0, A1]).compose(QuantumError([B0, B1]), front=True)
-        kraus, p = error.error_term(0)
-        self.assertEqual(p, 1)
+        target = SuperOp(Kraus([b_0, b_1]).compose(Kraus([a_0, a_1])))
+        # dot method
+        error = QuantumError([a_0, a_1]).dot(QuantumError([b_0, b_1]))
+        kraus, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0])
         error_superop = SuperOp(Kraus(kraus[0]['params']))
-        self.assertEqual(target, error_superop, msg="Incorrect front compose kraus")
+        self.assertEqual(target,
+                         error_superop,
+                         msg="Incorrect kraus dot method")
+        # * method
+        error = QuantumError([a_0, a_1]) * QuantumError([b_0, b_1])
+        kraus, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(kraus[0]['name'], 'kraus')
+        self.assertEqual(kraus[0]['qubits'], [0])
+        error_superop = SuperOp(Kraus(kraus[0]['params']))
+        self.assertEqual(target,
+                         error_superop,
+                         msg="Incorrect kraus dot method")
 
-    def test_compose_front_both_unitary(self):
-        """Test front composition of two unitary errors."""
+    def test_dot_both_unitary(self):
+        """Test dot of two unitary errors."""
         unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
         probs0 = [0.9, 0.1]
         unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
@@ -591,7 +601,7 @@ class TestQuantumError(common.QiskitAerTestCase):
             np.sqrt(probs1[1]) * unitaries1[1]
         ],
                               standard_gates=False)
-        error = error1.compose(error0, front=True)
+        error = error1.dot(error0)
         # Kronecker product unitaries
         target_unitaries = [
             np.dot(unitaries1[0], unitaries0[0]),
@@ -606,26 +616,26 @@ class TestQuantumError(common.QiskitAerTestCase):
         ]
 
         for j in range(4):
-            circ, p = error.error_term(j)
+            circ, prob = error.error_term(j)
             unitary = circ[0]['params'][0]
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0])
             # Remove prob from target if it is found
             # later we will check that target_probs is empty so all
             # the required ones have been removed
-            self.remove_if_found(p, target_probs)
+            self.remove_if_found(prob, target_probs)
             self.remove_if_found(unitary, target_unitaries)
         # Check we had all the correct target probs and unitaries
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(
-            target_probs, [], msg="Incorrect compose probabilities")
-        self.assertEqual(
-            target_unitaries, [], msg="Incorrect compose unitaries")
+        self.assertEqual(target_probs, [],
+                         msg="Incorrect compose probabilities")
+        self.assertEqual(target_unitaries, [],
+                         msg="Incorrect compose unitaries")
 
-    def test_compose_front_both_qobj(self):
-        """Test front composition of two circuit errors"""
+    def test_dot_both_qobj(self):
+        """Test dot of two circuit errors"""
         unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
         probs0 = [0.9, 0.1]
         unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
@@ -640,7 +650,7 @@ class TestQuantumError(common.QiskitAerTestCase):
             np.sqrt(probs1[1]) * unitaries1[1]
         ],
                               standard_gates=True)
-        error = error1.compose(error0, front=True)
+        error = error1.dot(error0)
         # Kronecker product probabilities
         target_probs = [
             probs1[0] * probs0[0], probs1[0] * probs0[1],
@@ -650,7 +660,7 @@ class TestQuantumError(common.QiskitAerTestCase):
         target_circs = [[{
             'name': 'x',
             'qubits': [0]
-        }], [ {
+        }], [{
             'name': 'y',
             'qubits': [0]
         }], [{
@@ -667,28 +677,28 @@ class TestQuantumError(common.QiskitAerTestCase):
             'qubits': [0]
         }]]
         for j in range(4):
-            circ, p = error.error_term(j)
+            circ, prob = error.error_term(j)
             # Remove prob from target if it is found
             # later we will check that target_probs is empty so all
             # the required ones have been removed
-            self.remove_if_found(p, target_probs)
+            self.remove_if_found(prob, target_probs)
             self.remove_if_found(circ, target_circs)
         # Check we had all the correct target probs and unitaries
         # by seeing if these lists are empty
         # Note that this doesn't actually check that the correct
         # prob was assigned to the correct unitary.
-        self.assertEqual(
-            target_probs, [], msg="Incorrect compose probabilities")
+        self.assertEqual(target_probs, [],
+                         msg="Incorrect compose probabilities")
         self.assertEqual(target_circs, [], msg="Incorrect compose circuits")
 
     def test_to_quantumchannel_kraus(self):
         """Test to_quantumchannel for Kraus inputs."""
-        A0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        A1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        B0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        B1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
-        target = SuperOp(Kraus([A0, A1])).tensor(SuperOp(Kraus([B0, B1])))
-        error = QuantumError([A0, A1]).tensor(QuantumError([B0, B1]))
+        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
+        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
+        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
+        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
+        target = SuperOp(Kraus([a_0, a_1])).tensor(SuperOp(Kraus([b_0, b_1])))
+        error = QuantumError([a_0, a_1]).tensor(QuantumError([b_0, b_1]))
         self.assertEqual(target, error.to_quantumchannel())
 
     def test_to_quantumchannel_circuit(self):
@@ -713,12 +723,12 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_equal(self):
         """Test two quantum errors are equal"""
-        Ai = np.sqrt(0.25) * standard_gate_unitary('id')
-        Ax = np.sqrt(0.25) * standard_gate_unitary('x')
-        Ay = np.sqrt(0.25) * standard_gate_unitary('y')
-        Az = np.sqrt(0.25) * standard_gate_unitary('z')
-        error1 = QuantumError([Ai, Ax, Ay, Az], standard_gates=True)
-        error2 = QuantumError([Ai, Ax, Ay, Az], standard_gates=False)
+        a_i = np.sqrt(0.25) * standard_gate_unitary('id')
+        a_x = np.sqrt(0.25) * standard_gate_unitary('x')
+        a_y = np.sqrt(0.25) * standard_gate_unitary('y')
+        a_z = np.sqrt(0.25) * standard_gate_unitary('z')
+        error1 = QuantumError([a_i, a_x, a_y, a_z], standard_gates=True)
+        error2 = QuantumError([a_i, a_x, a_y, a_z], standard_gates=False)
         self.assertEqual(error1, error2)
 
 

--- a/test/terra/noise/test_readout_error.py
+++ b/test/terra/noise/test_readout_error.py
@@ -14,17 +14,16 @@ ReadoutError class tests
 """
 
 import unittest
+from test.terra import common
 
 import numpy as np
 
-from test.terra import common
 from qiskit.providers.aer.noise.noiseerror import NoiseError
 from qiskit.providers.aer.noise.errors.readout_error import ReadoutError
 
 
 class TestReadoutError(common.QiskitAerTestCase):
     """Testing ReadoutError class"""
-
     def test_probabilities_normalized_exception(self):
         """Test exception is raised for probabilities greater than 1."""
         probs = [[0.9, 0.2], [0, 1]]
@@ -146,14 +145,19 @@ class TestReadoutError(common.QiskitAerTestCase):
         }
         error0 = ReadoutError(probs0)
         error1 = ReadoutError(probs1)
+        # compose method
         error = error0.compose(error1)
-
+        self.assertEqual(error.number_of_qubits, 1)
+        self.assertEqual(error.probabilities.tolist(), probs)
+        self.assertEqual(error.to_dict(), error_dict)
+        # @ method
+        error = error0 @ error1
         self.assertEqual(error.number_of_qubits, 1)
         self.assertEqual(error.probabilities.tolist(), probs)
         self.assertEqual(error.to_dict(), error_dict)
 
-    def test_compose_front(self):
-        """Test front compose of two readout errors."""
+    def test_dot_front(self):
+        """Test dot of two readout errors."""
         probs0 = [[0.9, 0.1], [0.4, 0.6]]
         probs1 = [[0.5, 0.5], [0.2, 0.8]]
         probs = np.dot(probs1, probs0).tolist()
@@ -164,8 +168,13 @@ class TestReadoutError(common.QiskitAerTestCase):
         }
         error0 = ReadoutError(probs0)
         error1 = ReadoutError(probs1)
-        error = error1.compose(error0, front=True)
-
+        # dot method
+        error = error1.dot(error0)
+        self.assertEqual(error.number_of_qubits, 1)
+        self.assertEqual(error.probabilities.tolist(), probs)
+        self.assertEqual(error.to_dict(), error_dict)
+        # * method
+        error = error1 * error0
         self.assertEqual(error.number_of_qubits, 1)
         self.assertEqual(error.probabilities.tolist(), probs)
         self.assertEqual(error.to_dict(), error_dict)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates QuantumError and ReadoutError to be consistent with changes to `Operator` API that will be introduced in Terra 0.12.

### Details and comments

* Add `dot` method to `QuantumError` and `ReadoutError`
* Add operator overloads for *, @, ^ for dot, compose, tensor to
  `QuantumError` and `ReadoutError`
* Raise `NotImplementedError` for overloads +, -, /. scalar *, as these aren't
  supported for`QuantumError`, `ReadoutError`.
* Deprecate `front=True` kwarg of compose for `QuantumError`, `ReadoutError`
* Remove deprecated `kron` method from `QuantumError`
* Fixes linting errors in the test files for QuantumError and ReadoutError