### PR TITLE
Small fix in cmake to try make travis work with sdist

### DIFF
--- a/cmake/compiler_utils.cmake
+++ b/cmake/compiler_utils.cmake
@@ -34,7 +34,7 @@ function(get_version version_str)
 endfunction()
 
 function(is_dir_empty dir)
-    file(GLOB RESULT dir)
+    file(GLOB RESULT ${dir})
     list(LENGTH RESULT num_files)
     if(num_files EQUAL 0)
         set(dir_is_empty TRUE PARENT_SCOPE)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix to make travis work with sdist

### Details and comments
Cmake was incorrectly considering the muparserx header dir empty although it was not.

