### PR TITLE
[stable] Removes static numpy initialization strategy for the Pulse simulator  (#609)

### DIFF
--- a/src/open_pulse/numeric_integrator.cpp
+++ b/src/open_pulse/numeric_integrator.cpp
@@ -123,7 +123,7 @@ PyArrayObject * td_ode_rhs(
     CALLGRIND_START_INSTRUMENTATION;
     #endif
 
-    const static auto numpy_initialized = init_numpy();
+    import_array();
 
     // I left this commented on porpose so we can use logging eventually
     // This is just a RAII for the logger

--- a/src/open_pulse/python_to_cpp.hpp
+++ b/src/open_pulse/python_to_cpp.hpp
@@ -32,14 +32,6 @@
 #include "iterators.hpp"
 #include "eval_hamiltonian.hpp"
 
-static bool init_numpy(){
-    static bool initialized = false;
-    if(!initialized){
-        import_array();
-        initialized = true;
-    }
-};
-
 bool check_is_integer(PyObject * value){
     if(value == nullptr)
         throw std::invalid_argument("PyObject is null!");
@@ -117,7 +109,7 @@ bool check_is_dict(PyObject * value){
 bool check_is_np_array(PyArrayObject * value){
     if(value == nullptr)
         throw std::invalid_argument("Numpy ndarray is null!");
-    init_numpy();
+    import_array();
     // Check that it's a numpy ndarray
     if(!PyArray_Check(value))
         return false;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
It was causing the error: Cannot import `numpy.core.multiarray` only on
older versions of CentOS.



