### PR TITLE
Remove cvxpy cap and exclude broken version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ conan>=1.22.2
 scikit-build
 cython
 asv
-cvxpy>=1.0.0,!=1.0.26,<1.1.0
+cvxpy>=1.0.0,!=1.0.26,!=1.1.0
 pylint
 pycodestyle
 Sphinx>=1.8.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

It looks like cvxpy 1.1.0 was just released with a regression which
caused the test failures. A day after 1.1.0 was released and #780 was
merged in aer to cap cvxpy 1.1.1 was pushed out without any issues
or PRs opened or without any release notes published. Looking at the git
log there was 1 commit on top of 1.1.0 for the 1.1.1 release [1] which
looks releated to the error message we were seeing with 1.1.0. This
commit removes the version cap to try (and changes it to exclude 1.1.0
only) to see if 1.1.1 fixes our problem.

### Details and comments

Potentially Fixes #779

[1] https://github.com/cvxgrp/cvxpy/commit/1ea3d6712abb7c1ad2e9a0bd491830a550863ec2
