### PR TITLE
Rework numpy cap and ensure scipy and numpy version are matched

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ stages:
           - bash: |
               set -e
               source activate qiskit-aer
-              pip install -c constraints.txt numpy scipy
+              pip install -U -c constraints.txt numpy scipy
             displayName: "Install 3.5 constrained dependencies"
             condition: eq(variables['python.version'], '3.5')
           - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,7 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
-              pip install -U pip wheel setuptools virtualenv
+              pip install --user -U pip wheel setuptools virtualenv
               python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
             displayName: Build wheels
           - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,6 +111,12 @@ stages:
               conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
             displayName: Create Anaconda environments
           - bash: |
+              set -e
+              source activate qiskit-aer
+              pip install -c constraints.txt numpy scipy
+            displayName: "Install 3.5 constrained dependencies"
+            condition: eq(variables['python.version'], '3.5')
+          - bash: |
               set -x
               set -e
               source activate qiskit-aer

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,8 +48,8 @@ stages:
                 conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
                 python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
                 virtualenv test-$version
-                test-$version/Scripts/pip install dist/*whl
-                test-$version/Scripts/pip install git+https://github.com/Qiskit/qiskit-terra
+                test-$version/Scripts/pip install -c constraints.txt dist/*whl
+                test-$version/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
                 test-$version/Scripts/python tools/verify_wheels.py
                 mv dist/*whl wheelhouse/.
                 rm -rf test-$version
@@ -114,7 +114,6 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
-              pip install --user -U pip wheel setuptools virtualenv
               python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
             displayName: Build wheels
           - bash: |
@@ -122,8 +121,8 @@ stages:
               set -e
               source activate qiskit-aer
               virtualenv test-wheel
-              test-wheel/Scripts/pip install dist/*whl
-              test-wheel/Scripts/pip install git+https://github.com/Qiskit/qiskit-terra
+              test-wheel/Scripts/pip install -c constraints.txt dist/*whl
+              test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
               test-wheel/Scripts/python tools/verify_wheels.py
             displayName: Verify wheels
       - job: 'Windows_sdist_Builds'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,13 +114,13 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
+              pip install -U pip wheel setuptools virtualenv
               python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
             displayName: Build wheels
           - bash: |
               set -x
               set -e
               source activate qiskit-aer
-              pip install -U pip wheel setuptools virtualenv
               virtualenv test-wheel
               test-wheel/Scripts/pip install dist/*whl
               test-wheel/Scripts/pip install git+https://github.com/Qiskit/qiskit-terra

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,6 +120,7 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
+              pip install -U pip wheel setuptools virtualenv
               virtualenv test-wheel
               test-wheel/Scripts/pip install dist/*whl
               test-wheel/Scripts/pip install git+https://github.com/Qiskit/qiskit-terra

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ stages:
                 source activate qiskit-aer-$version
                 conda update --yes -n base conda
                 conda config --add channels conda-forge
-                conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython
+                conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
                 python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
                 virtualenv test-$version
                 test-$version/Scripts/pip install dist/*whl
@@ -108,7 +108,7 @@ stages:
               source activate qiskit-aer
               conda update --yes -n base conda
               conda config --add channels conda-forge
-              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython
+              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
             displayName: Create Anaconda environments
           - bash: |
               set -x
@@ -157,7 +157,7 @@ stages:
               source activate qiskit-aer
               conda update --yes -n base conda
               conda config --add channels conda-forge
-              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython
+              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
             displayName: Create Anaconda environments
           - bash: |
               set -x
@@ -189,7 +189,7 @@ stages:
               source activate qiskit-aer
               conda update --yes -n base conda
               conda config --add channels conda-forge
-              conda install --yes --quiet --name qiskit-aer conan numpy cmake
+              conda install --yes --quiet --name qiskit-aer conan numpy cmake scipy
             displayName: Create Anaconda environments
           - bash: |
               set -x
@@ -283,7 +283,7 @@ stages:
               set -x
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
-              conda install --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python==$(python.version) numpy pip virtualenv
+              conda install --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python==$(python.version) numpy pip virtualenv scipy
               conda install -c conda-forge --yes --quiet --name qiskit-aer-$(Build.BuildNumber) python==$(python.version) setuptools
             displayName: Install Anaconda packages
             condition: ne(variables['python.version'], '3.5')
@@ -310,7 +310,7 @@ stages:
           - bash: |
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
-              pip install 'numpy<1.19.0'
+              pip install -U pip setuptools wheel virtualenv
               pip install -r requirements-dev.txt
               if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == *"master"* || $BUILD_SOURCEBRANCH == *"master"* ]] ; then
                   pip install git+https://github.com/Qiskit/qiskit-terra.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,6 +169,7 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
+              pip install -U pip setuptools virtualenv wheel
               pip install dist/*tar.gz
               pip install git+https://github.com/Qiskit/qiskit-terra
               python tools/verify_wheels.py
@@ -311,7 +312,7 @@ stages:
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)
               pip install -U pip setuptools wheel virtualenv
-              pip install -r requirements-dev.txt
+              pip install -c constraints.txt -r requirements-dev.txt
               if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == *"master"* || $BUILD_SOURCEBRANCH == *"master"* ]] ; then
                   pip install git+https://github.com/Qiskit/qiskit-terra.git
               else

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,5 @@
 pylint==2.4.4
 astroid==2.3.3
 six>1.10,<=1.14
+numpy>=1.16.3,<1.19.0;python_version<"3.6"
+scipy>=1.0,<1.5.0;python_version<"3.6"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in windows CI around the numpy version and
scipy which is tightly coupled to numpy. In #749 a cap was added to
avoid a broken numpy pre-release version that was getting installed
because an old version of pip was used by the default conda py3.5 env.
This was causing CI failures because the pre-release was for 1.19.0
which breaks compat with python 3.5. This pin however is now causing an
issue with scipy (since pip lacks a real dependency solver) because
the latest scipy requires numpy 1.19.0 to work downgrading numpy after
we've installed scipy makes scipy unusable. This commit fixes this by
installing a pinned scipy and numpy prior to building wheels on
windows 3.5 jobs to ensure we keep the versions matched at a version
works with python 3.5.

### Details and comments