### PR TITLE
Fix incorrect stage name for wheel jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -223,11 +223,11 @@ jobs:
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.5.6
-    # "wheels" stage
+    # "deploy" stage
     ##########################################################################
     #
     - name: Release Linux Wheel Builds and Upload
-      stage: wheels
+      stage: deploy
       language: python
       python: 3.7
       os: linux
@@ -248,7 +248,7 @@ jobs:
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - name: sdist Build and Upload
-      stage: wheels
+      stage: deploy
       if: tag IS present
       <<: *stage_linux
       env:
@@ -261,7 +261,7 @@ jobs:
         - twine upload dist/*
     - name: Release MacOS Wheel Builds and Upload
       os: osx
-      stage: wheels
+      stage: deploy
       if: tag IS present
       env:
         - CIBW_BEFORE_BUILD="pip install -U Cython pip virtualenv pybind11"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #168 a small oversight was made in the last
revision to that PR. The name of the stage was updated from wheels to
deploy, but the stage listed for the individual jobs was never updated.
This commit corrects the oversight and uses a consistent stage name for
the new jobs.

### Details and comments