### PR TITLE
Add scipy constraint on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ requirements = [
     'qiskit-terra>=0.12.0',
     'numpy>=1.16.3;python_version>"3.5"',
     'numpy>=1.16.3,<1.19.0;python_version<"3.6"',
-    'scipy>=1.0',
+    'scipy>=1.0;python_version>"3.5"',
+    'scipy>=1.0,<1.5.0;python_version<"3.6"',
     'cython>=0.27.1',
     'pybind11>=2.4'  # This isn't really an install requirement,
                      # Pybind11 is required to be pre-installed for


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Scipy has dropped support for python 3.5 in their new release: 1.5.0, so we have
to tell setuptools to not try installing this version when building for Python 3.5


### Details and comments
https://github.com/scipy/scipy/releases/tag/v1.5.0rc1
Saw the problem here:
https://dev.azure.com/qiskit-ci/qiskit-aer/_build/results?buildId=14320&view=logs&j=e75d9aed-3891-5f4d-4db6-188bb674529f&t=25841d21-5fa7-5cd2-f4f9-be64287d296a&l=1412


