### PR TITLE
[Stable] Fix bug in QuantumError compose method (#605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ Removed
 
 Fixed
 -----
-
+- Fixed bug in QuantumError compose method when composing Kraus with non-Kraus
+  errors (\#605).
 
 
 [0.4.0](https://github.com/Qiskit/qiskit-aer/compare/0.3.4...0.4.0) - 2020-06-02

--- a/qiskit/providers/aer/noise/errors/errorutils.py
+++ b/qiskit/providers/aer/noise/errors/errorutils.py
@@ -76,19 +76,19 @@ def standard_gate_instruction(instruction, ignore_phase=True):
         return [instruction]
 
     # Check single qubit gates
-    mat_dagger = np.conj(params[0])
+    mat = params[0]
     if len(qubits) == 1:
         # Check clifford gates
         for j in range(24):
             if matrix_equal(
-                    mat_dagger,
+                    mat,
                     single_qubit_clifford_matrix(j),
                     ignore_phase=ignore_phase):
                 return single_qubit_clifford_instructions(j, qubit=qubits[0])
         # Check t gates
         for name in ["t", "tdg"]:
             if matrix_equal(
-                    mat_dagger,
+                    mat,
                     standard_gate_unitary(name),
                     ignore_phase=ignore_phase):
                 return [{"name": name, "qubits": qubits}]
@@ -97,13 +97,13 @@ def standard_gate_instruction(instruction, ignore_phase=True):
     if len(qubits) == 2:
         for name in ["cx", "cz", "swap"]:
             if matrix_equal(
-                    mat_dagger,
+                    mat,
                     standard_gate_unitary(name),
                     ignore_phase=ignore_phase):
                 return [{"name": name, "qubits": qubits}]
         # Check reversed CX
         if matrix_equal(
-                mat_dagger,
+                mat,
                 standard_gate_unitary("cx_10"),
                 ignore_phase=ignore_phase):
             return [{"name": "cx", "qubits": [qubits[1], qubits[0]]}]
@@ -114,7 +114,7 @@ def standard_gate_instruction(instruction, ignore_phase=True):
                 pmat = np.kron(
                     standard_gate_unitary(pauli1),
                     standard_gate_unitary(pauli0))
-                if matrix_equal(mat_dagger, pmat, ignore_phase=ignore_phase):
+                if matrix_equal(mat, pmat, ignore_phase=ignore_phase):
                     if pauli0 == "id":
                         return [{"name": pauli1, "qubits": [qubits[1]]}]
                     elif pauli1 == "id":
@@ -130,12 +130,12 @@ def standard_gate_instruction(instruction, ignore_phase=True):
     # Check three qubit toffoli
     if len(qubits) == 3:
         if matrix_equal(
-                mat_dagger,
+                mat,
                 standard_gate_unitary("ccx_012"),
                 ignore_phase=ignore_phase):
             return [{"name": "ccx", "qubits": qubits}]
         if matrix_equal(
-                mat_dagger,
+                mat,
                 standard_gate_unitary("ccx_021"),
                 ignore_phase=ignore_phase):
             return [{
@@ -143,7 +143,7 @@ def standard_gate_instruction(instruction, ignore_phase=True):
                 "qubits": [qubits[0], qubits[2], qubits[1]]
             }]
         if matrix_equal(
-                mat_dagger,
+                mat,
                 standard_gate_unitary("ccx_120"),
                 ignore_phase=ignore_phase):
             return [{

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2019, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,15 +17,33 @@ import unittest
 from test.terra import common
 import numpy as np
 
-from qiskit.quantum_info.operators.channel.superop import SuperOp
-from qiskit.quantum_info.operators.channel.kraus import Kraus
+from qiskit.quantum_info.operators import SuperOp, Kraus
+from qiskit.providers.aer.noise import QuantumError
 from qiskit.providers.aer.noise.noiseerror import NoiseError
-from qiskit.providers.aer.noise.errors.quantum_error import QuantumError
 from qiskit.providers.aer.noise.errors.errorutils import standard_gate_unitary
 
 
 class TestQuantumError(common.QiskitAerTestCase):
     """Testing QuantumError class"""
+
+    def kraus_error(self, param):
+        """Return a Kraus error list"""
+        return [
+            np.array([[1, 0], [0, np.sqrt(1 - param)]], dtype=complex),
+            np.array([[0, 0], [0, np.sqrt(param)]], dtype=complex)
+        ]
+
+    def mixed_unitary_error(self, probs, labels):
+        """Return a mixed unitary error list"""
+        return [np.sqrt(prob) * standard_gate_unitary(label)
+                for prob, label in zip(probs, labels)]
+
+    def depol_error(self, param):
+        """Return depol error unitary list"""
+        return self.mixed_unitary_error(
+            [1 - param * 0.75, param * 0.25, param * 0.25, param * 0.25],
+            ['id', 'x', 'y', 'z'])
+
     def test_standard_gate_unitary(self):
         """Test standard gates are correct"""
         def norm(op_a, op_b):
@@ -139,283 +157,171 @@ class TestQuantumError(common.QiskitAerTestCase):
 
     def test_pauli_conversion_standard_gates(self):
         """Test conversion of Pauli channel kraus to gates"""
-        a_i = np.sqrt(0.25) * standard_gate_unitary('id')
-        a_x = np.sqrt(0.25) * standard_gate_unitary('x')
-        a_y = np.sqrt(0.25) * standard_gate_unitary('y')
-        a_z = np.sqrt(0.25) * standard_gate_unitary('z')
-        error_dict = QuantumError([a_i, a_x, a_y, a_z],
-                                  standard_gates=True).to_dict()
-        self.assertEqual(error_dict['type'], 'qerror')
-        self.assertAlmostEqual(
-            np.linalg.norm(
-                np.array(4 * [0.25]) - np.array(error_dict['probabilities'])),
-            0.0)
-        for instr in error_dict['instructions']:
+        error = QuantumError(self.depol_error(1), standard_gates=True)
+        for j in range(4):
+            instr, _ = error.error_term(j)
             self.assertEqual(len(instr), 1)
             self.assertIn(instr[0]['name'], ['x', 'y', 'z', 'id'])
             self.assertEqual(instr[0]['qubits'], [0])
+        target = SuperOp(Kraus(self.depol_error(1)))
+        self.assertEqual(target, SuperOp(error))
 
     def test_pauli_conversion_unitary(self):
         """Test conversion of Pauli channel kraus to unitary qobj"""
-        a_i = np.sqrt(0.25) * standard_gate_unitary('id')
-        a_x = np.sqrt(0.25) * standard_gate_unitary('x')
-        a_y = np.sqrt(0.25) * standard_gate_unitary('y')
-        a_z = np.sqrt(0.25) * standard_gate_unitary('z')
-        error_dict = QuantumError([a_i, a_x, a_y, a_z],
-                                  standard_gates=False).to_dict()
-        self.assertEqual(error_dict['type'], 'qerror')
-        self.assertAlmostEqual(
-            np.linalg.norm(
-                np.array(4 * [0.25]) - np.array(error_dict['probabilities'])),
-            0.0)
-        for instr in error_dict['instructions']:
+        error = QuantumError(self.depol_error(1), standard_gates=False)
+        for j in range(4):
+            instr, _ = error.error_term(j)
             self.assertEqual(len(instr), 1)
             self.assertIn(instr[0]['name'], ['unitary', 'id'])
             self.assertEqual(instr[0]['qubits'], [0])
+        target = SuperOp(Kraus(self.depol_error(1)))
+        self.assertEqual(target, SuperOp(error))
 
     def test_tensor_both_kraus(self):
         """Test tensor of two kraus errors"""
-        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
-        # Use quantum channels for reference
-        target = SuperOp(Kraus([a_0, a_1]).tensor(Kraus([b_0, b_1])))
-        error = QuantumError([a_0, a_1]).tensor(QuantumError([b_0, b_1]))
+        kraus0 = self.kraus_error(0.3)
+        kraus1 = self.kraus_error(0.5)
+        error = QuantumError(kraus0).tensor(QuantumError(kraus1))
+        target = SuperOp(Kraus(kraus0)).tensor(Kraus(kraus1))
+
         kraus, prob = error.error_term(0)
         self.assertEqual(prob, 1)
         self.assertEqual(kraus[0]['name'], 'kraus')
         self.assertEqual(kraus[0]['qubits'], [0, 1])
-        error_superop = SuperOp(Kraus(kraus[0]['params']))
-        self.assertEqual(target, error_superop, msg="Incorrect tensor kraus")
+        self.assertEqual(target, SuperOp(error), msg="Incorrect tensor kraus")
 
     def test_tensor_both_unitary_instruction(self):
         """Test tensor of two unitary instruction errors."""
-        unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
-        probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
-        probs1 = [0.6, 0.4]
-        error0 = QuantumError([
-            np.sqrt(probs0[0]) * unitaries0[0],
-            np.sqrt(probs0[1]) * unitaries0[1]
-        ],
-                              standard_gates=False)
-        error1 = QuantumError([
-            np.sqrt(probs1[0]) * unitaries1[0],
-            np.sqrt(probs1[1]) * unitaries1[1]
-        ],
-                              standard_gates=False)
-        error = error1.tensor(error0)
-        # Kronecker product unitaries
-        target_unitaries = [
-            np.kron(unitaries1[0], unitaries0[0]),
-            np.kron(unitaries1[0], unitaries0[1]),
-            np.kron(unitaries1[1], unitaries0[0]),
-            np.kron(unitaries1[1], unitaries0[1])
-        ]
-        # Kronecker product probabilities
-        target_probs = [
-            probs1[0] * probs0[0], probs1[0] * probs0[1],
-            probs1[1] * probs0[0], probs1[1] * probs0[1]
-        ]
+        unitaries0 = self.mixed_unitary_error([0.9, 0.1], ['z', 's'])
+        unitaries1 = self.mixed_unitary_error([0.6, 0.4], ['x', 'y'])
+
+        error0 = QuantumError(unitaries0, standard_gates=False)
+        error1 = QuantumError(unitaries1, standard_gates=False)
+        error = error0.tensor(error1)
+        target = SuperOp(Kraus(unitaries0)).tensor(Kraus(unitaries1))
 
         for j in range(4):
-            circ, prob = error.error_term(j)
-            unitary = circ[0]['params'][0]
+            circ, _ = error.error_term(j)
+            self.assertEqual(len(circ), 1)
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0, 1])
-            # Remove prob from target if it is found
-            # later we will check that target_probs is empty so all
-            # the required ones have been removed
-            self.remove_if_found(prob, target_probs)
-            self.remove_if_found(unitary, target_unitaries)
-        # Check we had all the correct target probs and unitaries
-        # by seeing if these lists are empty
-        # Note that this doesn't actually check that the correct
-        # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [],
-                         msg="Incorrect tensor probabilities")
-        self.assertEqual(target_unitaries, [],
-                         msg="Incorrect tensor unitaries")
+        self.assertEqual(SuperOp(error), target)
 
     def test_tensor_both_unitary_standard_gates(self):
         """Test tensor of two unitary standard gate errors"""
-        unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
-        probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
-        probs1 = [0.6, 0.4]
-        error0 = QuantumError([
-            np.sqrt(probs0[0]) * unitaries0[0],
-            np.sqrt(probs0[1]) * unitaries0[1]
-        ],
-                              standard_gates=True)
-        error1 = QuantumError([
-            np.sqrt(probs1[0]) * unitaries1[0],
-            np.sqrt(probs1[1]) * unitaries1[1]
-        ],
-                              standard_gates=True)
-        error = error1.tensor(error0)
-        # Kronecker product probabilities
-        target_probs = [
-            probs1[0] * probs0[0], probs1[0] * probs0[1],
-            probs1[1] * probs0[0], probs1[1] * probs0[1]
-        ]
-        # Target circuits
-        target_circs = [[{
-            'name': 'x',
-            'qubits': [1]
-        }], [{
-            'name': 'y',
-            'qubits': [1]
-        }], [{
-            'name': 'z',
-            'qubits': [0]
-        }, {
-            'name': 'x',
-            'qubits': [1]
-        }], [{
-            'name': 'z',
-            'qubits': [0]
-        }, {
-            'name': 'y',
-            'qubits': [1]
-        }]]
+        unitaries0 = self.mixed_unitary_error([0.9, 0.1], ['z', 's'])
+        unitaries1 = self.mixed_unitary_error([0.6, 0.4], ['x', 'y'])
+        error0 = QuantumError(unitaries0, standard_gates=True)
+        error1 = QuantumError(unitaries1, standard_gates=True)
+        error = error0.tensor(error1)
+        target = SuperOp(Kraus(unitaries0)).tensor(Kraus(unitaries1))
+
         for j in range(4):
-            circ, prob = error.error_term(j)
-            # Remove prob from target if it is found
-            # later we will check that target_probs is empty so all
-            # the required ones have been removed
-            self.remove_if_found(prob, target_probs)
-            self.remove_if_found(circ, target_circs)
-        # Check we had all the correct target probs and unitaries
-        # by seeing if these lists are empty
-        # Note that this doesn't actually check that the correct
-        # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [],
-                         msg="Incorrect tensor probabilities")
-        self.assertEqual(target_circs, [], msg="Incorrect tensor circuits")
+            circ, _ = error.error_term(j)
+            self.assertEqual(len(circ), 2)
+            for instr in circ:
+                self.assertIn(instr['name'], ['s', 'x', 'y', 'z'])
+                self.assertIn(instr['qubits'], [[0], [1]])
+        self.assertEqual(SuperOp(error), target)
+
+    def test_tensor_kraus_and_unitary(self):
+        """Test tensor of a kraus and unitary error."""
+        kraus = self.kraus_error(0.4)
+        unitaries = self.depol_error(0.1)
+        error = QuantumError(kraus).tensor(QuantumError(unitaries))
+        target = SuperOp(Kraus(kraus)).tensor(Kraus(unitaries))
+
+        circ, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0, 1])
+        self.assertEqual(target, SuperOp(error))
+
+    def test_tensor_unitary_and_kraus(self):
+        """Test tensor of a unitary and kraus error."""
+        kraus = self.kraus_error(0.4)
+        unitaries = self.depol_error(0.1)
+        error = QuantumError(unitaries).tensor(QuantumError(kraus))
+        target = SuperOp(Kraus(unitaries)).tensor(Kraus(kraus))
+
+        circ, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0, 1])
+        self.assertEqual(target, SuperOp(error))
 
     def test_expand_both_kraus(self):
         """Test expand of two kraus errors"""
