### PR TITLE
Add support for terra diagonal gate

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -234,9 +234,9 @@ class QasmSimulator(AerBackend):
         'coupling_map': None,
         'basis_gates': [
             'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
-            't', 'tdg', 'swap', 'ccx', 'unitary', 'initialize', 'cu1', 'cu2',
-            'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcu1', 'mcu2', 'mcu3',
-            'mcswap', 'multiplexer', 'kraus', 'roerror'
+            't', 'tdg', 'swap', 'ccx', 'unitary', 'diagonal', 'initialize',
+            'cu1', 'cu2', 'cu3', 'cswap', 'mcx', 'mcy', 'mcz',
+            'mcu1', 'mcu2', 'mcu3', 'mcswap', 'multiplexer', 'kraus', 'roerror'
         ],
         'gates': [{
             'name': 'u1',
@@ -349,9 +349,16 @@ class QasmSimulator(AerBackend):
             'name': 'unitary',
             'parameters': ['matrix'],
             'conditional': True,
-            'description': 'N-qubit arbitrary unitary gate. '
+            'description': 'N-qubit unitary gate. '
                            'The parameter is the N-qubit matrix to apply.',
             'qasm_def': 'unitary(matrix) q1, q2,...'
+        }, {
+            'name': 'diagonal',
+            'parameters': ['diag_elements'],
+            'conditional': True,
+            'description': 'N-qubit diagonal unitary gate. The parameters are the'
+                           ' diagonal entries of the N-qubit matrix to apply.',
+            'qasm_def': 'TODO'
         }, {
             'name': 'initialize',
             'parameters': ['vector'],

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -89,9 +89,9 @@ class StatevectorSimulator(AerBackend):
         'coupling_map': None,
         'basis_gates': [
             'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
-            't', 'tdg', 'swap', 'ccx', 'unitary', 'initialize', 'cu1', 'cu2',
-            'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcu1', 'mcu2', 'mcu3',
-            'mcswap', 'multiplexer',
+            't', 'tdg', 'swap', 'ccx', 'unitary', 'diagonal', 'initialize',
+            'cu1', 'cu2', 'cu3', 'cswap', 'mcx', 'mcy', 'mcz',
+            'mcu1', 'mcu2', 'mcu3', 'mcswap', 'multiplexer',
         ],
         'gates': [{
             'name': 'u1',
@@ -207,6 +207,13 @@ class StatevectorSimulator(AerBackend):
             'description': 'N-qubit arbitrary unitary gate. '
                            'The parameter is the N-qubit matrix to apply.',
             'qasm_def': 'unitary(matrix) q1, q2,...'
+        }, {
+            'name': 'diagonal',
+            'parameters': ['diag_elements'],
+            'conditional': True,
+            'description': 'N-qubit diagonal unitary gate. The parameters are the'
+                           ' diagonal entries of the N-qubit matrix to apply.',
+            'qasm_def': 'TODO'
         }, {
             'name': 'initialize',
             'parameters': ['vector'],

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -96,7 +96,7 @@ class UnitarySimulator(AerBackend):
         'coupling_map': None,
         'basis_gates': [
             'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
-            't', 'tdg', 'swap', 'ccx', 'unitary', 'cu1', 'cu2',
+            't', 'tdg', 'swap', 'ccx', 'unitary', 'diagonal', 'cu1', 'cu2',
             'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcu1', 'mcu2', 'mcu3',
             'mcswap', 'multiplexer',
         ],
@@ -214,6 +214,13 @@ class UnitarySimulator(AerBackend):
             'description': 'N-qubit arbitrary unitary gate. '
                            'The parameter is the N-qubit matrix to apply.',
             'qasm_def': 'unitary(matrix) q1, q2,...'
+        }, {
+            'name': 'diagonal',
+            'parameters': ['diag_elements'],
+            'conditional': True,
+            'description': 'N-qubit diagonal unitary gate. The parameters are the'
+                           ' diagonal entries of the N-qubit matrix to apply.',
+            'qasm_def': 'TODO'
         }, {
             'name': 'cu1',
             'parameters': ['lam'],

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -24,6 +24,7 @@
 #include "framework/types.hpp"
 #include "framework/json.hpp"
 #include "framework/utils.hpp"
+#include "framework/linalg/almost_equal.hpp"
 
 namespace AER {
 namespace Operations {
@@ -36,7 +37,7 @@ enum class RegComparison {Equal, NotEqual, Less, LessEqual, Greater, GreaterEqua
 // Enum class for operation types
 enum class OpType {
   gate, measure, reset, bfunc, barrier, snapshot,
-  matrix, multiplexer, kraus, superop, roerror, noise_switch, initialize
+  matrix, diagonal_matrix, multiplexer, kraus, superop, roerror, noise_switch, initialize
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
@@ -60,7 +61,10 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     stream << "snapshot";
     break;
   case OpType::matrix:
-    stream << "matrix";
+    stream << "unitary";
+    break;
+  case OpType::diagonal_matrix:
+    stream << "diagonal";
     break;
   case OpType::multiplexer:
     stream << "multiplexer";
@@ -561,6 +565,7 @@ Op json_to_op_snapshot_pauli(const json_t &js);
 
 // Matrices
 Op json_to_op_unitary(const json_t &js);
+Op json_to_op_diagonal(const json_t &js);
 Op json_to_op_superop(const json_t &js);
 Op json_to_op_multiplexer(const json_t &js);
 Op json_to_op_kraus(const json_t &js);
@@ -596,6 +601,8 @@ Op json_to_op(const json_t &js) {
   // Arbitrary matrix gates
   if (name == "unitary")
     return json_to_op_unitary(js);
+  if (name == "diagonal")
+    return json_to_op_diagonal(js);
   if (name == "superop")
     return json_to_op_superop(js);
   // Snapshot
@@ -856,6 +863,35 @@ Op json_to_op_unitary(const json_t &js) {
       throw std::invalid_argument("\"unitary\" matrix is not unitary.");
     }
   }
+  // Check for a label
+  std::string label;
+  JSON::get_value(label, "label", js);
+  op.string_params.push_back(label);
+
+  // Conditional
+  add_condtional(Allowed::Yes, op, js);
+  return op;
+}
+
+Op json_to_op_diagonal(const json_t &js) {
+  Op op;
+  op.type = OpType::diagonal_matrix;
+  op.name = "diagonal";
+  JSON::get_value(op.qubits, "qubits", js);
+  JSON::get_value(op.params, "params", js);
+
+  // Validation
+  check_empty_qubits(op);
+  check_duplicate_qubits(op);
+  if (op.params.size() != 1ULL << op.qubits.size()) {
+    throw std::invalid_argument("\"diagonal\" matrix is wrong size.");
+  }
+  for (const auto val : op.params) {
+    if (!Linalg::almost_equal(std::abs(val), 1.0)) {
+      throw std::invalid_argument("\"diagonal\" matrix is not unitary.");
+    }
+  }
+
   // Check for a label
   std::string label;
   JSON::get_value(label, "label", js);

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -77,6 +77,7 @@ public:
       Operations::OpType::bfunc,
       Operations::OpType::roerror,
       Operations::OpType::matrix,
+      Operations::OpType::diagonal_matrix,
       Operations::OpType::kraus,
       Operations::OpType::superop
     });
@@ -416,6 +417,9 @@ void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
         break;
       case Operations::OpType::matrix:
         apply_matrix(op.qubits, op.mats[0]);
+        break;
+      case Operations::OpType::diagonal_matrix:
+        BaseState::qreg_.apply_diagonal_matrix(op.qubits, op.params);
         break;
       case Operations::OpType::superop:
         BaseState::qreg_.apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -80,6 +80,7 @@ public:
       Operations::OpType::bfunc,
       Operations::OpType::roerror,
       Operations::OpType::matrix,
+      Operations::OpType::diagonal_matrix,
       Operations::OpType::multiplexer,
       Operations::OpType::kraus
     });
@@ -468,6 +469,9 @@ void State<statevec_t>::apply_ops(const std::vector<Operations::Op> &ops,
           break;
         case Operations::OpType::matrix:
           apply_matrix(op);
+          break;
+        case Operations::OpType::diagonal_matrix:
+          BaseState::qreg_.apply_diagonal_matrix(op.qubits, op.params);
           break;
         case Operations::OpType::multiplexer:
           apply_multiplexer(op.regs[0], op.regs[1], op.mats); // control qubits ([0]) & target qubits([1])

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -65,6 +65,7 @@ public:
       Operations::OpType::snapshot,
       Operations::OpType::barrier,
       Operations::OpType::matrix,
+      Operations::OpType::diagonal_matrix,
       Operations::OpType::kraus,
       Operations::OpType::superop
     });
@@ -233,6 +234,9 @@ void State<data_t>::apply_ops(const std::vector<Operations::Op> &ops,
         break;
       case Operations::OpType::matrix:
         apply_matrix(op.qubits, op.mats[0]);
+        break;
+      case Operations::OpType::diagonal_matrix:
+        BaseState::qreg_.apply_diagonal_matrix(op.qubits, op.params);
         break;
       case Operations::OpType::kraus:
         apply_kraus(op.qubits, op.mats);

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -69,9 +69,13 @@ class State : public Base::State<unitary_matrix_t> {
 
   // Return the set of qobj instruction types supported by the State
   virtual Operations::OpSet::optypeset_t allowed_ops() const override {
-    return Operations::OpSet::optypeset_t(
-        {Operations::OpType::gate, Operations::OpType::barrier,
-         Operations::OpType::matrix, Operations::OpType::snapshot});
+    return Operations::OpSet::optypeset_t({
+      Operations::OpType::gate,
+      Operations::OpType::barrier,
+      Operations::OpType::matrix,
+      Operations::OpType::diagonal_matrix,
+      Operations::OpType::snapshot
+    });
   }
 
   // Return the set of qobj gate instruction names supported by the State
@@ -232,6 +236,9 @@ void State<unitary_matrix_t>::apply_ops(
         break;
       case Operations::OpType::matrix:
         apply_matrix(op.qubits, op.mats[0]);
+        break;
+      case Operations::OpType::diagonal_matrix:
+        BaseState::qreg_.apply_diagonal_matrix(op.qubits, op.params);
         break;
       default:
         throw std::invalid_argument(

--- a/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
+++ b/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
@@ -13,10 +13,11 @@
 QasmSimulator Integration Tests
 """
 
+
+from test.terra.reference import ref_unitary_gate, ref_diagonal_gate
+
 from qiskit import execute
 from qiskit.providers.aer import QasmSimulator
-
-from test.terra.reference import ref_unitary_gate
 
 
 class QasmUnitaryGateTests:
@@ -48,3 +49,25 @@ class QasmUnitaryGateTests:
         result = execute(circuits, self.SIMULATOR, shots=shots).result()
         self.assertTrue(getattr(result, 'success', False))
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+
+
+class QasmDiagonalGateTests:
+    """QasmSimulator additional tests."""
+
+    SIMULATOR = QasmSimulator()
+    BACKEND_OPTS = {}
+
+    # ---------------------------------------------------------------------
+    # Test unitary gate qobj instruction
+    # ---------------------------------------------------------------------
+
+    def test_diagonal_gate(self):
+        """Test simulation with unitary gate circuit instructions."""
+        shots = 100
+        circuits = ref_diagonal_gate.diagonal_gate_circuits_deterministic(
+            final_measure=True)
+        targets = ref_diagonal_gate.diagonal_gate_counts_deterministic(
+            shots)
+        result = execute(circuits, self.SIMULATOR, shots=shots).result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_counts(result, circuits, targets, delta=0)

--- a/test/terra/backends/statevector_simulator/statevector_basics.py
+++ b/test/terra/backends/statevector_simulator/statevector_basics.py
@@ -21,6 +21,7 @@ from test.terra.reference import ref_1q_clifford
 from test.terra.reference import ref_2q_clifford
 from test.terra.reference import ref_non_clifford
 from test.terra.reference import ref_unitary_gate
+from test.terra.reference import ref_diagonal_gate
 
 from qiskit import execute
 from qiskit.compiler import assemble
@@ -1064,6 +1065,19 @@ class StatevectorSimulatorTests:
         circuits = ref_unitary_gate.unitary_gate_circuits_deterministic(
             final_measure=False)
         targets = ref_unitary_gate.unitary_gate_statevector_deterministic()
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=1,
+                      backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_statevector(result, circuits, targets)
+
+    def test_diagonal_gate(self):
+        """Test simulation with diagonal gate circuit instructions."""
+        circuits = ref_diagonal_gate.diagonal_gate_circuits_deterministic(
+            final_measure=False)
+        targets = ref_diagonal_gate.diagonal_gate_statevector_deterministic()
         job = execute(circuits,
                       self.SIMULATOR,
                       shots=1,

--- a/test/terra/backends/test_qasm_simulator.py
+++ b/test/terra/backends/test_qasm_simulator.py
@@ -28,6 +28,7 @@ from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonClifford
 from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsWaltzBasis
 from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsMinimalBasis
 from test.terra.backends.qasm_simulator.qasm_unitary_gate import QasmUnitaryGateTests
+from test.terra.backends.qasm_simulator.qasm_unitary_gate import QasmDiagonalGateTests
 from test.terra.backends.qasm_simulator.qasm_initialize import QasmInitializeTests
 # Conditional instruction tests
 from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalGateTests
@@ -77,6 +78,7 @@ class TestQasmSimulator(common.QiskitAerTestCase,
                         QasmAlgorithmTestsWaltzBasis,
                         QasmAlgorithmTestsMinimalBasis,
                         QasmUnitaryGateTests,
+                        QasmDiagonalGateTests,
                         QasmReadoutNoiseTests,
                         QasmPauliNoiseTests,
                         QasmThreadManagementTests,

--- a/test/terra/backends/test_qasm_simulator_density_matrix.py
+++ b/test/terra/backends/test_qasm_simulator_density_matrix.py
@@ -28,6 +28,7 @@ from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonClifford
 from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsWaltzBasis
 from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsMinimalBasis
 from test.terra.backends.qasm_simulator.qasm_unitary_gate import QasmUnitaryGateTests
+from test.terra.backends.qasm_simulator.qasm_unitary_gate import QasmDiagonalGateTests
 # Conditional instruction tests
 from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalGateTests
 from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalUnitaryTests
@@ -61,7 +62,7 @@ class DensityMatrixTests(
         QasmCliffordTestsMinimalBasis, QasmNonCliffordTests,
         QasmNonCliffordTestsWaltzBasis, QasmNonCliffordTestsMinimalBasis,
         QasmAlgorithmTests, QasmAlgorithmTestsWaltzBasis,
-        QasmAlgorithmTestsMinimalBasis, QasmUnitaryGateTests,
+        QasmAlgorithmTestsMinimalBasis, QasmUnitaryGateTests, QasmDiagonalGateTests,
         QasmReadoutNoiseTests, QasmPauliNoiseTests, QasmResetNoiseTests,
         QasmKrausNoiseTests, QasmSnapshotStatevectorTests,
         QasmSnapshotDensityMatrixTests, QasmSnapshotProbabilitiesTests,

--- a/test/terra/backends/test_qasm_simulator_statevector.py
+++ b/test/terra/backends/test_qasm_simulator_statevector.py
@@ -28,6 +28,7 @@ from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonClifford
 from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsWaltzBasis
 from test.terra.backends.qasm_simulator.qasm_noncliffords import QasmNonCliffordTestsMinimalBasis
 from test.terra.backends.qasm_simulator.qasm_unitary_gate import QasmUnitaryGateTests
+from test.terra.backends.qasm_simulator.qasm_unitary_gate import QasmDiagonalGateTests
 from test.terra.backends.qasm_simulator.qasm_initialize import QasmInitializeTests
 # Conditional instruction tests
 from test.terra.backends.qasm_simulator.qasm_conditional import QasmConditionalGateTests
@@ -66,7 +67,7 @@ class StatevectorTests(
         QasmCliffordTestsMinimalBasis, QasmNonCliffordTests,
         QasmNonCliffordTestsWaltzBasis, QasmNonCliffordTestsMinimalBasis,
         QasmAlgorithmTests, QasmAlgorithmTestsWaltzBasis,
-        QasmAlgorithmTestsMinimalBasis, QasmUnitaryGateTests,
+        QasmAlgorithmTestsMinimalBasis, QasmUnitaryGateTests, QasmDiagonalGateTests,
         QasmReadoutNoiseTests, QasmPauliNoiseTests, QasmThreadManagementTests,
         QasmFusionTests, QasmDelayMeasureTests, QasmQubitsTruncateTests,
         QasmResetNoiseTests, QasmKrausNoiseTests, QasmBasicsTests,

--- a/test/terra/backends/unitary_simulator/unitary_basics.py
+++ b/test/terra/backends/unitary_simulator/unitary_basics.py
@@ -19,6 +19,7 @@ from test.terra.reference import ref_1q_clifford
 from test.terra.reference import ref_2q_clifford
 from test.terra.reference import ref_non_clifford
 from test.terra.reference import ref_unitary_gate
+from test.terra.reference import ref_diagonal_gate
 
 from qiskit import execute
 from qiskit.providers.aer import UnitarySimulator
@@ -1042,6 +1043,19 @@ class UnitarySimulatorTests:
         circuits = ref_unitary_gate.unitary_gate_circuits_deterministic(
             final_measure=False)
         targets = ref_unitary_gate.unitary_gate_unitary_deterministic()
+        job = execute(circuits,
+                      self.SIMULATOR,
+                      shots=1,
+                      backend_options=self.BACKEND_OPTS)
+        result = job.result()
+        self.assertTrue(getattr(result, 'success', False))
+        self.compare_unitary(result, circuits, targets)
+
+    def test_diagonal_gate(self):
+        """Test simulation with diagonal gate circuit instructions."""
+        circuits = ref_diagonal_gate.diagonal_gate_circuits_deterministic(
+            final_measure=False)
+        targets = ref_diagonal_gate.diagonal_gate_unitary_deterministic()
         job = execute(circuits,
                       self.SIMULATOR,
                       shots=1,

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -118,16 +118,19 @@ class QiskitAerTestCase(unittest.TestCase):
         for pos, test_case in enumerate(zip(circuits, targets)):
             circuit, target = test_case
             output = result.get_statevector(circuit)
-            msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
-                   " {} != {}".format(output, target))
-            if (global_phase):
-                # Test equal including global phase
-                self.assertAlmostEqual(norm(output - target), 0, places=places,
-                                       msg=msg)
-            else:
-                # Test equal ignorning global phase
-                self.assertAlmostEqual(state_fidelity(output, target) - 1, 0, places=places,
-                                       msg=msg + " up to global phase")
+            test_msg = "Circuit ({}/{}):".format(pos + 1, len(circuits))
+            with self.subTest(msg=test_msg):
+                msg = " {} != {}".format(output, target)
+                if global_phase:
+                    # Test equal including global phase
+                    self.assertAlmostEqual(
+                        norm(output - target), 0, places=places,
+                        msg=msg)
+                else:
+                    # Test equal ignorning global phase
+                    self.assertAlmostEqual(
+                        state_fidelity(output, target) - 1, 0, places=places,
+                        msg=msg + " up to global phase")
 
     def compare_unitary(self, result, circuits, targets,
                         global_phase=True, places=None):
@@ -135,17 +138,19 @@ class QiskitAerTestCase(unittest.TestCase):
         for pos, test_case in enumerate(zip(circuits, targets)):
             circuit, target = test_case
             output = result.get_unitary(circuit)
-            msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
-                   " {} != {}".format(output, target))
-            if (global_phase):
-                # Test equal including global phase
-                self.assertAlmostEqual(norm(output - target), 0,
-                                       places=places, msg=msg)
-            else:
-                # Test equal ignorning global phase
-                delta = np.trace(np.dot(np.conj(np.transpose(output)), target)) - len(output)
-                self.assertAlmostEqual(delta, 0, places=places,
-                                       msg=msg + " up to global phase")
+            test_msg = "Circuit ({}/{}):".format(pos + 1, len(circuits))
+            with self.subTest(msg=test_msg):
+                msg = "\n{}\n {} != {}".format(circuit, output, target)
+                if global_phase:
+                    # Test equal including global phase
+                    self.assertAlmostEqual(
+                        norm(output - target), 0, places=places, msg=msg)
+                else:
+                    # Test equal ignorning global phase
+                    delta = np.trace(np.dot(
+                        np.conj(np.transpose(output)), target)) - len(output)
+                    self.assertAlmostEqual(
+                        delta, 0, places=places, msg=msg + " up to global phase")
 
     def compare_counts(self, result, circuits, targets, hex_counts=True, delta=0):
         """Compare counts dictionary to targets."""
@@ -157,9 +162,11 @@ class QiskitAerTestCase(unittest.TestCase):
             else:
                 # Use get counts method which converts hex
                 output = result.get_counts(circuit)
-            msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
-                   " {} != {}".format(output, target))
-            self.assertDictAlmostEqual(output, target, delta=delta, msg=msg)
+            test_msg = "Circuit ({}/{}):".format(pos + 1, len(circuits))
+            with self.subTest(msg=test_msg):
+                msg = " {} != {}".format(output, target)
+                self.assertDictAlmostEqual(
+                    output, target, delta=delta, msg=msg)
 
     def compare_memory(self, result, circuits, targets, hex_counts=True):
         """Compare memory list to target."""
@@ -172,9 +179,10 @@ class QiskitAerTestCase(unittest.TestCase):
             else:
                 # Use get counts method which converts hex
                 output = result.get_memory(circuit)
-            msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
-                   " {} != {}".format(output, target))
-            self.assertEqual(output, target, msg=msg)
+            test_msg = "Circuit ({}/{}):".format(pos + 1, len(circuits))
+            with self.subTest(msg=test_msg):
+                msg = " {} != {}".format(output, target)
+                self.assertEqual(output, target, msg=msg)
 
     def compare_result_metadata(self, result, circuits, key, targets):
         """Compare result metadata key value."""
@@ -186,9 +194,10 @@ class QiskitAerTestCase(unittest.TestCase):
             metadata = getattr(result.results[0], 'metadata')
             if metadata:
                 value = metadata.get(key)
-            msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
-                   " metadata {} value {} != {}".format(key, value, target))
-            self.assertEqual(value, target, msg=msg)
+            test_msg = "Circuit ({}/{}):".format(pos + 1, len(circuits))
+            with self.subTest(msg=test_msg):
+                msg = " metadata {} value {} != {}".format(key, value, target)
+                self.assertEqual(value, target, msg=msg)
 
     def assertDictAlmostEqual(self, dict1, dict2, delta=None, msg=None,
                               places=None, default_value=0):

--- a/test/terra/reference/ref_diagonal_gate.py
+++ b/test/terra/reference/ref_diagonal_gate.py
@@ -1,0 +1,137 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Test circuits and reference outputs for diagonal instruction.
+"""
+
+
+import numpy as np
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+
+def diagonal_gate_circuits_deterministic(final_measure=True):
+    """Diagonal gate test circuits with deterministic count output."""
+
+    circuits = []
+    qr = QuantumRegister(2, 'qr')
+    if final_measure:
+        cr = ClassicalRegister(2, 'cr')
+        regs = (qr, cr)
+    else:
+        regs = (qr, )
+
+    # Swap |00> <--> |01> states
+    circuit = QuantumCircuit(*regs)
+    circuit.h(0)
+    circuit.diagonal([1, -1], [0])
+    circuit.h(0)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # Swap |00> <--> |10> states
+    circuit = QuantumCircuit(*regs)
+    circuit.h(1)
+    circuit.diagonal([1, -1], [1])
+    circuit.h(1)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # Swap |00> <--> |11> states
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr)
+    circuit.diagonal([1, -1, -1, 1], qr)
+    circuit.h(qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # CS01.XX, 1j|11> state
+    circuit = QuantumCircuit(*regs)
+    circuit.x(qr)
+    circuit.diagonal([1, 1, 1, 1j], qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
+def diagonal_gate_counts_deterministic(shots, hex_counts=True):
+    """Diagonal gate circuits reference counts."""
+    targets = []
+    if hex_counts:
+        # Swap |00> <--> |01> states
+        targets.append({'0x1': shots})
+        # Swap |00> <--> |10> states
+        targets.append({'0x2': shots})
+        # Swap |00> <--> |11> states
+        targets.append({'0x3': shots})
+        # CS01.XX, 1j|11> state
+        targets.append({'0x3': shots})
+    else:
+        # Swap |00> <--> |01> states
+        targets.append({'01': shots})
+        # Swap |00> <--> |10> states
+        targets.append({'10': shots})
+        # Swap |00> <--> |11> states
+        targets.append({'11': shots})
+        # CS01.XX, 1j|11> state
+        targets.append({'11': shots})
+    return targets
+
+
+def diagonal_gate_statevector_deterministic():
+    """Diagonal gate test circuits with deterministic counts."""
+    targets = []
+    # Swap |00> <--> |01> states
+    targets.append(np.array([0, 1, 0, 0]))
+    # Swap |00> <--> |10> states
+    targets.append(np.array([0, 0, 1, 0]))
+    # Swap |00> <--> |11> states
+    targets.append(np.array([0, 0, 0, 1]))
+    # CS01.XX, 1j|11> state
+    targets.append(np.array([0, 0, 0, 1j]))
+    return targets
+
+
+def diagonal_gate_unitary_deterministic():
+    """Diagonal gate circuits reference unitaries."""
+    targets = []
+
+    # Swap |00> <--> |01> states
+    targets.append(np.array([[0, 1, 0, 0],
+                             [1, 0, 0, 0],
+                             [0, 0, 0, 1],
+                             [0, 0, 1, 0]]))
+    # Swap |00> <--> |10> states
+    targets.append(np.array([[0, 0, 1, 0],
+                             [0, 0, 0, 1],
+                             [1, 0, 0, 0],
+                             [0, 1, 0, 0]]))
+    # Swap |00> <--> |11> states
+    targets.append(np.array([[0, 0, 0, 1],
+                             [0, 0, 1, 0],
+                             [0, 1, 0, 0],
+                             [1, 0, 0, 0]]))
+    # CS01.XX, 1j|11> state
+    targets.append(np.array([[0, 0, 0, 1],
+                             [0, 0, 1, 0],
+                             [0, 1, 0, 0],
+                             [1j, 0, 0, 0]]))
+    return targets


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds explicit support for terras diagonal gate operation. 

Closes #682 

### Details and comments

This was previously internally supported through the unitary instruction but now adds an explicit diagonal_matrix op type for diagonal unitaries.
