### PR TITLE
Fix bugs in density matrix simulation method for diagonal gates and conditionals

### DIFF
--- a/releasenotes/notes/fix-density-matrix-diagonal-bb8ce049e2fa3c64.yaml
+++ b/releasenotes/notes/fix-density-matrix-diagonal-bb8ce049e2fa3c64.yaml
@@ -3,3 +3,6 @@ fixes:
   - |
     Fixes the "diagonal" qobj gate instructions being applied incorrectly
     in the density matrix Qasm Simulator method.
+  - |
+    Fixes bug where conditional gates were not being applied correctly
+    on the density matrix simulation method.

--- a/releasenotes/notes/fix-density-matrix-diagonal-bb8ce049e2fa3c64.yaml
+++ b/releasenotes/notes/fix-density-matrix-diagonal-bb8ce049e2fa3c64.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the "diagonal" qobj gate instructions being applied incorrectly
+    in the density matrix Qasm Simulator method.

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -410,7 +410,7 @@ void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
         apply_matrix(op.qubits, op.mats[0]);
         break;
       case Operations::OpType::diagonal_matrix:
-        BaseState::qreg_.apply_diagonal_matrix(op.qubits, op.params);
+        BaseState::qreg_.apply_diagonal_unitary_matrix(op.qubits, op.params);
         break;
       case Operations::OpType::superop:
         BaseState::qreg_.apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -383,44 +383,44 @@ void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
   // Simple loop over vector of input operations
   for (const auto op: ops) {
     // If conditional op check conditional
-    if (BaseState::creg_.check_conditional(op) == false)
-      return;
-    switch (op.type) {
-      case Operations::OpType::barrier:
-        break;
-      case Operations::OpType::reset:
-        apply_reset(op.qubits);
-        break;
-      case Operations::OpType::measure:
-        apply_measure(op.qubits, op.memory, op.registers, rng);
-        break;
-      case Operations::OpType::bfunc:
-        BaseState::creg_.apply_bfunc(op);
-        break;
-      case Operations::OpType::roerror:
-        BaseState::creg_.apply_roerror(op, rng);
-        break;
-      case Operations::OpType::gate:
-        apply_gate(op);
-        break;
-      case Operations::OpType::snapshot:
-        apply_snapshot(op, data);
-        break;
-      case Operations::OpType::matrix:
-        apply_matrix(op.qubits, op.mats[0]);
-        break;
-      case Operations::OpType::diagonal_matrix:
-        BaseState::qreg_.apply_diagonal_unitary_matrix(op.qubits, op.params);
-        break;
-      case Operations::OpType::superop:
-        BaseState::qreg_.apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
-        break;
-      case Operations::OpType::kraus:
-        apply_kraus(op.qubits, op.mats);
-        break;
-      default:
-        throw std::invalid_argument("DensityMatrix::State::invalid instruction \'" +
-                                    op.name + "\'.");
+    if (BaseState::creg_.check_conditional(op)) {
+      switch (op.type) {
+        case Operations::OpType::barrier:
+          break;
+        case Operations::OpType::reset:
+          apply_reset(op.qubits);
+          break;
+        case Operations::OpType::measure:
+          apply_measure(op.qubits, op.memory, op.registers, rng);
+          break;
+        case Operations::OpType::bfunc:
+          BaseState::creg_.apply_bfunc(op);
+          break;
+        case Operations::OpType::roerror:
+          BaseState::creg_.apply_roerror(op, rng);
+          break;
+        case Operations::OpType::gate:
+          apply_gate(op);
+          break;
+        case Operations::OpType::snapshot:
+          apply_snapshot(op, data);
+          break;
+        case Operations::OpType::matrix:
+          apply_matrix(op.qubits, op.mats[0]);
+          break;
+        case Operations::OpType::diagonal_matrix:
+          BaseState::qreg_.apply_diagonal_unitary_matrix(op.qubits, op.params);
+          break;
+        case Operations::OpType::superop:
+          BaseState::qreg_.apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
+          break;
+        case Operations::OpType::kraus:
+          apply_kraus(op.qubits, op.mats);
+          break;
+        default:
+          throw std::invalid_argument("DensityMatrix::State::invalid instruction \'" +
+                                      op.name + "\'.");
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes two bugs with the density matrix simulation
1. The new Diagonal terra gate was being applied incorrectly using the base statevector method due to a typo
2. The condition for checking conditional gates was not working correctly.

These weren't showing up as test failures due to problems with the tests themselves which are fixed in #765 

### Details and comments


