### PR TITLE
nlohmann_json back to 3.1.1

### DIFF
--- a/cmake/conan_utils.cmake
+++ b/cmake/conan_utils.cmake
@@ -5,7 +5,7 @@ macro(setup_conan)
     # Right now every dependency shall be static
     set(CONAN_OPTIONS ${CONAN_OPTIONS} "*:shared=False")
 
-    set(REQUIREMENTS nlohmann_json/3.7.3 spdlog/1.5.0)
+    set(REQUIREMENTS nlohmann_json/3.1.1 spdlog/1.5.0)
     if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         set(REQUIREMENTS ${REQUIREMENTS} llvm-openmp/8.0.1)
         if(SKBUILD)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Nlohmann_json library back to 3.1.1 to avoid compilation errors with nvcc (CUDA).

### Details and comments
Fixes #764

