### PR TITLE
Optimize Pauli expectation value performance

### DIFF
--- a/releasenotes/notes/expval_pauli-ec2ce5650dd82c49.yaml
+++ b/releasenotes/notes/expval_pauli-ec2ce5650dd82c49.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adds Pauli expectation value snapshot support to the density matrix
+    simulation method.
+upgrade:
+  - |
+    Greatly improves performance of the Pauli expectation value snapshot for
+    the statevector qasm simulation method.

--- a/src/simulators/density_matrix/densitymatrix.hpp
+++ b/src/simulators/density_matrix/densitymatrix.hpp
@@ -376,60 +376,37 @@ double DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
   size_t num_x = 0;
   size_t num_y = 0;
   size_t num_z = 0;
-  uint_t x_indices = 0;
-  uint_t z_indices = 0;
+  uint_t x_mask = 0;
+  uint_t z_mask = 0;
   for (size_t i = 0; i < N; ++i) {
     const auto bit = BITS[qubits[i]];
     switch (pauli[N - 1 - i]) {
       case 'I':
         break;
       case 'X': {
-        x_indices += bit;
+        x_mask += bit;
         num_x++;
         break;
       }
       case 'Z': {
-        z_indices += bit;
+        z_mask += bit;
         num_z++;
         break;
       }
       case 'Y': {
-        x_indices += bit;
-        z_indices += bit;
+        x_mask += bit;
+        z_mask += bit;
         num_y++;
         break;
       }
     }
   }
 
-  // The shift for density matrix indices in the vectorized vector
-  const size_t start = 0;
-  const size_t stop = BITS[num_qubits()];
-
   // Special case for only Z & I Paulis
-  if (num_x + num_y == 0) {
-    // All I Paulis returns the trace of the density matrix
-    if (num_z == 0)
-      return std::real(BaseMatrix::trace());
-    const auto shift = stop + 1;
-    auto lambda = [&](const int_t i, double &val_re, double &val_im)->void {
-      (void)val_im; // unused
-      const auto val = std::real(BaseVector::data_[shift * i]);
-      val_re += (__builtin_popcountll(i & z_indices) % 2) ? -val: val;
-    };
-    return std::real(BaseVector::apply_reduction_lambda(lambda, start, stop));
+  if (num_x + num_y + num_z == 0) {
+    return std::real(BaseMatrix::trace());
   }
 
-  // Special case for only X & I Paulis
-  if (num_z + num_y == 0) {
-    auto lambda = [&](const int_t i, double &val_re, double &val_im)->void {
-      (void)val_im; // unused
-      val_re += std::real(BaseVector::data_[i ^ x_indices + stop * i]);
-    };
-    return std::real(BaseVector::apply_reduction_lambda(lambda, start, stop));
-  }
-
-  // General case
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms
   std::complex<data_t> phase(1, 0);
@@ -450,10 +427,26 @@ double DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
       phase = std::complex<data_t>(0, 1);
       break;
   }
+  // The shift for density matrix indices in the vectorized vector
+  const size_t start = 0;
+  const size_t stop = BITS[num_qubits()];
   auto lambda = [&](const int_t i, double &val_re, double &val_im)->void {
     (void)val_im; // unused
-    const auto val = std::real(phase * BaseVector::data_[i ^ x_indices + stop * i]);
-    val_re += (__builtin_popcountll(i & z_indices) % 2) ? -val : val;
+    auto val = std::real(phase * BaseVector::data_[i ^ x_mask + stop * i]);
+    if (z_mask) {
+      // Portable implementation of __builtin_popcountll
+      auto count = i & z_mask;
+      count = (count & 0x5555555555555555) + ((count >> 1) & 0x5555555555555555);
+      count = (count & 0x3333333333333333) + ((count >> 2) & 0x3333333333333333);
+      count = (count & 0x0f0f0f0f0f0f0f0f) + ((count >> 4) & 0x0f0f0f0f0f0f0f0f);
+      count = (count & 0x00ff00ff00ff00ff) + ((count >> 8) & 0x00ff00ff00ff00ff);
+      count = (count & 0x0000ffff0000ffff) + ((count >>16) & 0x0000ffff0000ffff);
+      count = (count & 0x00000000ffffffff) + ((count >>32) & 0x00000000ffffffff);
+      if (count & 1) {
+        val = -val;
+      }
+    }
+    val_re += val;
   };
   return std::real(BaseVector::apply_reduction_lambda(lambda, start, stop));
 }

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -129,6 +129,18 @@ public:
   // generating samples.
   virtual reg_t sample_measure(const std::vector<double> &rnds) const override;
 
