### PR TITLE
Use bionic for CI and stop using toolchain test ppa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,11 @@ stage_generic: &stage_generic
 stage_linux: &stage_linux
   <<: *stage_generic
   os: linux
-  dist: xenial
+  dist: bionic
   language: python
   python: 3.7
   sudo: true
   before_install:
-    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get -y update
     - sudo apt-get -y install g++-7
     - sudo apt-get -y install libopenblas-dev


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the travis configuration so we no longer are relying
on a test PPA of the dev toolchain for ubuntu to get the compiler
version we need. To do this the ubuntu version we're using is upgrade to
bionic which has all the compiler versions we need to build aer already
and is only 2 years old instead of 4. This enables us to stop using the
test ppa to be able to build aer.

### Details and comments

These changes are already pending on stable/0.4 as part of the backport
PR #636
