### PR TITLE
Fix depol error param for device noise model with depol + relaxation error

### DIFF
--- a/qiskit/providers/aer/noise/device/basic_device_model.py
+++ b/qiskit/providers/aer/noise/device/basic_device_model.py
@@ -23,6 +23,7 @@ def basic_device_noise_model(properties,
                              thermal_relaxation=True,
                              temperature=0,
                              gate_lengths=None,
+                             gate_length_units='ns',
                              standard_gates=True):
     """
     Return a noise model derived from a devices backend properties.
@@ -98,6 +99,8 @@ def basic_device_noise_model(properties,
         gate_lengths (list): Custom gate times for thermal relaxation errors.
                              Used to extend or override the gate times in
                              the backend properties (Default: None))
+        gate_length_units (str): Time units for gate length values in gate_lengths.
+                                 Can be 'ns', 'ms', 'us', or 's' (Default: 'ns').
         standard_gates (bool): If true return errors as standard
                                qobj gates. If false return as unitary
                                qobj instructions (Default: True)
@@ -120,4 +123,5 @@ def basic_device_noise_model(properties,
                                    thermal_relaxation=thermal_relaxation,
                                    temperature=temperature,
                                    gate_lengths=gate_lengths,
+                                   gate_length_units=gate_length_units,
                                    standard_gates=standard_gates)

--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -25,7 +25,6 @@ from .parameters import gate_param_values
 from .parameters import thermal_relaxation_values
 from .parameters import _NANOSECOND_UNITS
 
-from ..noiseerror import NoiseError
 from ..errors.readout_error import ReadoutError
 from ..errors.standard_errors import depolarizing_error
 from ..errors.standard_errors import thermal_relaxation_error

--- a/qiskit/providers/aer/noise/device/parameters.py
+++ b/qiskit/providers/aer/noise/device/parameters.py
@@ -17,7 +17,6 @@ Functions to extract device error parameters from backend properties.
 from numpy import inf
 
 # Time and frequency unit conversions
-_MICROSECOND_UNITS = {'s': 1e6, 'ms': 1e3, 'µs': 1, 'us': 1, 'ns': 1e-3}
 _NANOSECOND_UNITS = {'s': 1e9, 'ms': 1e6, 'µs': 1e3, 'us': 1e3, 'ns': 1}
 _GHZ_UNITS = {'Hz': 1e-9, 'KHz': 1e-6, 'MHz': 1e-3, 'GHz': 1, 'THz': 1e3}
 
@@ -168,13 +167,13 @@ def thermal_relaxation_values(properties):
         if hasattr(t1_params, 'value'):
             t1 = t1_params.value
             if hasattr(t1_params, 'unit'):
-                # Convert to micro seconds
-                t1 *= _MICROSECOND_UNITS.get(t1_params.unit, 1)
+                # Convert to nanoseconds
+                t1 *= _NANOSECOND_UNITS.get(t1_params.unit, 1)
         if hasattr(t2_params, 'value'):
             t2 = t2_params.value
             if hasattr(t2_params, 'unit'):
-                # Convert to micro seconds
-                t2 *= _MICROSECOND_UNITS.get(t2_params.unit, 1)
+                # Convert to nanoseconds
+                t2 *= _NANOSECOND_UNITS.get(t2_params.unit, 1)
         if hasattr(t2_params, 'value'):
             freq = freq_params.value
             if hasattr(freq_params, 'unit'):

--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -631,7 +631,7 @@ class QuantumError:
                 composed = SuperOp(np.eye(4 ** num_qubits))
             else:
                 composed = Operator(np.eye(2 ** num_qubits))
-            composed.compose(op0, qargs=qubits0).compose(op1, qargs=qubits1)
+            composed = composed.compose(op0, qargs=qubits0).compose(op1, qargs=qubits1)
             qubits = list(range(num_qubits))
         # Get instruction params
         if name == 'kraus':

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -178,6 +178,7 @@ class NoiseModel:
                      thermal_relaxation=True,
                      temperature=0,
                      gate_lengths=None,
+                     gate_length_units='ns',
                      standard_gates=True):
         """Return a noise model derived from a devices backend properties.
 