-        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
-        # Use quantum channels for reference
-        target = SuperOp(Kraus([a_0, a_1]).expand(Kraus([b_0, b_1])))
-        error = QuantumError([a_0, a_1]).expand(QuantumError([b_0, b_1]))
-        kraus, prob = error.error_term(0)
+        kraus0 = self.kraus_error(0.3)
+        kraus1 = self.kraus_error(0.5)
+        error = QuantumError(kraus0).expand(QuantumError(kraus1))
+        target = SuperOp(Kraus(kraus0)).expand(Kraus(kraus1))
+
+        circ, prob = error.error_term(0)
         self.assertEqual(prob, 1)
-        self.assertEqual(kraus[0]['name'], 'kraus')
-        self.assertEqual(kraus[0]['qubits'], [0, 1])
-        error_superop = SuperOp(Kraus(kraus[0]['params']))
-        self.assertEqual(target, error_superop, msg="Incorrect expand kraus")
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0, 1])
+        self.assertEqual(target, SuperOp(error))
 
     def test_expand_both_unitary_instruction(self):
         """Test expand of two unitary instruction errors."""
-        unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
-        probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
-        probs1 = [0.6, 0.4]
-        error0 = QuantumError([
-            np.sqrt(probs0[0]) * unitaries0[0],
-            np.sqrt(probs0[1]) * unitaries0[1]
-        ],
-                              standard_gates=False)
-        error1 = QuantumError([
-            np.sqrt(probs1[0]) * unitaries1[0],
-            np.sqrt(probs1[1]) * unitaries1[1]
-        ],
-                              standard_gates=False)
+        unitaries0 = self.mixed_unitary_error([0.9, 0.1], ['z', 's'])
+        unitaries1 = self.mixed_unitary_error([0.6, 0.4], ['x', 'y'])
+
+        error0 = QuantumError(unitaries0, standard_gates=False)
+        error1 = QuantumError(unitaries1, standard_gates=False)
         error = error0.expand(error1)
