### PR TITLE
Handle complex numbers in pulse defaults

### DIFF
--- a/qiskit/providers/aer/pulse/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/pulse_system_model.py
@@ -156,7 +156,10 @@ class PulseSystemModel():
                         q_idx = u_term_dict.get('q')
                         if len(u_string) > 0:
                             u_string += ' + '
-                        u_string += str(scale[0] + scale[1] * 1j) + 'q' + str(q_idx)
+                        if isinstance(scale, complex):
+                            u_string = str(scale) + 'q' + str(q_idx)
+                        else:
+                            u_string += str(scale[0] + scale[1] * 1j) + 'q' + str(q_idx)
                     control_channel_labels[u_idx] = {'driven_q': drive_idx, 'freq': u_string}
 
         return cls(hamiltonian=hamiltonian,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-terra#4016 the pulse defaults (as well as backend
configuration and properties) were updated to not rely on marshmallow. A
side effect of this change is that the return from to_dict() on pulse
defaults no longer will convert complex -> [real, imag] since this is
typically an unecessary conversion that complicates using the output.
However, the pulse system model class was not handling this as expected
and will fail trying to access the the components from [real, imag].
This commit updates this to handle the case when a complex number is
passed in.

### Details and comments

This will be blocked until Qiskit/qiskit-terra#4124 merges.