### PR TITLE
Changed FP comparisons to use Linalg::almost_equal

### DIFF
--- a/src/simulators/matrix_product_state/svd.cpp
+++ b/src/simulators/matrix_product_state/svd.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 #include "svd.hpp"
 #include "framework/utils.hpp"
+#include "framework/linalg/almost_equal.hpp"
 
 #define mul_factor 1e2
 #define tiny_factor 1e30
@@ -134,7 +135,8 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 			z = std::sqrt( z );
 			b[k] = z;
 			w = std::abs( A(k,k) );
-			if ( w == 0.0 ) {
+			if (Linalg::almost_equal(static_cast<long double>(w), 
+						 static_cast<long double>(0.0) )) {
 				q = complex_t( 1.0, 0.0 );
 			}
 			else {
@@ -182,7 +184,8 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 			c[k1] = z;
 			w = std::abs( A(k,k1) );
 
-			if ( w == 0.0 ){
+			if (Linalg::almost_equal(static_cast<long double>(w), 
+						 static_cast<long double>(0.0) )){
 				q = complex_t( 1.0, 0.0 );
 			}
 			else{
@@ -316,7 +319,8 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 				h = sn * g;
 				g = cs * g;
 				w = std::sqrt( h * h + f * f );
-				if (w == 0) {
+				if (Linalg::almost_equal(static_cast<long double>(w), 
+							 static_cast<long double>(0.0) )) {
 #ifdef DEBUG
 				  std::cout << "ERROR 1: w is exactly 0: h = " << h << " , f = " << f << std::endl;
 				  std::cout << " w = " << w << std::endl;
@@ -328,7 +332,8 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 				f = x * cs + g * sn; // might be 0
 
 				long double large_f = 0;
-				if (f==0) {
+				if (Linalg::almost_equal(static_cast<long double>(f), 
+							 static_cast<long double>(0.0) )) {
 #ifdef DEBUG
 				  std::cout << "f == 0 because " << "x = " << x << ", cs = " << cs << ", g = " << g << ", sn = " << sn  <<std::endl;
 #endif
@@ -361,14 +366,16 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 #ifdef DEBUG
 				std::cout << " h = " << h << " f = " << f << " large_f = " << large_f << std::endl;
 #endif
-				if (std::abs(h)  < 1e-13 && std::abs(f) < 1e-13 && large_f != 0) {
+				if (std::abs(h) < 1e-13 && std::abs(f) < 1e-13 && 
+				    !Linalg::almost_equal(large_f, 
+							  static_cast<long double>(0.0))) {
 				  tiny_w = true;
-				}
-				else {
+				} else {
 				  w = std::sqrt( h * h + f * f );
 				}
 				w = std::sqrt( h * h + f * f );
-				if (w == 0 && !tiny_w) {
+				if (Linalg::almost_equal(static_cast<long double>(w), 
+							 static_cast<long double>(0.0)) && !tiny_w) {
 
 #ifdef DEBUG
 				  std::cout << "ERROR: w is exactly 0: h = " << h << " , f = " << f << std::endl;
@@ -450,7 +457,8 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 
     for( k = n-1 ; k >= 0; k--)
 	{
-		if ( b[k] != 0.0 )
+	  if (!Linalg::almost_equal(static_cast<long double>(b[k]), 
+				    static_cast<long double>(0.0)) )
 		{
 			q = -A(k,k) / std::abs( A(k,k) );
 			for( j = 0; j < m; j++){
@@ -473,7 +481,9 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 	for( k = n-1 -1; k >= 0; k--)
 	{
 		k1 = k + 1;
-		if ( c[k1] != 0.0 )
+		//if (c[k1] != 0.0)
+		if ( !Linalg::almost_equal(static_cast<long double>(c[k1]), 
+					   static_cast<long double>(0.0) ))
 		{
 			q = -std::conj( A(k,k1) ) / std::abs( A(k,k1) );
 
@@ -503,9 +513,9 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 	const auto ncols = temp_A.GetColumns();
 	bool equal = true;
 
-	for (i=0; i < nrows; i++)
-	    for (j=0; j < ncols; j++)
-	      if (std::real(std::abs(temp_A(i, j) - temp(i, j))) > THRESHOLD)
+	for (uint_t ii=0; ii < nrows; ii++)
+	    for (uint_t jj=0; jj < ncols; jj++)
+	      if (std::real(std::abs(temp_A(ii, jj) - temp(ii, jj))) > THRESHOLD)
 	      {
 	    	  equal = false;
 	      }
@@ -555,7 +565,7 @@ void csvd_wrapper (cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
   }
 
   //Divide by mul_factor every singular value after we multiplied matrix a
-  for(int k = 0; k < S.size(); k++)
+  for(uint_t k = 0; k < S.size(); k++)
     S[k] /= pow(mul_factor, times);
 
 }

--- a/src/simulators/matrix_product_state/svd.cpp
+++ b/src/simulators/matrix_product_state/svd.cpp
@@ -481,7 +481,6 @@ status csvd(cmatrix_t &A, cmatrix_t &U,rvector_t &S,cmatrix_t &V)
 	for( k = n-1 -1; k >= 0; k--)
 	{
 		k1 = k + 1;
-		//if (c[k1] != 0.0)
 		if ( !Linalg::almost_equal(static_cast<long double>(c[k1]), 
 					   static_cast<long double>(0.0) ))
 		{


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
In svd.cpp: replaced all floating point `==` and `!=` to use `Linalg::almost_equal`. This cleans all the warnings out of the compilation of svd.cpp.


### Details and comments
This PR addresses issue #468  .