-        # Kronecker product unitaries
-        target_unitaries = [
-            np.kron(unitaries1[0], unitaries0[0]),
-            np.kron(unitaries1[0], unitaries0[1]),
-            np.kron(unitaries1[1], unitaries0[0]),
-            np.kron(unitaries1[1], unitaries0[1])
-        ]
-        # Kronecker product probabilities
-        target_probs = [
-            probs1[0] * probs0[0], probs1[0] * probs0[1],
-            probs1[1] * probs0[0], probs1[1] * probs0[1]
-        ]
+        target = SuperOp(Kraus(unitaries0)).expand(Kraus(unitaries1))
 
         for j in range(4):
-            circ, prob = error.error_term(j)
-            unitary = circ[0]['params'][0]
+            circ, _ = error.error_term(j)
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0, 1])
-            # Remove prob from target if it is found
-            # later we will check that target_probs is empty so all
-            # the required ones have been removed
-            self.remove_if_found(prob, target_probs)
-            self.remove_if_found(unitary, target_unitaries)
-        # Check we had all the correct target probs and unitaries
-        # by seeing if these lists are empty
-        # Note that this doesn't actually check that the correct
-        # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [],
-                         msg="Incorrect expand probabilities")
-        self.assertEqual(target_unitaries, [],
-                         msg="Incorrect expand unitaries")
+        self.assertEqual(SuperOp(error), target)
 
     def test_expand_both_unitary_standard_gates(self):
         """Test expand of two unitary standard gate errors"""
