### PR TITLE
[WIP] Adding Delay, ShiftPhase, and SetPhase instruction handling to pulse simulator

### DIFF
--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -440,5 +440,5 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds,
 
     if structs['tlist'][-1] > structs['acquire'][-1][0]:
         structs['can_sample'] = False
-
+    
     return structs

--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -336,7 +336,15 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds,
 
             # Frame changes
             elif inst['name'] == 'fc':
-                structs['channels'][chan_name][1].extend([inst['t0'] * dt, inst['phase'], cond])
+                # get current phase value
+                current_phase = 0
+                if len(structs['channels'][chan_name][1]) > 0:
+                    current_phase = structs['channels'][chan_name][1][-2]
+
+                structs['channels'][chan_name][1].extend([inst['t0'] * dt,
+                                                          current_phase + inst['phase'],
+                                                          cond])
+
 
             # A standard pulse
             else:

--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -345,7 +345,6 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds,
                                                           current_phase + inst['phase'],
                                                           cond])
 
-
             # A standard pulse
             else:
                 start = inst['t0'] * dt

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -21,6 +21,7 @@ from warnings import warn
 import numpy as np
 from ..system_models.string_model_parser.string_model_parser import NoiseParser
 from ..qutip_extra_lite import qobj_generators as qobj_gen
+from ..qutip_extra_lite.qobj import Qobj
 from .digest_pulse_qobj import digest_pulse_qobj
 from ..de_solvers.pulse_de_options import OPoptions
 from .unitary_controller import run_unitary_experiments
@@ -79,7 +80,11 @@ def pulse_controller(qobj, system_model, backend_options):
     dim_osc = {}
     # convert estates into a Qutip qobj
     estates = [qobj_gen.state(state) for state in ham_model._estates.T[:]]
-    pulse_sim_desc.initial_state = estates[0]
+    if 'initial_state' in backend_options:
+        pulse_sim_desc.initial_state = Qobj(backend_options['initial_state'])
+    else:
+        pulse_sim_desc.initial_state = estates[0]
+
     pulse_sim_desc.global_data['vars'] = list(pulse_sim_desc.vars.values())
     # Need this info for evaluating the hamiltonian vars in the c++ solver
     pulse_sim_desc.global_data['vars_names'] = list(pulse_sim_desc.vars.keys())

--- a/src/open_pulse/numeric_integrator.cpp
+++ b/src/open_pulse/numeric_integrator.cpp
@@ -74,16 +74,11 @@ complex_t chan_value(
         // get the index of the phase change
         auto phase_idx = 0;
         auto found = false;
-        while(found == false){
+        while((found == false) && (phase_idx < num_times)){
             if(t < fc_array[3 * phase_idx]){
                 found = true;
             }else{
                 phase_idx++;
-            }
-
-            // if the time is greater than the last frame change, exit the loop
-            if(phase_idx == num_times){
-                found = true;
             }
         }
 

--- a/src/open_pulse/numeric_integrator.cpp
+++ b/src/open_pulse/numeric_integrator.cpp
@@ -69,8 +69,31 @@ complex_t chan_value(
     // TODO floating point comparsion with complex<double> ?!
     // Seems like this is equivalent to: out != complex_t(0., 0.)
     if(out != 0.){
-        double phase = 0.;
         num_times = floor_div(fc_array.shape[0], 3);
+
+        // get the index of the phase change
+        auto phase_idx = 0;
+        auto found = false;
+        while(found == false){
+            if(t < fc_array[3 * phase_idx]){
+                found = true;
+            }else{
+                phase_idx++;
+            }
+
+            // if the time is greater than the last frame change, exit the loop
+            if(phase_idx == num_times){
+                found = true;
+            }
+        }
+
+        double phase = 0.;
+        if(phase_idx > 0){
+            phase = fc_array[3 * (phase_idx - 1) + 1];
+        }
+
+
+        /* original phase determination
         for(auto i = 0; i < num_times; ++i){
             // TODO floating point comparison
             if(t >= fc_array[3 * i]){
@@ -87,6 +110,7 @@ complex_t chan_value(
                 break;
             }
         }
+        */
         if(phase != 0.){
             out *= std::exp(complex_t(0.,1.) * phase);
         }

--- a/src/open_pulse/numeric_integrator.cpp
+++ b/src/open_pulse/numeric_integrator.cpp
@@ -87,25 +87,6 @@ complex_t chan_value(
             phase = fc_array[3 * (phase_idx - 1) + 1];
         }
 
-
-        /* original phase determination
-        for(auto i = 0; i < num_times; ++i){
-            // TODO floating point comparison
-            if(t >= fc_array[3 * i]){
-                bool do_fc = true;
-                if(fc_array[3 * i + 2] >= 0){
-                    if(!reg[static_cast<int>(fc_array[3 * i + 2])]){
-                       do_fc = false;
-                    }
-                }
-                if(do_fc){
-                    phase += fc_array[3 * i + 1];
-                }
-            }else{
-                break;
-            }
-        }
-        */
         if(phase != 0.){
             out *= std::exp(complex_t(0.,1.) * phase);
         }


### PR DESCRIPTION
### Summary

This handles the first part of issue #736 , adding support/testing for the instructions in the title. 

### Details and comments

Current status:
- Luckily, `Delay` instructions don't need anything new - they don't even appear in the `qobj`.
    - A test has been added to verify the functioning of schedules with delays and it is currently passing
- `ShiftPhase` exactly replaces `FrameChange`, though in the qobj they have the same name, so `ShiftPhase` doesn't technically need anything new, however incorporating `SetPhase` requires tracking absolute phase.
     - I've changed the phase storage array constructed in `digest` to store absolute phase as opposed to relative phase, and it is now populated accordingly for `ShiftPhase` instructions. The C++ RHS-related function has also been changed accordingly (it previously added up all relative phase changes, now it just finds the relevant phase and uses that).
     - A new `ShiftPhase` test has been added and is working, and replaced the `FrameChange` test.

To do:
- Add more `ShiftPhase` tests
- Add `SetPhase` handling and tests

Encountered issue:
- While thinking of tests for phase handling, I've run into an issue where I think that the channel values may not be being evaluated consistently with the pulse spec - will make an issue for discussion/investigation of this.