### PR TITLE
enable fusion by default for 20 or more qubits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Changed
 - Moved the location of several functions (\#568):
   - Moved contents of `qiskit.provider.aer.noise.errors` into the `qiskit.providers.noise` module
   - Moved contents of `qiskit.provider.aer.noise.utils` into the `qiskit.provider.aer.utils` module.
+- Enabled optimization to aggregate consecutive gates in a circuit (fusion) by default (\#579).
 
 Deprecated
 ----------

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -99,6 +99,16 @@ namespace Simulator {
  *      If specified, is divided by the number of parallel shots/experiments.
  *      [Default: 0]
  *
+ * From Transpile:Fision Class
+ * - fusion_enable (bool): Enable fusion optimization in circuit optimization
+ *       passes [Default: True]
+ * - fusion_verbose (bool): Output gates generated in fusion optimization
+ *       into metadata [Default: False]
+ * - fusion_max_qubit (int): Maximum number of qubits for a operation generated
+ *       in a fusion optimization [Default: 5]
+ * - fusion_threshold (int): Threshold that number of qubits must be greater
+ *       than or equal to enable fusion optimization [Default: 20]
+ *
  **************************************************************************/
 
 class QasmController : public Base::Controller {

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -30,16 +30,21 @@ using reg_t = std::vector<uint_t>;
 class Fusion : public CircuitOptimization {
 public:
   // constructor
-  Fusion(uint_t max_qubit = 5, uint_t threshold = 16, double cost_factor = 1.8);
+  Fusion(uint_t max_qubit = 5, uint_t threshold = 20, double cost_factor = 1.8);
 
   /*
    * Fusion optimization uses following configuration options
-   *   - fusion_verbose (bool): if true, output generated gates in metadata (default: false)
-   *   - fusion_enable (bool): if true, activate fusion optimization (default: false)
-   *   - fusion_max_qubit (int): maximum number of qubits for a operation (default: 5)
-   *   - fusion_threshold (int): a threshold to activate fusion optimization when fusion_enable is true (default: 16)
-   *   - fusion_cost_factor (double): a cost function to estimate an aggregate gate (default: 1.8)
-  */
+   * - fusion_enable (bool): Enable fusion optimization in circuit optimization
+   *       passes [Default: True]
+   * - fusion_verbose (bool): Output gates generated in fusion optimization
+   *       into metadata [Default: False]
+   * - fusion_max_qubit (int): Maximum number of qubits for a operation generated
+   *       in a fusion optimization [Default: 5]
+   * - fusion_threshold (int): Threshold that number of qubits must be greater
+   *       than to enable fusion optimization [Default: 20]
+   * - fusion_cost_factor (double): a cost function to estimate an aggregate
+   *       gate [Default: 1.8]
+   */
   void set_config(const json_t &config) override;
 
   void optimize_circuit(Circuit& circ,
@@ -94,7 +99,7 @@ private:
   uint_t threshold_;
   double cost_factor_;
   bool verbose_ = false;
-  bool active_ = false;
+  bool active_ = true;
 };
 
 const std::vector<std::string> Fusion::supported_gates({

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -258,6 +258,51 @@ class QasmFusionTests:
             ['metadata'],
             msg="fusion must not work by default for satevector")
 
+
+    def test_default_fusion(self):
+        """Test default Fusion option"""
+        default_threshold = 20
+        shots = 100
+        circuit = qft_circuit(default_threshold - 1, measure=True)
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed_simulator=1)
+
+        backend_options = self.BACKEND_OPTS.copy()
+        backend_options['fusion_verbose'] = True
+        backend_options['optimize_ideal_threshold'] = 1
+        backend_options['optimize_noise_threshold'] = 1
+
+        result_verbose = self.SIMULATOR.run(
+            qobj,
+            backend_options=backend_options).result()
+        self.assertTrue(getattr(result_verbose, 'success', 'False'))
+        self.assertTrue(
+            'results' in result_verbose.to_dict(),
+            msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result_verbose.to_dict()['results'][0],
+            msg="metadata must not exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' not in result_verbose.to_dict()['results'][0]
+            ['metadata'],
+            msg="fusion must work for satevector")
+
+        circuit = qft_circuit(default_threshold, measure=True)
+        qobj = assemble([circuit], self.SIMULATOR, shots=shots, seed_simulator=1)
+        result_verbose = self.SIMULATOR.run(
+            qobj,
+            backend_options=backend_options).result()
+        self.assertTrue(getattr(result_verbose, 'success', 'False'))
+        self.assertTrue(
+            'results' in result_verbose.to_dict(),
+            msg="results must exist in result")
+        self.assertTrue(
+            'metadata' in result_verbose.to_dict()['results'][0],
+            msg="metadata must exist in results[0]")
+        self.assertTrue(
+            'fusion_verbose' in result_verbose.to_dict()['results'][0]
+            ['metadata'],
+            msg="fusion must work for satevector")
+        
     def test_fusion_operations(self):
         """Test Fusion enable/disable option"""
         shots = 100


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Enable fusion optimization for all the circuits with 20 or more qubits by default

### Details and comments
If a circuit uses 20 or more qubits, fusion works efficiently. 

**Performance of Quantum Volume (Red: Fusion-enabled, Blue: Fusion-disabled)**
<img width="291" alt="image" src="https://user-images.githubusercontent.com/13864484/73719419-b78c1700-4762-11ea-85f7-f065da45b1a1.png">

**Performance of [QCBM](https://github.com/Roger-luo/quantum-benchmarks) (Red: Fusion-enabled, Blue: Fusion-disabled)**
<img width="293" alt="image" src="https://user-images.githubusercontent.com/13864484/73719503-02a62a00-4763-11ea-8e2b-124d3e4a130e.png">

**Performance of QFT**
<img width="291" alt="image" src="https://user-images.githubusercontent.com/13864484/73719517-0f2a8280-4763-11ea-94cb-041cfebc84b7.png">

Configuration
```
Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz x2, 376G RAM
Ubuntu 18.04.3 LTS, GCC 7.4.0
```