### PR TITLE
Avoid using AOL and RTOL for docstring in QuantumError and ReadoutError

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -186,12 +186,12 @@ class QuantumError:
         return copy.deepcopy(self)
 
     @property
-    def atol(self):
+    def _atol(self):
         """The absolute tolerance parameter for float comparisons."""
         return self.ATOL
 
-    @atol.setter
-    def atol(self, atol):
+    @_atol.setter
+    def _atol(self, atol):
         """Set the absolute tolerance parameter for float comparisons."""
         max_tol = self.MAX_TOL
         if atol < 0:
@@ -202,12 +202,12 @@ class QuantumError:
         self.ATOL = atol
 
     @property
-    def rtol(self):
+    def _rtol(self):
         """The relative tolerance parameter for float comparisons."""
         return self.RTOL
 
-    @rtol.setter
-    def rtol(self, rtol):
+    @_rtol.setter
+    def _rtol(self, rtol):
         """Set the relative tolerance parameter for float comparisons."""
         max_tol = self.MAX_TOL
         if rtol < 0:

--- a/qiskit/providers/aer/noise/errors/readout_error.py
+++ b/qiskit/providers/aer/noise/errors/readout_error.py
@@ -92,7 +92,7 @@ class ReadoutError:
         if self.number_of_qubits != other.number_of_qubits:
             return False
         return np.allclose(self._probabilities, other._probabilities,
-                           atol=self.atol, rtol=self.rtol)
+                           atol=self._atol, rtol=self._rtol)
 
     def copy(self):
         """Make a copy of current ReadoutError."""
@@ -111,12 +111,12 @@ class ReadoutError:
         return self._probabilities
 
     @property
-    def atol(self):
+    def _atol(self):
         """The absolute tolerance parameter for float comparisons."""
         return self.ATOL
 
-    @atol.setter
-    def atol(self, atol):
+    @_atol.setter
+    def _atol(self, atol):
         """Set the absolute tolerance parameter for float comparisons."""
         max_tol = self.MAX_TOL
         if atol < 0:
@@ -127,12 +127,12 @@ class ReadoutError:
         self.ATOL = atol
 
     @property
-    def rtol(self):
+    def _rtol(self):
         """The relative tolerance parameter for float comparisons."""
         return self.RTOL
 
-    @rtol.setter
-    def rtol(self, rtol):
+    @_rtol.setter
+    def _rtol(self, rtol):
         """Set the relative tolerance parameter for float comparisons."""
         max_tol = self.MAX_TOL
         if rtol < 0:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`sphinx-build` fails if file system does not support case-sensitive path.

### Details and comments
`QuantumError` and `ReadoutError` have `atol` methods, `ATOL` field, `rtol` methods, and `RTOL` filed. `sphinx-build` generates stub files for them. If the file system does not support case-sensitive path (as Mac does), `sphinx-build` fails (ref: https://github.com/sphinx-doc/sphinx/issues/4874).

