### PR TITLE
[Stable] Bump minimum required version of numpy (#594)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except ImportError:
 import setuptools
 
 requirements = [
-    'numpy>=1.13',
+    'numpy>=1.16.3',
     'scipy>=1.0',
     'cython>=0.27.1',
     'pybind11>=2.4'  # This isn't really an install requirement,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

It appears that the newly added pulse simulator has an implicit
requirement on having a newer version of numpy installed. We should
encode this minimum in the aer package requirements so people don't
accidentally install aer with a version of numpy too old to work.

### Details and comments

(cherry picked from commit 12f97c8ba24e733633bc36077e76faf485a4e5eb)

Backported from #594 
Fixes #592