@@ -252,6 +253,9 @@ class NoiseModel:
             gate_lengths (list): Custom gate times for thermal relaxation errors.
                                   Used to extend or override the gate times in
                                   the backend properties (Default: None))
+            gate_length_units (str): Time units for gate length values in
+                                     gate_lengths. Can be 'ns', 'ms', 'us',
+                                     or 's' (Default: 'ns').
             standard_gates (bool): If true return errors as standard
                                    qobj gates. If false return as unitary
                                    qobj instructions (Default: True)
@@ -285,6 +289,7 @@ class NoiseModel:
             gate_error=gate_error,
             thermal_relaxation=thermal_relaxation,
             gate_lengths=gate_lengths,
+            gate_length_units='ns',
             temperature=temperature,
             standard_gates=standard_gates)
         for name, qubits, error in gate_errors:

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -289,7 +289,7 @@ class NoiseModel:
             gate_error=gate_error,
             thermal_relaxation=thermal_relaxation,
             gate_lengths=gate_lengths,
-            gate_length_units='ns',
+            gate_length_units=gate_length_units,
             temperature=temperature,
             standard_gates=standard_gates)
         for name, qubits, error in gate_errors:

--- a/releasenotes/notes/device-errors-bb231623712ecda7.yaml
+++ b/releasenotes/notes/device-errors-bb231623712ecda7.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    Add ``gate_length_units`` kwarg to
+    :meth:`qiskit.providers.aer.noise.NoiseModel.from_device`
+    for specifying custom ``gate_lengths`` in the device noise model function
+    to handle unit conversions for internal code.
+fixes:
+  - |
+    Fix error in gate time unit conversion for device noise model with thermal
+    relaxation errors and gate errors. The error probability the depolarizing
+    error was being  calculated with gate time in microseconds, while for
+    thermal relaxation it was being calculated in nanoseconds. This resulted
+    in no depolarizing error being applied as the incorrect units would make
+    the device seem to be coherence limited.

--- a/releasenotes/notes/device-errors-bb231623712ecda7.yaml
+++ b/releasenotes/notes/device-errors-bb231623712ecda7.yaml
@@ -13,3 +13,6 @@ fixes:
     thermal relaxation it was being calculated in nanoseconds. This resulted
     in no depolarizing error being applied as the incorrect units would make
     the device seem to be coherence limited.
+  - |
+    Fix bug in incorrect composition of QuantumErrors when the qubits of
+    composed instructions differ.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #703 

### Details and comments

Running example code in issue 703 now returns:

```python
Gate Infidelities (relax + depol, depol, relax)
id[0] = [0.00076, 0.00042, 0.00076]
u2[0] = [0.00076, 0.00042, 0.00076]
u3[0] = [0.00152, 0.00085, 0.00152]
id[1] = [0.00041, 0.00041, 0.00014]
u2[1] = [0.00041, 0.00041, 0.00014]
u3[1] = [0.00083, 0.00083, 0.00029]
id[2] = [0.00045, 0.00045, 0.00014]
u2[2] = [0.00045, 0.00045, 0.00014]
u3[2] = [0.0009, 0.0009, 0.00028]
id[3] = [0.00057, 0.00057, 0.0002]
u2[3] = [0.00057, 0.00057, 0.0002]
u3[3] = [0.00115, 0.00115, 0.0004]
id[4] = [0.00061, 0.00061, 0.00036]
u2[4] = [0.00061, 0.00061, 0.00036]
u3[4] = [0.00122, 0.00122, 0.00071]
cx[0, 1] = [0.01053, 0.00789, 0.01053]
cx[1, 0] = [0.01159, 0.00789, 0.01159]
cx[1, 2] = [0.00754, 0.00754, 0.00218]
cx[1, 3] = [0.01122, 0.01122, 0.0058]
cx[2, 1] = [0.00754, 0.00754, 0.00252]
cx[3, 1] = [0.01122, 0.01122, 0.00539]
cx[3, 4] = [0.00755, 0.00755, 0.00509]
cx[4, 3] = [0.00755, 0.00755, 0.00575]
```

So the relax + depol error is approx equal to the max error of the depol only or relax only error case.