### PR TITLE
Improve efficiency of checking measurement sampling conditions

### DIFF
--- a/releasenotes/notes/upgrade-measure-sampling-b9bd728e7c90704e.yaml
+++ b/releasenotes/notes/upgrade-measure-sampling-b9bd728e7c90704e.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Improves how measurement sampling optimization is checked. The expensive
+    part of this operation is now done once during circuit construction where
+    rather than multiple times during simulation for when checking memory
+    requirements, simulation method, and final exection.

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -248,10 +248,10 @@ class QasmController : public Base::Controller {
                        RngEngine &rng) const;
 
   // Check if measure sampling optimization is valid for the input circuit
-  // if so return a pair {true, pos} where pos is the position of the
-  // first measurement operation in the input circuit
-  std::pair<bool, size_t> check_measure_sampling_opt(const Circuit &circ,
-                                                     const Method method) const;
+  // for the given method. This checks if operation types before
+  // the first measurement in the circuit prevent sampling
+  bool check_measure_sampling_opt(const Circuit &circ,
+                                  const Method method) const;
 
   //-----------------------------------------------------------------------
   // Config
@@ -629,7 +629,7 @@ QasmController::Method QasmController::simulation_method(
           circ.shots > (1 << circ.num_qubits) &&
           validate_memory_requirements(DensityMatrix::State<>(), circ, false) &&
           validate_state(DensityMatrix::State<>(), circ, noise_model, false) &&
-          check_measure_sampling_opt(circ, Method::density_matrix).first) {
+          check_measure_sampling_opt(circ, Method::density_matrix)) {
         return Method::density_matrix;
       }
       // Finally we check the statevector memory requirement for the