-        unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
-        probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
-        probs1 = [0.6, 0.4]
-        error0 = QuantumError([
-            np.sqrt(probs0[0]) * unitaries0[0],
-            np.sqrt(probs0[1]) * unitaries0[1]
-        ],
-                              standard_gates=True)
-        error1 = QuantumError([
-            np.sqrt(probs1[0]) * unitaries1[0],
-            np.sqrt(probs1[1]) * unitaries1[1]
-        ],
-                              standard_gates=True)
+        unitaries0 = self.mixed_unitary_error([0.9, 0.1], ['z', 's'])
+        unitaries1 = self.mixed_unitary_error([0.6, 0.4], ['x', 'y'])
+
+        error0 = QuantumError(unitaries0, standard_gates=True)
+        error1 = QuantumError(unitaries1, standard_gates=True)
         error = error0.expand(error1)
-        # Kronecker product probabilities
-        target_probs = [
-            probs1[0] * probs0[0], probs1[0] * probs0[1],
-            probs1[1] * probs0[0], probs1[1] * probs0[1]
-        ]
-        # Target circuits
-        target_circs = [[{
-            'name': 'x',
-            'qubits': [1]
-        }], [{
-            'name': 'y',
-            'qubits': [1]
-        }], [{
-            'name': 'z',
-            'qubits': [0]
-        }, {
-            'name': 'x',
-            'qubits': [1]
-        }], [{
-            'name': 'z',
-            'qubits': [0]
-        }, {
-            'name': 'y',
-            'qubits': [1]
-        }]]
+        target = SuperOp(Kraus(unitaries0)).expand(Kraus(unitaries1))
+
         for j in range(4):
