### PR TITLE
Stop install ibmq provider as part of travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ stage_osx: &stage_osx
   language: generic
   python: 3.7
   env:
+        - QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.7.2
   cache:
@@ -235,6 +236,7 @@ jobs:
       <<: *stage_osx
       python: 3.8
       env:
+        - QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
         - PYTHON_VERSION=3.8.1
 
     # MacOS, Python 3.7 (via pyenv)
@@ -245,6 +247,7 @@ jobs:
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.7.2
+        - QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 
     # MacOS, Python 3.6 (via pyenv)
     - stage: test
@@ -255,6 +258,7 @@ jobs:
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.6.5
+        - QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 
     # MacOS, Python 3.5 (via pyenv)
     - stage: test
@@ -265,6 +269,7 @@ jobs:
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.5.6
+        - QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
     # "deploy" stage
     ##########################################################################
     #

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,10 @@ stage_generic: &stage_generic
       else
           pip install -U -c constraints.txt qiskit-terra
       fi
-    # Installing qiskit-ibmq-provider stable branch
-    # This is only needed to suppress warnings when importing Qiskit
-    - pip install https://github.com/Qiskit/qiskit-ibmq-provider/archive/stable.zip
     # Installing qiskit-aer...
     - pip install -U -c constraints.txt -r requirements-dev.txt
+  env:
+    - QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 
 stage_linux: &stage_linux
   <<: *stage_generic


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The travis jobs were installing the qiskit-ibmq-provider from a github
zip link from the stable branch. However, that branch no longer exists
as qiskit-ibmq-provider recently changed there release model to match
the rest of qiskit (using qiskit-bot). While we could just switch to
install from pypi, this commit just removes that step since it was only
listed there as being done to supress the packaging warnings from terra
when the provider is not installed. Since qiskit-terra 0.13.0 there has
been an env variable that lets you do that. This commit adds that env
variable to the generic configuration so we don't emit a warning and
don't try to install from a dead link.

### Details and comments


