### PR TITLE
Disable jsonschema validation by default

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -83,7 +83,7 @@ class AerBackend(BaseBackend):
         self._controller = controller
 
     # pylint: disable=arguments-differ
-    def run(self, qobj, backend_options=None, noise_model=None, validate=True):
+    def run(self, qobj, backend_options=None, noise_model=None, validate=False):
         """Run a qobj on the backend.
 
         Args:

--- a/qiskit/providers/aer/releasenotes/notes/validation-opt-in-e43a002f160ddd11.yaml
+++ b/qiskit/providers/aer/releasenotes/notes/validation-opt-in-e43a002f160ddd11.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    For Aer's backend the jsonschema validation of input qobj objects from
+    terra is now opt-in instead of being enabled by default. If you want
+    to enable jsonschema validation of qobj set the ``validate`` kwarg on
+    the :meth:`qiskit.providers.aer.QasmSimualtor.run` method for the backend
+    object to ``True``.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently the aer backends are running jsonschema validation on the Qobj
objects passed in via terra by default. This is unnecessary overhead as
terra is programatically creating these objects and they're extremely
unlikely to be structurally invalid (which is all jsonschema will
catch). Even, if it was this will be caught later when something goes to
use it and the error message from that is more likely to be useful since
the way the json schemas are constructed precludes useful error message.
This commit changes the default value of this to be opt-in on the run()
method to avoid this unnecessary overhead.

### Details and comments