### PR TITLE
Exclude new cvxpy release and update pip via conda on azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,6 +144,7 @@ stages:
           - bash: |
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
+              pip install -U pip virtualenv setuptools
               pip install -r requirements-dev.txt
               pip install git+https://github.com/Qiskit/qiskit-terra.git
             displayName: "Install dependencies"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,6 @@ stages:
           - bash: |
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
-              pip install -U pip virtualenv setuptools
               pip install -r requirements-dev.txt
               pip install git+https://github.com/Qiskit/qiskit-terra.git
             displayName: "Install dependencies"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ stages:
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
               conda install --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python=$(python.version) mkl
-              conda install -c conda-forge --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python=$(python.version) openblas
+              conda install -c conda-forge --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python=$(python.version) openblas pip setuptools
             displayName: Install Anaconda packages
             condition: or(eq(variables['python.version'], '3.5'), eq(variables['python.version'], '3.8'))
           - bash: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ cmake
 scikit-build
 cython
 asv
-cvxpy>=1.0.0
+cvxpy>=1.0.0,!=1.0.26
 pylint
 pycodestyle
 Sphinx>=1.8.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since the latest cvxpy release is causing failures on python3.5. This
commit excludes the version so that CI jobs pass. Hopefully the next
release won't have the same failure. At the same time the python 3.5 job
was also failing because the version of pip and setuptools was too old.
This also bumps the version using conda to ensure it's new enough to install
cvxpy.

### Details and comments