### PR TITLE
Add subsystem density matrix snapshots to qasm simulator

### DIFF
--- a/releasenotes/notes/density-matrix-snapshot-50de5e74c123a122.yaml
+++ b/releasenotes/notes/density-matrix-snapshot-50de5e74c123a122.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add density matrix snapshot support to "statevector" and "statevector_gpu"
+    methods of the QasmSimulator.
+  - |
+    Allow density matrix snapshots on specific qubits, not just all qubits.
+    This computes the partial trace of the state over the remaining qubits.

--- a/src/simulators/density_matrix/densitymatrix.hpp
+++ b/src/simulators/density_matrix/densitymatrix.hpp
@@ -67,6 +67,10 @@ public:
   // Returns the number of qubits for the superoperator
   virtual uint_t num_qubits() const override {return BaseMatrix::num_qubits_;}
 
+  // Convert qubit indicies to vectorized-density matrix qubitvector indices
+  // For the QubitVector apply matrix function
+  virtual reg_t superop_qubits(const reg_t &qubits) const;
+
   //-----------------------------------------------------------------------
   // Apply Matrices
   //-----------------------------------------------------------------------
@@ -133,10 +137,6 @@ public:
   double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
 
 protected:
-
-  // Convert qubit indicies to vectorized-density matrix qubitvector indices
-  // For the QubitVector apply matrix function
-  virtual reg_t superop_qubits(const reg_t &qubits) const;
 
   // Construct a vectorized superoperator from a vectorized matrix
   // This is equivalent to vec(tensor(conj(A), A))

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -549,7 +549,7 @@ void State<densmat_t>::snapshot_density_matrix(const Operations::Op &op,
   data.add_average_snapshot("density_matrix",
                             op.string_params[0],
                             BaseState::creg_.memory_hex(),
-                            reduced_state,
+                            std::move(reduced_state),
                             false);
 }
 

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -549,7 +549,7 @@ void State<densmat_t>::snapshot_density_matrix(const Operations::Op &op,
   data.add_average_snapshot("density_matrix",
                             op.string_params[0],
                             BaseState::creg_.memory_hex(),
-                            std::move(reduced_state),
+                            reduced_state,
                             false);
 }
 

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -71,6 +71,10 @@ public:
   // Returns the number of qubits for the superoperator
   virtual uint_t num_qubits() const override {return BaseMatrix::num_qubits_;}
 
+  // Convert qubit indicies to vectorized-density matrix qubitvector indices
+  // For the QubitVector apply matrix function
+  virtual reg_t superop_qubits(const reg_t &qubits) const;
+
   //-----------------------------------------------------------------------
   // Apply Matrices
   //-----------------------------------------------------------------------
@@ -142,10 +146,6 @@ public:
   double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
 
 protected:
-
-  // Convert qubit indicies to vectorized-density matrix qubitvector indices
-  // For the QubitVector apply matrix function
-  virtual reg_t superop_qubits(const reg_t &qubits) const;
 
   // Construct a vectorized superoperator from a vectorized matrix
   // This is equivalent to vec(tensor(conj(A), A))

