### PR TITLE
Fix issues with pulse system model test using FakeArmonk

### DIFF
--- a/test/terra/openpulse/test_system_models.py
+++ b/test/terra/openpulse/test_system_models.py
@@ -158,7 +158,8 @@ class TestPulseSystemModel(BaseTestPulseSystemModel):
         test_model = PulseSystemModel.from_backend(backend)
         qubit_lo_from_hamiltonian = test_model.hamiltonian.get_qubit_lo_from_drift()
         freqs = test_model.calculate_channel_frequencies(qubit_lo_from_hamiltonian)
-        self.assertAlmostEqual(freqs['D0'], 4.974286046328553)
+        expected = getattr(backend.configuration(), 'hamiltonian')['vars']['wq0'] / (2 * np. pi)
+        self.assertAlmostEqual(freqs['D0'], expected)
 
     def _compute_u_lo_freqs(self, qubit_lo_freq):
         """


### PR DESCRIPTION
### Summary

The `PulseSystemModel` test `test_qubit_lo_from_configurable_backend` depends on the `FakeArmonk` backend - and was comparing a derived value from that backend to a hardcoded value. There are some inconsistencies resulting in the test failing occasionally - not sure why but it could e.g. come from changes to `FakeArmonk`. 

Changed the test to directly look at the values in `FakeArmonk` to make it insensitive to changes.


