### PR TITLE
[Stable] Find muparserx system library before using distributed one and download code (#621)

### DIFF
--- a/cmake/FindMuparserx.cmake
+++ b/cmake/FindMuparserx.cmake
@@ -1,0 +1,47 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+#.rst:
+# FindMuparserx
+# =============
+# This module finds a muparserx library installed in the system (see https://beltoforion.de/article.php?a=muparserx
+# and https://github.com/beltoforion/muparserx).
+#
+# This module defines the following target:
+#
+# ::
+#
+#   PkgConfig::muparserx
+#
+# and sets the typical package variables:
+#
+# ::
+#
+#   muparserx_FOUND
+#   muparserx_INCLUDE_DIRS
+#   muparserx_LIBRARIES
+#   muparserx_VERSION
+#   ....
+#
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(muparserx QUIET IMPORTED_TARGET muparserx)
+
+if(NOT muparserx_FIND_QUIETLY)
+    if(NOT muparserx_FOUND)
+        message(FATAL_ERROR "muparserx library not found!")
+    endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(muparserx REQUIRED_VARS muparserx_INCLUDE_DIRS muparserx_LIBRARIES
+        VERSION_VAR muparserx_VERSION)

--- a/cmake/compiler_utils.cmake
+++ b/cmake/compiler_utils.cmake
@@ -141,7 +141,19 @@ function(uncompress_muparsersx_lib)
 endfunction()
 
 function(add_muparserx_lib)
-    message(STATUS "Uncompressing muparserx static library...")
+    message(STATUS "Looking for muparserx library...")
+
+    # Look first for already installed muparserx
+    find_package(muparserx QUIET)
+
+    if(muparserx_FOUND)
+        message(STATUS "Muparserx library version '${muparserx_VERSION}' found")
+        set(AER_LIBRARIES ${AER_LIBRARIES} PkgConfig::muparserx PARENT_SCOPE)
+        return()
+    endif()
+
+    message(STATUS "Muparserx library not found. Uncompressing muparserx static library...")
+
     uncompress_muparsersx_lib()
 
     find_library(MUPARSERX_LIB NAMES libmuparserx.a muparserx HINTS ${MUPARSERX_LIB_PATH})


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Search for an already installed muparserx library.

### Details and comments

Try to find an already installed muparserx library before uncompressing the distributed one and download code. This is linked to issue #599.

Backported from #621 
(cherry picked from commit 7056d4cb05d8695b09660caa5fa57876a7032fde)