### PR TITLE
Remove "extended_stabilizer" from automatic simulation methods.

### DIFF
--- a/releasenotes/notes/automatic-method-930a74f765b9a94c.yaml
+++ b/releasenotes/notes/automatic-method-930a74f765b9a94c.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Remove "extended_stabilizer" from the automatically selected simulation
+    methods. This is needed as the extended stabilizer method is not exact
+    and may give incorrect results for certain circuits unless the user
+    knows how to optimize its configuration parameters.
+    
+    The automatic method now only selects from "stabilizer", "density_matrix",
+    and "statevector" methods. If a non-Clifford circuit that is too large for
+    the statevector method is executed an exception will be raised suggesting
+    you could try explicitly using the "extended_stabilizer" or
+    "matrix_product_state" methods instead.

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -639,8 +639,8 @@ QasmController::Method QasmController::simulation_method(
       }
       // Finally we check the statevector memory requirement for the
       // current number of qubits. If it fits in available memory we
-      // default to the Statevector method. Otherwise we attempt to use
-      // the extended stabilizer simulator.
+      // default to the Statevector method. Otherwise we raise an exception
+      // and suggest using one of the other simulation methods.
       bool enough_memory = true;
       if (simulation_precision_ == Precision::single_precision) {
         Statevector::State<QV::QubitVector<float>> sv_state;
@@ -650,13 +650,11 @@ QasmController::Method QasmController::simulation_method(
         enough_memory = validate_memory_requirements(sv_state, circ, false);
       }
       if (!enough_memory) {
-        if (validate_state(ExtendedStabilizer::State(), circ, noise_model,
-                           false)) {
-          return Method::extended_stabilizer;
-        } else {
-          throw std::runtime_error(
-              "QasmSimulator: Circuit cannot be run using available methods.");
-        }
+        throw std::runtime_error(
+          "QasmSimulator: Insufficient memory for " + std::to_string(circ.num_qubits) +  "-qubit"
+          R"( circuit using "statevector" method. You could try using the)"
+          R"( "matrix_product_state" or "extended_stabilizer" method instead.)"
+        );
       }
     }
     // If we didn't select extended stabilizer above proceed to the default


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Removes the extended stabilizer simulator from automatically selected simulation methods. It must now explicitly be called as with the matrix product state method. If a user attempts to run a non-Clifford circuit with insufficient memory for the statevector method when using the automatic method an exception will be raised rather than trying to use the extended stabilizer method.

### Details and comments

This is to avoid issues where the extended stabilizer simulator can return incorrect results if it is not configured correctly depending on the expected distribution of outputs for a given circuit. If an advanced user knows what they are doing they can call this method explicitly, however it shouldn't be used by default unknowingly as it could cause a drastic change in simulator behaviour when the method kicked in at the qubit threshold for circuits that can no longer fit in statevector memory (this caused some issues in Aqua tests for example).

