### PR TITLE
Unblock ci for new jupyter-sphinx release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
     'sphinx_tabs.tabs',
-    'jupyter_sphinx.execute',
+    'jupyter_sphinx',
     'reno.sphinxext',
 ]
 html_static_path = ['_static']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The latest jupyter-sphinx release deprecated the plugin path we were
using which will now emit a deprecation warning. However because
warnings are marked as fatal with -W this is breaking the docs builds.
This commit updates are jupyter-sphinx usage to use the new path and fix
the warning/failure.

### Details and comments
