### PR TITLE
Fix number of parallel shots for statevector and unitary sims

### DIFF
--- a/releasenotes/notes/fix-controller-parallel-shots-d32967c029259790.yaml
+++ b/releasenotes/notes/fix-controller-parallel-shots-d32967c029259790.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed bug with statevector and unitary simulators running a number of (parallel)
+    shots equal to the number of CPU threads instead of only running a single shot.

--- a/src/controllers/statevector_controller.hpp
+++ b/src/controllers/statevector_controller.hpp
@@ -137,6 +137,10 @@ void StatevectorController::set_config(const json_t& config) {
   // Set base controller config
   Base::Controller::set_config(config);
 
+  // Override max parallel shots to be 1 since this should only be used
+  // for single shot simulations
+  Base::Controller::max_parallel_shots_ = 1;
+
   // Add custom initial state
   if (JSON::get_value(initial_state_, "initial_statevector", config)) {
     // Check initial state is normalized

--- a/src/controllers/unitary_controller.hpp
+++ b/src/controllers/unitary_controller.hpp
@@ -129,6 +129,10 @@ void UnitaryController::set_config(const json_t &config) {
   // Set base controller config
   Base::Controller::set_config(config);
 
+  // Override max parallel shots to be 1 since this should only be used
+  // for single shot simulations
+  Base::Controller::max_parallel_shots_ = 1;
+
   // Add custom initial unitary
   if (JSON::get_value(initial_unitary_, "initial_unitary", config)) {
     // Check initial state is unitary


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #720

### Details and comments


