### PR TITLE
Remove unnecessary copy of ExperimentResult objects

### DIFF
--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -25,11 +25,12 @@
 #include <vector>
 
 #if defined(__linux__) || defined(__APPLE__)
-   #include <unistd.h>
+#include <unistd.h>
 #elif defined(_WIN64)
-   // This is needed because windows.h redefine min()/max() so interferes with std::min/max
-   #define NOMINMAX
-   #include <windows.h>
+// This is needed because windows.h redefine min()/max() so interferes with
+// std::min/max
+#define NOMINMAX
+#include <windows.h>
 #endif
 
 #ifdef _OPENMP
@@ -37,15 +38,14 @@
 #endif
 
 // Base Controller
-#include "framework/qobj.hpp"
-#include "framework/rng.hpp"
 #include "framework/creg.hpp"
-#include "framework/results/result.hpp"
+#include "framework/qobj.hpp"
 #include "framework/results/experiment_data.hpp"
+#include "framework/results/result.hpp"
+#include "framework/rng.hpp"
 #include "noise/noise_model.hpp"
 #include "transpile/basic_opts.hpp"
 #include "transpile/truncate_qubits.hpp"
-
 
 namespace AER {
 namespace Base {
@@ -103,8 +103,7 @@ namespace Base {
 
 class Controller {
 public:
-
-  Controller() {clear_parallelization();}
+  Controller() { clear_parallelization(); }
 
   //-----------------------------------------------------------------------
   // Execute qobj
@@ -130,7 +129,6 @@ public:
   void virtual clear_config();
 
 protected:
-
   //-----------------------------------------------------------------------
   // Circuit Execution
   //-----------------------------------------------------------------------
@@ -145,11 +143,9 @@ protected:
   // Abstract method for executing a circuit.
   // This method must initialize a state and return output data for
   // the required number of shots.
-  virtual ExperimentData run_circuit(const Circuit &circ,
-                                     const Noise::NoiseModel &noise,
-                                     const json_t &config,
-                                     uint_t shots,
-                                     uint_t rng_seed) const = 0;
+  virtual void run_circuit(const Circuit &circ, const Noise::NoiseModel &noise,
+                           const json_t &config, uint_t shots, uint_t rng_seed,
+                           ExperimentData &data) const = 0;
 
   //-------------------------------------------------------------------------
   // State validation
@@ -160,17 +156,15 @@ protected:
   // If throw_except is true an exception will be thrown on the return false
   // case listing the invalid instructions in the circuit or noise model.
   template <class state_t>
-  static bool validate_state(const state_t &state,
-                             const Circuit &circ,
+  static bool validate_state(const state_t &state, const Circuit &circ,
                              const Noise::NoiseModel &noise,
                              bool throw_except = false);
 
   // Return True if a given circuit are valid for execution on the given state.
-  // Otherwise return false. 
+  // Otherwise return false.
   // If throw_except is true an exception will be thrown directly.
   template <class state_t>
-  bool validate_memory_requirements(const state_t &state,
-                                    const Circuit &circ,
+  bool validate_memory_requirements(const state_t &state, const Circuit &circ,
                                     bool throw_except = false) const;
 
   //-----------------------------------------------------------------------
@@ -194,16 +188,17 @@ protected:
   void clear_parallelization();
 
   // Set parallelization for experiments
-  virtual void set_parallelization_experiments(const std::vector<Circuit>& circuits,
-                                               const Noise::NoiseModel& noise);
+  virtual void
+  set_parallelization_experiments(const std::vector<Circuit> &circuits,
+                                  const Noise::NoiseModel &noise);
 
   // Set parallelization for a circuit
-  virtual void set_parallelization_circuit(const Circuit& circuit,
-                                           const Noise::NoiseModel& noise);
+  virtual void set_parallelization_circuit(const Circuit &circuit,
+                                           const Noise::NoiseModel &noise);
 
   // Return an estimate of the required memory for a circuit.
-  virtual size_t required_memory_mb(const Circuit& circuit,
-                                    const Noise::NoiseModel& noise) const = 0;
+  virtual size_t required_memory_mb(const Circuit &circuit,
+                                    const Noise::NoiseModel &noise) const = 0;
 
   // Get system memory size
   size_t get_system_memory_mb();
@@ -225,7 +220,6 @@ protected:
   int parallel_state_update_;
 };
 
-
 //=========================================================================
 // Implementations
 //=========================================================================
@@ -239,28 +233,29 @@ void Controller::set_config(const json_t &config) {
   // Load validation threshold
   JSON::get_value(validation_threshold_, "validation_threshold", config);
 
-  #ifdef _OPENMP
+#ifdef _OPENMP
   // Load OpenMP maximum thread settings
   if (JSON::check_key("max_parallel_threads", config))
     JSON::get_value(max_parallel_threads_, "max_parallel_threads", config);
   if (JSON::check_key("max_parallel_experiments", config))
-    JSON::get_value(max_parallel_experiments_, "max_parallel_experiments", config);
+    JSON::get_value(max_parallel_experiments_, "max_parallel_experiments",
+                    config);
   if (JSON::check_key("max_parallel_shots", config))
     JSON::get_value(max_parallel_shots_, "max_parallel_shots", config);
   // Limit max threads based on number of available OpenMP threads
   auto omp_threads = omp_get_max_threads();
   max_parallel_threads_ = (max_parallel_threads_ > 0)
-      ? std::min(max_parallel_threads_, omp_threads)
-      : std::max(1, omp_threads);
-  #else
+                              ? std::min(max_parallel_threads_, omp_threads)
+                              : std::max(1, omp_threads);
+#else
   // No OpenMP so we disable parallelization
   max_parallel_threads_ = 1;
   max_parallel_shots_ = 1;
   max_parallel_experiments_ = 1;
-  #endif
+#endif
 
   // Load configurations for parallelization
-  
+
   if (JSON::check_key("max_memory_mb", config)) {
     JSON::get_value(max_memory_mb_, "max_memory_mb", config);
   }
@@ -284,9 +279,9 @@ void Controller::set_config(const json_t &config) {
   }
 
   if (explicit_parallelization_) {
-    parallel_experiments_ = std::max<int>( { parallel_experiments_, 1 });
-    parallel_shots_ = std::max<int>( { parallel_shots_, 1 });
-    parallel_state_update_ = std::max<int>( { parallel_state_update_, 1 });
+    parallel_experiments_ = std::max<int>({parallel_experiments_, 1});
+    parallel_shots_ = std::max<int>({parallel_shots_, 1});
+    parallel_state_update_ = std::max<int>({parallel_state_update_, 1});
   }
 }
 
@@ -308,14 +303,15 @@ void Controller::clear_parallelization() {
   max_memory_mb_ = get_system_memory_mb() / 2;
 }
 
-void Controller::set_parallelization_experiments(const std::vector<Circuit>& circuits,
-                                                 const Noise::NoiseModel& noise) {
+void Controller::set_parallelization_experiments(
+    const std::vector<Circuit> &circuits, const Noise::NoiseModel &noise) {
   // Use a local variable to not override stored maximum based
   // on currently executed circuits
-  const auto max_experiments = (max_parallel_experiments_ > 0)
-    ? std::min({max_parallel_experiments_, max_parallel_threads_})
-    : max_parallel_threads_;
-  
+  const auto max_experiments =
+      (max_parallel_experiments_ > 0)
+          ? std::min({max_parallel_experiments_, max_parallel_threads_})
+          : max_parallel_threads_;
+
   if (max_experiments == 1) {
     // No parallel experiment execution
     parallel_experiments_ = 1;
@@ -324,10 +320,11 @@ void Controller::set_parallelization_experiments(const std::vector<Circuit>& cir
 
   // If memory allows, execute experiments in parallel
   std::vector<size_t> required_memory_mb_list(circuits.size());
-  for (size_t j=0; j<circuits.size(); j++) {
+  for (size_t j = 0; j < circuits.size(); j++) {
     required_memory_mb_list[j] = required_memory_mb(circuits[j], noise);
   }
-  std::sort(required_memory_mb_list.begin(), required_memory_mb_list.end(), std::greater<>());
+  std::sort(required_memory_mb_list.begin(), required_memory_mb_list.end(),
+            std::greater<>());
   size_t total_memory = 0;
   parallel_experiments_ = 0;
   for (size_t required_memory_mb : required_memory_mb_list) {
@@ -338,21 +335,22 @@ void Controller::set_parallelization_experiments(const std::vector<Circuit>& cir
   }
 
   if (parallel_experiments_ <= 0)
-    throw std::runtime_error("a circuit requires more memory than max_memory_mb.");
-  parallel_experiments_ = std::min<int>({parallel_experiments_,
-                                         max_experiments,
-                                         max_parallel_threads_,
-                                         static_cast<int>(circuits.size())});
+    throw std::runtime_error(
+        "a circuit requires more memory than max_memory_mb.");
+  parallel_experiments_ =
+      std::min<int>({parallel_experiments_, max_experiments,
+                     max_parallel_threads_, static_cast<int>(circuits.size())});
 }
 
-void Controller::set_parallelization_circuit(const Circuit& circ,
-                                             const Noise::NoiseModel& noise) {
+void Controller::set_parallelization_circuit(const Circuit &circ,
+                                             const Noise::NoiseModel &noise) {
 
   // Use a local variable to not override stored maximum based
   // on currently executed circuits
-  const auto max_shots = (max_parallel_shots_ > 0)
-    ? std::min({max_parallel_shots_, max_parallel_threads_})
-    : max_parallel_threads_;
+  const auto max_shots =
+      (max_parallel_shots_ > 0)
+          ? std::min({max_parallel_shots_, max_parallel_threads_})
+          : max_parallel_threads_;
 
   // If we are executing circuits in parallel we disable
   // parallel shots
@@ -364,33 +362,34 @@ void Controller::set_parallelization_circuit(const Circuit& circ,
     // And assign the remaining threads to state update
     int circ_memory_mb = required_memory_mb(circ, noise);
     if (max_memory_mb_ < circ_memory_mb)
-      throw std::runtime_error("a circuit requires more memory than max_memory_mb.");
+      throw std::runtime_error(
+          "a circuit requires more memory than max_memory_mb.");
     // If circ memory is 0, set it to 1 so that we don't divide by zero
     circ_memory_mb = std::max<int>({1, circ_memory_mb});
 
-    parallel_shots_ = std::min<int>({static_cast<int>(max_memory_mb_ / circ_memory_mb),
-                                     max_shots,
-                                     static_cast<int>(circ.shots)});
+    parallel_shots_ =
+        std::min<int>({static_cast<int>(max_memory_mb_ / circ_memory_mb),
+                       max_shots, static_cast<int>(circ.shots)});
   }
-  parallel_state_update_ = (parallel_shots_ > 1)
-    ? std::max<int>({1, max_parallel_threads_ / parallel_shots_})
-    : std::max<int>({1, max_parallel_threads_ / parallel_experiments_});
+  parallel_state_update_ =
+      (parallel_shots_ > 1)
+          ? std::max<int>({1, max_parallel_threads_ / parallel_shots_})
+          : std::max<int>({1, max_parallel_threads_ / parallel_experiments_});
 }
 
-
-size_t Controller::get_system_memory_mb(){
+size_t Controller::get_system_memory_mb() {
   size_t total_physical_memory = 0;
 #if defined(__linux__) || defined(__APPLE__)
-   auto pages = sysconf(_SC_PHYS_PAGES);
-   auto page_size = sysconf(_SC_PAGE_SIZE);
-   total_physical_memory = pages * page_size;
+  auto pages = sysconf(_SC_PHYS_PAGES);
+  auto page_size = sysconf(_SC_PAGE_SIZE);
+  total_physical_memory = pages * page_size;
 #elif defined(_WIN64)
-   MEMORYSTATUSEX status;
-   status.dwLength = sizeof(status);
-   GlobalMemoryStatusEx(&status);
-   total_physical_memory = status.ullTotalPhys;
+  MEMORYSTATUSEX status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatusEx(&status);
+  total_physical_memory = status.ullTotalPhys;
 #endif
-   return total_physical_memory >> 20;
+  return total_physical_memory >> 20;
 }
 
 //-------------------------------------------------------------------------
@@ -398,15 +397,13 @@ size_t Controller::get_system_memory_mb(){
 //-------------------------------------------------------------------------
 
 template <class state_t>
-bool Controller::validate_state(const state_t &state,
-                                const Circuit &circ,
+bool Controller::validate_state(const state_t &state, const Circuit &circ,
                                 const Noise::NoiseModel &noise,
                                 bool throw_except) {
   // First check if a noise model is valid a given state
   bool noise_valid = noise.is_ideal() || state.opset().contains(noise.opset());
   bool circ_valid = state.opset().contains(circ.opset());
-  if (noise_valid && circ_valid)
-  {
+  if (noise_valid && circ_valid) {
     return true;
   }
 
@@ -439,8 +436,8 @@ bool Controller::validate_memory_requirements(const state_t &state,
     return true;
 
   size_t required_mb = state.required_memory_mb(circ.num_qubits, circ.ops);
-  if(max_memory_mb_ < required_mb) {
-    if(throw_except) {
+  if (max_memory_mb_ < required_mb) {
+    if (throw_except) {
       std::string name = "";
       JSON::get_value(name, "name", circ.header);
       throw std::runtime_error("Insufficient memory to run circuit \"" + name +
@@ -475,11 +472,12 @@ Result Controller::execute(const json_t &qobj_js) {
     // Get QOBJ id and pass through header to result
     result.qobj_id = qobj.id;
     if (!qobj.header.empty()) {
-        result.header = qobj.header;
+      result.header = qobj.header;
     }
     // Stop the timer and add total timing data including qobj parsing
     auto timer_stop = myclock_t::now();
-    result.metadata["time_taken"] = std::chrono::duration<double>(timer_stop - timer_start).count();
+    result.metadata["time_taken"] =
+        std::chrono::duration<double>(timer_stop - timer_start).count();
     return result;
   } catch (std::exception &e) {
     // qobj was invalid, return valid output containing error message
@@ -511,45 +509,42 @@ Result Controller::execute(std::vector<Circuit> &circuits,
       set_parallelization_experiments(circuits, noise_model);
     }
 
-  #ifdef _OPENMP
+#ifdef _OPENMP
     result.metadata["omp_enabled"] = true;
-  #else
+#else
     result.metadata["omp_enabled"] = false;
-  #endif
+#endif
     result.metadata["parallel_experiments"] = parallel_experiments_;
     result.metadata["max_memory_mb"] = max_memory_mb_;
-    
 
-  #ifdef _OPENMP
+#ifdef _OPENMP
     if (parallel_shots_ > 1 || parallel_state_update_ > 1)
       omp_set_nested(1);
-  #endif
+#endif
     if (parallel_experiments_ > 1) {
-      // Parallel circuit execution
-      #pragma omp parallel for num_threads(parallel_experiments_)
+// Parallel circuit execution
+#pragma omp parallel for num_threads(parallel_experiments_)
       for (int j = 0; j < result.results.size(); ++j) {
         // Make a copy of the noise model for each circuit execution
         // so that it can be modified if required
         auto circ_noise_model = noise_model;
-        result.results[j] = execute_circuit(circuits[j],
-                                            circ_noise_model,
-                                            config);
+        result.results[j] =
+            execute_circuit(circuits[j], circ_noise_model, config);
       }
     } else {
       // Serial circuit execution
       for (int j = 0; j < num_circuits; ++j) {
         // Make a copy of the noise model for each circuit execution
         auto circ_noise_model = noise_model;
-        result.results[j] = execute_circuit(circuits[j],
-                                            circ_noise_model,
-                                            config);
+        result.results[j] =
+            execute_circuit(circuits[j], circ_noise_model, config);
       }
     }
 
     // Check each experiment result for completed status.
     // If only some experiments completed return partial completed status.
     result.status = Result::Status::completed;
-    for (const auto& experiment: result.results) {
+    for (const auto &experiment : result.results) {
       if (experiment.status != ExperimentResult::Status::completed) {
         result.status = Result::Status::partial_completed;
         break;
@@ -557,7 +552,8 @@ Result Controller::execute(std::vector<Circuit> &circuits,
     }
     // Stop the timer and add total timing data
     auto timer_stop = myclock_t::now();
-    result.metadata["time_taken"] = std::chrono::duration<double>(timer_stop - timer_start).count();
+    result.metadata["time_taken"] =
+        std::chrono::duration<double>(timer_stop - timer_start).count();
   }
   // If execution failed return valid output reporting error
   catch (std::exception &e) {
@@ -567,9 +563,8 @@ Result Controller::execute(std::vector<Circuit> &circuits,
   return result;
 }
 
-
 ExperimentResult Controller::execute_circuit(Circuit &circ,
-                                             Noise::NoiseModel& noise,
+                                             Noise::NoiseModel &noise,
                                              const json_t &config) {
 
   // Start individual circuit timer
@@ -577,21 +572,21 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
 
   // Initialize circuit json return
   ExperimentResult exp_result;
-  ExperimentData data;
-  data.set_config(config);
+  exp_result.data.set_config(config);
 
   // Execute in try block so we can catch errors and return the error message
   // for individual circuit failures.
   try {
     // Remove barriers from circuit
     Transpile::ReduceBarrier barrier_pass;
-    barrier_pass.optimize_circuit(circ, noise, circ.opset(), data);
+    barrier_pass.optimize_circuit(circ, noise, circ.opset(), exp_result.data);
 
     // Truncate unused qubits from circuit and noise model
     if (truncate_qubits_) {
       Transpile::TruncateQubits truncate_pass;
       truncate_pass.set_config(config);
-      truncate_pass.optimize_circuit(circ, noise, circ.opset(), data);
+      truncate_pass.optimize_circuit(circ, noise, circ.opset(),
+                                     exp_result.data);
     }
 
     // set parallelization for this circuit
@@ -601,9 +596,8 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
 
     // Single shot thread execution
     if (parallel_shots_ <= 1) {
-      auto tmp_data = run_circuit(circ, noise, config, circ.shots, circ.seed);
-      data.combine(std::move(tmp_data));
-    // Parallel shot thread execution
+      run_circuit(circ, noise, config, circ.shots, circ.seed, exp_result.data);
+      // Parallel shot thread execution
     } else {
       // Calculate shots per thread
       std::vector<unsigned int> subshots;
@@ -611,34 +605,34 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
         subshots.push_back(circ.shots / parallel_shots_);
       }
       // If shots is not perfectly divisible by threads, assign the remainder
-      for (int j=0; j < int(circ.shots % parallel_shots_); ++j) {
+      for (int j = 0; j < int(circ.shots % parallel_shots_); ++j) {
         subshots[j] += 1;
       }
 
       // Vector to store parallel thread output data
       std::vector<ExperimentData> par_data(parallel_shots_);
       std::vector<std::string> error_msgs(parallel_shots_);
-      #pragma omp parallel for if (parallel_shots_ > 1) num_threads(parallel_shots_)
+#pragma omp parallel for if (parallel_shots_ > 1) num_threads(parallel_shots_)
       for (int i = 0; i < parallel_shots_; i++) {
         try {
-          par_data[i] = run_circuit(circ, noise, config, subshots[i], circ.seed + i);
+          run_circuit(circ, noise, config, subshots[i], circ.seed + i,
+                      par_data[i]);
         } catch (std::runtime_error &error) {
           error_msgs[i] = error.what();
         }
       }
 
-      for (std::string error_msg: error_msgs)
+      for (std::string error_msg : error_msgs)
         if (error_msg != "")
           throw std::runtime_error(error_msg);
 
       // Accumulate results across shots
       // Use move semantics to avoid copying data
       for (auto &datum : par_data) {
-        data.combine(std::move(datum));
+        exp_result.data.combine(std::move(datum));
       }
     }
     // Report success
-    exp_result.data = std::move(data);
     exp_result.status = ExperimentResult::Status::completed;
 
     // Pass through circuit header and add metadata
@@ -647,7 +641,7 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
     exp_result.seed = circ.seed;
     // Move any metadata from the subclass run_circuit data
     // to the experiment resultmetadata field
-    for(const auto& pair: exp_result.data.metadata()) {
+    for (const auto &pair : exp_result.data.metadata()) {
       exp_result.add_metadata(pair.first, pair.second);
     }
     // Remove the metatdata field from data
@@ -656,7 +650,8 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
     exp_result.metadata["parallel_state_update"] = parallel_state_update_;
     // Add timer data
     auto timer_stop = myclock_t::now(); // stop timer
-    double time_taken = std::chrono::duration<double>(timer_stop - timer_start).count();
+    double time_taken =
+        std::chrono::duration<double>(timer_stop - timer_start).count();
     exp_result.time_taken = time_taken;
   }
   // If an exception occurs during execution, catch it and pass it to the output

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -638,7 +638,7 @@ ExperimentResult Controller::execute_circuit(Circuit &circ,
       }
     }
     // Report success
-    exp_result.data = data;
+    exp_result.data = std::move(data);
     exp_result.status = ExperimentResult::Status::completed;
 
     // Pass through circuit header and add metadata

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -532,12 +532,21 @@ Result Controller::execute(std::vector<Circuit> &circuits,
 
     // Check each experiment result for completed status.
     // If only some experiments completed return partial completed status.
+
+    bool all_failed = true;
     result.status = Result::Status::completed;
-    for (const auto &experiment : result.results) {
-      if (experiment.status != ExperimentResult::Status::completed) {
+    for (size_t i = 0; i < result.results.size(); ++i) {
+      auto& experiment = result.results[i];
+      if (experiment.status == ExperimentResult::Status::completed) {
+        all_failed = false;
+      } else {
         result.status = Result::Status::partial_completed;
-        break;
+        result.message += std::string(" [Experiment ") + std::to_string(i)
+                          + std::string("] ") + experiment.message;
       }
+    }
+    if (all_failed) {
+      result.status = Result::Status::error;
     }
 
     // Stop the timer and add total timing data

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -158,10 +158,11 @@ class QasmController : public Base::Controller {
   // Abstract method for executing a circuit.
   // This method must initialize a state and return output data for
   // the required number of shots.
-  virtual ExperimentData run_circuit(const Circuit &circ,
-                                     const Noise::NoiseModel &noise,
-                                     const json_t &config, uint_t shots,
-                                     uint_t rng_seed) const override;
+  virtual void run_circuit(const Circuit &circ,
+                           const Noise::NoiseModel &noise,
+                           const json_t &config, uint_t shots,
+                           uint_t rng_seed,
+                           ExperimentData &data) const override;
 
   //----------------------------------------------------------------
   // Utility functions
@@ -194,12 +195,13 @@ class QasmController : public Base::Controller {
 
   // Execute n-shots of a circuit on the input state
   template <class State_t, class Initstate_t>
-  ExperimentData run_circuit_helper(const Circuit &circ,
-                                    const Noise::NoiseModel &noise,
-                                    const json_t &config, uint_t shots,
-                                    uint_t rng_seed,
-                                    const Initstate_t &initial_state,
-                                    const Method method) const;
+  void run_circuit_helper(const Circuit &circ,
+                          const Noise::NoiseModel &noise,
+                          const json_t &config, uint_t shots,
+                          uint_t rng_seed,
+                          const Initstate_t &initial_state,
+                          const Method method,
+                          ExperimentData &data) const;
 
   // Execute a single shot a circuit by initializing the state vector
   // to initial_state, running all ops in circ, and updating data with
@@ -360,10 +362,11 @@ void QasmController::clear_config() {
 // Base class override
 //-------------------------------------------------------------------------
 
-ExperimentData QasmController::run_circuit(const Circuit &circ,
-                                           const Noise::NoiseModel &noise,
-                                           const json_t &config, uint_t shots,
-                                           uint_t rng_seed) const {
+void QasmController::run_circuit(const Circuit &circ,
+                                 const Noise::NoiseModel &noise,
+                                 const json_t &config, uint_t shots,
+                                 uint_t rng_seed,
+                                 ExperimentData &data) const {
   // Validate circuit for simulation method
   switch (simulation_method(circ, noise, true)) {
     case Method::statevector:
@@ -371,12 +374,12 @@ ExperimentData QasmController::run_circuit(const Circuit &circ,
         // Double-precision Statevector simulation
         return run_circuit_helper<Statevector::State<QV::QubitVector<double>>>(
             circ, noise, config, shots, rng_seed, initial_statevector_,
-            Method::statevector);
+            Method::statevector, data);
       } else {
         // Single-precision Statevector simulation
         return run_circuit_helper<Statevector::State<QV::QubitVector<float>>>(
             circ, noise, config, shots, rng_seed, initial_statevector_,
-            Method::statevector);
+            Method::statevector, data);
       }
     case Method::statevector_thrust_gpu:
 #ifndef AER_THRUST_CUDA
@@ -389,13 +392,13 @@ ExperimentData QasmController::run_circuit(const Circuit &circ,
         return run_circuit_helper<
             Statevector::State<QV::QubitVectorThrust<double>>>(
             circ, noise, config, shots, rng_seed, initial_statevector_,
-            Method::statevector_thrust_gpu);
+            Method::statevector_thrust_gpu, data);
       } else {
         // Single-precision Statevector simulation
         return run_circuit_helper<
             Statevector::State<QV::QubitVectorThrust<float>>>(
             circ, noise, config, shots, rng_seed, initial_statevector_,
-            Method::statevector_thrust_gpu);
+            Method::statevector_thrust_gpu, data);
       }
 #endif
     case Method::statevector_thrust_cpu:
@@ -409,13 +412,13 @@ ExperimentData QasmController::run_circuit(const Circuit &circ,
         return run_circuit_helper<
             Statevector::State<QV::QubitVectorThrust<double>>>(
             circ, noise, config, shots, rng_seed, initial_statevector_,
-            Method::statevector_thrust_cpu);
+            Method::statevector_thrust_cpu, data);
       } else {
         // Single-precision Statevector simulation
         return run_circuit_helper<
             Statevector::State<QV::QubitVectorThrust<float>>>(
             circ, noise, config, shots, rng_seed, initial_statevector_,
-            Method::statevector_thrust_cpu);
+            Method::statevector_thrust_cpu, data);
       }
 #endif
     case Method::density_matrix:
@@ -424,13 +427,13 @@ ExperimentData QasmController::run_circuit(const Circuit &circ,
         return run_circuit_helper<
             DensityMatrix::State<QV::DensityMatrix<double>>>(
             circ, noise, config, shots, rng_seed, cvector_t(),
-            Method::density_matrix);
+            Method::density_matrix, data);
       } else {
         // Single-precision density matrix simulation
         return run_circuit_helper<
             DensityMatrix::State<QV::DensityMatrix<float>>>(
             circ, noise, config, shots, rng_seed, cvector_t(),
-            Method::density_matrix);
+            Method::density_matrix, data);
       }
     case Method::density_matrix_thrust_gpu:
 #ifndef AER_THRUST_CUDA
@@ -443,13 +446,13 @@ ExperimentData QasmController::run_circuit(const Circuit &circ,
         return run_circuit_helper<
             DensityMatrix::State<QV::DensityMatrixThrust<double>>>(
             circ, noise, config, shots, rng_seed, cvector_t(),
-            Method::density_matrix_thrust_gpu);
+            Method::density_matrix_thrust_gpu, data);
       } else {
         // Single-precision density matrix simulation
         return run_circuit_helper<
             DensityMatrix::State<QV::DensityMatrixThrust<float>>>(
             circ, noise, config, shots, rng_seed, cvector_t(),
-            Method::density_matrix_thrust_gpu);
+            Method::density_matrix_thrust_gpu, data);
       }
 #endif
     case Method::density_matrix_thrust_cpu:
@@ -463,13 +466,13 @@ ExperimentData QasmController::run_circuit(const Circuit &circ,
         return run_circuit_helper<
             DensityMatrix::State<QV::DensityMatrixThrust<double>>>(
             circ, noise, config, shots, rng_seed, cvector_t(),
-            Method::density_matrix_thrust_cpu);
+            Method::density_matrix_thrust_cpu, data);
       } else {
         // Single-precision density matrix simulation
         return run_circuit_helper<
             DensityMatrix::State<QV::DensityMatrixThrust<float>>>(
             circ, noise, config, shots, rng_seed, cvector_t(),
-            Method::density_matrix_thrust_cpu);
+            Method::density_matrix_thrust_cpu, data);
       }
 #endif
     case Method::stabilizer:
@@ -477,16 +480,16 @@ ExperimentData QasmController::run_circuit(const Circuit &circ,
       // TODO: Stabilizer doesn't yet support custom state initialization
       return run_circuit_helper<Stabilizer::State>(
           circ, noise, config, shots, rng_seed, Clifford::Clifford(),
-          Method::stabilizer);
+          Method::stabilizer, data);
     case Method::extended_stabilizer:
       return run_circuit_helper<ExtendedStabilizer::State>(
           circ, noise, config, shots, rng_seed, CHSimulator::Runner(),
-          Method::extended_stabilizer);
+          Method::extended_stabilizer, data);
 
     case Method::matrix_product_state:
       return run_circuit_helper<MatrixProductState::State>(
           circ, noise, config, shots, rng_seed, MatrixProductState::MPS(),
-          Method::matrix_product_state);
+          Method::matrix_product_state, data);
 
     default:
       throw std::runtime_error("QasmController:Invalid simulation method");
@@ -805,10 +808,10 @@ void QasmController::set_parallelization_circuit(
 //-------------------------------------------------------------------------
 
 template <class State_t, class Initstate_t>
-ExperimentData QasmController::run_circuit_helper(
+void QasmController::run_circuit_helper(
     const Circuit &circ, const Noise::NoiseModel &noise, const json_t &config,
     uint_t shots, uint_t rng_seed, const Initstate_t &initial_state,
-    const Method method) const {
+    const Method method, ExperimentData &data) const {
   // Initialize new state object
   State_t state;
 
@@ -824,7 +827,6 @@ ExperimentData QasmController::run_circuit_helper(
   rng.set_seed(rng_seed);
 
   // Output data container
-  ExperimentData data;
   data.set_config(config);
   data.add_metadata("method", state.name());
   // Add measure sampling to metadata
@@ -853,7 +855,6 @@ ExperimentData QasmController::run_circuit_helper(
     // Run sampling a noisy instance of the circuit for each shot
     run_circuit_with_noise(circ, noise, config, shots, state, initial_state, method, data, rng);
   }
-  return data;
 }
 
 template <class State_t, class Initstate_t>

--- a/src/controllers/statevector_controller.hpp
+++ b/src/controllers/statevector_controller.hpp
@@ -97,17 +97,19 @@ class StatevectorController : public Base::Controller {
 
   // This simulator will only return a single shot, regardless of the
   // input shot number
-  virtual ExperimentData run_circuit(const Circuit& circ,
-                                     const Noise::NoiseModel& noise,
-                                     const json_t& config, uint_t shots,
-                                     uint_t rng_seed) const override;
+  virtual void run_circuit(const Circuit& circ,
+                           const Noise::NoiseModel& noise,
+                           const json_t& config, uint_t shots,
+                           uint_t rng_seed,
+                           ExperimentData &data) const override;
 
   // Execute n-shots of a circuit on the input state
   template <class State_t>
-  ExperimentData run_circuit_helper(const Circuit& circ,
-                                    const Noise::NoiseModel& noise,
-                                    const json_t& config, uint_t shots,
-                                    uint_t rng_seed) const;
+  void run_circuit_helper(const Circuit& circ,
+                          const Noise::NoiseModel& noise,
+                          const json_t& config, uint_t shots,
+                          uint_t rng_seed,
+                          ExperimentData &data) const;
   //-----------------------------------------------------------------------
   // Custom initial state
   //-----------------------------------------------------------------------
@@ -195,20 +197,20 @@ size_t StatevectorController::required_memory_mb(
 // Run circuit
 //-------------------------------------------------------------------------
 
-ExperimentData StatevectorController::run_circuit(
+void StatevectorController::run_circuit(
     const Circuit& circ, const Noise::NoiseModel& noise, const json_t& config,
-    uint_t shots, uint_t rng_seed) const {
+    uint_t shots, uint_t rng_seed, ExperimentData &data) const {
   switch (method_) {
     case Method::automatic:
     case Method::statevector_cpu: {
       if (precision_ == Precision::double_precision) {
         // Double-precision Statevector simulation
         return run_circuit_helper<Statevector::State<QV::QubitVector<double>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       } else {
         // Single-precision Statevector simulation
         return run_circuit_helper<Statevector::State<QV::QubitVector<float>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       }
     }
     case Method::statevector_thrust_gpu: {
@@ -217,12 +219,12 @@ ExperimentData StatevectorController::run_circuit(
         // Double-precision Statevector simulation
         return run_circuit_helper<
             Statevector::State<QV::QubitVectorThrust<double>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       } else {
         // Single-precision Statevector simulation
         return run_circuit_helper<
             Statevector::State<QV::QubitVectorThrust<float>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       }
 #else
       throw std::runtime_error(
@@ -237,12 +239,12 @@ ExperimentData StatevectorController::run_circuit(
         // Double-precision Statevector simulation
         return run_circuit_helper<
             Statevector::State<QV::QubitVectorThrust<double>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       } else {
         // Single-precision Statevector simulation
         return run_circuit_helper<
             Statevector::State<QV::QubitVectorThrust<float>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       }
 #else
       throw std::runtime_error(
@@ -258,9 +260,9 @@ ExperimentData StatevectorController::run_circuit(
 }
 
 template <class State_t>
-ExperimentData StatevectorController::run_circuit_helper(
+void StatevectorController::run_circuit_helper(
     const Circuit& circ, const Noise::NoiseModel& noise, const json_t& config,
-    uint_t shots, uint_t rng_seed) const {
+    uint_t shots, uint_t rng_seed, ExperimentData &data) const {
   // Initialize  state
   Statevector::State<> state;
 
@@ -287,7 +289,6 @@ ExperimentData StatevectorController::run_circuit_helper(
   rng.set_seed(rng_seed);
 
   // Output data container
-  ExperimentData data;
   data.set_config(config);
 
   // Run single shot collecting measure data or snapshots
@@ -301,8 +302,6 @@ ExperimentData StatevectorController::run_circuit_helper(
 
   // Add final state to the data
   data.add_additional_data("statevector", state.qreg().vector());
-
-  return data;
 }
 
 //-------------------------------------------------------------------------

--- a/src/controllers/unitary_controller.hpp
+++ b/src/controllers/unitary_controller.hpp
@@ -89,16 +89,16 @@ class UnitaryController : public Base::Controller {
 
   // This simulator will only return a single shot, regardless of the
   // input shot number
-  virtual ExperimentData run_circuit(const Circuit &circ,
-                                     const Noise::NoiseModel &noise,
-                                     const json_t &config, uint_t shots,
-                                     uint_t rng_seed) const override;
+  virtual void run_circuit(const Circuit &circ,
+                           const Noise::NoiseModel &noise,
+                           const json_t &config, uint_t shots,
+                           uint_t rng_seed, ExperimentData &data) const override;
 
   template <class State_t>
-  ExperimentData run_circuit_helper(const Circuit &circ,
-                                    const Noise::NoiseModel &noise,
-                                    const json_t &config, uint_t shots,
-                                    uint_t rng_seed) const;
+  void run_circuit_helper(const Circuit &circ,
+                          const Noise::NoiseModel &noise,
+                          const json_t &config, uint_t shots,
+                          uint_t rng_seed, ExperimentData &data) const;
 
   //-----------------------------------------------------------------------
   // Custom initial state
@@ -187,11 +187,11 @@ size_t UnitaryController::required_memory_mb(
 // Run circuit
 //-------------------------------------------------------------------------
 
-ExperimentData UnitaryController::run_circuit(const Circuit &circ,
-                                              const Noise::NoiseModel &noise,
-                                              const json_t &config,
-                                              uint_t shots,
-                                              uint_t rng_seed) const {
+void UnitaryController::run_circuit(const Circuit &circ,
+                                    const Noise::NoiseModel &noise,
+                                    const json_t &config,
+                                    uint_t shots,
+                                    uint_t rng_seed, ExperimentData &data) const {
   switch (method_) {
     case Method::automatic:
     case Method::unitary_cpu: {
@@ -199,12 +199,12 @@ ExperimentData UnitaryController::run_circuit(const Circuit &circ,
         // Double-precision unitary simulation
         return run_circuit_helper<
             QubitUnitary::State<QV::UnitaryMatrix<double>>>(circ, noise, config,
-                                                            shots, rng_seed);
+                                                            shots, rng_seed, data);
       } else {
         // Single-precision unitary simulation
         return run_circuit_helper<
             QubitUnitary::State<QV::UnitaryMatrix<float>>>(circ, noise, config,
-                                                           shots, rng_seed);
+                                                           shots, rng_seed, data);
       }
     }
     case Method::unitary_thrust_gpu: {
@@ -213,12 +213,12 @@ ExperimentData UnitaryController::run_circuit(const Circuit &circ,
         // Double-precision unitary simulation
         return run_circuit_helper<
             QubitUnitary::State<QV::UnitaryMatrixThrust<double>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       } else {
         // Single-precision unitary simulation
         return run_circuit_helper<
             QubitUnitary::State<QV::UnitaryMatrixThrust<float>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       }
 #else
       throw std::runtime_error(
@@ -232,12 +232,12 @@ ExperimentData UnitaryController::run_circuit(const Circuit &circ,
         // Double-precision unitary simulation
         return run_circuit_helper<
             QubitUnitary::State<QV::UnitaryMatrixThrust<double>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       } else {
         // Single-precision unitary simulation
         return run_circuit_helper<
             QubitUnitary::State<QV::UnitaryMatrixThrust<float>>>(
-            circ, noise, config, shots, rng_seed);
+            circ, noise, config, shots, rng_seed, data);
       }
 #else
       throw std::runtime_error(
@@ -251,9 +251,9 @@ ExperimentData UnitaryController::run_circuit(const Circuit &circ,
 }
 
 template <class State_t>
-ExperimentData UnitaryController::run_circuit_helper(
+void UnitaryController::run_circuit_helper(
     const Circuit &circ, const Noise::NoiseModel &noise, const json_t &config,
-    uint_t shots, uint_t rng_seed) const {
+    uint_t shots, uint_t rng_seed, ExperimentData &data) const {
   // Initialize state
   State_t state;
 
@@ -287,7 +287,6 @@ ExperimentData UnitaryController::run_circuit_helper(
   rng.set_seed(rng_seed);
 
   // Output data container
-  ExperimentData data;
   data.set_config(config);
   data.add_metadata("method", state.name());
 
@@ -302,8 +301,6 @@ ExperimentData UnitaryController::run_circuit_helper(
 
   // Add final state unitary to the data
   data.add_additional_data("unitary", state.qreg().matrix());
-
-  return data;
 }
 
 //-------------------------------------------------------------------------

--- a/src/framework/matrix.hpp
+++ b/src/framework/matrix.hpp
@@ -208,7 +208,7 @@ public:
                                 // sqrt(dims)
   matrix(const matrix<T> &m);
   matrix(const matrix<T> &m, const char uplo);
-  matrix(matrix<T>&& m); // move constructor
+  matrix(matrix<T>&& m) noexcept; // move constructor
   // Initialize an empty matrix() to matrix(size_t  rows, size_t cols)
   void initialize(size_t rows, size_t cols);
   // Clear used memory
@@ -219,7 +219,7 @@ public:
 
   // Assignment operator
   matrix<T> &operator=(const matrix<T> &m);
-  matrix<T> &operator=(matrix<T> &&m); // Move assignment
+  matrix<T> &operator=(matrix<T> &&m) noexcept; // Move assignment
   template <class S>
   matrix<T> &operator=(const matrix<S> &m); // Still would like to have real
                                             // assigend by complex -- take real
@@ -322,7 +322,7 @@ inline matrix<T>::matrix(const matrix<T> &rhs)
 }
 
 template <class T>
-inline matrix<T>::matrix(matrix<T>&& rhs)
+inline matrix<T>::matrix(matrix<T>&& rhs) noexcept 
     : rows_(rhs.rows_), cols_(rhs.cols_), size_(rhs.size_), LD_(rows_),
       outputstyle_(rhs.outputstyle_), mat_(rhs.mat_) {
   rhs.mat_ = nullptr; // Remove pointer from RHS
@@ -395,7 +395,7 @@ template <class T> inline matrix<T>::~matrix() {
     delete[](mat_);
 }
 template <class T>
-inline matrix<T>& matrix<T>::operator=(matrix<T>&& rhs) {
+inline matrix<T>& matrix<T>::operator=(matrix<T>&& rhs) noexcept {
   // Delete any currently assigned memory
   if (mat_ != nullptr) {
     delete[](mat_);

--- a/src/framework/results/data/data_container.hpp
+++ b/src/framework/results/data/data_container.hpp
@@ -245,17 +245,17 @@ template <typename T>
 DataContainer<T> &DataContainer<T>::combine(DataContainer<T> &&other) {
 
   // Additional data
-  for (const auto &pair : other.additional_data_) {
+  for (auto &pair : other.additional_data_) {
     additional_data_[pair.first] = std::move(pair.second);
   }
 
   // Pershot snapshots
-  for (const auto &pair : other.pershot_snapshots_) {
+  for (auto &pair : other.pershot_snapshots_) {
     pershot_snapshots_[pair.first].combine(std::move(pair.second));
   }
 
   // Average snapshots
-  for (const auto &pair : other.average_snapshots_) {
+  for (auto &pair : other.average_snapshots_) {
     average_snapshots_[pair.first].combine(std::move(pair.second));
   }
 

--- a/src/framework/results/data/pershot_data.hpp
+++ b/src/framework/results/data/pershot_data.hpp
@@ -23,8 +23,6 @@ namespace AER {
 template <typename T>
 class PershotData {
  public:
-  // Constructor
-  PershotData(size_t num_shots = 0) { data_.reserve(num_shots); }
 
   // Add a new shot of data by appending to data vector
   // Uses copy semantics


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

2 unnecessary copies of `ExperimentResult` objects were happening during every execution due to lack of a move assignment operator for the class being auto-generated by the compiler.

This PR fixes this by explicitly passing in the result containers as references during the execution functions.

### Details and comments

Here is an example comparing memory profiler for a density matrix snapshot.

Before fix (including before #794)

![mprof_snapshot_dm](https://user-images.githubusercontent.com/2235104/84721873-b0b2b380-af4f-11ea-8030-78e8b2f9f36d.png)

The small spikes are `matrix` copies and `ExperimentData` copies, the 2 large spikes are `ExperimentResult` copies.

After both fixes

![mprof_snapshot_dm_fixed_all](https://user-images.githubusercontent.com/2235104/84721881-b8725800-af4f-11ea-9b0b-77da884a915a.png)

The long ramp at the end (from 10-35sec in the above figure) is the Pybind11 `Result` object conversion which we should address in a future PR.