@@ -753,8 +753,9 @@ void QasmController::set_parallelization_circuit(
     case Method::statevector_thrust_cpu:
     case Method::stabilizer:
     case Method::matrix_product_state: {
-      if ((noise_model.is_ideal() || !noise_model.has_quantum_errors()) &&
-          check_measure_sampling_opt(circ, Method::statevector).first) {
+      if (circ.shots == 1 || (
+          noise_model.has_quantum_errors() == false &&
+          check_measure_sampling_opt(circ, Method::statevector))){
         parallel_shots_ = 1;
         parallel_state_update_ =
             std::max<int>({1, max_parallel_threads_ / parallel_experiments_});
@@ -766,7 +767,7 @@ void QasmController::set_parallelization_circuit(
     case Method::density_matrix:
     case Method::density_matrix_thrust_gpu:
     case Method::density_matrix_thrust_cpu:{
-      if (check_measure_sampling_opt(circ, Method::density_matrix).first) {
+      if (circ.shots == 1 || check_measure_sampling_opt(circ, Method::density_matrix)) {
         parallel_shots_ = 1;
         parallel_state_update_ =
             std::max<int>({1, max_parallel_threads_ / parallel_experiments_});
@@ -855,14 +856,17 @@ void QasmController::run_circuit_with_noise(const Circuit &circ,
                                             const Method method,
                                             ExperimentData &data,
                                             RngEngine &rng) const {
-  // Initialize fusion transpile pass
+  // Transpile passes
   auto fusion_pass = transpile_fusion(method, config);
+  Transpile::DelayMeasure measure_pass;
+  measure_pass.set_config(config);
   Noise::NoiseModel dummy_noise;
 
   while (shots-- > 0) {
     Circuit noise_circ = noise.sample_noise(circ, rng);
     noise_circ.shots = 1;
     fusion_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(), data);
+    measure_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(), data);
     run_single_shot(noise_circ, state, initial_state, data, rng);
   }
 }
@@ -880,26 +884,19 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
   // Dummy noise model for transpiler passes
   Noise::NoiseModel dummy_noise;
 
+  // Apply fusion transpilation pass
+  auto fusion_pass = transpile_fusion(method, config);
+  fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
+
   // Apply delay measure transpilation pass
   Transpile::DelayMeasure measure_pass;
   measure_pass.set_config(config);
   measure_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
 
-  // Apply fusion transpilation pass
-  auto fusion_pass = transpile_fusion(method, config);
-  fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
-
   // Check if measure sampler and optimization are valid
-  auto check = check_measure_sampling_opt(opt_circ, method);
-  if (check.first == false) {
-    // Perform standard execution if we cannot apply the
-    // measurement sampling optimization
-    while (shots-- > 0) {
-      run_single_shot(opt_circ, state, initial_state, data, rng);
-    }
-  } else {
+  if (check_measure_sampling_opt(opt_circ, method)) {
     // Implement measure sampler
-    auto pos = check.second;  // Position of first measurement op
+    auto pos = opt_circ.first_measure_pos;  // Position of first measurement op
 
     // Run circuit instructions before first measure
     std::vector<Operations::Op> ops(opt_circ.ops.begin(),
@@ -911,8 +908,15 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
     ops = std::vector<Operations::Op>(opt_circ.ops.begin() + pos,
                                       opt_circ.ops.end());
     measure_sampler(ops, shots, state, data, rng);
+
     // Add measure sampling metadata
     data.add_metadata("measure_sampling", true);
+  } else {
+    // Perform standard execution if we cannot apply the
+    // measurement sampling optimization
+    while (shots-- > 0) {
+      run_single_shot(opt_circ, state, initial_state, data, rng);
+    }
   }
 }
 
@@ -920,47 +924,37 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
 // Measure sampling optimization
 //-------------------------------------------------------------------------
 
-std::pair<bool, size_t> QasmController::check_measure_sampling_opt(
+bool QasmController::check_measure_sampling_opt(
     const Circuit &circ, const Method method) const {
-  // Find first instance of a measurement and check there
-  // are no reset or initialize operations before the measurement
+  // Check if circuit contains no measurements, or has sampling flag disabled
+  if (circ.can_sample == false || !circ.opset().contains(Operations::OpType::measure)) {
+    return false;
+  }
+
+  // Check if stabilizer measure sampling has been disabled
   if (method == Method::extended_stabilizer &&
       !extended_stabilizer_measure_sampling_) {
-    return std::make_pair(false, 0);
+    return false;
   }
-  auto start = circ.ops.begin();
-  while (start != circ.ops.end()) {
-    const auto type = start->type;
-    if (method != Method::density_matrix &&
-        method != Method::density_matrix_thrust_gpu &&
-        method != Method::density_matrix_thrust_cpu) {
-      if (type == Operations::OpType::reset ||
-          type == Operations::OpType::initialize ||
-          type == Operations::OpType::kraus ||
-          type == Operations::OpType::superop) {
-        return std::make_pair(false, 0);
-      }
-    }
-    if (type == Operations::OpType::measure ||
-        type == Operations::OpType::roerror)
-      break;
-    ++start;
+
+  // Check if non-density matrix simulation and circuit contains
+  // a stochastic instruction before measurement
+  // ie. initialize, reset, kraus, superop, conditional
+  // TODO:
+  // * If initialize should be allowed if applied to product states (ie start of circuit)
+  // * Resets should be allowed if applied to |0> state (no gates before).
+  bool density_mat = (method == Method::density_matrix ||
+                      method == Method::density_matrix_thrust_gpu ||
+                      method == Method::density_matrix_thrust_cpu);
+  if (!density_mat && (
+      circ.opset().contains(Operations::OpType::reset) ||
+      circ.opset().contains(Operations::OpType::initialize) ||
+      circ.opset().contains(Operations::OpType::kraus) ||
+      circ.opset().contains(Operations::OpType::superop))) {
+    return false;
   }
-  // Record position for if optimization passes
-  auto start_meas = start;
-  // Check all remaining operations are measurements
-  while (start != circ.ops.end()) {
-    if ((start->type != Operations::OpType::measure &&
-         start->type != Operations::OpType::roerror) ||
-        start->conditional) {
-      return std::make_pair(false, 0);
-    }
-    ++start;
-  }
-  // If we made it this far we can apply the optimization
-  // size_t meas_pos = start_meas - circ.ops.begin();
-  size_t meas_pos = std::distance(circ.ops.begin(), start_meas);
-  return std::make_pair(true, meas_pos);
+  // Otherwise true
+  return true;
 }
 
 template <class State_t>

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -753,8 +753,7 @@ void QasmController::set_parallelization_circuit(
     case Method::statevector_thrust_cpu:
     case Method::stabilizer:
     case Method::matrix_product_state: {
-      if (circ.shots == 1 || (
-          noise_model.has_quantum_errors() == false &&
+      if (circ.shots == 1 || ( !noise_model.has_quantum_errors() &&
           check_measure_sampling_opt(circ, Method::statevector))){
         parallel_shots_ = 1;
         parallel_state_update_ =

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -926,8 +926,8 @@ void QasmController::run_circuit_without_noise(const Circuit &circ,
 
 bool QasmController::check_measure_sampling_opt(
     const Circuit &circ, const Method method) const {
-  // Check if circuit contains no measurements, or has sampling flag disabled
-  if (circ.can_sample == false || !circ.opset().contains(Operations::OpType::measure)) {
+  // Check if circuit has sampling flag disabled
+  if (circ.can_sample == false) {
     return false;
   }
 

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -41,12 +41,17 @@ public:
   uint_t num_qubits = 0;        // maximum number of qubits needed for ops
   uint_t num_memory = 0;        // maximum number of memory clbits needed for ops
   uint_t num_registers = 0;     // maximum number of registers clbits needed for ops
-  bool has_conditional = false; // True if any ops are conditional
   
+  // Measurement params
+  bool has_conditional = false; // True if any ops are conditional
+  bool can_sample = true;       // True if circuit tail contains measure, roerror, barrier.
+  size_t first_measure_pos = 0; // Position of first measure instruction
+
   // Circuit metadata constructed from json QobjExperiment
   uint_t shots = 1;
   uint_t seed;
   json_t header;
+  
 
   // Constructor
   // The constructor automatically calculates the num_qubits, num_memory, num_registers
@@ -107,15 +112,35 @@ void Circuit::set_params() {
   qubitset_.clear();
   memoryset_.clear();
   registerset_.clear();
+  can_sample = true;
+  first_measure_pos = 0;
 
   // Check maximum qubit, and register size
-  // Memory size is loaded from qobj config  
-  for (const auto &op: ops) {
+  // Memory size is loaded from qobj config
+  // Also check if measure sampling is in principle possible
+  bool first_measure = true;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    const auto& op = ops[i];
     has_conditional |= op.conditional;
     opset_.insert(op);
     qubitset_.insert(op.qubits.begin(), op.qubits.end());
     memoryset_.insert(op.memory.begin(), op.memory.end());
     registerset_.insert(op.registers.begin(), op.registers.end());
+
+    // Compute measure sampling check
+    if (can_sample) {
+      if (first_measure) {
+        if (op.type == OpType::measure || op.type == OpType::roerror) {
+          first_measure = false;
+        } else {
+          first_measure_pos++;
+        }
+      } else if((op.type == OpType::barrier ||
+                 op.type == OpType::measure ||
+                 op.type == OpType::roerror) == false) {
+        can_sample = false;
+      }
+    }
   }
 
   // Get required number of qubits, memory, registers from set maximums

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -135,9 +135,9 @@ void Circuit::set_params() {
         } else {
           first_measure_pos++;
         }
-      } else if((op.type == OpType::barrier ||
-                 op.type == OpType::measure ||
-                 op.type == OpType::roerror) == false) {
+      } else if(!(op.type == OpType::barrier ||
+                  op.type == OpType::measure ||
+                  op.type == OpType::roerror)) {
         can_sample = false;
       }
     }

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -37,7 +37,8 @@ enum class RegComparison {Equal, NotEqual, Less, LessEqual, Greater, GreaterEqua
 // Enum class for operation types
 enum class OpType {
   gate, measure, reset, bfunc, barrier, snapshot,
-  matrix, diagonal_matrix, multiplexer, kraus, superop, roerror, noise_switch, initialize
+  matrix, diagonal_matrix, multiplexer, kraus, superop, roerror,
+  noise_switch, initialize, nop
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
@@ -83,6 +84,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     break;
   case OpType::initialize:
     stream << "initialize";
+    break;
+  case OpType::nop:
+    stream << "nop";
     break;
   default:
     stream << "unknown";

--- a/src/transpile/basic_opts.hpp
+++ b/src/transpile/basic_opts.hpp
@@ -39,18 +39,25 @@ void ReduceBarrier::optimize_circuit(Circuit& circ,
                                      Noise::NoiseModel& noise,
                                      const opset_t &allowed_opset,
                                      ExperimentData &data) const {
-
+  // Position of first sampling op
   size_t idx = 0;
+  size_t new_measure_pos = circ.first_measure_pos;
   for (size_t i = 0; i < circ.ops.size(); ++i) {
     if (circ.ops[i].type != optype_t::barrier) {
-      if (idx != i)
+      if (idx != i) {
         circ.ops[idx] = circ.ops[i];
+        
+      }
       ++idx;
+    } else if (i < circ.first_measure_pos) {
+      // Lower sample position by 1 for removed barrier
+      new_measure_pos--;
     }
   }
-
   if (idx != circ.ops.size())
     circ.ops.erase(circ.ops.begin() + idx, circ.ops.end());
+  // Update position of first measurement instruction
+  circ.first_measure_pos = new_measure_pos;
 }
 
 class Debug : public CircuitOptimization {

--- a/src/transpile/basic_opts.hpp
+++ b/src/transpile/basic_opts.hpp
@@ -46,7 +46,6 @@ void ReduceBarrier::optimize_circuit(Circuit& circ,
     if (circ.ops[i].type != optype_t::barrier) {
       if (idx != i) {
         circ.ops[idx] = circ.ops[i];
-        
       }
       ++idx;
     } else if (i < circ.first_measure_pos) {

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -210,7 +210,7 @@ void Fusion::optimize_circuit(Circuit& circ,
   if (applied) {
     size_t idx = 0;
     for (size_t i = 0; i < circ.ops.size(); ++i) {
-      if (circ.ops[i].name != "nop") {
+      if (circ.ops[i].type != optype_t::nop) {
         if (i != idx)
           circ.ops[idx] = circ.ops[i];
         ++idx;
@@ -376,7 +376,7 @@ bool Fusion::aggregate_operations(oplist_t& ops,
       for (int j = to; j <= i; ++j) {
         fusioned_ops.push_back(ops[j]);
         fusioned_qubits.insert(ops[j].qubits.cbegin(), ops[j].qubits.cend());
-        ops[j].name = "nop";
+        ops[j].type = optype_t::nop;
       }
       if (!fusioned_ops.empty()) {
         // We need to remap qubits in fusion subcircuits for simulation

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -208,7 +208,6 @@ void Fusion::optimize_circuit(Circuit& circ,
     applied = true;
 
   if (applied) {
-
     size_t idx = 0;
     for (size_t i = 0; i < circ.ops.size(); ++i) {
       if (circ.ops[i].name != "nop") {
@@ -221,10 +220,13 @@ void Fusion::optimize_circuit(Circuit& circ,
     if (idx != circ.ops.size())
       circ.ops.erase(circ.ops.begin() + idx, circ.ops.end());
     metadata["applied"] = true;
+
+    // Update circuit params for fused circuit
+    circ.set_params();
   }
 
   // Final metadata
-  if (verbose) {
+  if (verbose && applied) {
     metadata["input_ops"] = circ.ops;
     metadata["output_ops"] = circ.ops;
   }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Improves how measurement sampling of circuits is checked to prevent circuit instructions being iterated over multiple times unnecessarily.

### Details and comments

* Now the basic measurement sampling check of all measure instructions intail is done during construction of Circuit objects.
* Specific tests checking for instructions that prevent sampling is now checked using the circuit OpSet.