### PR TITLE
Switch linux wheel compile job to mirror deploy job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,10 +139,22 @@ jobs:
     # Linux Wheel
     - stage: compile
       name: Python Wheel Build Linux
-      <<: *stage_linux
-      before_script: true
+      language: python
+      python: 3.7
+      os: linux
+      services:
+        - docker
+      env:
+        - CIBW_BEFORE_BUILD="pip install -U Cython pip virtualenv pybind11 && yum install -y openblas-devel"
+        - CIBW_SKIP="cp27-* cp34-* *-manylinux_i686"
+        - CIBW_MANYLINUX_X86_64_IMAGE="manylinux2010"
+        - CIBW_MANYLINUX_I686_IMAGE="manylinux2010"
+        - CIBW_TEST_COMMAND="python3 {project}/tools/verify_wheels.py"
+        - CIBW_TEST_REQUIRES="git+https://github.com/Qiskit/qiskit-terra.git"
       script:
-        - python setup.py bdist_wheel -- -DCMAKE_CXX_COMPILER=g++-7 -DAER_THRUST_BACKEND=OMP -- -j4
+        - pip install -U pip virtualenv twine
+        - pip install cibuildwheel==1.1.0
+        - cibuildwheel --output-dir wheelhouse
     - stage: compile
       name: Python sdist Build Linux
       <<: *stage_linux


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the linux wheel compile job to mirror the
configuration we use for building wheels on linux at release time. This
adds 2 additional points of coverage. the first and most importantly is
that python packaging on linux has stringent requitements [1] that
require us to publish wheels in a specific docker image. To make sure
that we don't introduce a change that breaks compilation (since there
have been issues with that in the past) with that limitation we should
build wheels in that environment in CI. The second aspect of additional
coverage here is that it adds compilation of all supported python
versions.

### Details and comments

[1] https://www.python.org/dev/peps/pep-0571/