### PR TITLE
Improve performance of average snapshots

### DIFF
--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -142,8 +142,7 @@ int main(int argc, char **argv) {
 
     // Initialize simulator
     AER::Simulator::QasmController sim;
-    auto result = sim.execute(qobj);
-    out << result.json().dump(4) << std::endl;
+    out << sim.execute(qobj).to_json().dump(4) << std::endl;
 
     // Check if execution was successful.
     bool success = false;

--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -142,7 +142,8 @@ int main(int argc, char **argv) {
 
     // Initialize simulator
     AER::Simulator::QasmController sim;
-    out << sim.execute(qobj).to_json().dump(4) << std::endl;
+    auto result = sim.execute(qobj).to_json();
+    out << result.dump(4) << std::endl;
 
     // Check if execution was successful.
     bool success = false;

--- a/releasenotes/notes/improve-ave-snapshots-768767618ff00c2d.yaml
+++ b/releasenotes/notes/improve-ave-snapshots-768767618ff00c2d.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Improve the performance of average snapshot data in simulator results.

--- a/src/controllers/controller_execute.hpp
+++ b/src/controllers/controller_execute.hpp
@@ -40,7 +40,7 @@ std::string controller_execute_json(const std::string &qobj_str) {
     Hacks::maybe_load_openmp(path);
   }
 
-  return controller.execute(qobj_js).json().dump(-1);
+  return controller.execute(qobj_js).to_json().dump(-1);
 }
 
 template <class controller_t>

--- a/src/framework/results/data/average_snapshot.hpp
+++ b/src/framework/results/data/average_snapshot.hpp
@@ -119,8 +119,8 @@ json_t AverageSnapshot<T>::to_json() {
       // Store mean and variance for snapshot
       json_t datum = inner_pair.second.to_json();
       // Add memory key if there are classical registers
-      auto memory = inner_pair.first;
-      if (memory.empty() == false) datum["memory"] = memory;
+      auto& memory = inner_pair.first;
+      if (!memory.empty()) datum["memory"] = memory;
       // Add to list of output
       js[outer_pair.first].emplace_back(std::move(datum));
     }

--- a/src/framework/results/data/average_snapshot.hpp
+++ b/src/framework/results/data/average_snapshot.hpp
@@ -57,6 +57,9 @@ class AverageSnapshot {
   // Return true if snapshot container is empty
   bool empty() const { return data_.empty(); }
 
+  // Convert to json
+  json_t to_json();
+
   // Return data reference
   stringmap_t<stringmap_t<AverageData<T>>> data() { return data_; }
 
@@ -108,23 +111,21 @@ void AverageSnapshot<T>::combine(AverageSnapshot<T> &&other) noexcept {
   other.clear();  
 }
 
-//------------------------------------------------------------------------------
-// JSON serialization
-//------------------------------------------------------------------------------
 template <typename T>
-void to_json(json_t &js, const AverageSnapshot<T> &snapshot) {
-  js = json_t::object();
-  for (const auto &outer_pair : snapshot.data()) {
-    for (const auto &inner_pair : outer_pair.second) {
+json_t AverageSnapshot<T>::to_json() {
+  json_t js = json_t::object();
+  for (auto &outer_pair : data_) {
+    for (auto &inner_pair : outer_pair.second) {
       // Store mean and variance for snapshot
-      json_t datum = inner_pair.second;
+      json_t datum = inner_pair.second.to_json();
       // Add memory key if there are classical registers
       auto memory = inner_pair.first;
-      if (memory.empty() == false) datum["memory"] = inner_pair.first;
+      if (memory.empty() == false) datum["memory"] = memory;
       // Add to list of output
-      js[outer_pair.first].push_back(datum);
+      js[outer_pair.first].emplace_back(std::move(datum));
     }
   }
+  return js;
 }
 
 //------------------------------------------------------------------------------

--- a/src/framework/results/data/data_container.hpp
+++ b/src/framework/results/data/data_container.hpp
@@ -76,6 +76,9 @@ public:
   // Empty engine of stored data
   void clear();
 
+  // Convert and add to json
+  void add_to_json(json_t &js);
+
   // Combine engines for accumulating data
   // Second engine should no longer be used after combining
   // as this function should use move semantics to minimize copying
@@ -270,25 +273,25 @@ DataContainer<T> &DataContainer<T>::combine(DataContainer<T> &&other) {
 //============================================================================
 
 template <typename T>
-void to_json(json_t &js, const DataContainer<T>& data) {
+void DataContainer<T>::add_to_json(json_t &js) {
   // Add data to json
   // Note other data types may also be adding to same
   // JSON so we should not re-initialize it
-  if (data.enabled_) {
+  if (enabled_) {
 
     // Add additional data
-    for (const auto &pair : data.additional_data_) {
+    for (auto &pair : additional_data_) {
       js[pair.first] = pair.second;
     }
 
     // Average snapshots
-    for (const auto &pair : data.average_snapshots_) {
-      js["snapshots"][pair.first] = pair.second;
+    for (auto &pair : average_snapshots_) {
+      js["snapshots"][pair.first] = pair.second.to_json();
     }
 
     // Pershot snapshots
-    for (auto &pair : data.pershot_snapshots_) {
-      js["snapshots"][pair.first] = pair.second;
+    for (auto &pair : pershot_snapshots_) {
+      js["snapshots"][pair.first] = pair.second.to_json();
     }
   }
 }

--- a/src/framework/results/data/pershot_data.hpp
+++ b/src/framework/results/data/pershot_data.hpp
@@ -57,6 +57,9 @@ class PershotData {
   // Return true if data is empty
   bool empty() const { return data_.empty(); }
 
+  // Convert to JSON
+  json_t to_json();
+
  protected:
   // Internal Storage
   std::vector<T> data_;
@@ -80,12 +83,10 @@ void PershotData<T>::combine(PershotData<T>&& other) noexcept {
                std::make_move_iterator(other.data_.end()));
 }
 
-//------------------------------------------------------------------------------
-// JSON serialization
-//------------------------------------------------------------------------------
 template <typename T>
-void to_json(json_t& js, const PershotData<T>& data) {
-  js = data.data();
+json_t PershotData<T>::to_json() {
+  json_t js = data_;
+  return js;
 }
 
 //------------------------------------------------------------------------------

--- a/src/framework/results/data/pershot_snapshot.hpp
+++ b/src/framework/results/data/pershot_snapshot.hpp
@@ -55,6 +55,9 @@ class PershotSnapshot {
   // Return true if snapshot container is empty
   bool empty() const { return data_.empty(); }
 
+  // Convert to json
+  json_t to_json();
+
   // Return data reference
   stringmap_t<PershotData<T>> data() { return data_; }
 
@@ -97,15 +100,13 @@ void PershotSnapshot<T>::combine(PershotSnapshot<T> &&other) noexcept {
   other.clear();
 }
 
-//------------------------------------------------------------------------------
-// JSON serialization
-//------------------------------------------------------------------------------
 template <typename T>
-void to_json(json_t &js, const PershotSnapshot<T> &snapshot) {
-  js = json_t::object();
-  for (const auto &pair : snapshot.data()) {
-    js[pair.first] = pair.second;
+json_t PershotSnapshot<T>::to_json() {
+  json_t js = json_t::object();
+  for (auto &pair : data_) {
+    js[pair.first] = pair.second.to_json();
   }
+  return js;
 }
 
 //------------------------------------------------------------------------------

--- a/src/framework/results/experiment_data.hpp
+++ b/src/framework/results/experiment_data.hpp
@@ -148,7 +148,7 @@ public:
   void clear();
 
   // Serialize engine data to JSON
-  json_t json() const;
+  json_t to_json();
 
   // Combine engines for accumulating data
   // Second engine should no longer be used after combining
@@ -474,19 +474,19 @@ ExperimentData &ExperimentData::combine(ExperimentData &&other) {
 // JSON serialization
 //------------------------------------------------------------------------------
 
-json_t ExperimentData::json() const {
+json_t ExperimentData::to_json() {
   // Initialize output as additional data JSON
   json_t js;
 
   // Add all container data
-  to_json(js, static_cast<const DataContainer<json_t>&>(*this));
-  to_json(js, static_cast<const DataContainer<complex_t>&>(*this));
-  to_json(js, static_cast<const DataContainer<std::vector<std::complex<float>>>&>(*this));
-  to_json(js, static_cast<const DataContainer<std::vector<std::complex<double>>>&>(*this));
-  to_json(js, static_cast<const DataContainer<matrix<std::complex<float>>>&>(*this));
-  to_json(js, static_cast<const DataContainer<matrix<std::complex<double>>>&>(*this));
-  to_json(js, static_cast<const DataContainer<std::map<std::string, complex_t>>&>(*this));
-  to_json(js, static_cast<const DataContainer<std::map<std::string, double>>&>(*this));
+  DataContainer<json_t>::add_to_json(js);
+  DataContainer<complex_t>::add_to_json(js);
+  DataContainer<std::vector<std::complex<float>>>::add_to_json(js);
+  DataContainer<std::vector<std::complex<double>>>::add_to_json(js);
+  DataContainer<matrix<std::complex<float>>>::add_to_json(js);
+  DataContainer<matrix<std::complex<double>>>::add_to_json(js);
+  DataContainer<std::map<std::string, complex_t>>::add_to_json(js);
+  DataContainer<std::map<std::string, double>>::add_to_json(js);
 
   // Measure data
   if (return_counts_ && counts_.empty() == false) js["counts"] = counts_;
@@ -497,10 +497,6 @@ json_t ExperimentData::json() const {
   // Check if data is null (empty) and if so return an empty JSON object
   if (js.is_null()) return json_t::object();
   return js;
-}
-
-inline void to_json(json_t &js, const ExperimentData &data) {
-  js = data.json();
 }
 
 //------------------------------------------------------------------------------

--- a/src/framework/results/experiment_result.hpp
+++ b/src/framework/results/experiment_result.hpp
@@ -50,7 +50,7 @@ public:
   void add_metadata(const std::string &key, T &&data);
 
   // Serialize engine data to JSON
-  json_t json() const;
+  json_t to_json();
 };
 
 
@@ -97,10 +97,10 @@ void ExperimentResult::add_metadata(const std::string &key, json_t &meta) {
 //------------------------------------------------------------------------------
 // JSON serialization
 //------------------------------------------------------------------------------
-json_t ExperimentResult::json() const {
+json_t ExperimentResult::to_json() {
   // Initialize output as additional data JSON
   json_t result;
-  result["data"] = data;
+  result["data"] = data.to_json();
   result["shots"] = shots;
   result["seed_simulator"] = seed;
   result["success"] = (status == Status::completed);
@@ -120,10 +120,6 @@ json_t ExperimentResult::json() const {
   if (metadata.empty() == false)
     result["metadata"] = metadata;
   return result;
-}
-
-inline void to_json(json_t &js, const ExperimentResult &result) {
-  js = result.json();
 }
 
 //------------------------------------------------------------------------------

--- a/src/framework/results/result.hpp
+++ b/src/framework/results/result.hpp
@@ -66,7 +66,7 @@ public:
   void add_metadata(const std::string &key, const T &data);
 
   // Serialize engine data to JSON
-  json_t json() const;
+  json_t to_json();
 };
 
 
@@ -89,39 +89,37 @@ void Result::clear_metadata(const std::string &key) {
 //------------------------------------------------------------------------------
 // JSON serialization
 //------------------------------------------------------------------------------
-json_t Result::json() const {
+json_t Result::to_json() {
   // Initialize output as additional data JSON
-  json_t result;
-  result["qobj_id"] = qobj_id;
+  json_t js;
+  js["qobj_id"] = qobj_id;
   
-  result["backend_name"] = backend_name;
-  result["backend_version"] = backend_version;
-  result["date"] = date;
-  result["job_id"] = job_id;
-  result["results"] = results;
+  js["backend_name"] = backend_name;
+  js["backend_version"] = backend_version;
+  js["date"] = date;
+  js["job_id"] = job_id;
+  for (auto& res : results) {
+    js["results"].push_back(res.to_json());
+  }
   if (header.empty() == false)
-    result["header"] = header;
+    js["header"] = header;
   if (metadata.empty() == false)
-    result["metadata"] = metadata;
-  result["success"] = (status == Status::completed);
+    js["metadata"] = metadata;
+  js["success"] = (status == Status::completed);
   switch (status) {
     case Status::completed:
-      result["status"] = std::string("COMPLETED");
+      js["status"] = std::string("COMPLETED");
       break;
     case Status:: partial_completed:
-      result["status"] = std::string("PARTIAL COMPLETED");
+      js["status"] = std::string("PARTIAL COMPLETED");
       break;
     case Status::error:
-      result["status"] = std::string("ERROR: ") + message;
+      js["status"] = std::string("ERROR: ") + message;
       break;
     case Status::empty:
-      result["status"] = std::string("EMPTY");
+      js["status"] = std::string("EMPTY");
   }
-  return result;
-}
-
-inline void to_json(json_t &js, const Result &result) {
-  js = result.json();
+  return js;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Previously the mean and variance were returned as a copy of stored
accumulated data. This allows them to modify the stored data and return
a reference that can be moved into result containers which can help
avoid copies for large data objects like probability and density matrix
snapshots. To make this work it was also necessary to allow JSON conversion of
results to be non const.

### Details and comments

Memory profiler comparisons for following circuit:

```py
nq = 14
circ = QuantumCircuit(nq)
circ.snapshot_density_matrix('state')

backend = QasmSimulator()
backend_options = {
    "method": "density_matrix",
    "fusion_enabled": False,
    "truncate_enabled": False,
    "max_parallel_threads": 1
}
qobj = assemble(circ, shots=1)

start = time.time()
result = backend.run(qobj, backend_options=backend_options).result()
stop = time.time()
time_py = stop - start
time_cpp = result.metadata['time_taken']
```

For this PR: time_py = 29.2 s, time_cpp = 26.7 s
For master: time_py = 31.8 s, time_cpp = 58.3 s

And memory profiling PR:

![mprof_dm_14q_pr](https://user-images.githubusercontent.com/2235104/85475412-0efd1900-b584-11ea-96c9-b0f92b4ecf70.png)

vs Master:

![mprof_dm_14q_master](https://user-images.githubusercontent.com/2235104/85475433-158b9080-b584-11ea-933a-fd3038395fdf.png)