-            circ, prob = error.error_term(j)
-            # Remove prob from target if it is found
-            # later we will check that target_probs is empty so all
-            # the required ones have been removed
-            self.remove_if_found(prob, target_probs)
-            self.remove_if_found(circ, target_circs)
-        # Check we had all the correct target probs and unitaries
-        # by seeing if these lists are empty
-        # Note that this doesn't actually check that the correct
-        # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [],
-                         msg="Incorrect expand probabilities")
-        self.assertEqual(target_circs, [], msg="Incorrect expand circuits")
+            circ, _ = error.error_term(j)
+            self.assertEqual(len(circ), 2)
+            for instr in circ:
+                self.assertIn(instr['name'], ['s', 'x', 'y', 'z'])
+                self.assertIn(instr['qubits'], [[0], [1]])
+        self.assertEqual(SuperOp(error), target)
+
+    def test_expand_kraus_and_unitary(self):
+        """Test expand of a kraus and unitary error."""
+        kraus = self.kraus_error(0.4)
+        unitaries = self.depol_error(0.1)
+        error = QuantumError(kraus).expand(QuantumError(unitaries))
+        target = SuperOp(Kraus(kraus)).expand(Kraus(unitaries))
+
+        circ, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0, 1])
+        self.assertEqual(target, SuperOp(error))
+
+    def test_expand_unitary_and_kraus(self):
+        """Test expand of a unitary and kraus error."""
+        kraus = self.kraus_error(0.4)
+        unitaries = self.depol_error(0.1)
+        error = QuantumError(unitaries).expand(QuantumError(kraus))
+        target = SuperOp(Kraus(unitaries)).expand(Kraus(kraus))
+
+        circ, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0, 1])
+        self.assertEqual(target, SuperOp(error))
 
     def test_raise_compose_different_dim(self):
         """Test composing incompatible errors raises exception"""
@@ -426,270 +332,144 @@ class TestQuantumError(common.QiskitAerTestCase):
         self.assertRaises(NoiseError, lambda: error1.compose(error0))
 
     def test_compose_both_kraus(self):
-        """Test composition of two kraus errors"""
-        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
-        # Use quantum channels for reference
-        target = SuperOp(Kraus([a_0, a_1]).compose(Kraus([b_0, b_1])))
-        # Compose method
-        error = QuantumError([a_0, a_1]).compose(QuantumError([b_0, b_1]))
-        kraus, prob = error.error_term(0)
-        self.assertEqual(prob, 1)
-        self.assertEqual(kraus[0]['name'], 'kraus')
-        self.assertEqual(kraus[0]['qubits'], [0])
-        error_superop = SuperOp(Kraus(kraus[0]['params']))
-        self.assertEqual(target, error_superop, msg="Incorrect compose kraus")
-        # @ method
-        error = QuantumError([a_0, a_1]) @ QuantumError([b_0, b_1])
-        kraus, prob = error.error_term(0)
-        self.assertEqual(prob, 1)
-        self.assertEqual(kraus[0]['name'], 'kraus')
-        self.assertEqual(kraus[0]['qubits'], [0])
-        error_superop = SuperOp(Kraus(kraus[0]['params']))
-        self.assertEqual(target, error_superop, msg="Incorrect compose kraus")
+        """Test compose of two kraus errors"""
+        kraus0 = self.kraus_error(0.3)
+        kraus1 = self.kraus_error(0.5)
+        error = QuantumError(kraus0).compose(QuantumError(kraus1))
+        target = SuperOp(Kraus(kraus0)).compose(Kraus(kraus1))
 
-    def test_compose_both_unitary(self):
-        """Test composition of two unitary errors."""
-        unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
-        probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
-        probs1 = [0.6, 0.4]
-        error0 = QuantumError([
-            np.sqrt(probs0[0]) * unitaries0[0],
-            np.sqrt(probs0[1]) * unitaries0[1]
-        ],
-                              standard_gates=False)
-        error1 = QuantumError([
-            np.sqrt(probs1[0]) * unitaries1[0],
-            np.sqrt(probs1[1]) * unitaries1[1]
-        ],
-                              standard_gates=False)
+        kraus, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(kraus[0]['name'], 'kraus')
+        self.assertEqual(kraus[0]['qubits'], [0])
+        self.assertEqual(target, SuperOp(error), msg="Incorrect tensor kraus")
+
+    def test_compose_both_unitary_instruction(self):
+        """Test compose of two unitary instruction errors."""
+        unitaries0 = self.mixed_unitary_error([0.9, 0.1], ['z', 's'])
+        unitaries1 = self.mixed_unitary_error([0.6, 0.4], ['x', 'y'])
+
+        error0 = QuantumError(unitaries0, standard_gates=False)
+        error1 = QuantumError(unitaries1, standard_gates=False)
         error = error0.compose(error1)
