### PR TITLE
Add terra to the aer requirements list

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-# Qiskit dep has been removed because we want to test against master Qiskit Terra branch
 cmake
 scikit-build
 cython

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ except ImportError:
 import setuptools
 
 requirements = [
+    'qiskit-terra>=0.12.0',
     'numpy>=1.13',
     'scipy>=1.0',
     'cython>=0.27.1',


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Installing the qiskit-aer python package always requires terra. This is
primarily because of the package namespacing the qiskit.providers package
doesn't exist outside of terra. But also because the majority of the
python functionality exposed via qiskit-aer depends on terra's api. We
should be enforcing that when you install aer terra is installed (and at
the correct version). Otherwise people could install aer and never get
it working.

### Details and comments