+  //-----------------------------------------------------------------------
+  // Expectation Value
+  //-----------------------------------------------------------------------
+
+  // These functions return the expectation value <psi|A|psi> for a matrix A.
+  // If A is hermitian these will return real values, if A is non-Hermitian
+  // they in general will return complex values.
+
+  // Return the expectation value of an N-qubit Pauli matrix.
+  // The Pauli is input as a length N string of I,X,Y,Z characters.
+  double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
+
 protected:
 
   // Convert qubit indicies to vectorized-density matrix qubitvector indices
@@ -533,6 +545,20 @@ reg_t DensityMatrixThrust<data_t>::sample_measure(const std::vector<double> &rnd
 #endif
 	
   return samples;
+}
+
+//-----------------------------------------------------------------------
+// Pauli expectation value
+//-----------------------------------------------------------------------
+
+template <typename data_t>
+double DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
+                                           const std::string &pauli) const {
+  // TODO!
+  throw std::runtime_error(
+    "Pauli expectation value is not implemented for GPU density matrix."
+  );
+  return 0;
 }
 
 //------------------------------------------------------------------------------

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -552,8 +552,8 @@ reg_t DensityMatrixThrust<data_t>::sample_measure(const std::vector<double> &rnd
 //-----------------------------------------------------------------------
 
 template <typename data_t>
-double DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
-                                           const std::string &pauli) const {
+double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
+                                                 const std::string &pauli) const {
   // TODO!
   throw std::runtime_error(
     "Pauli expectation value is not implemented for GPU density matrix."

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -610,8 +610,8 @@ public:
       count = (count & 0x3333333333333333) + ((count >> 2) & 0x3333333333333333);
       count = (count & 0x0f0f0f0f0f0f0f0f) + ((count >> 4) & 0x0f0f0f0f0f0f0f0f);
       count = (count & 0x00ff00ff00ff00ff) + ((count >> 8) & 0x00ff00ff00ff00ff);
-      count = (count & 0x0000ffff0000ffff) + ((count >>16) & 0x0000ffff0000ffff);
-      count = (count & 0x00000000ffffffff) + ((count >>32) & 0x00000000ffffffff);
+      count = (count & 0x0000ffff0000ffff) + ((count >> 16) & 0x0000ffff0000ffff);
+      count = (count & 0x00000000ffffffff) + ((count >> 32) & 0x00000000ffffffff);
       if(count & 1)
         ret = -ret;
     }
@@ -628,24 +628,20 @@ double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
   // Break string up into Z and X
   // With Y being both Z and X (plus a phase)
   const size_t N = qubits.size();
-  size_t num_x = 0;
-  size_t num_y = 0;
-  size_t num_z = 0;
   uint_t x_mask = 0;
   uint_t z_mask = 0;
+  uint_t num_y = 0;
   for (size_t i = 0; i < N; ++i) {
-    const auto bit = 1ull << qubits[i];
+    const auto bit = BITS[qubits[i]];
     switch (pauli[N - 1 - i]) {
       case 'I':
         break;
       case 'X': {
         x_mask += bit;
-        num_x++;
         break;
       }
       case 'Z': {
         z_mask += bit;
-        num_z++;
         break;
       }
       case 'Y': {
@@ -654,19 +650,20 @@ double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
         num_y++;
         break;
       }
+      default:
+        throw std::invalid_argument("Invalid Pauli \"" + std::to_string(pauli[N - 1 - i]) + "\".");
     }
   }
 
-  // Special case for all I Paulis
-  if (num_x + num_y + num_z == 0) {
+  // Special case for only I Paulis
+  if (x_mask + z_mask == 0) {
     std::real(BaseMatrix::trace());
   }
 
-  // General case
   // Compute the overall phase of the operator.
-  // This is (-1j) ** number of Y terms
+  // This is (-1j) ** number of Y terms modulo 4
   thrust::complex<data_t> phase(1, 0);
-  switch (num_y % 4) {
+  switch ((x_mask & z_mask) & 3) {
     case 0:
       // phase = 1
       break;

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -603,9 +603,8 @@ public:
     ret = q0.real();
 
     if(z_mask_ != 0){
-      uint_t count;
       //count bits (__builtin_popcountll can not be used on GPU)
-      count = i_row & z_mask_;
+      uint_t count = i_row & z_mask_;
       count = (count & 0x5555555555555555) + ((count >> 1) & 0x5555555555555555);
       count = (count & 0x3333333333333333) + ((count >> 2) & 0x3333333333333333);
       count = (count & 0x0f0f0f0f0f0f0f0f) + ((count >> 4) & 0x0f0f0f0f0f0f0f0f);
@@ -663,7 +662,7 @@ double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
   thrust::complex<data_t> phase(1, 0);
-  switch ((x_mask & z_mask) & 3) {
+  switch (num_y & 3) {
     case 0:
       // phase = 1
       break;

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -631,26 +631,26 @@ double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
   size_t num_x = 0;
   size_t num_y = 0;
   size_t num_z = 0;
-  uint_t x_indices = 0;
-  uint_t z_indices = 0;
+  uint_t x_mask = 0;
+  uint_t z_mask = 0;
   for (size_t i = 0; i < N; ++i) {
     const auto bit = 1ull << qubits[i];
     switch (pauli[N - 1 - i]) {
       case 'I':
         break;
       case 'X': {
-        x_indices += bit;
+        x_mask += bit;
         num_x++;
         break;
       }
       case 'Z': {
-        z_indices += bit;
+        z_mask += bit;
         num_z++;
         break;
       }
       case 'Y': {
-        x_indices += bit;
-        z_indices += bit;
+        x_mask += bit;
+        z_mask += bit;
         num_y++;
         break;
       }
@@ -683,7 +683,7 @@ double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
       phase = thrust::complex<data_t>(0, 1);
       break;
   }
-  return BaseVector::apply_function(density_expval_pauli_func<data_t>(num_qubits(),x_indices,z_indices,phase),qubits);
+  return BaseVector::apply_function(density_expval_pauli_func<data_t>(num_qubits(),x_mask,z_mask,phase),qubits);
 }
 
 //------------------------------------------------------------------------------

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -2166,11 +2166,9 @@ double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
   // Break string up into Z and X
   // With Y being both Z and X (plus a phase)
   const size_t N = qubits.size();
-  size_t num_x = 0;
-  size_t num_y = 0;
-  size_t num_z = 0;
   uint_t x_mask = 0;
   uint_t z_mask = 0;
+  uint_t num_y = 0;
   for (size_t i = 0; i < N; ++i) {
     const auto bit = BITS[qubits[i]];
     switch (pauli[N - 1 - i]) {
@@ -2178,12 +2176,10 @@ double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
         break;
       case 'X': {
         x_mask += bit;
-        num_x++;
         break;
       }
       case 'Z': {
         z_mask += bit;
-        num_z++;
         break;
       }
       case 'Y': {
@@ -2192,18 +2188,20 @@ double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
         num_y++;
         break;
       }
+      default:
+        throw std::invalid_argument("Invalid Pauli \"" + std::to_string(pauli[N - 1 - i]) + "\".");
     }
   }
 
-  // Special case for all I Paulis
-  if (num_x + num_y + num_z == 0) {
+  // Special case for only I Paulis
+  if (x_mask + z_mask == 0) {
     return norm();
   }
 
   // Compute the overall phase of the operator.
-  // This is (-1j) ** number of Y terms
+  // This is (-1j) ** number of Y terms modulo 4
   std::complex<data_t> phase(1, 0);
-  switch (num_y % 4) {
+  switch (num_y & 3) {
     case 0:
       // phase = 1
       break;
@@ -2231,8 +2229,8 @@ double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
       count = (count & 0x3333333333333333) + ((count >> 2) & 0x3333333333333333);
       count = (count & 0x0f0f0f0f0f0f0f0f) + ((count >> 4) & 0x0f0f0f0f0f0f0f0f);
       count = (count & 0x00ff00ff00ff00ff) + ((count >> 8) & 0x00ff00ff00ff00ff);
-      count = (count & 0x0000ffff0000ffff) + ((count >>16) & 0x0000ffff0000ffff);
-      count = (count & 0x00000000ffffffff) + ((count >>32) & 0x00000000ffffffff);
+      count = (count & 0x0000ffff0000ffff) + ((count >> 16) & 0x0000ffff0000ffff);
+      count = (count & 0x00000000ffffffff) + ((count >> 32) & 0x00000000ffffffff);
       if (count & 1) {
         val = -val;
       }

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -1048,6 +1048,18 @@ public:
   double norm_diagonal(const reg_t &qubits, const cvector_t<double> &mat) const;
 
   //-----------------------------------------------------------------------
+  // Expectation Value
+  //-----------------------------------------------------------------------
+
+  // These functions return the expectation value <psi|A|psi> for a matrix A.
+  // If A is hermitian these will return real values, if A is non-Hermitian
+  // they in general will return complex values.
+
+  // Return the expectation value of an N-qubit Pauli matrix.
+  // The Pauli is input as a length N string of I,X,Y,Z characters.
+  double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
+
+  //-----------------------------------------------------------------------
   // JSON configuration settings
   //-----------------------------------------------------------------------
 
@@ -4508,6 +4520,21 @@ void QubitVectorThrust<data_t>::DebugDump(void) const
 
 #endif
 
+/*******************************************************************************
+ *
+ * EXPECTATION VALUES
+ *
+ ******************************************************************************/
+
+template <typename data_t>
+double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
+                                         const std::string &pauli) const {
+  // TODO!
+  throw std::runtime_error(
+    "Pauli expectation value is not implemented for GPU statevector."
+  );
+  return 0;
+}                                       
 //------------------------------------------------------------------------------
 } // end namespace QV
 //------------------------------------------------------------------------------

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -4627,28 +4627,15 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
     }
   }
 
-  thrust::complex<data_t> phase(1,0);
-  double ret;
-
-  // Special case for only Z & I Paulis
-  if (num_x + num_y == 0) {
-    // All I Paulis returns the norm of the state
-    if (num_z == 0)
-      return norm();
-
-    ret = apply_function(expval_pauli_func<data_t>(0,z_indices,phase),qubits);
-    return ret;
-  }
-
-  // Special case for only X & I Paulis
-  if (num_z + num_y == 0) {
-    ret = apply_function(expval_pauli_func<data_t>(x_indices,0,phase),qubits);
-    return ret;
+  // Special case for all identity
+  if (num_x + num_y + num_z == 0) {
+    return norm();
   }
 
   // General case
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms
+  thrust::complex<data_t> phase(1,0);
   switch (num_y % 4) {
     case 0:
       // phase = 1
@@ -4666,8 +4653,7 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
       phase = thrust::complex<data_t>(0, 1);
       break;
   }
-  ret = apply_function(expval_pauli_func<data_t>(x_indices,z_indices,phase),qubits);
-  return ret;
+  return apply_function(expval_pauli_func<data_t>(x_indices, z_indices, phase),qubits);
 }
 
 //------------------------------------------------------------------------------

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -4527,14 +4527,149 @@ void QubitVectorThrust<data_t>::DebugDump(void) const
  ******************************************************************************/
 
 template <typename data_t>
+class expval_pauli_func : public GateFuncBase
+{
+protected:
+  uint_t x_mask_;
+  uint_t z_mask_;
+  thrust::complex<data_t> phase_;
+public:
+  expval_pauli_func(uint_t x,uint_t z,thrust::complex<data_t> p)
+  {
+    x_mask_ = x;
+    z_mask_ = z;
+    phase_ = p;
+  }
+
+  bool IsDiagonal(void)
+  {
+    return true;
+  }
+  bool Reduction(void)
+  {
+    return true;
+  }
+
+  __host__ __device__ double operator()(const thrust::tuple<uint_t,struct GateParams<data_t>> &iter) const
+  {
+    uint_t i;
+    thrust::complex<data_t>* pV;
+    thrust::complex<data_t> q0;
+    thrust::complex<data_t> q1;
+    double ret;
+    struct GateParams<data_t> params;
+
+    i = ExtractIndexFromTuple(iter);
+    params = ExtractParamsFromTuple(iter);
+    pV = params.buf_;
+
+    ret = 0.0;
+
+    q0 = pV[i];
+    q1 = pV[i ^ x_mask_];
+    q1 = q1 * phase_;
+    ret = q0.real()*q1.real() + q0.imag()*q1.imag();
+
+    if(z_mask_ != 0){
+      uint_t count;
+      //count bits (__builtin_popcountll can not be used on GPU)
+      count = i & z_mask_;
+      count = (count & 0x5555555555555555) + ((count >> 1) & 0x5555555555555555);
+      count = (count & 0x3333333333333333) + ((count >> 2) & 0x3333333333333333);
+      count = (count & 0x0f0f0f0f0f0f0f0f) + ((count >> 4) & 0x0f0f0f0f0f0f0f0f);
+      count = (count & 0x00ff00ff00ff00ff) + ((count >> 8) & 0x00ff00ff00ff00ff);
+      count = (count & 0x0000ffff0000ffff) + ((count >>16) & 0x0000ffff0000ffff);
+      count = (count & 0x00000000ffffffff) + ((count >>32) & 0x00000000ffffffff);
+      if(count & 1)
+        ret = -ret;
+    }
+    return ret;
+  }
+  const char* Name(void)
+  {
+    return "expval_pauli";
+  }
+};
+
+template <typename data_t>
 double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
-                                               const std::string &pauli) const {
-  // TODO!
-  throw std::runtime_error(
-    "Pauli expectation value is not implemented for GPU statevector."
-  );
-  return 0;
-}                                       
+                                               const std::string &pauli) const 
+{
+  // Break string up into Z and X
+  // With Y being both Z and X (plus a phase)
+  const size_t N = qubits.size();
+  size_t num_x = 0;
+  size_t num_y = 0;
+  size_t num_z = 0;
+  uint_t x_indices = 0;
+  uint_t z_indices = 0;
+  for (size_t i = 0; i < N; ++i) {
+    const auto bit = 1ull << qubits[i];
+    switch (pauli[N - 1 - i]) {
+      case 'I':
+        break;
+      case 'X': {
+        x_indices += bit;
+        num_x++;
+        break;
+      }
+      case 'Z': {
+        z_indices += bit;
+        num_z++;
+        break;
+      }
+      case 'Y': {
+        x_indices += bit;
+        z_indices += bit;
+        num_y++;
+        break;
+      }
+    }
+  }
+
+  thrust::complex<data_t> phase(1,0);
+  double ret;
+
+  // Special case for only Z & I Paulis
+  if (num_x + num_y == 0) {
+    // All I Paulis returns the norm of the state
+    if (num_z == 0)
+      return norm();
+
+    ret = apply_function(expval_pauli_func<data_t>(0,z_indices,phase),qubits);
+    return ret;
+  }
+
+  // Special case for only X & I Paulis
+  if (num_z + num_y == 0) {
+    ret = apply_function(expval_pauli_func<data_t>(x_indices,0,phase),qubits);
+    return ret;
+  }
+
+  // General case
+  // Compute the overall phase of the operator.
+  // This is (-1j) ** number of Y terms
+  switch (num_y % 4) {
+    case 0:
+      // phase = 1
+      break;
+    case 1:
+      // phase = -1j
+      phase = thrust::complex<data_t>(0, -1);
+      break;
+    case 2:
+      // phase = -1
+      phase = thrust::complex<data_t>(-1, 0);
+      break;
+    case 3:
+      // phase = 1j
+      phase = thrust::complex<data_t>(0, 1);
+      break;
+  }
+  ret = apply_function(expval_pauli_func<data_t>(x_indices,z_indices,phase),qubits);
+  return ret;
+}
+
 //------------------------------------------------------------------------------
 } // end namespace QV
 //------------------------------------------------------------------------------

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -4527,8 +4527,8 @@ void QubitVectorThrust<data_t>::DebugDump(void) const
  ******************************************************************************/
 
 template <typename data_t>
-double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
-                                         const std::string &pauli) const {
+double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
+                                               const std::string &pauli) const {
   // TODO!
   throw std::runtime_error(
     "Pauli expectation value is not implemented for GPU statevector."

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -4576,8 +4576,8 @@ public:
       count = (count & 0x3333333333333333) + ((count >> 2) & 0x3333333333333333);
       count = (count & 0x0f0f0f0f0f0f0f0f) + ((count >> 4) & 0x0f0f0f0f0f0f0f0f);
       count = (count & 0x00ff00ff00ff00ff) + ((count >> 8) & 0x00ff00ff00ff00ff);
-      count = (count & 0x0000ffff0000ffff) + ((count >>16) & 0x0000ffff0000ffff);
-      count = (count & 0x00000000ffffffff) + ((count >>32) & 0x00000000ffffffff);
+      count = (count & 0x0000ffff0000ffff) + ((count >> 16) & 0x0000ffff0000ffff);
+      count = (count & 0x00000000ffffffff) + ((count >> 32) & 0x00000000ffffffff);
       if(count & 1)
         ret = -ret;
     }
@@ -4596,24 +4596,20 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
   // Break string up into Z and X
   // With Y being both Z and X (plus a phase)
   const size_t N = qubits.size();
-  size_t num_x = 0;
-  size_t num_y = 0;
-  size_t num_z = 0;
   uint_t x_mask = 0;
   uint_t z_mask = 0;
+  uint_t num_y = 0;
   for (size_t i = 0; i < N; ++i) {
-    const auto bit = 1ull << qubits[i];
+    const auto bit = BITS[qubits[i]];
     switch (pauli[N - 1 - i]) {
       case 'I':
         break;
       case 'X': {
         x_mask += bit;
-        num_x++;
         break;
       }
       case 'Z': {
         z_mask += bit;
-        num_z++;
         break;
       }
       case 'Y': {
@@ -4622,19 +4618,20 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
         num_y++;
         break;
       }
+      default:
+        throw std::invalid_argument("Invalid Pauli \"" + std::to_string(pauli[N - 1 - i]) + "\".");
     }
   }
 
-  // Special case for all identity
-  if (num_x + num_y + num_z == 0) {
+  // Special case for only I Paulis
+  if (x_mask + z_mask == 0) {
     return norm();
   }
 
-  // General case
   // Compute the overall phase of the operator.
-  // This is (-1j) ** number of Y terms
+  // This is (-1j) ** number of Y terms modulo 4
   thrust::complex<data_t> phase(1,0);
-  switch (num_y % 4) {
+  switch (num_y & 3) {
     case 0:
       // phase = 1
       break;

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -4556,14 +4556,12 @@ public:
     thrust::complex<data_t>* pV;
     thrust::complex<data_t> q0;
     thrust::complex<data_t> q1;
-    double ret;
+    double ret = 0.0;
     struct GateParams<data_t> params;
 
     i = ExtractIndexFromTuple(iter);
     params = ExtractParamsFromTuple(iter);
     pV = params.buf_;
-
-    ret = 0.0;
 
     q0 = pV[i];
     q1 = pV[i ^ x_mask_];
@@ -4601,26 +4599,26 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
   size_t num_x = 0;
   size_t num_y = 0;
   size_t num_z = 0;
-  uint_t x_indices = 0;
-  uint_t z_indices = 0;
+  uint_t x_mask = 0;
+  uint_t z_mask = 0;
   for (size_t i = 0; i < N; ++i) {
     const auto bit = 1ull << qubits[i];
     switch (pauli[N - 1 - i]) {
       case 'I':
         break;
       case 'X': {
-        x_indices += bit;
+        x_mask += bit;
         num_x++;
         break;
       }
       case 'Z': {
-        z_indices += bit;
+        z_mask += bit;
         num_z++;
         break;
       }
       case 'Y': {
-        x_indices += bit;
-        z_indices += bit;
+        x_mask += bit;
+        z_mask += bit;
         num_y++;
         break;
       }
@@ -4653,7 +4651,7 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
       phase = thrust::complex<data_t>(0, 1);
       break;
   }
-  return apply_function(expval_pauli_func<data_t>(x_indices, z_indices, phase),qubits);
+  return apply_function(expval_pauli_func<data_t>(x_mask, z_mask, phase),qubits);
 }
 
 //------------------------------------------------------------------------------

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -551,50 +551,15 @@ void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
     throw std::invalid_argument("Invalid expval snapshot (Pauli components are empty).");
   }
 
-  // Cache the current quantum state
-  BaseState::qreg_.checkpoint();
-  bool first = true; // flag for first pass so we don't unnecessarily revert from checkpoint
-
-  // Compute expval components
+  // Accumulate expval components
   complex_t expval(0., 0.);
   for (const auto &param : op.params_expval_pauli) {
-    // Revert the quantum state to cached checkpoint
-    if (first)
-      first = false;
-    else
-      BaseState::qreg_.revert(true);
-    // Apply each pauli operator as a gate to the corresponding qubit
-    // qubits are stored as a list where position is qubit number:
-    // eq op.qubits = [a, b, c], a is qubit-0, b is qubit-1, c is qubit-2
-    // Pauli string labels are stored in little-endian ordering:
-    // eg label = "CBA", A is the Pauli for qubit-0, B for qubit-1, C for qubit-2
     const auto& coeff = param.first;
     const auto& pauli = param.second;
-    for (uint_t pos=0; pos < op.qubits.size(); ++pos) {
-      switch (pauli[pauli.size() - 1 - pos]) {
-        case 'I':
-          break;
-        case 'X':
-          BaseState::qreg_.apply_mcx({op.qubits[pos]});
-          break;
-        case 'Y':
-          BaseState::qreg_.apply_mcy({op.qubits[pos]});
-          break;
-        case 'Z':
-          BaseState::qreg_.apply_mcphase({op.qubits[pos]}, -1);
-          break;
-        default: {
-          std::stringstream msg;
-          msg << "QubitVectorState::invalid Pauli string \'" << pauli[pos] << "\'.";
-          throw std::invalid_argument(msg.str());
-        }
-      }
-    }
-    // Pauli expecation values should always be real for a valid state
-    // so we truncate the imaginary part
-    expval += coeff * std::real(BaseState::qreg_.inner_product());
+    expval += coeff * BaseState::qreg_.expval_pauli(op.qubits, pauli);
   }
-  // add to snapshot
+
+  // Add to snapshot
   Utils::chop_inplace(expval, json_chop_threshold_);
   switch (type) {
     case SnapshotDataType::average:
@@ -609,8 +574,6 @@ void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
       data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);
       break;
   }
-  // Revert to original state
-  BaseState::qreg_.revert(false);
 }
 
 template <class statevec_t>

--- a/src/simulators/unitary/unitarymatrix_thrust.hpp
+++ b/src/simulators/unitary/unitarymatrix_thrust.hpp
@@ -316,7 +316,7 @@ std::complex<double> UnitaryMatrixThrust<data_t>::trace() const {
   {
 #pragma omp for
   for (int_t k = 0; k < NROWS; ++k) {
-  	d = BaseVector::get_state(k * DIAG,BaseVector::m_maxChunkBits);
+  	d = BaseVector::get_state(k * DIAG);
     val_re += std::real(d);
     val_im += std::imag(d);
   }

--- a/test/terra/backends/test_qasm_simulator.py
+++ b/test/terra/backends/test_qasm_simulator.py
@@ -49,6 +49,7 @@ from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensity
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStabilizerTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabilitiesTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpvalPauliNCTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValMatrixTests
 # Other tests
 from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
@@ -92,6 +93,7 @@ class TestQasmSimulator(common.QiskitAerTestCase,
                         QasmSnapshotDensityMatrixTests,
                         QasmSnapshotProbabilitiesTests,
                         QasmSnapshotExpValPauliTests,
+                        QasmSnapshotExpvalPauliNCTests,
                         QasmSnapshotExpValMatrixTests,
                         QasmSnapshotStabilizerTests):
     """QasmSimulator automatic method tests."""

--- a/test/terra/backends/test_qasm_simulator_density_matrix.py
+++ b/test/terra/backends/test_qasm_simulator_density_matrix.py
@@ -51,6 +51,7 @@ from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensity
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStabilizerTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabilitiesTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpvalPauliNCTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValMatrixTests
 
 
@@ -66,8 +67,8 @@ class DensityMatrixTests(
         QasmReadoutNoiseTests, QasmPauliNoiseTests, QasmResetNoiseTests,
         QasmKrausNoiseTests, QasmSnapshotStatevectorTests,
         QasmSnapshotDensityMatrixTests, QasmSnapshotProbabilitiesTests,
-        QasmSnapshotExpValPauliTests, QasmSnapshotExpValMatrixTests,
-        QasmSnapshotStabilizerTests):
+        QasmSnapshotExpValPauliTests, QasmSnapshotExpvalPauliNCTests,
+        QasmSnapshotExpValMatrixTests, QasmSnapshotStabilizerTests):
     """Container class of density_matrix method tests."""
     pass
 

--- a/test/terra/backends/test_qasm_simulator_matrix_product_state.py
+++ b/test/terra/backends/test_qasm_simulator_matrix_product_state.py
@@ -47,6 +47,7 @@ from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStateve
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStabilizerTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabilitiesTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpvalPauliNCTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValMatrixTests
 # Other tests
 from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
@@ -78,6 +79,7 @@ class TestQasmMatrixProductStateSimulator(
         QasmSnapshotProbabilitiesTests,
         QasmSnapshotStabilizerTests,
         QasmSnapshotExpValPauliTests,
+        QasmSnapshotExpvalPauliNCTests,
         QasmSnapshotExpValMatrixTests,
         ):
     """QasmSimulator matrix product state method tests."""

--- a/test/terra/backends/test_qasm_simulator_statevector.py
+++ b/test/terra/backends/test_qasm_simulator_statevector.py
@@ -49,6 +49,7 @@ from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensity
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStabilizerTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabilitiesTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpvalPauliNCTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValMatrixTests
 # Other tests
 from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
@@ -73,7 +74,8 @@ class StatevectorTests(
         QasmResetNoiseTests, QasmKrausNoiseTests, QasmBasicsTests,
         QasmSnapshotStatevectorTests, QasmSnapshotDensityMatrixTests,
         QasmSnapshotProbabilitiesTests, QasmSnapshotExpValPauliTests,
-        QasmSnapshotExpValMatrixTests, QasmSnapshotStabilizerTests):
+        QasmSnapshotExpvalPauliNCTests, QasmSnapshotExpValMatrixTests,
+        QasmSnapshotStabilizerTests):
     """Container class of statevector method tests."""
     pass
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Greatly improves the performance of the Pauli expectation value snapshot instruction for the statevector method, and adds optimized pauli expectation value snapshots to the density matrix simulator.


### TODO

* [x] Add some extra tests
* [x] Add release note
* [x] @doichanj Add method to `QubitVectorThrust` and `DensityMatrixThrust` (this missing is reason for failing tests)

### Details and comments

Some simple benchmark comparisons for snapshots of Hamiltonian operators with N^2 number of N-qubit Pauli terms.

![pauli_expval_n2](https://user-images.githubusercontent.com/2235104/81218078-9cbc7f00-8fab-11ea-986d-51638fd13f09.png)

Relative speed up

![pauli_expval_rel_n2](https://user-images.githubusercontent.com/2235104/81218079-9cbc7f00-8fab-11ea-8c8e-86ec094e1060.png)



