### PR TITLE
Update transpilation pass interface in controller

### DIFF
--- a/releasenotes/notes/controller-transpile-298ea8d76a406648.yaml
+++ b/releasenotes/notes/controller-transpile-298ea8d76a406648.yaml
@@ -1,0 +1,16 @@
+---
+upgrade:
+  - |
+    Changes how transpilation passes are handled in the C++ Controller classes
+    so that each pass must be explicitly called. This allows for greater
+    customization on when each pass should be called, and with what parameters.
+    In particular this enables setting different parameters for the gate
+    fusion optimization pass depending on the QasmController simulation method.
+fixes:
+  - |
+    Fixes Controller classes so that the ReduceBarrier transpilation pass is
+    applied first. This prevents barrier instructions from preventing truncation
+    of unused qubits if the only instruction defined on them was a barrier.
+  - |
+    Disables gate fusion for the matrix product state simulation method as this
+    was causing issues with incorrect results being returned in some cases.

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -43,7 +43,6 @@
 #include "framework/results/result.hpp"
 #include "framework/results/experiment_data.hpp"
 #include "noise/noise_model.hpp"
-#include "transpile/circuitopt.hpp"
 #include "transpile/basic_opts.hpp"
 #include "transpile/truncate_qubits.hpp"
 
@@ -130,13 +129,6 @@ public:
   // Clear the current config
   void virtual clear_config();
 
-  // Add circuit optimization
-  template <typename Type>
-  inline auto add_circuit_optimization(Type&& opt)-> typename std::enable_if_t<std::is_base_of<Transpile::CircuitOptimization, std::remove_const_t<std::remove_reference_t<Type>>>::value >
-  {
-      optimizations_.push_back(std::make_shared<std::remove_const_t<std::remove_reference_t<Type>>>(std::forward<Type>(opt)));
-  }
-
 protected:
 
   //-----------------------------------------------------------------------
@@ -199,8 +191,8 @@ protected:
   // Timer type
   using myclock_t = std::chrono::high_resolution_clock;
 
-  // Circuit optimization
-  std::vector<std::shared_ptr<Transpile::CircuitOptimization>> optimizations_;
+  // Transpile pass override flags
+  bool truncate_qubits_ = true;
 
   // Validation threshold for validating states and operators
   double validation_threshold_ = 1e-8;
@@ -242,9 +234,6 @@ protected:
   int parallel_experiments_;
   int parallel_shots_;
   int parallel_state_update_;
-
-  // Truncate qubits
-  bool truncate_qubits_ = true;
 };
 
 
