### PR TITLE
Use substring match for master in azure config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,7 +138,7 @@ stages:
               source activate qiskit-aer-$(Build.BuildNumber)
               conda install -c conda-forge --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python=$(python.version) osqp
               pip install -r requirements-dev.txt
-              if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == "master" || $BUILD_SOURCEBRANCH == "master" ]] ; then
+              if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == *"master"* || $BUILD_SOURCEBRANCH == *"refs/heads/master"* ]] ; then
                   pip install git+https://github.com/Qiskit/qiskit-terra.git
               else
                   pip install qiskit-terra
@@ -149,7 +149,7 @@ stages:
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
               pip install -r requirements-dev.txt
-              if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == "master" || $BUILD_SOURCEBRANCH == "master" ]] ; then
+              if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == *"master"* || $BUILD_SOURCEBRANCH == *"master"* ]] ; then
                   pip install git+https://github.com/Qiskit/qiskit-terra.git
               else
                   pip install qiskit-terra


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now the azure ci jobs are failing because the env variable checks
used to determine if we're running a job on master vs stable is not
working for jobs post-merge on master. Now that the tests have been
update on aer master have been updated to use a pulse syntax only
available on terra master this has started failing because it
incorrectly fallsback to using terra from release. This commit attempts
to fix the situation by using a substring match instead of full match.
The assumption is that the value of BUILD_SOURCEBRANCH is actually
something like refs/heads/master instead of just master. So matching on
*master* should match any build running on master which is the behavior
we want.

### Details and comments