### PR TITLE
Add backwards compatibility for terra < 0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "pybind11>2.4"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake!=3.17.1,!=3.17.0", "ninja", "pybind11>2.4"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-cmake
+cmake!=3.17.1,!=3.17.0
 scikit-build
 cython
 asv

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requirements = [
 
 setup_requirements = requirements + [
     'scikit-build',
-    'cmake'
+    'cmake!=3.17,!=3.17.0'
 ]
 
 if not hasattr(setuptools,

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -601,7 +601,7 @@ Op json_to_op(const json_t &js) {
   // Arbitrary matrix gates
   if (name == "unitary")
     return json_to_op_unitary(js);
-  if (name == "diagonal")
+  if (name == "diagonal" || name == "diag")
     return json_to_op_diagonal(js);
   if (name == "superop")
     return json_to_op_superop(js);

--- a/test/terra/decorators.py
+++ b/test/terra/decorators.py
@@ -21,6 +21,10 @@ from qiskit import QuantumCircuit, assemble, execute
 from qiskit.providers.aer import AerProvider, QasmSimulator
 from qiskit.providers.aer import AerError
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
+
 
 def is_method_available(backend, method):
     """Check if input method is available for the qasm simulator."""

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -16,7 +16,7 @@ NoiseModel class integration tests
 
 import unittest
 from test.terra import common
-from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, execute
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.compiler import assemble, transpile
 from qiskit.providers.aer.backends import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
@@ -24,6 +24,10 @@ from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 from qiskit.providers.aer.noise.errors.standard_errors import reset_error
 from qiskit.providers.aer.noise.errors.standard_errors import amplitude_damping_error
 from qiskit.test import mock
+
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
 
 
 class TestNoise(common.QiskitAerTestCase):

--- a/test/terra/reference/ref_algorithms.py
+++ b/test/terra/reference/ref_algorithms.py
@@ -17,6 +17,10 @@ Test circuits and reference outputs for standard algorithms.
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
+
 
 def grovers_circuit(final_measure=True, allow_sampling=True):
     """Testing a circuit originated in the Grover algorithm"""

--- a/test/terra/reference/ref_diagonal_gate.py
+++ b/test/terra/reference/ref_diagonal_gate.py
@@ -18,6 +18,10 @@ Test circuits and reference outputs for diagonal instruction.
 import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'diagonal'):
+    QuantumCircuit.diagonal = QuantumCircuit.diag_gate
+
 
 def diagonal_gate_circuits_deterministic(final_measure=True):
     """Diagonal gate test circuits with deterministic count output."""

--- a/test/terra/reference/ref_kraus_noise.py
+++ b/test/terra/reference/ref_kraus_noise.py
@@ -20,6 +20,10 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import amplitude_damping_error
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
+
 
 # ==========================================================================
 # Amplitude damping error

--- a/test/terra/reference/ref_measure.py
+++ b/test/terra/reference/ref_measure.py
@@ -18,6 +18,10 @@ from numpy import array
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Instruction
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
+
 
 # ==========================================================================
 # Single-qubit measurements with deterministic output

--- a/test/terra/reference/ref_pauli_noise.py
+++ b/test/terra/reference/ref_pauli_noise.py
@@ -20,6 +20,10 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
+
 
 # ==========================================================================
 # Pauli Gate Errors

--- a/test/terra/reference/ref_reset_noise.py
+++ b/test/terra/reference/ref_reset_noise.py
@@ -20,6 +20,10 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import reset_error
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
+
 
 # ==========================================================================
 # Reset Gate Errors

--- a/test/terra/reference/ref_snapshot_expval.py
+++ b/test/terra/reference/ref_snapshot_expval.py
@@ -18,6 +18,10 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.quantum_info.states import Statevector
 from qiskit.providers.aer.extensions.snapshot_expectation_value import *
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
+
 
 def snapshot_expval_labels():
     """List of labels for exp val snapshots."""
@@ -223,6 +227,7 @@ def snapshot_expval_post_meas_values():
         targets.append(values)
     return targets
 
+
 def snapshot_expval_circuit_parameterized(single_shot=False,
                                           measure=True,
                                           snapshot=False):
@@ -235,12 +240,12 @@ def snapshot_expval_circuit_parameterized(single_shot=False,
     regs = (qr, cr)
 
     circuit = QuantumCircuit(*regs)
-    circuit.u3(0, 0, 0, qubit=0)
-    circuit.u1(0, qubit=0)
-    circuit.u3(0, 0, 0, qubit=1)
-    circuit.cu3(0, 0, 0, control_qubit=0, target_qubit=1)
-    circuit.u3(0, 0, 0, qubit=1)
-    circuit.id(qubit=0)
+    circuit.u3(0, 0, 0, 0)
+    circuit.u1(0, 0)
+    circuit.u3(0, 0, 0, 1)
+    circuit.cu3(0, 0, 0, 0, 1)
+    circuit.u3(0, 0, 0, 1)
+    circuit.i(0)
     if snapshot:
         for label, (params, qubits) in snapshot_expval_params(pauli=True).items():
             circuit.snapshot_expectation_value(label,

--- a/tools/verify_wheels.py
+++ b/tools/verify_wheels.py
@@ -22,6 +22,10 @@ from qiskit.providers.aer import StatevectorSimulator
 from qiskit.providers.aer import UnitarySimulator
 from qiskit.providers.aer import PulseSimulator
 
+# Backwards compatibility for Terra <= 0.13
+if not hasattr(QuantumCircuit, 'i'):
+    QuantumCircuit.i = QuantumCircuit.iden
+
 
 def assertAlmostEqual(first, second, places=None, msg=None,
                       delta=None):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes some import issues for updating tests to remove deprecation warnings for 0.13, by allowing backwards compatibility with terra 0.12.

### Details and comments


