### PR TITLE
Fix Hamiltonian parsing edge cases in pulse simulator

### DIFF
--- a/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
+++ b/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
@@ -37,7 +37,7 @@ class HamiltonianModel():
             subsystem_dims (dict): dict of subsystem dimensions.
 
         Raises:
-            ValueError: if arguments are invalid.
+            AerError: if arguments are invalid.
         """
 
         # Initialize internal variables
@@ -255,7 +255,7 @@ def _hamiltonian_pre_parse_exceptions(hamiltonian):
     """
 
     ham_str = hamiltonian.get('h_str', [])
-    if (ham_str == []) or (ham_str == ['']):
+    if ham_str in ([], ['']):
         raise AerError("Hamiltonian dict requires a non-empty 'h_str' entry.")
 
     if hamiltonian.get('qub', {}) == {}:

--- a/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
+++ b/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
@@ -85,7 +85,9 @@ class HamiltonianModel():
         _hamiltonian_parse_exceptions(hamiltonian)
 
         # get variables
-        variables = OrderedDict(hamiltonian['vars'])
+        variables = OrderedDict({})
+        if 'vars' in hamiltonian:
+            variables = OrderedDict(hamiltonian['vars'])
 
         # Get qubit subspace dimensions
         if 'qub' in hamiltonian:
@@ -208,7 +210,9 @@ class HamiltonianModel():
         for var in self._variables:
             exec('%s=%f' % (var, self._variables[var]))
 
-        ham_full = np.zeros(np.shape(self._system[0][0].full()), dtype=complex)
+        full_dim = np.prod(list(self._subsystem_dims.values()))
+
+        ham_full = np.zeros((full_dim, full_dim), dtype=complex)
         for ham_part in self._system:
             ham_full += ham_part[0].full() * eval(ham_part[1])
         # Remap eigenvalues and eigenstates
@@ -246,6 +250,7 @@ def _hamiltonian_parse_exceptions(hamiltonian):
     Raises:
         AerError: if some part of the hamiltonian dictionary is unsupported
     """
+
     if hamiltonian.get('osc', {}) != {}:
         raise AerError('Oscillator-type systems are not supported.')
 

--- a/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
+++ b/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
@@ -64,6 +64,9 @@ class HamiltonianModel():
         # populate self._channels
         self._calculate_hamiltonian_channels()
 
+        if len(self._channels) == 0:
+            raise AerError('HamiltonianModel must contain channels to simulate.')
+
         # populate self._h_diag, self._evals, self._estates
         self._compute_drift_data()
 
@@ -82,10 +85,10 @@ class HamiltonianModel():
             ValueError: if arguments are invalid.
         """
 
-        _hamiltonian_parse_exceptions(hamiltonian)
+        _hamiltonian_pre_parse_exceptions(hamiltonian)
 
         # get variables
-        variables = OrderedDict({})
+        variables = OrderedDict()
         if 'vars' in hamiltonian:
             variables = OrderedDict(hamiltonian['vars'])
 
@@ -241,7 +244,7 @@ class HamiltonianModel():
         self._h_diag = np.ascontiguousarray(np.diag(ham_full).real)
 
 
-def _hamiltonian_parse_exceptions(hamiltonian):
+def _hamiltonian_pre_parse_exceptions(hamiltonian):
     """Raises exceptions for hamiltonian specification.
 
     Parameters:
@@ -250,6 +253,13 @@ def _hamiltonian_parse_exceptions(hamiltonian):
     Raises:
         AerError: if some part of the hamiltonian dictionary is unsupported
     """
+
+    ham_str = hamiltonian.get('h_str', [])
+    if (ham_str == []) or (ham_str == ['']):
+        raise AerError("Hamiltonian dict requires a non-empty 'h_str' entry.")
+
+    if hamiltonian.get('qub', {}) == {}:
+        raise AerError("Hamiltonian dict requires non-empty 'qub' entry with subsystem dimensions.")
 
     if hamiltonian.get('osc', {}) != {}:
         raise AerError('Oscillator-type systems are not supported.')

--- a/qiskit/providers/aer/pulse/system_models/string_model_parser/string_model_parser.py
+++ b/qiskit/providers/aer/pulse/system_models/string_model_parser/string_model_parser.py
@@ -98,6 +98,10 @@ class HamiltonianParser:
                 if token is None:
                     continue
                 token = self._shunting_yard(token)
+
+                if (coef == '') or (coef is None):
+                    coef = '1.'
+
                 _tc = self._token2qobj(token), coef
 
                 self.__tc_hams.append(_tc)

--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -247,8 +247,8 @@ class TestHamiltonianModel(QiskitAerTestCase):
         Y = np.array([[0,-1j], [1j, 0]])
         Z = np.array([[1,0], [0, -1]])
 
-        simple_ham = {'h_str': ['a*X0','b*Y0', 'c*Z0'],
-                      'vars': {'a': 0.1, 'b': 0.1, 'c' : 1},
+        simple_ham = {'h_str': ['a*X0','b*Y0', 'c*Z0', 'd*X0||D0'],
+                      'vars': {'a': 0.1, 'b': 0.1, 'c' : 1, 'd': 0.},
                       'qub': {'0': 2}}
 
         ham_model = HamiltonianModel.from_dict(simple_ham)
@@ -264,8 +264,8 @@ class TestHamiltonianModel(QiskitAerTestCase):
             self.assertAlmostEqual(norm(diff), 0)
 
         # Same test but with strongly off-diagonal hamiltonian, which should raise warning
-        simple_ham = {'h_str': ['a*X0','b*Y0', 'c*Z0'],
-                      'vars': {'a': 100, 'b': 32.1, 'c' : 0.12},
+        simple_ham = {'h_str': ['a*X0','b*Y0', 'c*Z0', 'd*X0||D0'],
+                      'vars': {'a': 100, 'b': 32.1, 'c' : 0.12, 'd': 0.},
                       'qub': {'0': 2}}
 
         ham_model = HamiltonianModel.from_dict(simple_ham)


### PR DESCRIPTION
### Summary

Closes #526 
Closes #530

Changes:
1. Added `AerError` exceptions to `HamiltonianModel` for various hamiltonian string parsing scenarios that result in models that cannot be simulated.
2. Improved handling of `'vars'` when parsing a hamiltonian dict - it is now possible to construct and simulate a Hamiltonian with no variables without error.
3. Added various tests associated to the above changes.

### Details

Changes in detail:
- Added exceptions to `HamiltonianModel` construction from dictionary:
     - Exception raised if `'h_str'` is empty 
     - Exception raised if `'qub'` is empty (gets translated into `subsystem_list`)
     - Exception raised if Hamiltonian has no channels in it after parsing (includes the case that a Hamiltonian had channels in it, but they ended up being removed when eliminating some subsystems)
- Improved handling of `'vars'`:
     - Default value of empty dictionary given if `'vars'` not provided in original Hamiltonian
     - Previously, if a Hamiltonian term had no variables in it, it would result in an empty string for the "coefficient" of that term, which would result in errors in later functions when they try to evaluate these strings. I've updated the parser so that it never returns empty strings - any string that is empty that would be added is instead converted to `'1.0'`, i.e. a coefficient of `1.0`
- Added tests:
     - Added `HamiltonianModel` tests for all of the above added exceptions
     - Added `HamiltonianModel` test for models with no variables.
     - Added a `PulseSimulator` test for simulation of a model with no variables. It reproduces the `test_x_gate` test, but all parameters are given concretely directly in `'h_str'`, with no variables.
