### PR TITLE
Handle numpy array inputs from qobj

### DIFF
--- a/qiskit/providers/aer/extensions/snapshot_expectation_value.py
+++ b/qiskit/providers/aer/extensions/snapshot_expectation_value.py
@@ -18,7 +18,7 @@ import numpy
 from qiskit import QuantumCircuit
 from qiskit.circuit import Instruction
 from qiskit.extensions.exceptions import ExtensionError
-from qiskit.qobj.qasm_qobj import QasmQobjInstruction
+from qiskit.qobj import QasmQobjInstruction
 from qiskit.quantum_info.operators import Pauli, Operator
 from qiskit.providers.aer.extensions import Snapshot
 

--- a/qiskit/providers/aer/extensions/snapshot_expectation_value.py
+++ b/qiskit/providers/aer/extensions/snapshot_expectation_value.py
@@ -18,6 +18,7 @@ import numpy
 from qiskit import QuantumCircuit
 from qiskit.circuit import Instruction
 from qiskit.extensions.exceptions import ExtensionError
+from qiskit.qobj.qasm_qobj import QasmQobjInstruction
 from qiskit.quantum_info.operators import Pauli, Operator
 from qiskit.providers.aer.extensions import Snapshot
 
@@ -106,6 +107,14 @@ class SnapshotExpectationValue(Snapshot):
             else:
                 return None
         return pauli_op
+
+    def assemble(self):
+        """Assemble a QasmQobjInstruction for snapshot_expectation_value."""
+        return QasmQobjInstruction(name=self.name,
+                                   params=[x.tolist() for x in self.params],
+                                   snapshot_type=self.snapshot_type,
+                                   qubits=list(range(self.num_qubits)),
+                                   label=self.label)
 
 
 def snapshot_expectation_value(self, label, op, qubits,

--- a/qiskit/providers/aer/pulse/qobj/digest.py
+++ b/qiskit/providers/aer/pulse/qobj/digest.py
@@ -320,7 +320,11 @@ def build_pulse_arrays(experiments, pulse_library):
     for _, pulse in enumerate(pulse_library):
         stop = pulses_idx[ind - 1] + len(pulse['samples'])
         pulses_idx[ind] = stop
-        oplist_to_array(pulse['samples'], pulses, pulses_idx[ind - 1])
+        start = pulses_idx[ind - 1]
+        if isinstance(pulse['samples'], np.ndarray):
+            pulses[start:stop] = pulse['samples']
+        else:
+            oplist_to_array(pulse['samples'], pulses, start)
         ind += 1
 
     for pv in pv_pulses:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Starting in Terra 0.13.0 the qobj passed to aer will not undergo type
coercion to be something python's `json.dumps()` natively understands.
This means that input qobj objects will have numpy arrays of complex
numbers instead of `list(list(re, im))`. This should be more efficient for
aer since it doesn't have to undergo a conversion step. However, we were
not handling this input type correctly in the pulse simulator and it
would lead to a failure trying to convert the list format to a numpy
array. This commit fixes this issue by checking if we have a numpy array
in the qobj and just using that directly instead of trying to convert
it.

Additionally, for the snapshot expectation value instruction has to hack around
a terra bug that doesn't allow `list` as a valid type for parameters on an instruction,
by casting it as a numpy array. However, since now that terra isn't converting numpy
arrays to  lists automatically this breaks when we receive the qobj back from terra
with a snapshot expectation value instruction in it. To address this case, this adds
a custom `assemble()` method for the instruction which will build the qobj with a list
instead of a numpy array.

### Details and comments

This is really 2 separate commits/PRs combined together. This is necessary to unblock CI, since the recent changes to terra are breaking build for 2 distinct (but related reasons)