### PR TITLE
fix memory leak in gpu simulator

### DIFF
--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -149,6 +149,8 @@ public:
   {
     m_size = size;
   }
+  virtual ~QubitVectorBuffer(){};
+
   uint_t Size(void)
   {
     return m_size;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix a bug to leak GPU memory in `qubitvector_thrust.hpp`.

### Details and comments
An abstract class to manage host or device memory does not have `virtual` for its desconstructor. 

This fix will resolve #662.