-        # Kronecker product unitaries
-        target_unitaries = [
-            np.dot(unitaries1[0], unitaries0[0]),
-            np.dot(unitaries1[0], unitaries0[1]),
-            np.dot(unitaries1[1], unitaries0[0]),
-            np.dot(unitaries1[1], unitaries0[1])
-        ]
-        # Kronecker product probabilities
-        target_probs = [
-            probs1[0] * probs0[0], probs1[0] * probs0[1],
-            probs1[1] * probs0[0], probs1[1] * probs0[1]
-        ]
+        target = SuperOp(Kraus(unitaries0)).compose(Kraus(unitaries1))
 
         for j in range(4):
-            circ, prob = error.error_term(j)
-            unitary = circ[0]['params'][0]
+            circ, _ = error.error_term(j)
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0])
-            # Remove prob from target if it is found
-            # later we will check that target_probs is empty so all
-            # the required ones have been removed
-            self.remove_if_found(prob, target_probs)
-            self.remove_if_found(unitary, target_unitaries)
-        # Check we had all the correct target probs and unitaries
-        # by seeing if these lists are empty
-        # Note that this doesn't actually check that the correct
-        # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [],
-                         msg="Incorrect compose probabilities")
-        self.assertEqual(target_unitaries, [],
-                         msg="Incorrect compose unitaries")
+        self.assertEqual(SuperOp(error), target)
 
-    def test_compose_both_qobj(self):
-        """Test composition of two circuit errors"""
-        unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
-        probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
-        probs1 = [0.6, 0.4]
-        error0 = QuantumError([
-            np.sqrt(probs0[0]) * unitaries0[0],
-            np.sqrt(probs0[1]) * unitaries0[1]
-        ],
-                              standard_gates=True)
-        error1 = QuantumError([
-            np.sqrt(probs1[0]) * unitaries1[0],
-            np.sqrt(probs1[1]) * unitaries1[1]
-        ],
-                              standard_gates=True)
+    def test_compose_both_unitary_standard_gates(self):
+        """Test compose of two unitary standard gate errors"""
+        unitaries0 = self.mixed_unitary_error([0.9, 0.1], ['z', 's'])
+        unitaries1 = self.mixed_unitary_error([0.6, 0.4], ['x', 'y'])
+        error0 = QuantumError(unitaries0, standard_gates=True)
+        error1 = QuantumError(unitaries1, standard_gates=True)
         error = error0.compose(error1)
-        # Kronecker product probabilities
-        target_probs = [
-            probs1[0] * probs0[0], probs1[0] * probs0[1],
-            probs1[1] * probs0[0], probs1[1] * probs0[1]
-        ]
-        # Target circuits
-        target_circs = [[{
-            'name': 'x',
-            'qubits': [0]
-        }], [{
-            'name': 'y',
-            'qubits': [0]
-        }], [{
-            'name': 'z',
-            'qubits': [0]
-        }, {
-            'name': 'x',
-            'qubits': [0]
-        }], [{
-            'name': 'z',
-            'qubits': [0]
-        }, {
-            'name': 'y',
-            'qubits': [0]
-        }]]
+        target = SuperOp(Kraus(unitaries0)).compose(Kraus(unitaries1))
+
         for j in range(4):
-            circ, prob = error.error_term(j)
-            # Remove prob from target if it is found
-            # later we will check that target_probs is empty so all
-            # the required ones have been removed
-            self.remove_if_found(prob, target_probs)
-            self.remove_if_found(circ, target_circs)
-        # Check we had all the correct target probs and unitaries
-        # by seeing if these lists are empty
-        # Note that this doesn't actually check that the correct
-        # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [],
-                         msg="Incorrect compose probabilities")
-        self.assertEqual(target_circs, [], msg="Incorrect compose circuits")
+            circ, _ = error.error_term(j)
+            self.assertIn(circ[0]['name'], ['s', 'x', 'y', 'z'])
+            self.assertEqual(circ[0]['qubits'], [0])
+        self.assertEqual(SuperOp(error), target)
+
+    def test_compose_kraus_and_unitary(self):
+        """Test compose of a kraus and unitary error."""
+        kraus = self.kraus_error(0.4)
+        unitaries = self.depol_error(0.1)
+        error = QuantumError(kraus).compose(QuantumError(unitaries))
+        target = SuperOp(Kraus(kraus)).compose(Kraus(unitaries))
+
+        circ, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0])
+        self.assertEqual(target, SuperOp(error))
+
+    def test_compose_unitary_and_kraus(self):
+        """Test compose of a unitary and kraus error."""
+        kraus = self.kraus_error(0.4)
+        unitaries = self.depol_error(0.1)
+        error = QuantumError(unitaries).compose(QuantumError(kraus))
+        target = SuperOp(Kraus(unitaries)).compose(Kraus(kraus))
+
+        circ, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0])
+        self.assertEqual(target, SuperOp(error))
 
     def test_dot_both_kraus(self):
         """Test dot of two kraus errors"""
