### PR TITLE
[Stable] Fix issue with wheel automation from first attempt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -269,7 +269,7 @@ jobs:
         - CIBW_TEST_REQUIRES="git+https://github.com/Qiskit/qiskit-terra.git"
       if: tag IS present
       script:
-        - pip install -U pip virtualenv
+        - pip install -U pip virtualenv twine
         - pip install cibuildwheel==1.1.0
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
@@ -280,7 +280,8 @@ jobs:
       env:
         - TWINE_USERNAME=qiskit
       python: 3.7
-      before_script: true
+      before_script:
+        - pip install -U pip setuptools virtualenv twine
       install: true
       script:
         - python setup.py sdist

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,8 +4,13 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
-- master
-- stable
+  branches:
+    include:
+      - master
+      - stable/*
+  tags:
+    include:
+      - '*'
 
 stages:
   - stage: 'Wheel_Builds'
@@ -55,6 +60,7 @@ stages:
           inputs: {pathtoPublish: 'wheelhouse'}
           condition: succeededOrFailed()
         - bash: |
+            pip install -U twine
             twine upload wheelhouse/*
           env:
             TWINE_PASSWORD: $(TWINE_PASSWORD)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We recently pushed out the 0.4.0 release which was our first attempt of
using the wheel automation in production. There were a few issues
identified by the process, first several jobs forgot to add twine to the
install. This was not caught because we never tested the actual wheel
upload during the dry runs. Then for the sdist job we needed to update
the version of pip used in the job to actually be able to install some
of aer's build dependencies. The last oversight was that we never added
the additional trigger for tags to trigger the wheel jobs on azure
pipelines. This meant at release time the jobs never got triggered or
ran. This commit fixes all these issues so for the next release the
process should all work correctly.

### Details and comments

Backported from #589
(cherry picked from commit 83b2c726a48daae298449aa0e3acf87e3f5d1501)