### PR TITLE
Fix issue with CZ and Z gates in GPU density matrix method

### DIFF
--- a/releasenotes/notes/fix-density-matrix-thrust-8f5f27748974f310.yaml
+++ b/releasenotes/notes/fix-density-matrix-thrust-8f5f27748974f310.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix bug in CZ gate and Z gate for "density_matrix_gpu" and
+    "density_matrix_thrust" QasmSimulator methods.

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -387,7 +387,6 @@ template <typename data_t>
 void DensityMatrixThrust<data_t>::apply_x(const uint_t qubit) {
   // Use the lambda function
   const reg_t qubits = {{qubit, qubit + num_qubits()}};
-
 	BaseVector::apply_function(DensityX<data_t>(qubits[0], qubits[1]), qubits);
 
 #ifdef AER_DEBUG
@@ -397,16 +396,65 @@ void DensityMatrixThrust<data_t>::apply_x(const uint_t qubit) {
 }
 
 template <typename data_t>
+class DensityY : public GateFuncBase
+{
+protected:
+  uint_t mask0;
+  uint_t mask1;
+
+public:
+  DensityY(int q0,int q1)
+  {
+  	if(q0 < q1){
+      mask0 = (1ull << q0) - 1;
+      mask1 = (1ull << q1) - 1;
+  	}
+  	else{
+      mask0 = (1ull << q1) - 1;
+      mask1 = (1ull << q0) - 1;
+  	}
+
+  }
+
+	__host__ __device__ double operator()(const thrust::tuple<uint_t,struct GateParams<data_t>> &iter) const
+  {
+    uint_t i,i0,i1,i2;
+	thrust::complex<data_t>* pV;
+	uint_t* offsets;
+    thrust::complex<data_t> q0,q1,q2,q3;
+		struct GateParams<data_t> params;
+
+  	i = ExtractIndexFromTuple(iter);
+		params = ExtractParamsFromTuple(iter);
+		pV = params.buf_;
+		offsets = params.offsets_;
+
+    i0 = i & mask0;
+    i2 = (i - i0) << 1;
+    i1 = i2 & mask1;
+    i2 = (i2 - i1) << 1;
+
+    i0 = i0 + i1 + i2;
+
+    q0 = pV[offsets[0]+i0];
+    q1 = pV[offsets[1]+i0];
+    q2 = pV[offsets[2]+i0];
+    q3 = pV[offsets[3]+i0];
+
+    pV[offsets[0]+i0] = q3;
+    pV[offsets[1]+i0] = -q2;
+    pV[offsets[2]+i0] = -q1;
+    pV[offsets[3]+i0] = q0;
+		return 0.0;
+  }
+
+};
+
+template <typename data_t>
 void DensityMatrixThrust<data_t>::apply_y(const uint_t qubit) {
-  cvector_t<double> vec;
-  vec.resize(16, 0.);
-  vec[0 * 4 + 3] = 1.;
-  vec[1 * 4 + 2] = -1.;
-  vec[2 * 4 + 1] = -1.;
-  vec[3 * 4 + 0] = 1.;
   // Use the lambda function
   const reg_t qubits = {{qubit, qubit + num_qubits()}};
-  BaseVector::apply_matrix(qubits, vec);
+  BaseVector::apply_function(DensityY<data_t>(qubits[0], qubits[1]), qubits);
 
 #ifdef AER_DEBUG
 	BaseVector::DebugMsg(" density::apply_y",qubits);

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -302,19 +302,14 @@ void DensityMatrixThrust<data_t>::apply_cnot(const uint_t qctrl, const uint_t qt
 
 template <typename data_t>
 void DensityMatrixThrust<data_t>::apply_cz(const uint_t q0, const uint_t q1) {
-  cvector_t<double> vec;
-  vec.resize(16, 0.);
-
-  vec[3] = -1.;
-  vec[7] = -1.;
-  vec[11] = -1.;
-  vec[12] = -1.;
-  vec[13] = -1.;
-  vec[14] = -1.;
+  cvector_t<double> diag({1., 1., 1., -1.,
+                          1., 1., 1., -1.,
+                          1., 1., 1., -1.,
+                          -1., -1., -1., 1.});
 
   const auto nq =  num_qubits();
   const reg_t qubits = {{q0, q1, q0 + nq, q1 + nq}};
-  BaseVector::apply_matrix(qubits, vec);
+  BaseVector::apply_diagonal_matrix(qubits, diag);
 #ifdef AER_DEBUG
 	BaseVector::DebugMsg(" density::apply_cz",qubits);
 #endif
@@ -420,16 +415,10 @@ void DensityMatrixThrust<data_t>::apply_y(const uint_t qubit) {
 
 template <typename data_t>
 void DensityMatrixThrust<data_t>::apply_z(const uint_t qubit) {
-  cvector_t<double> vec;
-  vec.resize(16, 0.);
-  vec[0 * 4 + 0] = 1.;
-  vec[1 * 4 + 1] = -1.;
-  vec[2 * 4 + 2] = -1.;
-  vec[3 * 4 + 3] = 1.;
-
+  cvector_t<double> diag({1., -1., -1., 1.});
   // Use the lambda function
   const reg_t qubits = {{qubit, qubit + num_qubits()}};
-  BaseVector::apply_matrix(qubits, vec);
+  BaseVector::apply_diagonal_matrix(qubits, diag);
 
 #ifdef AER_DEBUG
 	BaseVector::DebugMsg(" density::apply_z",qubits);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes following bugs for DensitMatrixThrust class
- Fixes issue where CZ and Z gate were being applied incorrectly.
- Improves efficiency of CZ and Z gates by applying them as diagonal gates instead of normal gates
- Adds specialized Y gate lambda.

Closes #754 

### Details and comments

These test  were not showing as failing because of #765 