--- a/src/simulators/statevector/indexes.hpp
+++ b/src/simulators/statevector/indexes.hpp
@@ -1,0 +1,168 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+
+
+#ifndef _qv_indexes_hpp_
+#define _qv_indexes_hpp_
+
+#include <array>
+#include <cstdint>
+#include <vector>
+#include <memory>
+
+namespace QV {
+
+// Type aliases
+using uint_t = uint64_t;
+using int_t = int64_t;
+using reg_t = std::vector<uint_t>;
+using indexes_t = std::unique_ptr<uint_t[]>;
+template <size_t N> using areg_t = std::array<uint_t, N>;
+
+//============================================================================
+// BIT MASKS and indexing
+//============================================================================
+
+const std::array<uint_t, 64> BITS {{
+  1ULL, 2ULL, 4ULL, 8ULL,
+  16ULL, 32ULL, 64ULL, 128ULL,
+  256ULL, 512ULL, 1024ULL, 2048ULL,
+  4096ULL, 8192ULL, 16384ULL, 32768ULL,
+  65536ULL, 131072ULL, 262144ULL, 524288ULL,
+  1048576ULL, 2097152ULL, 4194304ULL, 8388608ULL,
+  16777216ULL, 33554432ULL, 67108864ULL, 134217728ULL,
+  268435456ULL, 536870912ULL, 1073741824ULL, 2147483648ULL,
+  4294967296ULL, 8589934592ULL, 17179869184ULL, 34359738368ULL,
+  68719476736ULL, 137438953472ULL, 274877906944ULL, 549755813888ULL,
+  1099511627776ULL, 2199023255552ULL, 4398046511104ULL, 8796093022208ULL,
+  17592186044416ULL, 35184372088832ULL, 70368744177664ULL, 140737488355328ULL, 
+  281474976710656ULL, 562949953421312ULL, 1125899906842624ULL, 2251799813685248ULL,
+  4503599627370496ULL, 9007199254740992ULL, 18014398509481984ULL, 36028797018963968ULL,
+  72057594037927936ULL, 144115188075855872ULL, 288230376151711744ULL, 576460752303423488ULL,
+  1152921504606846976ULL, 2305843009213693952ULL, 4611686018427387904ULL, 9223372036854775808ULL
+}};
+
+
+const std::array<uint_t, 64> MASKS {{
+  0ULL, 1ULL, 3ULL, 7ULL,
+  15ULL, 31ULL, 63ULL, 127ULL,
+  255ULL, 511ULL, 1023ULL, 2047ULL,
+  4095ULL, 8191ULL, 16383ULL, 32767ULL,
+  65535ULL, 131071ULL, 262143ULL, 524287ULL,
+  1048575ULL, 2097151ULL, 4194303ULL, 8388607ULL,
+  16777215ULL, 33554431ULL, 67108863ULL, 134217727ULL,
+  268435455ULL, 536870911ULL, 1073741823ULL, 2147483647ULL,
+  4294967295ULL, 8589934591ULL, 17179869183ULL, 34359738367ULL,
+  68719476735ULL, 137438953471ULL, 274877906943ULL, 549755813887ULL,
+  1099511627775ULL, 2199023255551ULL, 4398046511103ULL, 8796093022207ULL,
+  17592186044415ULL, 35184372088831ULL, 70368744177663ULL, 140737488355327ULL,
+  281474976710655ULL, 562949953421311ULL, 1125899906842623ULL, 2251799813685247ULL,
+  4503599627370495ULL, 9007199254740991ULL, 18014398509481983ULL, 36028797018963967ULL,
+  72057594037927935ULL, 144115188075855871ULL, 288230376151711743ULL, 576460752303423487ULL,
+  1152921504606846975ULL, 2305843009213693951ULL, 4611686018427387903ULL, 9223372036854775807ULL
+}};
+
+
+// index0 returns the integer representation of a number of bits set
+// to zero inserted into an arbitrary bit string.
+// Eg: for qubits 0,2 in a state k = ba ( ba = 00 => k=0, etc).
+// indexes0([1], k) -> int(b0a)
+// indexes0([1,3], k) -> int(0b0a)
+// Example: k = 77  = 1001101 , qubits_sorted = [1,4]
+// ==> output = 297 = 100101001 (with 0's put into places 1 and 4).
+template<typename list_t>
+uint_t index0(const list_t &qubits_sorted, const uint_t k);
+
+// Return a std::unique_ptr to an array of of 2^N in ints
+// each int corresponds to an N qubit bitstring for M-N qubit bits in state k,
+// and the specified N qubits in states [0, ..., 2^N - 1]
+// qubits_sorted must be sorted lowest to highest. Eg. {0, 1}.
+// qubits specifies the location of the qubits in the returned strings.
+// NOTE: since the return is a unique_ptr it cannot be copied.
+// indexes returns the array of all bit values for the specified qubits
+// (Eg: for qubits 0,2 in a state k = ba:
+// indexes([1], [1], k) = [int(b0a), int(b1a)],
+// if it were two qubits inserted say at 1,3 it would be:
+// indexes([1,3], [1,3], k) -> [int(0b0a), int(0b1a), int(1b0a), (1b1a)]
+// If the qubits were passed in reverse order it would swap qubit position in the list:
+// indexes([3,1], [1,3], k) -> [int(0b0a), int(1b0a), int(0b1a), (1b1a)]
+// Example: k=77, qubits=qubits_sorted=[1,4] ==> output=[297,299,313,315]
+// input: k = 77  = 1001101
+// output[0]: 297 = 100101001 (with 0's put into places 1 and 4).
+// output[1]: 299 = 100101011 (with 0 put into place 1, and 1 put into place 4).
+// output[2]: 313 = 100111001 (with 1 put into place 1, and 0 put into place 4).
+// output[3]: 313 = 100111011 (with 1's put into places 1 and 4).
+indexes_t indexes(const reg_t &qubits, const reg_t &qubits_sorted, const uint_t k);
+
+// As above but returns a fixed sized array of of 2^N in ints
+template<size_t N>
+areg_t<1ULL << N> indexes(const areg_t<N> &qs, const areg_t<N> &qubits_sorted, const uint_t k);
+
+
+/*******************************************************************************
+ *
+ * Implementations
+ *
+ ******************************************************************************/
+
+template <typename list_t>
+uint_t index0(const list_t &qubits_sorted, const uint_t k) {
+  uint_t lowbits, retval = k;
+  for (size_t j = 0; j < qubits_sorted.size(); j++) {
+    lowbits = retval & MASKS[qubits_sorted[j]];
+    retval >>= qubits_sorted[j];
+    retval <<= qubits_sorted[j] + 1;
+    retval |= lowbits;
+  }
+  return retval;
+}
+
+template <size_t N>
+areg_t<1ULL << N> indexes(const areg_t<N> &qs,
+                          const areg_t<N> &qubits_sorted,
+                          const uint_t k) {
+  areg_t<1ULL << N> ret;
+  ret[0] = index0(qubits_sorted, k);
+  for (size_t i = 0; i < N; i++) {
+    const auto n = BITS[i];
+    const auto bit = BITS[qs[i]];
+    for (size_t j = 0; j < n; j++)
+      ret[n + j] = ret[j] | bit;
+  }
+  return ret;
+}
+
+indexes_t indexes(const reg_t& qubits,
+                  const reg_t& qubits_sorted,
+                  const uint_t k) {
+  const auto N = qubits_sorted.size();
+  indexes_t ret(new uint_t[BITS[N]]);
+  // Get index0
+  ret[0] = index0(qubits_sorted, k);
+  for (size_t i = 0; i < N; i++) {
+    const auto n = BITS[i];
+    const auto bit = BITS[qubits[i]];
+    for (size_t j = 0; j < n; j++)
+      ret[n + j] = ret[j] | bit;
+  }
+  return ret;
+}
+
+//------------------------------------------------------------------------------
+} // end namespace QV
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+#endif // end module

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -28,73 +28,12 @@
 #include <sstream>
 #include <stdexcept>
 
