### PR TITLE
Avoid to_dict() when possible in pulse system model

### DIFF
--- a/qiskit/providers/aer/pulse/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/pulse_system_model.py
@@ -151,7 +151,7 @@ class PulseSystemModel():
                 if drive_idx is not None:
                     # construct string for u channel
                     u_string = ''
-                    for u_term_dict in u_lo.to_dict():
+                    for u_term_dict in u_lo:
                         scale = getattr(u_term_dict, 'scale', [1.0, 0])
                         q_idx = getattr(u_term_dict, 'q')
                         if len(u_string) > 0:

--- a/qiskit/providers/aer/pulse/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/pulse_system_model.py
@@ -153,7 +153,7 @@ class PulseSystemModel():
                     u_string = ''
                     for u_term_dict in u_lo.to_dict():
                         scale = getattr(u_term_dict, 'scale', [1.0, 0])
-                        q_idx = u_term_dict.get('q')
+                        q_idx = getattr(u_term_dict, 'q')
                         if len(u_string) > 0:
                             u_string += ' + '
                         if isinstance(scale, complex):

--- a/qiskit/providers/aer/pulse/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/pulse_system_model.py
@@ -152,7 +152,7 @@ class PulseSystemModel():
                     # construct string for u channel
                     u_string = ''
                     for u_term_dict in u_lo.to_dict():
-                        scale = u_term_dict.get('scale', [1.0, 0])
+                        scale = getattr(u_term_dict, 'scale', [1.0, 0])
                         q_idx = u_term_dict.get('q')
                         if len(u_string) > 0:
                             u_string += ' + '

--- a/qiskit/providers/aer/pulse/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/pulse_system_model.py
@@ -110,23 +110,23 @@ class PulseSystemModel():
             raise AerError("{} is not a Qiskit backend".format(backend))
 
         # get relevant information from backend
-        defaults = backend.defaults().to_dict()
-        config = backend.configuration().to_dict()
+        defaults = backend.defaults()
+        config = backend.configuration()
 
-        if not config['open_pulse']:
+        if not config.open_pulse:
             raise AerError('{} is not an open pulse backend'.format(backend))
 
         # draw defaults
-        qubit_freq_est = defaults.get('qubit_freq_est', None)
-        meas_freq_est = defaults.get('meas_freq_est', None)
+        qubit_freq_est = getattr(defaults, 'qubit_freq_est', None)
+        meas_freq_est = getattr(defaults, 'meas_freq_est', None)
 
         # draw from configuration
         # if no subsystem_list, use all for device
-        subsystem_list = subsystem_list or list(range(config['n_qubits']))
-        ham_string = config['hamiltonian']
+        subsystem_list = subsystem_list or list(range(config.n_qubits))
+        ham_string = config.hamiltonian
         hamiltonian = HamiltonianModel.from_dict(ham_string, subsystem_list)
-        u_channel_lo = config.get('u_channel_lo', None)
-        dt = config.get('dt', None)
+        u_channel_lo = getattr(config, 'u_channel_lo', None)
+        dt = getattr(config, 'dt', None)
 
         control_channel_labels = [None] * len(u_channel_lo)
         # populate control_channel_dict
@@ -151,12 +151,15 @@ class PulseSystemModel():
                 if drive_idx is not None:
                     # construct string for u channel
                     u_string = ''
-                    for u_term_dict in u_lo:
+                    for u_term_dict in u_lo.to_dict():
                         scale = u_term_dict.get('scale', [1.0, 0])
                         q_idx = u_term_dict.get('q')
                         if len(u_string) > 0:
                             u_string += ' + '
-                        u_string += str(scale[0] + scale[1] * 1j) + 'q' + str(q_idx)
+                        if isinstance(scale, complex):
+                            u_string += str(scale) + 'q' + str(q_idx)
+                        else:
+                            u_string += str(scale[0] + scale[1] * 1j) + 'q' + str(q_idx)
                     control_channel_labels[u_idx] = {'driven_q': drive_idx, 'freq': u_string}
 
         return cls(hamiltonian=hamiltonian,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As fall out from Qiskit/qiskit-terra#4016 there was a bug in the
to_dict() method of the backend configuration that was resulting in
UChannelLO objects not getting converted to their dict form in the
output of to_dict(). While this is being fixed in
Qiskit/qiskit-terra#4124 this commit side steps the issue by adapting
the access patterns in the pulse system model to rely on class attribute
access and getattr() instead of dict access and get().

### Details and comments

This is an alternative to the fix from a combination of #694 and Qiskit/qiskit-terra#4124
