### PR TITLE
Fix required memory checks for QasmSimulator with custom method

### DIFF
--- a/releasenotes/notes/fix-required-memory-check-0a138e0478d8ff32.yaml
+++ b/releasenotes/notes/fix-required-memory-check-0a138e0478d8ff32.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes issue where memory requirements of simulation were not being checked
+    on the QasmSimulator when using a non-automatic simulation method.

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -443,9 +443,8 @@ bool Controller::validate_memory_requirements(const state_t &state,
     if(throw_except) {
       std::string name = "";
       JSON::get_value(name, "name", circ.header);
-      throw std::runtime_error("AER::Base::Controller: State " + state.name() +
-                               " has insufficient memory to run the circuit " +
-                               name);
+      throw std::runtime_error("Insufficient memory to run circuit \"" + name +
+                               "\" using the " + state.name() + " simulator.");
     }
     return false;
   }

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -507,9 +507,11 @@ QasmController::Method QasmController::simulation_method(
         if (simulation_precision_ == Precision::single_precision) {
           Statevector::State<QV::QubitVector<float>> state;
           validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         } else {
           Statevector::State<QV::QubitVector<>> state;
           validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         }
       }
       return Method::statevector;
@@ -524,9 +526,11 @@ QasmController::Method QasmController::simulation_method(
         if (simulation_precision_ == Precision::single_precision) {
           Statevector::State<QV::QubitVectorThrust<float>> state;
           validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         } else {
           Statevector::State<QV::QubitVectorThrust<>> state;
           validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         }
       }
       return Method::statevector_thrust_gpu;
@@ -542,9 +546,11 @@ QasmController::Method QasmController::simulation_method(
         if (simulation_precision_ == Precision::single_precision) {
           Statevector::State<QV::QubitVectorThrust<float>> state;
           validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         } else {
           Statevector::State<QV::QubitVectorThrust<>> state;
           validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         }
       }
       return Method::statevector_thrust_cpu;
@@ -553,11 +559,13 @@ QasmController::Method QasmController::simulation_method(
     case Method::density_matrix: {
       if (validate) {
         if (simulation_precision_ == Precision::single_precision) {
-          validate_state(DensityMatrix::State<QV::DensityMatrix<float>>(), circ,
-                         noise_model, true);
+          DensityMatrix::State<QV::DensityMatrix<float>> state;
+          validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         } else {
-          validate_state(DensityMatrix::State<QV::DensityMatrix<double>>(),
-                         circ, noise_model, true);
+          DensityMatrix::State<QV::DensityMatrix<double>> state;
+          validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         }
       }
       return Method::density_matrix;
@@ -570,12 +578,13 @@ QasmController::Method QasmController::simulation_method(
 #else
       if (validate) {
         if (simulation_precision_ == Precision::single_precision) {
-          validate_state(DensityMatrix::State<QV::DensityMatrixThrust<float>>(),
-                         circ, noise_model, true);
+          DensityMatrix::State<QV::DensityMatrixThrust<float>> state;
+          validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         } else {
-          validate_state(
-              DensityMatrix::State<QV::DensityMatrixThrust<double>>(), circ,
-              noise_model, true);
+          DensityMatrix::State<QV::DensityMatrixThrust<double>> state;
+          validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         }
       }
       return Method::density_matrix_thrust_gpu;
@@ -589,30 +598,40 @@ QasmController::Method QasmController::simulation_method(
 #else
       if (validate) {
         if (simulation_precision_ == Precision::single_precision) {
-          validate_state(DensityMatrix::State<QV::DensityMatrixThrust<float>>(),
-                         circ, noise_model, true);
+          DensityMatrix::State<QV::DensityMatrixThrust<float>> state;
+          validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         } else {
-          validate_state(
-              DensityMatrix::State<QV::DensityMatrixThrust<double>>(), circ,
-              noise_model, true);
+           DensityMatrix::State<QV::DensityMatrixThrust<double>> state;
+          validate_state(state, circ, noise_model, true);
+          validate_memory_requirements(state, circ, true);
         }
       }
       return Method::density_matrix_thrust_cpu;
 #endif
     }
     case Method::stabilizer: {
-      if (validate)
+      if (validate) {
+         Stabilizer::State state;
         validate_state(Stabilizer::State(), circ, noise_model, true);
+        validate_memory_requirements(state, circ, true);
+      }
       return Method::stabilizer;
     }
     case Method::extended_stabilizer: {
-      if (validate)
-        validate_state(ExtendedStabilizer::State(), circ, noise_model, true);
+      if (validate) {
+        ExtendedStabilizer::State state;
+        validate_state(state, circ, noise_model, true);
+        validate_memory_requirements(ExtendedStabilizer::State(), circ, true);
+      }
       return Method::extended_stabilizer;
     }
     case Method::matrix_product_state: {
-      if (validate)
-        validate_state(MatrixProductState::State(), circ, noise_model, true);
+      if (validate) {
+        MatrixProductState::State state;
+        validate_state(state, circ, noise_model, true);
+        validate_memory_requirements(state, circ, true);
+      }
       return Method::matrix_product_state;
     }
     case Method::automatic: {

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -352,12 +352,8 @@ template <class densmat_t>
 size_t State<densmat_t>::required_memory_mb(uint_t num_qubits,
                                             const std::vector<Operations::Op> &ops)
                                             const {
-  // An n-qubit state vector as 2^n complex doubles
-  // where each complex double is 16 bytes
   (void)ops; // avoid unused variable compiler warning
-  size_t shift_mb = std::max<int_t>(0, num_qubits + 4 - 20);
-  size_t mem_mb = 1ULL << shift_mb;
-  return mem_mb;
+  return BaseState::qreg_.required_memory_mb(2 * num_qubits);
 }
 
 template <class densmat_t>

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -392,8 +392,6 @@ template <class statevec_t>
 size_t State<statevec_t>::required_memory_mb(uint_t num_qubits,
                                              const std::vector<Operations::Op> &ops)
                                              const {
-  // An n-qubit state vector as 2^n complex doubles
-  // where each complex double is 16 bytes
   (void)ops; // avoid unused variable compiler warning
   return BaseState::qreg_.required_memory_mb(num_qubits);
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes issue where memory requirements of simulation were not being checked on the QasmSimulator when using a non-automatic simulation method.

Closes #755 

### Details and comments