-        a_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.3)]], dtype=complex)
-        a_1 = np.array([[0, 0], [0, np.sqrt(0.3)]], dtype=complex)
-        b_0 = np.array([[1, 0], [0, np.sqrt(1 - 0.5)]], dtype=complex)
-        b_1 = np.array([[0, 0], [0, np.sqrt(0.5)]], dtype=complex)
-        # Use quantum channels for reference
-        target = SuperOp(Kraus([b_0, b_1]).compose(Kraus([a_0, a_1])))
-        # dot method
-        error = QuantumError([a_0, a_1]).dot(QuantumError([b_0, b_1]))
-        kraus, prob = error.error_term(0)
-        self.assertEqual(prob, 1)
-        self.assertEqual(kraus[0]['name'], 'kraus')
-        self.assertEqual(kraus[0]['qubits'], [0])
-        error_superop = SuperOp(Kraus(kraus[0]['params']))
-        self.assertEqual(target,
-                         error_superop,
-                         msg="Incorrect kraus dot method")
-        # * method
-        error = QuantumError([a_0, a_1]) * QuantumError([b_0, b_1])
-        kraus, prob = error.error_term(0)
-        self.assertEqual(prob, 1)
-        self.assertEqual(kraus[0]['name'], 'kraus')
-        self.assertEqual(kraus[0]['qubits'], [0])
-        error_superop = SuperOp(Kraus(kraus[0]['params']))
-        self.assertEqual(target,
-                         error_superop,
-                         msg="Incorrect kraus dot method")
+        kraus0 = self.kraus_error(0.3)
+        kraus1 = self.kraus_error(0.5)
+        error = QuantumError(kraus0).dot(QuantumError(kraus1))
+        target = SuperOp(Kraus(kraus0)).dot(Kraus(kraus1))
 
-    def test_dot_both_unitary(self):
-        """Test dot of two unitary errors."""
-        unitaries0 = [standard_gate_unitary('z'), standard_gate_unitary('s')]
-        probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
-        probs1 = [0.6, 0.4]
-        error0 = QuantumError([
-            np.sqrt(probs0[0]) * unitaries0[0],
-            np.sqrt(probs0[1]) * unitaries0[1]
-        ],
-                              standard_gates=False)
-        error1 = QuantumError([
-            np.sqrt(probs1[0]) * unitaries1[0],
-            np.sqrt(probs1[1]) * unitaries1[1]
-        ],
-                              standard_gates=False)
-        error = error1.dot(error0)
-        # Kronecker product unitaries
-        target_unitaries = [
-            np.dot(unitaries1[0], unitaries0[0]),
-            np.dot(unitaries1[0], unitaries0[1]),
-            np.dot(unitaries1[1], unitaries0[0]),
-            np.dot(unitaries1[1], unitaries0[1])
-        ]
-        # Kronecker product probabilities
-        target_probs = [
-            probs1[0] * probs0[0], probs1[0] * probs0[1],
-            probs1[1] * probs0[0], probs1[1] * probs0[1]
-        ]
+        kraus, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(kraus[0]['name'], 'kraus')
+        self.assertEqual(kraus[0]['qubits'], [0])
+        self.assertEqual(target, SuperOp(error), msg="Incorrect dot kraus")
+
+    def test_dot_both_unitary_instruction(self):
+        """Test dot of two unitary instruction errors."""
+        unitaries0 = self.mixed_unitary_error([0.9, 0.1], ['z', 's'])
+        unitaries1 = self.mixed_unitary_error([0.6, 0.4], ['x', 'y'])
+
+        error0 = QuantumError(unitaries0, standard_gates=False)
+        error1 = QuantumError(unitaries1, standard_gates=False)
+        error = error0.dot(error1)
+        target = SuperOp(Kraus(unitaries0)).dot(Kraus(unitaries1))
 
         for j in range(4):
-            circ, prob = error.error_term(j)
-            unitary = circ[0]['params'][0]
+            circ, _ = error.error_term(j)
             self.assertEqual(circ[0]['name'], 'unitary')
             self.assertEqual(circ[0]['qubits'], [0])
