### PR TITLE
Fix QuantumError sometimes casting probabilities to complex

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -171,7 +171,7 @@ class AerBackend(BaseBackend):
         # Double-check noise_model is a dict type
         if 'noise_model' in config and not isinstance(config["noise_model"], dict):
             if hasattr(config["noise_model"], 'to_dict'):
-                config["noise_model"] = config["noise_model"].to_dict(serializable=True)
+                config["noise_model"] = config["noise_model"].to_dict()
             else:
                 raise ValueError("noise_model must be a dict : " + str(type(config["noise_model"])))
 

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -171,7 +171,7 @@ class AerBackend(BaseBackend):
         # Double-check noise_model is a dict type
         if 'noise_model' in config and not isinstance(config["noise_model"], dict):
             if hasattr(config["noise_model"], 'to_dict'):
-                config["noise_model"] = config["noise_model"].to_dict()
+                config["noise_model"] = config["noise_model"].to_dict(serializable=True)
             else:
                 raise ValueError("noise_model must be a dict : " + str(type(config["noise_model"])))
 

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -153,7 +153,7 @@ class QuantumError:
             raise NoiseError(
                 "Probabilities are not normalized: {} != 1".format(
                     total_probs))
-        if [p for p in self._noise_probabilities if p < 0]:
+        if [p for p in self._noise_probabilities if (isinstance(p, complex) or (p < 0))]:
             raise NoiseError("Probabilities are invalid.")
         # Rescale probabilities if their sum is ok to avoid
         # accumulation of rounding errors

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -543,7 +543,7 @@ class QuantumError:
                                                           instr['qubits'])
             # Renormalize the Choi operator to find probability
             # of Kraus error
-            chan_prob = np.trace(choi_sum.data) / dim
+            chan_prob = abs(np.trace(choi_sum.data) / dim)
             chan_instr = {
                 "name": "kraus",
                 "qubits": list(range(num_qubits)),

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -24,7 +24,6 @@ from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 from qiskit.providers.aer.noise.errors.standard_errors import reset_error
 from qiskit.providers.aer.noise.errors.standard_errors import amplitude_damping_error
 from qiskit.test import mock
-#from qiskit.providers import aer
 
 
 class TestNoise(common.QiskitAerTestCase):

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -16,13 +16,15 @@ NoiseModel class integration tests
 
 import unittest
 from test.terra import common
-from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, execute
 from qiskit.compiler import assemble, transpile
 from qiskit.providers.aer.backends import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 from qiskit.providers.aer.noise.errors.standard_errors import reset_error
 from qiskit.providers.aer.noise.errors.standard_errors import amplitude_damping_error
+from qiskit.test import mock
+#from qiskit.providers import aer
 
 
 class TestNoise(common.QiskitAerTestCase):
@@ -183,6 +185,45 @@ class TestNoise(common.QiskitAerTestCase):
 
         model2 = NoiseModel(basis_gates=['u3', 'cx'])
         model2.add_all_qubit_quantum_error(error, ['u3'], False)
+
+    def test_noise_model_from_backend_singapore(self):
+        circ = QuantumCircuit(2)
+        circ.x(0)
+        circ.x(1)
+        circ.measure_all()
+
+        backend = mock.FakeSingapore()
+        noise_model = NoiseModel.from_backend(backend)
+        qobj = assemble(transpile(circ, backend), backend)
+        sim = QasmSimulator()
+        result = sim.run(qobj, noise_model=noise_model).result()
+        self.assertTrue(result.success)
+
+    def test_noise_model_from_backend_almaden(self):
+        circ = QuantumCircuit(2)
+        circ.x(0)
+        circ.x(1)
+        circ.measure_all()
+
+        backend = mock.FakeAlmaden()
+        noise_model = NoiseModel.from_backend(backend)
+        qobj = assemble(transpile(circ, backend), backend)
+        sim = QasmSimulator()
+        result = sim.run(qobj, noise_model=noise_model).result()
+        self.assertTrue(result.success)
+
+    def test_noise_model_from_rochester(self):
+        circ = QuantumCircuit(2)
+        circ.x(0)
+        circ.x(1)
+        circ.measure_all()
+
+        backend = mock.FakeRochester()
+        noise_model = NoiseModel.from_backend(backend)
+        qobj = assemble(transpile(circ, backend), backend)
+        sim = QasmSimulator()
+        result = sim.run(qobj, noise_model=noise_model).result()
+        self.assertTrue(result.success)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

[This PR](https://github.com/Qiskit/qiskit-terra/pull/3890) is currently blocked by bugs in Aer. This PR will hopefully fix some of those bugs. 

### Details and comments

Currently, Noise Models are being received on the C++ side with probability attributes having (what appears to be) complex types - ~~we have yet to identify why~~ but the existing changes will at least raise a reasonable exception when it does happen. 

Bug was caused by a missing cast from complex type to float type in a QuantumError factory. Thanks @chriseclectic 
