### PR TITLE
Temporary fix for pulse name errors

### DIFF
--- a/qiskit/providers/aer/pulse/qobj/digest.py
+++ b/qiskit/providers/aer/pulse/qobj/digest.py
@@ -415,7 +415,7 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds,
                 # form inst['name'] + '-' + hash
                 pulse_name = inst['name']
                 for key in pulse_to_int.keys():
-                    if pulse_name in key and key[len(pulse_name)] == '-':
+                    if pulse_name in key:
                         pulse_name = key
                         break
 

--- a/qiskit/providers/aer/pulse/qobj/digest.py
+++ b/qiskit/providers/aer/pulse/qobj/digest.py
@@ -408,7 +408,18 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds,
             # A standard pulse
             else:
                 start = inst['t0'] * dt
-                pulse_int = pulse_to_int[inst['name']]
+
+                # temporary fix: the pulses in pulse_library have added hashes at the end,
+                # whereas corresponding instructions do not.
+                # For now we associate a pulse instruction to the pulse in pulse_library of the
+                # form inst['name'] + '-' + hash
+                pulse_name = inst['name']
+                for key in pulse_to_int.keys():
+                    if pulse_name in key and key[len(pulse_name)] == '-':
+                        pulse_name = key
+                        break
+
+                pulse_int = pulse_to_int[pulse_name]
                 pulse_width = (pulse_inds[pulse_int + 1] - pulse_inds[pulse_int]) * dt
                 stop = start + pulse_width
                 structs['channels'][chan_name][0].extend([start, stop, pulse_int, cond])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Temporary fix for issue in digest where pulse names in `pulse_library` now have a hash added to the end, whereas the instructions still contain the original name.


### Details and comments

In the function `experiment_to_structs`: to compare names of instructions to pulses in the pulse library, now just checks to see if the instruction name is contained in the pulse name.
