### PR TITLE
Move Muparserx related things to Terra Add-on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,19 +203,6 @@ else()
 	set(SPDLOG_LIB "")
 endif()
 
-message(STATUS "Uncompressing muparserx static library...")
-
-uncompress_muparsersx_lib()
-
-find_library(MUPARSERX_LIB NAMES libmuparserx.a muparserx HINTS ${MUPARSERX_LIB_PATH})
-if(${MUPARSERX_LIB} MATCHES "MUPARSERX_LIB-NOTFOUND")
-	message(FATAL_ERROR "No muparserx library found")
-endif()
-message(STATUS "Muparserx library found: ${MUPARSERX_LIB}")
-get_muparserx_source_code()
-# I keep this disabled on purpose, just in case I need to debug muparserx related problems
-# file(GLOB MUPARSERX_SOURCES "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/headers/muparserx/parser/*.cpp")
-
 # Windows don't have a DL library (dlopen, dlclose, etc...)
 if(NOT MSVC)
 	find_library(DL_LIB NAMES dl)
@@ -268,11 +255,12 @@ set(AER_LIBRARIES
 	Threads::Threads
 	${SPDLOG_LIB}
 	${DL_LIB}
-	${MUPARSERX_LIB}
 	${THRUST_DEPENDANT_LIBS})
 
 # Cython build is only enabled if building through scikit-build.
 if(SKBUILD) # Terra Addon build
+	add_muparserx_lib()
+
 	add_subdirectory(qiskit/providers/aer/pulse/cy)
 	add_subdirectory(qiskit/providers/aer/pulse/qutip_lite/cy)
 	add_subdirectory(qiskit/providers/aer/backends/wrappers)

--- a/cmake/compiler_utils.cmake
+++ b/cmake/compiler_utils.cmake
@@ -114,3 +114,19 @@ function(uncompress_muparsersx_lib)
             WORKING_DIRECTORY  "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/${PLATFORM}/lib/")
     set(MUPARSERX_LIB_PATH "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/${PLATFORM}/lib" PARENT_SCOPE)
 endfunction()
+
+function(add_muparserx_lib)
+    message(STATUS "Uncompressing muparserx static library...")
+    uncompress_muparsersx_lib()
+
+    find_library(MUPARSERX_LIB NAMES libmuparserx.a muparserx HINTS ${MUPARSERX_LIB_PATH})
+    if(${MUPARSERX_LIB} MATCHES "MUPARSERX_LIB-NOTFOUND")
+        message(FATAL_ERROR "No muparserx library found")
+    endif()
+    message(STATUS "Muparserx library found: ${MUPARSERX_LIB}")
+    get_muparserx_source_code()
+    # I keep this disabled on purpose, just in case I need to debug muparserx related problems
+    # file(GLOB MUPARSERX_SOURCES "${AER_SIMULATOR_CPP_SRC_DIR}/third-party/headers/muparserx/parser/*.cpp")
+
+    set(AER_LIBRARIES ${AER_LIBRARIES} ${MUPARSERX_LIB} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Move Muparserx library related things in CMake to Terra-Addon build.

### Details and comments
Muparserx libraries are not needed by standalone tool. Moved to Terra addon build as requested by Chris



