### PR TITLE
Avoid use of numpy prerelease candidate 1.19.0rc1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -275,8 +275,8 @@ stages:
               else
                   pip install qiskit-terra
               fi
-              displayName: "Install dependencies"
-              condition: eq(variables['python.version'], '3.5')
+            displayName: "Install dependencies"
+            condition: eq(variables['python.version'], '3.5')
           - bash: |
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,7 +268,7 @@ stages:
           - bash: |
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
-              pip install numpy<1.19.0
+              pip install 'numpy<1.19.0'
               pip install -r requirements-dev.txt
               if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == *"master"* || $BUILD_SOURCEBRANCH == *"master"* ]] ; then
                   pip install git+https://github.com/Qiskit/qiskit-terra.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,6 +268,18 @@ stages:
           - bash: |
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
+              pip install numpy<1.19.0
+              pip install -r requirements-dev.txt
+              if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == *"master"* || $BUILD_SOURCEBRANCH == *"master"* ]] ; then
+                  pip install git+https://github.com/Qiskit/qiskit-terra.git
+              else
+                  pip install qiskit-terra
+              fi
+              displayName: "Install dependencies"
+              condition: eq(variables['python.version'], '3.5')
+          - bash: |
+              set -e
+              source activate qiskit-aer-$(Build.BuildNumber)
               pip install -r requirements-dev.txt
               if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == *"master"* || $BUILD_SOURCEBRANCH == *"master"* ]] ; then
                   pip install git+https://github.com/Qiskit/qiskit-terra.git
@@ -275,7 +287,7 @@ stages:
                   pip install qiskit-terra
               fi
             displayName: "Install dependencies"
-            condition: ne(variables['python.version'], '3.8')
+            condition: and(ne(variables['python.version'], '3.5'), ne(variables['python.version'], '3.8'))
           - bash: |
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ import setuptools
 
 requirements = [
     'qiskit-terra>=0.12.0',
-    'numpy>=1.16.3',
+    'numpy>=1.16.3;python version>3.5',
+    'numpy>=1.16.3,<1.19.0;python version<3.6',
     'scipy>=1.0',
     'cython>=0.27.1',
     'pybind11>=2.4'  # This isn't really an install requirement,

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ import setuptools
 
 requirements = [
     'qiskit-terra>=0.12.0',
-    'numpy>=1.16.3;python version>3.5',
-    'numpy>=1.16.3,<1.19.0;python version<3.6',
+    'numpy>=1.16.3;python_version>"3.5"',
+    'numpy>=1.16.3,<1.19.0;python_version<"3.6"',
     'scipy>=1.0',
     'cython>=0.27.1',
     'pybind11>=2.4'  # This isn't really an install requirement,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Avoid use of numpy prerelease candidate 1.19.0rc1

### Details and comments

Azure `Compile: Windows_Wheel_Builds Python35` and `Test: Windows Python35` fail because at some point it tries to install Numpy non-stable version 1.19.0rc1, and for some reason this breaks ([[1](https://dev.azure.com/qiskit-ci/qiskit-aer/_build/results?buildId=13867&view=logs&j=e75d9aed-3891-5f4d-4db6-188bb674529f&t=25841d21-5fa7-5cd2-f4f9-be64287d296a)] and [[2](https://dev.azure.com/qiskit-ci/qiskit-aer/_build/results?buildId=13867&view=logs&j=6cffd7fe-8559-5039-bd0f-14cdd5e20947&t=eb2406f7-5076-5344-3510-a196e012e349)]). In the first case it fails in our own `python ./setup.py` and in the second one when it tries to build one of the dependencies (`scs`).
  