-            # Remove prob from target if it is found
-            # later we will check that target_probs is empty so all
-            # the required ones have been removed
-            self.remove_if_found(prob, target_probs)
-            self.remove_if_found(unitary, target_unitaries)
-        # Check we had all the correct target probs and unitaries
-        # by seeing if these lists are empty
-        # Note that this doesn't actually check that the correct
-        # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [],
-                         msg="Incorrect compose probabilities")
-        self.assertEqual(target_unitaries, [],
-                         msg="Incorrect compose unitaries")
+        self.assertEqual(SuperOp(error), target)
 
-    def test_dot_both_qobj(self):
-        """Test dot of two circuit errors"""
-        unitaries0 = [standard_gate_unitary('id'), standard_gate_unitary('z')]
-        probs0 = [0.9, 0.1]
-        unitaries1 = [standard_gate_unitary('x'), standard_gate_unitary('y')]
-        probs1 = [0.6, 0.4]
-        error0 = QuantumError([
-            np.sqrt(probs0[0]) * unitaries0[0],
-            np.sqrt(probs0[1]) * unitaries0[1]
-        ],
-                              standard_gates=True)
-        error1 = QuantumError([
-            np.sqrt(probs1[0]) * unitaries1[0],
-            np.sqrt(probs1[1]) * unitaries1[1]
-        ],
-                              standard_gates=True)
-        error = error1.dot(error0)
-        # Kronecker product probabilities
-        target_probs = [
-            probs1[0] * probs0[0], probs1[0] * probs0[1],
-            probs1[1] * probs0[0], probs1[1] * probs0[1]
-        ]
-        # Target circuits
-        target_circs = [[{
-            'name': 'x',
-            'qubits': [0]
-        }], [{
-            'name': 'y',
-            'qubits': [0]
-        }], [{
-            'name': 'z',
-            'qubits': [0]
-        }, {
-            'name': 'x',
-            'qubits': [0]
-        }], [{
-            'name': 'z',
-            'qubits': [0]
-        }, {
-            'name': 'y',
-            'qubits': [0]
-        }]]
+    def test_dot_both_unitary_standard_gates(self):
+        """Test dot of two unitary standard gate errors"""
+        unitaries0 = self.mixed_unitary_error([0.9, 0.1], ['z', 's'])
+        unitaries1 = self.mixed_unitary_error([0.6, 0.4], ['x', 'y'])
+        error0 = QuantumError(unitaries0, standard_gates=True)
+        error1 = QuantumError(unitaries1, standard_gates=True)
+        error = error0.dot(error1)
+        target = SuperOp(Kraus(unitaries0)).dot(Kraus(unitaries1))
+
         for j in range(4):
-            circ, prob = error.error_term(j)
-            # Remove prob from target if it is found
-            # later we will check that target_probs is empty so all
-            # the required ones have been removed
-            self.remove_if_found(prob, target_probs)
-            self.remove_if_found(circ, target_circs)
-        # Check we had all the correct target probs and unitaries
-        # by seeing if these lists are empty
-        # Note that this doesn't actually check that the correct
-        # prob was assigned to the correct unitary.
-        self.assertEqual(target_probs, [],
-                         msg="Incorrect compose probabilities")
-        self.assertEqual(target_circs, [], msg="Incorrect compose circuits")
+            circ, _ = error.error_term(j)
+            self.assertIn(circ[0]['name'], ['s', 'x', 'y', 'z'])
+            self.assertEqual(circ[0]['qubits'], [0])
+        self.assertEqual(SuperOp(error), target)
+
+    def test_dot_kraus_and_unitary(self):
+        """Test dot of a kraus and unitary error."""
+        kraus = self.kraus_error(0.4)
+        unitaries = self.depol_error(0.1)
+        error = QuantumError(kraus).dot(QuantumError(unitaries))
+        target = SuperOp(Kraus(kraus)).dot(Kraus(unitaries))
+
+        circ, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0])
+        self.assertEqual(target, SuperOp(error))
+
+    def test_dot_unitary_and_kraus(self):
+        """Test dot of a unitary and kraus error."""
+        kraus = self.kraus_error(0.4)
+        unitaries = self.depol_error(0.1)
+        error = QuantumError(unitaries).dot(QuantumError(kraus))
+        target = SuperOp(Kraus(unitaries)).dot(Kraus(kraus))
+
+        circ, prob = error.error_term(0)
+        self.assertEqual(prob, 1)
+        self.assertEqual(circ[0]['name'], 'kraus')
+        self.assertEqual(circ[0]['qubits'], [0])
+        self.assertEqual(target, SuperOp(error))
 
     def test_to_quantumchannel_kraus(self):
         """Test to_quantumchannel for Kraus inputs."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Composing certain kinds of quantum errors would fail when combining Kraus operators in the final error object. This rewrite the logic for simplifying Kraus terms

### Details and comments
Fixes bug in QuantumError.compose which would fail to combine certain Kraus error terms correctly.

Backported from #605 
(cherry picked from commit 5f27f23f6bd00bc9014921fb859a2f25f0268259)