### PR TITLE
Fixing subsystem_list handling in pulse simulator

### DIFF
--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -116,7 +116,6 @@ def pulse_controller(qobj, system_model, backend_options):
     pulse_sim_desc.global_data['memory_slots'] = digested_qobj.memory_slots
     pulse_sim_desc.global_data['memory'] = digested_qobj.memory
     pulse_sim_desc.global_data['n_registers'] = digested_qobj.n_registers
-
     pulse_sim_desc.global_data['pulse_array'] = digested_qobj.pulse_array
     pulse_sim_desc.global_data['pulse_indices'] = digested_qobj.pulse_indices
     pulse_sim_desc.pulse_to_int = digested_qobj.pulse_to_int
@@ -183,9 +182,9 @@ def pulse_controller(qobj, system_model, backend_options):
                 for jj in acq[1]:
                     if jj > qubit_list[-1]:
                         continue
-                    if not pulse_sim_desc.global_data['measurement_ops'][jj]:
+                    if not pulse_sim_desc.global_data['measurement_ops'][qubit_list.index(jj)]:
                         q_level_meas = pulse_sim_desc.global_data['q_level_meas']
-                        pulse_sim_desc.global_data['measurement_ops'][jj] = \
+                        pulse_sim_desc.global_data['measurement_ops'][qubit_list.index(jj)] = \
                             qobj_gen.qubit_occ_oper_dressed(jj,
                                                             estates,
                                                             h_osc=dim_osc,
@@ -309,7 +308,6 @@ def format_exp_results(exp_results, exp_times, op_system):
 
         # meas_level 2 return the shots
         if m_lev == 2:
-
             # convert the memory **array** into a n
             # integer
             # e.g. [1,0] -> 2
@@ -327,7 +325,6 @@ def format_exp_results(exp_results, exp_times, op_system):
             for kk in range(unique[0].shape[0]):
                 key = hex(unique[0][kk])
                 hex_dict[key] = unique[1][kk]
-
             results['data']['counts'] = hex_dict
 
         # meas_level 1 returns the <n>

--- a/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
+++ b/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
@@ -91,6 +91,10 @@ class HamiltonianModel():
         if 'qub' in hamiltonian:
             if subsystem_list is None:
                 subsystem_list = [int(qubit) for qubit in hamiltonian['qub']]
+            else:
+                # if user supplied, make a copy and sort it
+                subsystem_list = subsystem_list.copy()
+                subsystem_list.sort()
 
             # force keys in hamiltonian['qub'] to be ints
             qub_dict = {

--- a/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
+++ b/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
@@ -103,7 +103,7 @@ class HamiltonianModel():
             }
 
             subsystem_dims = {
-                int(qubit) : qub_dict[int(qubit)]
+                int(qubit): qub_dict[int(qubit)]
                 for qubit in subsystem_list
             }
         else:

--- a/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
+++ b/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
@@ -92,9 +92,15 @@ class HamiltonianModel():
             if subsystem_list is None:
                 subsystem_list = [int(qubit) for qubit in hamiltonian['qub']]
 
-            subsystem_dims = {
+            # force keys in hamiltonian['qub'] to be ints
+            qub_dict = {
                 int(key): val
                 for key, val in hamiltonian['qub'].items()
+            }
+
+            subsystem_dims = {
+                int(qubit) : qub_dict[int(qubit)]
+                for qubit in subsystem_list
             }
         else:
             subsystem_dims = {}

--- a/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
+++ b/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
@@ -131,15 +131,19 @@ class HamiltonianModel():
         """ Computes a list of qubit frequencies corresponding to the exact energy
         gap between the ground and first excited states of each qubit.
 
+        If the keys in self._subsystem_dims skips over a qubit, it will default to outputting
+        a 0 frequency for that qubit.
+
         Returns:
             qubit_lo_freq (list): the list of frequencies
         """
-        qubit_lo_freq = [0] * len(self._subsystem_dims)
+        # need to specify frequencies up to max qubit index
+        qubit_lo_freq = [0] * (max(self._subsystem_dims.keys()) + 1)
 
         # compute difference between first excited state of each qubit and
         # the ground energy
         min_eval = np.min(self._evals)
-        for q_idx in range(len(self._subsystem_dims)):
+        for q_idx in self._subsystem_dims.keys():
             single_excite = _first_excited_state(q_idx, self._subsystem_dims)
             dressed_eval = _eval_for_max_espace_overlap(
                 single_excite, self._evals, self._estates)
@@ -250,10 +254,6 @@ def _first_excited_state(qubit_idx, subsystem_dims):
     """
     Returns the vector corresponding to all qubits in the 0 state, except for
     qubit_idx in the 1 state.
-
-    Assumption: the keys in dim_qub consist exactly of the str version of the int
-                in range(len(dim_qub)). They don't need to be in order, but they
-                need to be of this format
 
     Parameters:
         qubit_idx (int): the qubit to be in the 1 state

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -653,13 +653,14 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                              omega_i_swap,
                                              subsystem_list=subsystem_list)
 
+        qubit_lo_freq = system_model.hamiltonian.get_qubit_lo_from_drift()
         schedule = self._schedule_2Q_interaction(total_samples, drive_idx=0, target_idx=2, U_idx=1)
         qobj = assemble([schedule],
                         backend=self.backend_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[subsystem_list],
-                        qubit_lo_freq=[omega_d0 / (2 * np.pi), omega_d1 / (2 * np.pi)],
+                        qubit_lo_freq=qubit_lo_freq,
                         memory_slots=2,
                         shots=shots)
         backend_options = {'seed': 12387}
@@ -727,14 +728,14 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                              omega_a_pi_swap,
                                              omega_i_swap,
                                              subsystem_list=subsystem_list)
-
+        qubit_lo_freq = system_model.hamiltonian.get_qubit_lo_from_drift()
         schedule = self._schedule_2Q_interaction(total_samples, drive_idx=1, target_idx=2, U_idx=2)
         qobj = assemble([schedule],
                         backend=self.backend_sim,
                         meas_level=2,
                         meas_return='single',
                         meas_map=[subsystem_list],
-                        qubit_lo_freq=[omega_d0 / (2 * np.pi), omega_d0 / (2 * np.pi)],
+                        qubit_lo_freq=qubit_lo_freq,
                         memory_slots=2,
                         shots=shots)
         backend_options = {'seed': 12387}

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -647,14 +647,15 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         omega_a_pi_swap = np.pi / total_samples
 
 
-        system_model = self._system_model_3Q(omega_0, omega_a_pi_swap, omega_i_swap, subsystem_list=[0, 2])
+        subsystem_list = [0, 2]
+        system_model = self._system_model_3Q(omega_0, omega_a_pi_swap, omega_i_swap, subsystem_list=subsystem_list)
 
         schedule = self._schedule_2Q_interaction(total_samples, drive_idx=0, target_idx=2, U_idx=1)
         qobj = assemble([schedule],
                         backend=self.backend_sim,
                         meas_level=2,
                         meas_return='single',
-                        meas_map=[[0, 2]],
+                        meas_map=[subsystem_list],
                         qubit_lo_freq=[omega_d0 / (2 * np.pi), omega_d1 / (2 * np.pi)],
                         memory_slots=2,
                         shots=shots)
@@ -664,7 +665,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         counts_pi_swap = result_pi_swap.get_counts()
 
         exp_counts_pi_swap = {
-            '10': shots
+            '100': shots
         }  # reverse bit order (qiskit convention)
         self.assertDictAlmostEqual(counts_pi_swap, exp_counts_pi_swap, delta=2)
 
@@ -673,7 +674,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # Q0 drive amp -> pi/2 pulse
         omega_a_pi2_swap = np.pi / 2 / total_samples
 
-        system_model = self._system_model_2Q(omega_0, omega_a_pi2_swap, omega_i_swap)
+        system_model = self._system_model_3Q(omega_0, omega_a_pi2_swap, omega_i_swap, subsystem_list=subsystem_list)
 
         result_pi2_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
         counts_pi2_swap = result_pi2_swap.get_counts()
@@ -683,7 +684,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         for key in counts_pi2_swap.keys():
             prop_pi2_swap[key] = counts_pi2_swap[key] / shots
 
-        exp_prop_pi2_swap = {'00': 0.5, '10': 0.5}  # reverse bit order
+        exp_prop_pi2_swap = {'000': 0.5, '100': 0.5}  # reverse bit order
 
         self.assertDictAlmostEqual(prop_pi2_swap,
                                    exp_prop_pi2_swap,
@@ -694,13 +695,13 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # Q0 drive amp -> pi pulse
         omega_a_no_swap = np.pi / total_samples
-        system_model = self._system_model_2Q(omega_0, omega_a_no_swap, omega_i_no_swap)
+        system_model = self._system_model_3Q(omega_0, omega_a_no_swap, omega_i_no_swap, subsystem_list=subsystem_list)
 
         result_no_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
         counts_no_swap = result_no_swap.get_counts()
 
         exp_counts_no_swap = {
-            '01': shots
+            '001': shots
         }  # non-swapped state (reverse bit order)
         self.assertDictAlmostEqual(counts_no_swap, exp_counts_no_swap)
 
@@ -805,7 +806,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         [{'q': 0, 'scale': [-1.0, 0.0]}, {'q': 2, 'scale': [1.0, 0.0]}],
                         [{'q': 1, 'scale': [-1.0, 0.0]}, {'q': 2, 'scale': [1.0, 0.0]}]]
         dt = 1.
-        
+
         return PulseSystemModel(hamiltonian=ham_model,
                                 u_channel_lo=u_channel_lo,
                                 subsystem_list=subsystem_list,

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -624,6 +624,85 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         }  # non-swapped state (reverse bit order)
         self.assertDictAlmostEqual(counts_no_swap, exp_counts_no_swap)
 
+    def test_subsystem_restriction(self):
+        r"""Test behavior of subsystem_list subsystem restriction"""
+
+        shots = 100000
+        total_samples = 100
+        # Do a standard SWAP gate
+
+        # Interaction amp (any non-zero creates the swap gate)
+        omega_i_swap = np.pi / 2 / total_samples
+        # set omega_d0=omega_0 (resonance)
+        omega_0 = 2 * np.pi
+        omega_d0 = omega_0
+
+        # For swapping, set omega_d1 = 0 (drive on Q0 resonance)
+        # Note: confused by this as there is no d1 term
+        omega_d1 = 0
+
+        # do pi pulse on Q0 and verify state swaps from '01' to '10' (reverse bit order)
+
+        # Q0 drive amp -> pi pulse
+        omega_a_pi_swap = np.pi / total_samples
+
+
+        system_model = self._system_model_3Q(omega_0, omega_a_pi_swap, omega_i_swap, subsystem_list=[0, 2])
+
+        schedule = self._schedule_2Q_interaction(total_samples, drive_idx=0, target_idx=2, U_idx=1)
+        qobj = assemble([schedule],
+                        backend=self.backend_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0, 2]],
+                        qubit_lo_freq=[omega_d0 / (2 * np.pi), omega_d1 / (2 * np.pi)],
+                        memory_slots=2,
+                        shots=shots)
+        backend_options = {'seed': 12387}
+
+        result_pi_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
+        counts_pi_swap = result_pi_swap.get_counts()
+
+        exp_counts_pi_swap = {
+            '10': shots
+        }  # reverse bit order (qiskit convention)
+        self.assertDictAlmostEqual(counts_pi_swap, exp_counts_pi_swap, delta=2)
+
+        # do pi/2 pulse on Q0 and verify half the counts are '00' and half are swapped state '10'
+
+        # Q0 drive amp -> pi/2 pulse
+        omega_a_pi2_swap = np.pi / 2 / total_samples
+
+        system_model = self._system_model_2Q(omega_0, omega_a_pi2_swap, omega_i_swap)
+
+        result_pi2_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
+        counts_pi2_swap = result_pi2_swap.get_counts()
+
+        # compare proportions for improved accuracy
+        prop_pi2_swap = {}
+        for key in counts_pi2_swap.keys():
+            prop_pi2_swap[key] = counts_pi2_swap[key] / shots
+
+        exp_prop_pi2_swap = {'00': 0.5, '10': 0.5}  # reverse bit order
+
+        self.assertDictAlmostEqual(prop_pi2_swap,
+                                   exp_prop_pi2_swap,
+                                   delta=0.01)
+
+        # Test that no SWAP occurs when omega_i=0 (no interaction)
+        omega_i_no_swap = 0
+
+        # Q0 drive amp -> pi pulse
+        omega_a_no_swap = np.pi / total_samples
+        system_model = self._system_model_2Q(omega_0, omega_a_no_swap, omega_i_no_swap)
+
+        result_no_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
+        counts_no_swap = result_no_swap.get_counts()
+
+        exp_counts_no_swap = {
+            '01': shots
+        }  # non-swapped state (reverse bit order)
+        self.assertDictAlmostEqual(counts_no_swap, exp_counts_no_swap)
 
 
     def _system_model_1Q(self, omega_0, omega_a, qubit_dim=2):
@@ -653,7 +732,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                                 dt=dt)
 
     def _system_model_2Q(self, omega_0, omega_a, omega_i, qubit_dim=2):
-        """Constructs a simple 1 qubit system model.
+        """Constructs a simple 2 qubit system model.
 
         Args:
             omega_0 (float): frequency of qubit
@@ -684,6 +763,49 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         subsystem_list = [0, 1]
         dt = 1.
 
+        return PulseSystemModel(hamiltonian=ham_model,
+                                u_channel_lo=u_channel_lo,
+                                subsystem_list=subsystem_list,
+                                dt=dt)
+
+    def _system_model_3Q(self, omega_0, omega_a, omega_i, qubit_dim=2, subsystem_list=None):
+        """Constructs a 3 qubit model. Purpose of this is for testing subsystem restrictions -
+        It is set up so that the system restricted to [0, 2] and [1, 2] is the same (up to
+        channel labelling).
+
+        Args:
+            omega_0 (float): frequency of qubit
+            omega_a (float): strength of drive term
+            omega_i (float): strength of interaction
+            qubit_dim (int): dimension of qubit
+        Returns:
+            PulseSystemModel: model for qubit system
+        """
+
+        # make Hamiltonian
+        hamiltonian = {}
+        # qubit 0 terms
+        hamiltonian['h_str'] = ['-0.5*omega0*Z0',
+                                '0.5*omegaa*X0||D0',
+                                '-0.5*omega0*Z1',
+                                '0.5*omegaa*X1||D1']
+        # interaction terms
+        hamiltonian['h_str'].append('omegai*(Sp0*Sm2+Sm0*Sp2)||U1')
+        hamiltonian['h_str'].append('omegai*(Sp1*Sm2+Sm1*Sp2)||U2')
+        hamiltonian['vars'] = {
+            'omega0': omega_0,
+            'omegaa': omega_a,
+            'omegai': omega_i
+        }
+        hamiltonian['qub'] = {'0' : qubit_dim, '1' : qubit_dim, '2': qubit_dim}
+        ham_model = HamiltonianModel.from_dict(hamiltonian, subsystem_list)
+
+
+        u_channel_lo = [[{'q': 0, 'scale': [1.0, 0.0]}],
+                        [{'q': 0, 'scale': [-1.0, 0.0]}, {'q': 2, 'scale': [1.0, 0.0]}],
+                        [{'q': 1, 'scale': [-1.0, 0.0]}, {'q': 2, 'scale': [1.0, 0.0]}]]
+        dt = 1.
+        
         return PulseSystemModel(hamiltonian=ham_model,
                                 u_channel_lo=u_channel_lo,
                                 subsystem_list=subsystem_list,
@@ -796,7 +918,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         exp_statevector = [np.cos(arg), -1j * np.sin(arg)]
         return exp_statevector
 
-    def _schedule_2Q_interaction(self, total_samples):
+    def _schedule_2Q_interaction(self, total_samples, drive_idx=0, target_idx=1, U_idx=1):
         """Creates schedule for testing two qubit interaction. Specifically, do a pi pulse on qub 0
         so it starts in the `1` state (drive channel) and then apply constant pulses to each
         qubit (on control channel 1). This will allow us to test a swap gate.
@@ -809,16 +931,16 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # create acquire schedule
         acq_sched = Schedule(name='acq_sched')
-        acq_sched |= Acquire(total_samples, AcquireChannel(0), MemorySlot(0))
-        acq_sched += Acquire(total_samples, AcquireChannel(1), MemorySlot(1))
+        acq_sched |= Acquire(total_samples, AcquireChannel(drive_idx), MemorySlot(drive_idx))
+        acq_sched += Acquire(total_samples, AcquireChannel(target_idx), MemorySlot(target_idx))
 
         # set up const pulse
         const_pulse = SamplePulse(np.ones(total_samples), name='const_pulse')
 
         # add commands to schedule
         schedule = Schedule(name='2q_schedule')
-        schedule |= Play(const_pulse, DriveChannel(0))
-        schedule += Play(const_pulse, ControlChannel(1)) << schedule.duration
+        schedule |= Play(const_pulse, DriveChannel(drive_idx))
+        schedule += Play(const_pulse, ControlChannel(U_idx)) << schedule.duration
         schedule |= acq_sched << schedule.duration
 
         return schedule

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -648,7 +648,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
 
         subsystem_list = [0, 2]
-        system_model = self._system_model_3Q(omega_0, omega_a_pi_swap, omega_i_swap, subsystem_list=subsystem_list)
+        system_model = self._system_model_3Q(omega_0,
+                                             omega_a_pi_swap,
+                                             omega_i_swap,
+                                             subsystem_list=subsystem_list)
 
         schedule = self._schedule_2Q_interaction(total_samples, drive_idx=0, target_idx=2, U_idx=1)
         qobj = assemble([schedule],
@@ -674,7 +677,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # Q0 drive amp -> pi/2 pulse
         omega_a_pi2_swap = np.pi / 2 / total_samples
 
-        system_model = self._system_model_3Q(omega_0, omega_a_pi2_swap, omega_i_swap, subsystem_list=subsystem_list)
+        system_model = self._system_model_3Q(omega_0,
+                                             omega_a_pi2_swap,
+                                             omega_i_swap,
+                                             subsystem_list=subsystem_list)
 
         result_pi2_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
         counts_pi2_swap = result_pi2_swap.get_counts()
@@ -695,7 +701,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # Q0 drive amp -> pi pulse
         omega_a_no_swap = np.pi / total_samples
-        system_model = self._system_model_3Q(omega_0, omega_a_no_swap, omega_i_no_swap, subsystem_list=subsystem_list)
+        system_model = self._system_model_3Q(omega_0,
+                                             omega_a_no_swap,
+                                             omega_i_no_swap,
+                                             subsystem_list=subsystem_list)
 
         result_no_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
         counts_no_swap = result_no_swap.get_counts()
@@ -714,7 +723,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         omega_a_pi_swap = np.pi / total_samples
 
         subsystem_list = [1, 2]
-        system_model = self._system_model_3Q(omega_0, omega_a_pi_swap, omega_i_swap, subsystem_list=subsystem_list)
+        system_model = self._system_model_3Q(omega_0,
+                                             omega_a_pi_swap,
+                                             omega_i_swap,
+                                             subsystem_list=subsystem_list)
 
         schedule = self._schedule_2Q_interaction(total_samples, drive_idx=1, target_idx=2, U_idx=2)
         qobj = assemble([schedule],
@@ -726,7 +738,6 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=shots)
         backend_options = {'seed': 12387}
-
         result_pi_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
         counts_pi_swap = result_pi_swap.get_counts()
 
@@ -740,7 +751,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         # Q0 drive amp -> pi/2 pulse
         omega_a_pi2_swap = np.pi / 2 / total_samples
 
-        system_model = self._system_model_3Q(omega_0, omega_a_pi2_swap, omega_i_swap, subsystem_list=subsystem_list)
+        system_model = self._system_model_3Q(omega_0,
+                                             omega_a_pi2_swap,
+                                             omega_i_swap,
+                                             subsystem_list=subsystem_list)
 
         result_pi2_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
         counts_pi2_swap = result_pi2_swap.get_counts()
@@ -761,7 +775,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         # Q0 drive amp -> pi pulse
         omega_a_no_swap = np.pi / total_samples
-        system_model = self._system_model_3Q(omega_0, omega_a_no_swap, omega_i_no_swap, subsystem_list=subsystem_list)
+        system_model = self._system_model_3Q(omega_0,
+                                             omega_a_no_swap,
+                                             omega_i_no_swap,
+                                             subsystem_list=subsystem_list)
 
         result_no_swap = self.backend_sim.run(qobj, system_model, backend_options).result()
         counts_no_swap = result_no_swap.get_counts()

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -15,7 +15,7 @@ Tests for PulseSystemModel and HamiltonianModel functionality
 
 import unittest
 import warnings
-from numpy import array
+import numpy as np
 from numpy.linalg import norm
 from test.terra.common import QiskitAerTestCase
 import qiskit
@@ -167,12 +167,67 @@ class TestPulseSystemModel(BaseTestPulseSystemModel):
 class TestHamiltonianModel(QiskitAerTestCase):
     """Tests for HamiltonianModel"""
 
+    def test_subsystem_list_from_dict(self):
+        """Test correct restriction of a Hamiltonian dict to a subset of systems"""
+
+        # construct 2 duffing oscillator hamiltonian
+        v0=5.0
+        v1=5.1
+        j=0.01
+        r=0.02
+        alpha0=-0.33
+        alpha1=-0.33
+
+        hamiltonian = {}
+        hamiltonian['h_str'] = ['np.pi*(2*v0-alpha0)*O0',
+                              'np.pi*alpha0*O0*O0',
+                              '2*np.pi*r*X0||D0',
+                              '2*np.pi*r*X0||U1',
+                              '2*np.pi*r*X1||U0',
+                              'np.pi*(2*v1-alpha1)*O1',
+                              'np.pi*alpha1*O1*O1',
+                              '2*np.pi*r*X1||D1',
+                              '2*np.pi*j*(Sp0*Sm1+Sm0*Sp1)']
+        hamiltonian['qub'] = {'0' : 3, '1' : 3}
+        hamiltonian['vars'] = {'v0': v0,
+                               'v1': v1,
+                               'j': j,
+                               'r': r,
+                               'alpha0': alpha0,
+                               'alpha1': alpha1}
+
+        # restrict to qubit 0 and verify some properties
+        ham_model0 = HamiltonianModel.from_dict(hamiltonian, subsystem_list=[0])
+        evals_expected0 = np.array([0,
+                                    np.pi*(2*v0-alpha0) + np.pi*alpha0,
+                                    (2 * np.pi*(2*v0-alpha0)) + (4 * np.pi*alpha0)])
+        eval_diff = norm(evals_expected0 - ham_model0._evals)
+        self.assertAlmostEqual(eval_diff, 0)
+
+        channel_labels0 = ham_model0._channels.keys()
+        for key in ['D0', 'U1']:
+            self.assertTrue(key in channel_labels0)
+        self.assertEqual(len(channel_labels0), 2)
+
+        # restrict to qubit 1 and verify some properties
+        ham_model1 = HamiltonianModel.from_dict(hamiltonian, subsystem_list=[1])
+        evals_expected1 = np.array([0,
+                                    np.pi*(2*v1-alpha1) + np.pi*alpha1,
+                                    (2 * np.pi*(2*v1-alpha1)) + (4 * np.pi*alpha1)])
+        eval_diff = norm(evals_expected1 - ham_model1._evals)
+        self.assertAlmostEqual(eval_diff, 0)
+
+        channel_labels1 = ham_model1._channels.keys()
+        for key in ['D1', 'U0']:
+            self.assertTrue(key in channel_labels1)
+        self.assertEqual(len(channel_labels1), 2)
+
     def test_eigen_sorting(self):
         """Test estate mappings"""
 
-        X = array([[0,1],[1,0]])
-        Y = array([[0,-1j], [1j, 0]])
-        Z = array([[1,0], [0, -1]])
+        X = np.array([[0,1],[1,0]])
+        Y = np.array([[0,-1j], [1j, 0]])
+        Z = np.array([[1,0], [0, -1]])
 
         simple_ham = {'h_str': ['a*X0','b*Y0', 'c*Z0'],
                       'vars': {'a': 0.1, 'b': 0.1, 'c' : 1},

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -209,6 +209,10 @@ class TestHamiltonianModel(QiskitAerTestCase):
             self.assertTrue(key in channel_labels0)
         self.assertEqual(len(channel_labels0), 2)
 
+        qubit_lo_freq0 = ham_model0.get_qubit_lo_from_drift()
+        expected_freq0 = np.array([(np.pi*(2*v0-alpha0) + np.pi*alpha0) / (2 * np.pi)])
+        self.assertAlmostEqual(norm(qubit_lo_freq0 - expected_freq0), 0)
+
         # restrict to qubit 1 and verify some properties
         ham_model1 = HamiltonianModel.from_dict(hamiltonian, subsystem_list=[1])
         evals_expected1 = np.array([0,
@@ -221,6 +225,10 @@ class TestHamiltonianModel(QiskitAerTestCase):
         for key in ['D1', 'U0']:
             self.assertTrue(key in channel_labels1)
         self.assertEqual(len(channel_labels1), 2)
+
+        qubit_lo_freq1 = ham_model1.get_qubit_lo_from_drift()
+        expected_freq1 = np.array([0, (np.pi*(2*v1-alpha1) + np.pi*alpha1) / (2 * np.pi)])
+        self.assertAlmostEqual(norm(qubit_lo_freq1 - expected_freq1), 0)
 
     def test_eigen_sorting(self):
         """Test estate mappings"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #719 

1. Corrected subsystem reduction to not include implicit identities on the subsystems not included in `subsystem_list` for `HamiltonianModel.from_dict` when representing `full()` operators. 
2. Also fixed `HamiltonianModel.get_qubit_lo_from_drift()` so that it works when `subsystem_list` is not `range(k)` for some `k`. 

Associated with the above fixes is a slightly awkward interface issue: when calling `assemble`, the frequencies in `qubit_lo_freq` are assumed to correspond to the frequencies of the drive channels with indices `range(len(qubit_lo_freq))`. I.e. the frequency of `DriveChannel(idx)` is always assumed to be `qubit_lo_freq[idx]` regardless of what `subsystem_list` is. This results in needing to pass in "dummy" values for drive channel frequencies of qubits that have been excluded from the model.
    - The fix to `HamiltonianModel.get_qubit_lo_from_drift()` is consistent with this - it now returns a frequency of `0` for any drive channel indices not in `subsystem_list`
    - An alternative is to have `qubit_lo_freq[idx]` correspond to the drive channel of `subsystem_list[idx]`, though this also has the potentially awkward aspect of requiring re-specifying `qubit_lo_freq` for different `subsystem_list`.
For now I'm fine with leaving it as is.

### Details and comments

1. Corrected reduction of `subsystem_dims` in `HamiltonianModel.from_dict` to only include the systems in `subsystem_list`.
2. Corrected subsystem referencing in construction of measurement operators.
3. Added a test for `HamiltonianModel.from_dict` to validate above change.
4. Added an integration test in `test_pulse_simulator` to validate the above change. 
