### PR TITLE
 * Add "omp_get_num_procs" symbol to the list of hooks

### DIFF
--- a/src/misc/clang_omp_symbols.hpp
+++ b/src/misc/clang_omp_symbols.hpp
@@ -196,6 +196,11 @@ extern "C" {
     void __KAI_KMPC_CONVENTION omp_set_nested(int foo){
         _hook_omp_set_nested(foo);
     }
+    using omp_get_num_procs_t = int(*)(void);
+    omp_get_num_procs_t _hook_omp_get_num_procs;
+    int __KAI_KMPC_CONVENTION omp_get_num_procs(void) {
+        return _hook_omp_get_num_procs();
+    }
 
 
     // Symbols above this line would be needed in a future, if clang changes
@@ -294,6 +299,7 @@ void populate_hooks(void * handle){
     _hook__kmpc_end_critical = reinterpret_cast<decltype(&__kmpc_end_critical)>(dlsym(handle, "__kmpc_end_critical"));
     _hook_omp_get_max_threads = reinterpret_cast<decltype(&omp_get_max_threads)>(dlsym(handle, "omp_get_max_threads"));
     _hook_omp_set_nested = reinterpret_cast<decltype(&omp_set_nested)>(dlsym(handle, "omp_set_nested"));
+    _hook_omp_get_num_procs = reinterpret_cast<decltype(&omp_get_num_procs)>(dlsym(handle, "omp_get_num_procs"));
 }
 
 }

--- a/src/misc/gcc_omp_symbols.hpp
+++ b/src/misc/gcc_omp_symbols.hpp
@@ -81,6 +81,11 @@ extern "C" {
     int __KAI_KMPC_CONVENTION omp_get_thread_num(void) {
         return _hook_omp_get_thread_num();
     }
+    using omp_get_num_procs_t = int(*)(void);
+    omp_get_num_procs_t _hook_omp_get_num_procs;
+    int __KAI_KMPC_CONVENTION omp_get_num_procs(void) {
+        return _hook_omp_get_num_procs();
+    }
 }
 
 namespace AER {
@@ -97,6 +102,7 @@ namespace Hacks {
         _hook_omp_get_max_threads = reinterpret_cast<decltype(&omp_get_max_threads)>(dlsym(handle, "omp_get_max_threads"));
         _hook_omp_set_nested = reinterpret_cast<decltype(&omp_set_nested)>(dlsym(handle, "omp_set_nested"));
         _hook_omp_get_thread_num = reinterpret_cast<decltype(&omp_get_thread_num)>(dlsym(handle, "omp_get_thread_num"));
+        _hook_omp_get_num_procs = reinterpret_cast<decltype(&omp_get_num_procs)>(dlsym(handle, "omp_get_num_procs"));
     }
 }
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
When we add support for new versions of the compilers, or when we add code that
uses OpenMP, new symbols can show up and we need to add them to a list of symbols
we hook in order to avoid the multiple initialization constraint of libomp on MacOS.
This time we have added new OpenMP code that internally uses omp_get_num_procs()
function, so we have to add this new symbol to the list.


