### PR TITLE
Add README as pypi long description

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include MANIFEST.in
+include README.md
 recursive-include qiskit *pyx
 recursive-include qiskit *pxd
 recursive-include qiskit *.pxi

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ VERSION_PATH = os.path.join(os.path.dirname(__file__),
 with open(VERSION_PATH, "r") as version_file:
     VERSION = version_file.read().strip()
 
+README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                           'README.md')
+with open(README_PATH) as readme_file:
+    README = readme_file.read()
 
 setup(
     name='qiskit-aer',
@@ -66,6 +70,8 @@ setup(
     packages=setuptools.find_namespace_packages(include=['qiskit.*']),
     cmake_source_dir='.',
     description="Qiskit Aer - High performance simulators for Qiskit",
+    long_description=README,
+    long_description_content_type='text/markdown',
     url="https://github.com/Qiskit/qiskit-aer",
     author="AER Development Team",
     author_email="qiskit@us.ibm.com",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The long description field was missing from the pypi package this leads
to the package page on pypi showing "The author of this package has not
provided a project description" instead of any details about the
package. This commit updates the package metadata to use the README as
the long description so that a rendered version will be shown on the
pypi page.

### Details and comments