@@ -260,9 +249,6 @@ void Controller::set_config(const json_t &config) {
 
   // Load validation threshold
   JSON::get_value(validation_threshold_, "validation_threshold", config);
-
-  // Load qubit truncation
-  JSON::get_value(truncate_qubits_, "truncate_enable", config);
 
   #ifdef _OPENMP
   // Load OpenMP maximum thread settings
@@ -289,9 +275,6 @@ void Controller::set_config(const json_t &config) {
   if (JSON::check_key("max_memory_mb", config)) {
     JSON::get_value(max_memory_mb_, "max_memory_mb", config);
   }
-
-  for (std::shared_ptr<Transpile::CircuitOptimization> opt: optimizations_)
-    opt->set_config(config);
 
   // for debugging
   if (JSON::check_key("_parallel_experiments", config)) {
@@ -479,25 +462,6 @@ bool Controller::validate_memory_requirements(const state_t &state,
 }
 
 //-------------------------------------------------------------------------
-// Circuit optimization
-//-------------------------------------------------------------------------
-template <class state_t>
-void Controller::optimize_circuit(Circuit &circ,
-                                  Noise::NoiseModel& noise,
-                                  state_t& state,
-                                  ExperimentData &data) const {
-
-  Operations::OpSet allowed_opset;
-  allowed_opset.optypes = state.allowed_ops();
-  allowed_opset.gates = state.allowed_gates();
-  allowed_opset.snapshots = state.allowed_snapshots();
-
-  for (std::shared_ptr<Transpile::CircuitOptimization> opt: optimizations_) {
-    opt->optimize_circuit(circ, noise, allowed_opset, data);
-  }
-}
-
-//-------------------------------------------------------------------------
 // Qobj execution
 //-------------------------------------------------------------------------
 Result Controller::execute(const json_t &qobj_js) {
@@ -629,7 +593,6 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
   // Execute in try block so we can catch errors and return the error message
   // for individual circuit failures.
   try {
-  
     // Remove barriers from circuit
     Transpile::ReduceBarrier barrier_pass;
     barrier_pass.optimize_circuit(circ, noise, circ.opset(), data);

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -173,17 +173,6 @@ protected:
                                     const Circuit &circ,
                                     bool throw_except = false) const;
 
-  //-------------------------------------------------------------------------
-  // Circuit optimization
-  //-------------------------------------------------------------------------
-
-  // Generate an equivalent circuit with input_circ as output_circ.
-  template <class state_t>
-  void optimize_circuit(Circuit &circ,
-                        Noise::NoiseModel& noise,
-                        state_t& state,
-                        ExperimentData &data) const;
-
   //-----------------------------------------------------------------------
   // Config
   //-----------------------------------------------------------------------

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -186,7 +186,6 @@ class QasmController : public Base::Controller {
   // Return a fusion transpilation pass configured for the current
   // method, circuit and config
   Transpile::Fusion transpile_fusion(Method method,
-                                     const Circuit &circ,
                                      const json_t &config) const;
 
   //----------------------------------------------------------------
@@ -727,7 +726,6 @@ size_t QasmController::required_memory_mb(
 }
 
 Transpile::Fusion QasmController::transpile_fusion(Method method,
-                                                   const Circuit &circ,
                                                    const json_t &config) const {
   Transpile::Fusion fusion_pass;
   switch (method) {
@@ -866,7 +864,7 @@ void QasmController::run_circuit_with_noise(const Circuit &circ,
   state_opset.snapshots = state.allowed_snapshots(); 
 
   // Initialize fusion transpile pass
-  auto fusion_pass = transpile_fusion(method, circ, config);
+  auto fusion_pass = transpile_fusion(method, config);
   Noise::NoiseModel dummy_noise;
 
   while (shots-- > 0) {
@@ -901,7 +899,7 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
   measure_pass.optimize_circuit(opt_circ, dummy_noise, state_opset, data);
 
   // Apply fusion transpilation pass
-  auto fusion_pass = transpile_fusion(method, circ, config);
+  auto fusion_pass = transpile_fusion(method, config);
   fusion_pass.optimize_circuit(opt_circ, dummy_noise, state_opset, data);
 
   // Check if measure sampler and optimization are valid

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -301,8 +301,8 @@ class QasmFusionTests:
         self.assertTrue(
             'fusion_verbose' in result_verbose.to_dict()['results'][0]
             ['metadata'],
-            msg="fusion must work for satevector")
-        
+            msg="fusion must work for statevector")
+
     def test_fusion_operations(self):
         """Test Fusion enable/disable option"""
         shots = 100


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Removes the single list `optimize_circuits` from the base Controller class so that transpile passes must be called individually in controllers. This is important as certain passes (such as truncate qubits or fusion) should be called at different points of execution.
* Adds a `transpile_fusion` method to QasmController that returns a fusion pass that may be configured differently depending on the simulation method, circuit, and config. Currently it is set to use the same default values for all statevector and density matrix methods, and to disable fusion for stabilizer, mps and extended stabilizer methods.

### Details and comments

Fixes #681. Fusion was causing problems with MPS simulation method so this disables it entirely for this method. This could be re-enabled if benchmarks or config settings are found where it becomes favorable to use fusion.