### PR TITLE
Fix gate fusion bug

### DIFF
--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -197,7 +197,7 @@ public:
   void insert(const std::vector<Op> &ops);
 
   //-----------------------------------------------------------------------
-  // Check if operations are in all in the OpSet
+  // Check if operations are in the OpSet
   //-----------------------------------------------------------------------
 
   // Return true if an operation is contained in the current OpSet

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -197,6 +197,13 @@ public:
   void insert(const std::vector<Op> &ops);
 
   //-----------------------------------------------------------------------
+  // Check if operations are in all in the OpSet
+  //-----------------------------------------------------------------------
+
+  // Return true if an operation is contained in the current OpSet
+  bool contains(const OpType &optype) const;
+
+  //-----------------------------------------------------------------------
   // Validate OpSet against sets of allowed operations
   //-----------------------------------------------------------------------
 
@@ -286,6 +293,12 @@ void OpSet::insert(const OpSet &opset) {
                 opset.gates.end());
   snapshots.insert(opset.snapshots.begin(),
                     opset.snapshots.end());
+}
+
+bool OpSet::contains(const OpType &optype) const {
+  if (optypes.find(optype) == optypes.end())
+    return false;
+  return true;
 }
 
 bool OpSet::validate(const optypeset_t &allowed_ops,
@@ -410,18 +423,6 @@ inline Op make_superop(const reg_t &qubits, const cmatrix_t &mat) {
   op.name = "superop";
   op.qubits = qubits;
   op.mats = {mat};
-  return op;
-}
-
-inline Op make_fusion(const reg_t &qubits, const cmatrix_t &mat, const std::vector<Op>& fusioned_ops, std::string label = "") {
-  Op op;
-  op.type = OpType::matrix;
-  op.name = "fusion";
-  op.qubits = qubits;
-  op.mats = {mat};
-  if (label != "")
-    op.string_params = {label};
-
   return op;
 }
 

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -607,9 +607,7 @@ void State::apply_matrix(const reg_t &qubits, const cmatrix_t &mat) {
     qreg_.apply_matrix(qubits, mat);
     return;
   }
-#ifdef DEBUG
-  cout << "Currently only support matrices applied to 1 or 2 qubits";
-#endif
+  throw std::runtime_error("\"matrix_product_state\" method only supports 1 and 2 qubit unitary matrices.");
 }
 
   void State::apply_matrix(const reg_t &qubits, const cvector_t &vmat) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #604 

1. Fixes bugs in gate fusion transpilation pass where the pass was not checking that unitary gates (`OpType::matrix`) where in the allowed instructions of simulator. This was causing simulations on the stabilizer simulator to fail for example when fusion was enabled automatically.

2. Fixes name of fusion instruction to be "unitary" rather than "fusion", and instead uses "fusion" is as the unitary gate label.

3. Adds exception to MPS simulator if it tries to apply a larger than 2-qubit gate. Previously this was silently ignoring the instruction.

### Details and comments