+#include "simulators/statevector/indexes.hpp"
 #include "framework/json.hpp"
 
 namespace QV {
 
-// Type aliases
-using uint_t = uint64_t;
-using int_t = int64_t;
-using reg_t = std::vector<uint_t>;
-using indexes_t = std::unique_ptr<uint_t[]>;
-template <size_t N> using areg_t = std::array<uint_t, N>;
 template <typename T> using cvector_t = std::vector<std::complex<T>>;
-
-//============================================================================
-// BIT MASKS and indexing
-//============================================================================
-
-/*
-# Auto generate these values with following python snippet
-import json
-
-def cpp_init_list(int_lst):
-    ret = json.dumps([str(i) + 'ULL' for i in int_lst])
-    return ret.replace('"', '').replace('[','{{').replace(']','}};')
-
-print('const std::array<uint_t, 64> BITS = ' + cpp_init_list([(1 << i) for i in range(64)]) + '\n')
-print('const std::array<uint_t, 64> MASKS = ' + cpp_init_list([(1 << i) - 1 for i in range(64)]))
-*/
-
-const std::array<uint_t, 64> BITS {{
-  1ULL, 2ULL, 4ULL, 8ULL,
-  16ULL, 32ULL, 64ULL, 128ULL,
-  256ULL, 512ULL, 1024ULL, 2048ULL,
-  4096ULL, 8192ULL, 16384ULL, 32768ULL,
-  65536ULL, 131072ULL, 262144ULL, 524288ULL,
-  1048576ULL, 2097152ULL, 4194304ULL, 8388608ULL,
-  16777216ULL, 33554432ULL, 67108864ULL, 134217728ULL,
-  268435456ULL, 536870912ULL, 1073741824ULL, 2147483648ULL,
-  4294967296ULL, 8589934592ULL, 17179869184ULL, 34359738368ULL,
-  68719476736ULL, 137438953472ULL, 274877906944ULL, 549755813888ULL,
-  1099511627776ULL, 2199023255552ULL, 4398046511104ULL, 8796093022208ULL,
-  17592186044416ULL, 35184372088832ULL, 70368744177664ULL, 140737488355328ULL, 
-  281474976710656ULL, 562949953421312ULL, 1125899906842624ULL, 2251799813685248ULL,
-  4503599627370496ULL, 9007199254740992ULL, 18014398509481984ULL, 36028797018963968ULL,
-  72057594037927936ULL, 144115188075855872ULL, 288230376151711744ULL, 576460752303423488ULL,
-  1152921504606846976ULL, 2305843009213693952ULL, 4611686018427387904ULL, 9223372036854775808ULL
-}};
-
-
-const std::array<uint_t, 64> MASKS {{
-  0ULL, 1ULL, 3ULL, 7ULL,
-  15ULL, 31ULL, 63ULL, 127ULL,
-  255ULL, 511ULL, 1023ULL, 2047ULL,
-  4095ULL, 8191ULL, 16383ULL, 32767ULL,
-  65535ULL, 131071ULL, 262143ULL, 524287ULL,
-  1048575ULL, 2097151ULL, 4194303ULL, 8388607ULL,
-  16777215ULL, 33554431ULL, 67108863ULL, 134217727ULL,
-  268435455ULL, 536870911ULL, 1073741823ULL, 2147483647ULL,
-  4294967295ULL, 8589934591ULL, 17179869183ULL, 34359738367ULL,
-  68719476735ULL, 137438953471ULL, 274877906943ULL, 549755813887ULL,
-  1099511627775ULL, 2199023255551ULL, 4398046511103ULL, 8796093022207ULL,
-  17592186044415ULL, 35184372088831ULL, 70368744177663ULL, 140737488355327ULL,
-  281474976710655ULL, 562949953421311ULL, 1125899906842623ULL, 2251799813685247ULL,
-  4503599627370495ULL, 9007199254740991ULL, 18014398509481983ULL, 36028797018963967ULL,
-  72057594037927935ULL, 144115188075855871ULL, 288230376151711743ULL, 576460752303423487ULL,
-  1152921504606846975ULL, 2305843009213693951ULL, 4611686018427387903ULL, 9223372036854775807ULL
-}};
-
 
 //============================================================================
 // QubitVector class
@@ -168,41 +107,6 @@ public:
 
   // convert vector type to data type of this qubit vector
   cvector_t<data_t> convert(const cvector_t<double>& v) const;
-
-  // index0 returns the integer representation of a number of bits set
-  // to zero inserted into an arbitrary bit string.
-  // Eg: for qubits 0,2 in a state k = ba ( ba = 00 => k=0, etc).
-  // indexes0([1], k) -> int(b0a)
-  // indexes0([1,3], k) -> int(0b0a)
-  // Example: k = 77  = 1001101 , qubits_sorted = [1,4]
-  // ==> output = 297 = 100101001 (with 0's put into places 1 and 4).
-  template<typename list_t>
-  uint_t index0(const list_t &qubits_sorted, const uint_t k) const;
-
-  // Return a std::unique_ptr to an array of of 2^N in ints
-  // each int corresponds to an N qubit bitstring for M-N qubit bits in state k,
-  // and the specified N qubits in states [0, ..., 2^N - 1]
-  // qubits_sorted must be sorted lowest to highest. Eg. {0, 1}.
-  // qubits specifies the location of the qubits in the returned strings.
-  // NOTE: since the return is a unique_ptr it cannot be copied.
-  // indexes returns the array of all bit values for the specified qubits
-  // (Eg: for qubits 0,2 in a state k = ba:
-  // indexes([1], [1], k) = [int(b0a), int(b1a)],
-  // if it were two qubits inserted say at 1,3 it would be:
-  // indexes([1,3], [1,3], k) -> [int(0b0a), int(0b1a), int(1b0a), (1b1a)]
-  // If the qubits were passed in reverse order it would swap qubit position in the list:
-  // indexes([3,1], [1,3], k) -> [int(0b0a), int(1b0a), int(0b1a), (1b1a)]
-  // Example: k=77, qubits=qubits_sorted=[1,4] ==> output=[297,299,313,315]
-  // input: k = 77  = 1001101
-  // output[0]: 297 = 100101001 (with 0's put into places 1 and 4).
-  // output[1]: 299 = 100101011 (with 0 put into place 1, and 1 put into place 4).
-  // output[2]: 313 = 100111001 (with 1 put into place 1, and 0 put into place 4).
-  // output[3]: 313 = 100111011 (with 1's put into places 1 and 4).
-  indexes_t indexes(const reg_t &qubits, const reg_t &qubits_sorted, const uint_t k) const;
-
-  // As above but returns a fixed sized array of of 2^N in ints
-  template<size_t N>
-  areg_t<1ULL << N> indexes(const areg_t<N> &qs, const areg_t<N> &qubits_sorted, const uint_t k) const;
 
   // State initialization of a component
   // Initialize the specified qubits to a desired statevector
@@ -693,56 +597,6 @@ cvector_t<data_t> QubitVector<data_t>::vector() const {
   #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
   for (int_t j=0; j < END; j++) {
     ret[j] = data_[j];
-  }
-  return ret;
-}
-
-//------------------------------------------------------------------------------
-// Indexing
-//------------------------------------------------------------------------------
-
-template <typename data_t>
-template <typename list_t>
-uint_t QubitVector<data_t>::index0(const list_t &qubits_sorted, const uint_t k) const {
-  uint_t lowbits, retval = k;
-  for (size_t j = 0; j < qubits_sorted.size(); j++) {
-    lowbits = retval & MASKS[qubits_sorted[j]];
-    retval >>= qubits_sorted[j];
-    retval <<= qubits_sorted[j] + 1;
-    retval |= lowbits;
-  }
-  return retval;
-}
-
-template <typename data_t>
-template <size_t N>
-areg_t<1ULL << N> QubitVector<data_t>::indexes(const areg_t<N> &qs,
-                                               const areg_t<N> &qubits_sorted,
-                                               const uint_t k) const {
-  areg_t<1ULL << N> ret;
-  ret[0] = index0(qubits_sorted, k);
-  for (size_t i = 0; i < N; i++) {
-    const auto n = BITS[i];
-    const auto bit = BITS[qs[i]];
-    for (size_t j = 0; j < n; j++)
-      ret[n + j] = ret[j] | bit;
-  }
-  return ret;
-}
-
-template <typename data_t>
-indexes_t QubitVector<data_t>::indexes(const reg_t& qubits,
-                                       const reg_t& qubits_sorted,
-                                       const uint_t k) const {
-  const auto N = qubits_sorted.size();
-  indexes_t ret(new uint_t[BITS[N]]);
-  // Get index0
-  ret[0] = index0(qubits_sorted, k);
-  for (size_t i = 0; i < N; i++) {
-    const auto n = BITS[i];
-    const auto bit = BITS[qubits[i]];
-    for (size_t j = 0; j < n; j++)
-      ret[n + j] = ret[j] | bit;
   }
   return ret;
 }

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -673,14 +673,14 @@ void State<statevec_t>::snapshot_density_matrix(const Operations::Op &op,
   switch (type) {
     case SnapshotDataType::average:
       data.add_average_snapshot("density_matrix", op.string_params[0],
-                            BaseState::creg_.memory_hex(), std::move(reduced_state), false);
+                            BaseState::creg_.memory_hex(), reduced_state, false);
       break;
     case SnapshotDataType::average_var:
       data.add_average_snapshot("density_matrix", op.string_params[0],
-                            BaseState::creg_.memory_hex(), std::move(reduced_state), true);
+                            BaseState::creg_.memory_hex(), reduced_state, true);
       break;
     case SnapshotDataType::pershot:
-      data.add_pershot_snapshot("density_matrix", op.string_params[0], std::move(reduced_state));
+      data.add_pershot_snapshot("density_matrix", op.string_params[0], reduced_state);
       break;
   }
 }

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -48,6 +48,7 @@ const Operations::OpSet StateOpSet(
   // Snapshots
   {"statevector", "memory", "register", "probabilities",
     "probabilities_with_variance", "expectation_value_pauli",
+    "density_matrix", "density_matrix_with_variance",
     "expectation_value_pauli_with_variance",
     "expectation_value_matrix_single_shot", "expectation_value_matrix",
     "expectation_value_matrix_with_variance",
@@ -64,7 +65,7 @@ enum class Gates {
 // Allowed snapshots enum class
 enum class Snapshots {
   statevector, cmemory, cregister,
-  probs, probs_var,
+  probs, probs_var, densmat, densmat_var,
   expval_pauli, expval_pauli_var, expval_pauli_shot,
   expval_matrix, expval_matrix_var, expval_matrix_shot
 };
@@ -239,6 +240,11 @@ protected:
                               ExperimentData &data,
                               SnapshotDataType type);
 
+  // Snapshot reduced density matrix
+  void snapshot_density_matrix(const Operations::Op &op,
+                               ExperimentData &data,
+                               SnapshotDataType type);
+
   //-----------------------------------------------------------------------
   // Single-qubit gate helpers
   //-----------------------------------------------------------------------
@@ -330,6 +336,8 @@ const stringmap_t<Snapshots> State<statevec_t>::snapshotset_({
   {"expectation_value_pauli", Snapshots::expval_pauli},
   {"expectation_value_matrix", Snapshots::expval_matrix},
   {"probabilities_with_variance", Snapshots::probs_var},
+  {"density_matrix", Snapshots::densmat},
+  {"density_matrix_with_variance", Snapshots::densmat_var},
   {"expectation_value_pauli_with_variance", Snapshots::expval_pauli_var},
   {"expectation_value_matrix_with_variance", Snapshots::expval_matrix_var},
   {"expectation_value_pauli_single_shot", Snapshots::expval_pauli_shot},
@@ -498,6 +506,9 @@ void State<statevec_t>::apply_snapshot(const Operations::Op &op,
       // get probs as hexadecimal
       snapshot_probabilities(op, data, SnapshotDataType::average);
     } break;
+    case Snapshots::densmat: {
+      snapshot_density_matrix(op, data, SnapshotDataType::average);
+    } break;
     case Snapshots::expval_pauli: {
       snapshot_pauli_expval(op, data, SnapshotDataType::average);
     } break;
@@ -507,6 +518,9 @@ void State<statevec_t>::apply_snapshot(const Operations::Op &op,
     case Snapshots::probs_var: {
       // get probs as hexadecimal
       snapshot_probabilities(op, data, SnapshotDataType::average_var);
+    } break;
+    case Snapshots::densmat_var: {
+      snapshot_density_matrix(op, data, SnapshotDataType::average_var);
     } break;
     case Snapshots::expval_pauli_var: {
       snapshot_pauli_expval(op, data, SnapshotDataType::average_var);
@@ -634,6 +648,62 @@ void State<statevec_t>::snapshot_matrix_expval(const Operations::Op &op,
   BaseState::qreg_.revert(false);
 }
 
+
+template <class statevec_t>
+void State<statevec_t>::snapshot_density_matrix(const Operations::Op &op,
+                                                ExperimentData &data,
+                                                SnapshotDataType type) {
+  cmatrix_t reduced_state;
+
+  // Check if tracing over all qubits
+  if (op.qubits.empty()) {
+    reduced_state = cmatrix_t(1, 1);
+    reduced_state[0] = BaseState::qreg_.norm();
+  } else {
+    const size_t N = op.qubits.size();
+    const size_t DIM = 1ULL << N;
+    reduced_state = cmatrix_t(DIM, DIM);
+    auto qubits_sorted = op.qubits;
+    std::sort(qubits_sorted.begin(), qubits_sorted.end());
+
+    // This is inefficient but we need to copy data to vector
+    // So we don't get errors with the Thrust / GPU backend
+    auto vec = BaseState::qreg_.vector();
+
+    // Return full density matrix
+    if ((N == BaseState::qreg_.num_qubits()) && (op.qubits == qubits_sorted)) {
+      for (size_t row = 0; row < DIM; ++row)
+        for (size_t col = 0; col < DIM; ++col) {
+          reduced_state(row, col) = complex_t(vec[row]) * complex_t(std::conj(vec[col]));
+      }
+    } else {
+      const size_t END = 1ULL << (BaseState::qreg_.num_qubits() - N);  
+      for (size_t k = 0; k < END; k++) {
+        // store entries touched by U
+        const auto inds = QV::indexes(op.qubits, qubits_sorted, k);
+        for (size_t row = 0; row < DIM; ++row)
+          for (size_t col = 0; col < DIM; ++col) {
+            reduced_state(row, col) += complex_t(vec[inds[row]]) * complex_t(std::conj(vec[inds[col]]));
+        }
+      }
+    }
+  }
+
+  // Add density matrix to result data
+  switch (type) {
+    case SnapshotDataType::average:
+      data.add_average_snapshot("density_matrix", op.string_params[0],
+                            BaseState::creg_.memory_hex(), std::move(reduced_state), false);
+      break;
+    case SnapshotDataType::average_var:
+      data.add_average_snapshot("density_matrix", op.string_params[0],
+                            BaseState::creg_.memory_hex(), std::move(reduced_state), true);
+      break;
+    case SnapshotDataType::pershot:
+      data.add_pershot_snapshot("density_matrix", op.string_params[0], std::move(reduced_state));
+      break;
+  }
+}
 
 //=========================================================================
 // Implementation: Matrix multiplication

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -673,14 +673,14 @@ void State<statevec_t>::snapshot_density_matrix(const Operations::Op &op,
   switch (type) {
     case SnapshotDataType::average:
       data.add_average_snapshot("density_matrix", op.string_params[0],
-                            BaseState::creg_.memory_hex(), reduced_state, false);
+                            BaseState::creg_.memory_hex(), std::move(reduced_state), false);
       break;
     case SnapshotDataType::average_var:
       data.add_average_snapshot("density_matrix", op.string_params[0],
-                            BaseState::creg_.memory_hex(), reduced_state, true);
+                            BaseState::creg_.memory_hex(), std::move(reduced_state), true);
       break;
     case SnapshotDataType::pershot:
-      data.add_pershot_snapshot("density_matrix", op.string_params[0], reduced_state);
+      data.add_pershot_snapshot("density_matrix", op.string_params[0], std::move(reduced_state));
       break;
   }
 }

--- a/test/terra/backends/qasm_simulator/qasm_snapshot.py
+++ b/test/terra/backends/qasm_simulator/qasm_snapshot.py
@@ -391,10 +391,6 @@ class QasmSnapshotDensityMatrixTests:
                         target = qi.partial_trace(target, [2])
                     elif num_qubits == 1:
                         target = qi.partial_trace(target, [1, 2])
-                    if value != target:
-                        print('FAILED:', squbits, equbits)
-                        print(value)
-                        print(target)
                     self.assertEqual(value, target)
 
 

--- a/test/terra/backends/qasm_simulator/qasm_snapshot.py
+++ b/test/terra/backends/qasm_simulator/qasm_snapshot.py
@@ -17,11 +17,13 @@ import logging
 import itertools as it
 import numpy as np
 
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, execute
+import qiskit.quantum_info as qi
 from qiskit.compiler import assemble
 from qiskit.quantum_info import DensityMatrix, Pauli, Operator
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer import AerError
+from qiskit.providers.aer.extensions import Snapshot
 
 from test.terra.reference.ref_snapshot_state import (
     snapshot_state_circuits_deterministic, snapshot_state_counts_deterministic,
@@ -358,149 +360,42 @@ class QasmSnapshotDensityMatrixTests:
     ]
     BACKEND_OPTS = {}
 
-    def density_snapshots(self, data, label):
-        """Format snapshots as list of Numpy arrays"""
-        # Check snapshot entry exists in data
-        snaps = data.get("snapshots", {}).get("density_matrix",
-                                              {}).get(label, [])
-        # Convert nested lists to numpy arrays
-        output = {}
-        for snap_dict in snaps:
-            memory = snap_dict['memory']
-            self.assertIsInstance(snap_dict['value'], np.ndarray)
-            output[memory] = snap_dict['value']
-        return output
-
-    def test_snapshot_density_matrix_pre_measure_det(self):
-        """Test snapshot density matrix before deterministic final measurement"""
-        shots = 10
-        label = "snap"
-        counts_targets = snapshot_state_counts_deterministic(shots)
-        statevec_targets = snapshot_state_pre_measure_statevector_deterministic(
-        )
-        circuits = snapshot_state_circuits_deterministic(label,
-                                                         'density_matrix',
-                                                         post_measure=False)
-
-        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
-        job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
-        result = job.result()
-        success = getattr(result, 'success', False)
+    def test_density_matrix_snapshot_ideal(self):
+        seed = 500
+        op = qi.random_unitary(8, seed=seed)
+        circ = QuantumCircuit(3)
+        circ.append(op, [0, 1, 2])
         method = self.BACKEND_OPTS.get('method', 'automatic')
-        if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
-            self.assertFalse(success)
-        else:
-            self.assertTrue(success)
-            self.compare_counts(result, circuits, counts_targets, delta=0)
-            # Check snapshots
-            for j, circuit in enumerate(circuits):
-                data = result.data(circuit)
-                snaps = self.density_snapshots(data, label)
-                self.assertTrue(len(snaps), 1)
-                target = np.outer(statevec_targets[j],
-                                  statevec_targets[j].conj())
-                # Pre-measurement all memory bits should be 0
-                value = snaps.get('0x0')
-                self.assertTrue(np.allclose(value, target))
-
-    def test_snapshot_density_matrix_pre_measure_nondet(self):
-        """Test snapshot density matrix before non-deterministic final measurement"""
-        shots = 100
-        label = "snap"
-        counts_targets = snapshot_state_counts_nondeterministic(shots)
-        statevec_targets = snapshot_state_pre_measure_statevector_nondeterministic(
-        )
-        circuits = snapshot_state_circuits_nondeterministic(label,
-                                                            'density_matrix',
-                                                            post_measure=False)
-
-        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
-        job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
-        result = job.result()
-        success = getattr(result, 'success', False)
-        method = self.BACKEND_OPTS.get('method', 'automatic')
-        if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
-            self.assertFalse(success)
-        else:
-            self.assertTrue(success)
-            self.compare_counts(result,
-                                circuits,
-                                counts_targets,
-                                delta=0.2 * shots)
-            # Check snapshots
-            for j, circuit in enumerate(circuits):
-                data = result.data(circuit)
-                snaps = self.density_snapshots(data, label)
-                self.assertTrue(len(snaps), 1)
-                target = np.outer(statevec_targets[j],
-                                  statevec_targets[j].conj())
-                value = snaps.get('0x0')
-                self.assertTrue(np.allclose(value, target))
-
-    def test_snapshot_density_matrix_post_measure_det(self):
-        """Test snapshot density matrix after deterministic final measurement"""
-        shots = 10
-        label = "snap"
-        counts_targets = snapshot_state_counts_deterministic(shots)
-        statevec_targets = snapshot_state_post_measure_statevector_deterministic(
-        )
-        circuits = snapshot_state_circuits_deterministic(label,
-                                                         'density_matrix',
-                                                         post_measure=True)
-
-        qobj = assemble(circuits, self.SIMULATOR, memory=True, shots=shots)
-        job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
-        result = job.result()
-        success = getattr(result, 'success', False)
-        method = self.BACKEND_OPTS.get('method', 'automatic')
-        if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
-            self.assertFalse(success)
-        else:
-            self.assertTrue(success)
-            self.compare_counts(result, circuits, counts_targets, delta=0)
-            # Check snapshots
-            for i, circuit in enumerate(circuits):
-                data = result.data(circuit)
-                snaps = self.density_snapshots(data, label)
-                for j, mem in enumerate(data['memory']):
-                    target = statevec_targets[i].get(mem)
-                    target = np.outer(target, target.conj())
-                    value = snaps.get(mem)
-                    self.assertTrue(np.allclose(value, target))
-
-    def test_snapshot_density_matrix_post_measure_nondet(self):
-        """Test snapshot density matrix after non-deterministic final measurement"""
-        shots = 100
-        label = "snap"
-        counts_targets = snapshot_state_counts_nondeterministic(shots)
-        statevec_targets = snapshot_state_post_measure_statevector_nondeterministic(
-        )
-        circuits = snapshot_state_circuits_nondeterministic(label,
-                                                            'density_matrix',
-                                                            post_measure=True)
-
-        qobj = assemble(circuits, self.SIMULATOR, memory=True, shots=shots)
-        job = self.SIMULATOR.run(qobj, backend_options=self.BACKEND_OPTS)
-        result = job.result()
-        success = getattr(result, 'success', False)
-        method = self.BACKEND_OPTS.get('method', 'automatic')
-        if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
-            self.assertFalse(success)
-        else:
-            self.assertTrue(success)
-            self.compare_counts(result,
-                                circuits,
-                                counts_targets,
-                                delta=0.2 * shots)
-            # Check snapshots
-            for i, circuit in enumerate(circuits):
-                data = result.data(circuit)
-                snaps = self.density_snapshots(data, label)
-                for j, mem in enumerate(data['memory']):
-                    target = statevec_targets[i].get(mem)
-                    target = np.outer(target, target.conj())
-                    value = snaps.get(mem)
-                    self.assertTrue(np.allclose(value, target))
+        label = 'density_matrix'
+        snap_qargs = [[0, 1, 2], [0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0],
+                      [0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1],
+                      [0], [1], [2]]
+        evolve_qargs = [[0, 1, 2], [0, 2, 1], [1, 0, 2], [2, 0, 1], [1, 2, 0], [2, 1, 0],
+                        [0, 1, 2], [1, 0, 2], [0, 2, 1], [1, 2, 0], [2, 0, 1], [2, 1, 0],
+                        [0, 1, 2], [1, 0, 2], [2, 1, 0]]
+        for squbits, equbits in zip(snap_qargs, evolve_qargs):
+            with self.subTest(msg='qubits={}'.format(squbits)):
+                num_qubits = len(squbits)
+                tmp = circ.copy()
+                tmp.append(Snapshot(label, 'density_matrix', num_qubits), squbits)
+                result = execute(tmp, self.SIMULATOR,
+                                 backend_options=self.BACKEND_OPTS).result()
+                if method not in QasmSnapshotDensityMatrixTests.SUPPORTED_QASM_METHODS:
+                    self.assertFalse(result.success)
+                else:
+                    self.assertSuccess(result)
+                    snapshots = result.data(0)['snapshots']['density_matrix']
+                    value = qi.DensityMatrix(snapshots[label][0]['value'])
+                    target = qi.DensityMatrix.from_label(3 * '0').evolve(circ, equbits)
+                    if num_qubits == 2:
+                        target = qi.partial_trace(target, [2])
+                    elif num_qubits == 1:
+                        target = qi.partial_trace(target, [1, 2])
+                    if value != target:
+                        print('FAILED:', squbits, equbits)
+                        print(value)
+                        print(target)
+                    self.assertEqual(value, target)
 
 
 class QasmSnapshotProbabilitiesTests:

--- a/test/terra/backends/qasm_simulator/qasm_snapshot.py
+++ b/test/terra/backends/qasm_simulator/qasm_snapshot.py
@@ -348,7 +348,12 @@ class QasmSnapshotDensityMatrixTests:
 
     SIMULATOR = QasmSimulator()
     SUPPORTED_QASM_METHODS = [
-        'automatic', 'density_matrix', 'density_matrix_gpu',
+        'automatic',
+        'statevector',
+        'statevector_gpu',
+        'statevector_thrust',
+        'density_matrix',
+        'density_matrix_gpu',
         'density_matrix_thrust'
     ]
     BACKEND_OPTS = {}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

~Blocked by #712~

* Adds support for the density matrix snapshot to return the reduced density matrix of specified qubits
* Adds density matrix snapshot support to the statevector method, but returning density matrix sampled from the average of statevectors for each shots

### Details and comments

- [x] Include subsystem density matrix snapshot tests
- [x] Include statevector method density matrix snapshot tests
- [x] Add release note
