### PR TITLE
Force conan to use CMake exec from which it has been launched

### DIFF
--- a/cmake/conan_utils.cmake
+++ b/cmake/conan_utils.cmake
@@ -34,5 +34,11 @@ macro(setup_conan)
         set(REQUIREMENTS ${REQUIREMENTS} catch2/2.12.1)
     endif()
 
-    conan_cmake_run(REQUIRES ${REQUIREMENTS} OPTIONS ${CONAN_OPTIONS} BASIC_SETUP CMAKE_TARGETS KEEP_RPATHS BUILD missing)
+    conan_cmake_run(REQUIRES ${REQUIREMENTS}
+                    OPTIONS ${CONAN_OPTIONS}
+                    ENV CONAN_CMAKE_PROGRAM=${CMAKE_COMMAND}
+                    BASIC_SETUP
+                    CMAKE_TARGETS
+                    KEEP_RPATHS
+                    BUILD missing)
 endmacro()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If `cmake is not installed in the system or in the `virtualenv, it is not able to find the one installed in the `.eggs directory, failing in case it has to build some package with `cmake.
This PR forces `conan to use the `cmake that has launched it

### Details and comments
Our `setup.py` launches `cmake`, which at some point calls `conan`. If `conan` cannot retrieve a binary it has to build it. If the package is built with `cmake`, `conan` will call `cmake` on its own. When the `cmake` executable is installed on the fly in the `.eggs` directory, `conan` is not able to use that `cmake`. 
The solution is to force `conan` to use the `cmake` binary that has launched it.

Fixes #758 

