### PR TITLE
Allow for suppressing warnings in NoiseModel.from_backend()

### DIFF
--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -193,22 +193,24 @@ def _device_depolarizing_error(qubits,
         # Check if reported error param is un-physical
         # The minimum average gate fidelity is F_min = 1 / (dim + 1)
         # So the maximum gate error is 1 - F_min = dim / (dim + 1)
-        if error_param > error_max and warnings:
-            logger.warning(
-                'Device reported a gate error parameter greater'
-                ' than maximum allowed value (%f > %f). Truncating to'
-                ' maximum value.', error_param, error_max)
+        if error_param > error_max:
+            if warnings:
+                logger.warning(
+                    'Device reported a gate error parameter greater'
+                    ' than maximum allowed value (%f > %f). Truncating to'
+                    ' maximum value.', error_param, error_max)
             error_param = error_max
         # Model gate error entirely as depolarizing error
         num_qubits = len(qubits)
         dim = 2 ** num_qubits
         depol_param = dim * (error_param - relax_infid) / (dim * relax_fid - 1)
         max_param = 4**num_qubits / (4**num_qubits - 1)
-        if depol_param > max_param and warnings:
-            logger.warning(
-                'Device model returned a depolarizing error parameter greater'
-                ' than maximum allowed value (%f > %f). Truncating to'
-                ' maximum value.', depol_param, max_param)
+        if depol_param > max_param:
+            if warnings:
+                logger.warning(
+                    'Device model returned a depolarizing error parameter greater'
+                    ' than maximum allowed value (%f > %f). Truncating to'
+                    ' maximum value.', depol_param, max_param)
             depol_param = min(depol_param, max_param)
         return depolarizing_error(
             depol_param, num_qubits, standard_gates=standard_gates)

--- a/qiskit/providers/aer/noise/device/models.py
+++ b/qiskit/providers/aer/noise/device/models.py
@@ -57,7 +57,8 @@ def basic_device_gate_errors(properties,
                              gate_lengths=None,
                              gate_length_units='ns',
                              temperature=0,
-                             standard_gates=True):
+                             standard_gates=True,
+                             warnings=True):
     """
     Return QuantumErrors derived from a devices BackendProperties.
 
@@ -82,6 +83,7 @@ def basic_device_gate_errors(properties,
         standard_gates (bool): If true return errors as standard
                                qobj gates. If false return as unitary
                                qobj instructions (Default: True).
+        warnings (bool): Display warnings (Default: True).
 
     Returns:
         list: A list of tuples ``(label, qubits, QuantumError)``, for gates
@@ -134,7 +136,7 @@ def basic_device_gate_errors(properties,
         # Get depolarizing error channel
         if gate_error:
             depol_error = _device_depolarizing_error(
-                qubits, error_param, relax_error, standard_gates)
+                qubits, error_param, relax_error, standard_gates, warnings=warnings)
 
         # Combine errors
         if depol_error is None and relax_error is None:
@@ -157,7 +159,8 @@ def basic_device_gate_errors(properties,
 def _device_depolarizing_error(qubits,
                                error_param,
                                relax_error=None,
-                               standard_gates=True):
+                               standard_gates=True,
+                               warnings=True):
     """Construct a depolarizing_error for device"""
 
     # We now deduce the depolarizing channel error parameter in the
@@ -190,7 +193,7 @@ def _device_depolarizing_error(qubits,
         # Check if reported error param is un-physical
         # The minimum average gate fidelity is F_min = 1 / (dim + 1)
         # So the maximum gate error is 1 - F_min = dim / (dim + 1)
-        if error_param > error_max:
+        if error_param > error_max and warnings:
             logger.warning(
                 'Device reported a gate error parameter greater'
                 ' than maximum allowed value (%f > %f). Truncating to'
@@ -201,7 +204,7 @@ def _device_depolarizing_error(qubits,
         dim = 2 ** num_qubits
         depol_param = dim * (error_param - relax_infid) / (dim * relax_fid - 1)
         max_param = 4**num_qubits / (4**num_qubits - 1)
-        if depol_param > max_param:
+        if depol_param > max_param and warnings:
             logger.warning(
                 'Device model returned a depolarizing error parameter greater'
                 ' than maximum allowed value (%f > %f). Truncating to'

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -179,7 +179,8 @@ class NoiseModel:
                      temperature=0,
                      gate_lengths=None,
                      gate_length_units='ns',
-                     standard_gates=True):
+                     standard_gates=True,
+                     warnings=True):
         """Return a noise model derived from a devices backend properties.
 
         This function generates a noise model based on:
@@ -259,6 +260,7 @@ class NoiseModel:
             standard_gates (bool): If true return errors as standard
                                    qobj gates. If false return as unitary
                                    qobj instructions (Default: True)
+            warnings (bool): Display warnings (Default: True).
 
         Returns:
             NoiseModel: An approximate noise model for the device backend.
@@ -281,7 +283,7 @@ class NoiseModel:
         # Add single-qubit readout errors
         if readout_error:
             for qubits, error in basic_device_readout_errors(properties):
-                noise_model.add_readout_error(error, qubits)
+                noise_model.add_readout_error(error, qubits, warnings=warnings)
 
         # Add gate errors
         gate_errors = basic_device_gate_errors(
@@ -291,9 +293,10 @@ class NoiseModel:
             gate_lengths=gate_lengths,
             gate_length_units=gate_length_units,
             temperature=temperature,
-            standard_gates=standard_gates)
+            standard_gates=standard_gates,
+            warnings=warnings)
         for name, qubits, error in gate_errors:
-            noise_model.add_quantum_error(error, name, qubits)
+            noise_model.add_quantum_error(error, name, qubits, warnings=warnings)
         return noise_model
 
     def __repr__(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The larger devices always have one or more bad gates that trigger warnings.  This allows for suppressing these.

### Details and comments


