### PR TITLE
Cache ODE RHS params

### DIFF
--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -25,8 +25,7 @@ from .digest_pulse_qobj import digest_pulse_qobj
 from .pulse_sim_options import PulseSimOptions
 from .unitary_controller import run_unitary_experiments
 from .mc_controller import run_monte_carlo_experiments
-from .pulse_utils import td_ode_rhs_static
-
+from .pulse_utils import get_ode_rhs_functor
 
 def pulse_controller(qobj, system_model, backend_options):
     """ Interprets PulseQobj input, runs simulations, and returns results
@@ -433,8 +432,9 @@ class PulseInternalDEModel:
         # Init register
         register = np.ones(self.n_registers, dtype=np.uint8)
 
+        ode_rhs_obj = get_ode_rhs_functor(self._rhs_dict, exp, self.system, channels, register)
         def rhs(t, y):
-            return td_ode_rhs_static(t, y, self._rhs_dict, exp, self.system, channels, register)
+            return ode_rhs_obj(t, y);
 
         return rhs
 

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -434,7 +434,7 @@ class PulseInternalDEModel:
 
         ode_rhs_obj = get_ode_rhs_functor(self._rhs_dict, exp, self.system, channels, register)
         def rhs(t, y):
-            return ode_rhs_obj(t, y);
+            return ode_rhs_obj(t, y)
 
         return rhs
 

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -27,6 +27,7 @@ from .unitary_controller import run_unitary_experiments
 from .mc_controller import run_monte_carlo_experiments
 from .pulse_utils import get_ode_rhs_functor
 
+
 def pulse_controller(qobj, system_model, backend_options):
     """ Interprets PulseQobj input, runs simulations, and returns results
 
@@ -433,6 +434,7 @@ class PulseInternalDEModel:
         register = np.ones(self.n_registers, dtype=np.uint8)
 
         ode_rhs_obj = get_ode_rhs_functor(self._rhs_dict, exp, self.system, channels, register)
+
         def rhs(t, y):
             return ode_rhs_obj(t, y)
 

--- a/src/open_pulse/numeric_integrator.cpp
+++ b/src/open_pulse/numeric_integrator.cpp
@@ -95,60 +95,78 @@ complex_t chan_value(
     return out;
 }
 
-py::array_t<complex_t> td_ode_rhs(double t,
-        py::array_t<complex_t> the_vec,
-        py::object the_global_data,
-        py::object the_exp,
-        py::object the_system,
-        py::object the_channels,
-        py::object the_reg)
-{
-    #ifdef DEBUG
-    CALLGRIND_START_INSTRUMENTATION;
-    #endif
+struct RhsData {
+  RhsData(py::object the_global_data,
+          py::object the_exp,
+          py::object the_system,
+          py::object the_channels,
+          py::object the_reg) {
 
-    // I left this commented on porpose so we can use logging eventually
-    // This is just a RAII for the logger
-    //const Unregister unregister;
-    //auto file_logger = spdlog::basic_logger_mt("basic_logger", "logs/td_ode_rhs.txt");
-    //spdlog::set_default_logger(file_logger);
-    //spdlog::set_level(spdlog::level::debug); // Set global log level to debug
-    //spdlog::flush_on(spdlog::level::debug);
+      PyObject *py_global_data = the_global_data.ptr();
+      PyObject *py_exp = the_exp.ptr();
+      PyObject *py_system = the_system.ptr();
+      PyObject *py_register = the_reg.ptr();
 
-    PyArrayObject * py_vec = reinterpret_cast<PyArrayObject *>(the_vec.ptr());
-    PyObject * py_global_data = the_global_data.ptr();
-    PyObject * py_exp = the_exp.ptr();
-    PyObject * py_system = the_system.ptr();
-    PyObject * py_register = the_reg.ptr();
+      if (py_global_data == nullptr ||
+          py_exp == nullptr ||
+          py_system == nullptr ||
+          py_register == nullptr) {
+          std::string msg = "These arguments cannot be null: ";
+          msg += (py_global_data == nullptr ? "py_global_data " : "");
+          msg += (py_exp == nullptr ? "py_exp " : "");
+          msg += (py_system == nullptr ? "py_system " : "");
+          msg += (py_register == nullptr ? "py_register " : "");
+          throw std::invalid_argument(msg);
+      }
 
-    if(py_vec == nullptr ||
-       py_global_data == nullptr ||
-       py_exp == nullptr ||
-       py_system == nullptr ||
-       py_register == nullptr){
-           std::string msg = "These arguments cannot be null: ";
-           msg += (py_vec == nullptr ? "py_vec " : "" );
-           msg += (py_global_data == nullptr ? "py_global_data " : "" );
-           msg += (py_exp == nullptr ? "py_exp " : "" );
-           msg += (py_system == nullptr ? "py_system " : "" );
-           msg += (py_register == nullptr ? "py_register " : "" );
-           throw std::invalid_argument(msg);
+      pulses = get_ordered_map_from_dict_item<std::string, std::vector<NpArray<double>>>(py_exp, "channels");
+      freqs = get_vec_from_dict_item<double>(py_global_data, "freqs");
+      pulse_array = get_value_from_dict_item<NpArray<complex_t>>(py_global_data, "pulse_array");
+      pulse_indices = get_value_from_dict_item<NpArray<int>>(py_global_data, "pulse_indices");
+      reg = get_value<NpArray<uint8_t>>(py_register);
+
+      systems = get_value<std::vector<TermExpression>>(py_system);
+      vars = get_vec_from_dict_item<double>(py_global_data, "vars");
+      vars_names = get_vec_from_dict_item<std::string>(py_global_data, "vars_names");
+      num_h_terms = get_value_from_dict_item<long>(py_global_data, "num_h_terms");
+      datas = get_vec_from_dict_item<NpArray<complex_t>>(py_global_data, "h_ops_data");
+      idxs = get_vec_from_dict_item<NpArray<int>>(py_global_data, "h_ops_ind");
+      ptrs = get_vec_from_dict_item<NpArray<int>>(py_global_data, "h_ops_ptr");
+      energy = get_value_from_dict_item<NpArray<double>>(py_global_data, "h_diag_elems");
+  }
+
+  ordered_map<std::string, std::vector<NpArray<double>>> pulses;
+  std::vector<double> freqs;
+  NpArray<complex_t> pulse_array;
+  NpArray<int> pulse_indices;
+  NpArray<uint8_t> reg;
+
+  std::vector<TermExpression> systems;
+  std::vector<double> vars;
+  std::vector<std::string> vars_names;
+  long num_h_terms;
+  std::vector<NpArray<complex_t>> datas;
+  std::vector<NpArray<int>> idxs;
+  std::vector<NpArray<int>> ptrs;
+  NpArray<double> energy;
+};
+
+py::array_t <complex_t> inner_ode_rhs(double t,
+                                      py::array_t <complex_t> the_vec,
+                                      const RhsData &rhs_data) {
+    if (the_vec.ptr() == nullptr) {
+        throw std::invalid_argument("py_vec cannot be null");
     }
 
-    auto vec = get_value<NpArray<complex_t>>(py_vec);
-    auto num_rows = vec.shape[0];
-    auto out = static_cast<complex_t *>(PyDataMem_NEW(num_rows * sizeof(complex_t)));
-   	memset(&out[0],0,num_rows * sizeof(complex_t));
-
-    auto pulses = get_ordered_map_from_dict_item<std::string, std::vector<NpArray<double>>>(py_exp, "channels");
-    auto freqs = get_vec_from_dict_item<double>(py_global_data, "freqs");
-    auto pulse_array = get_value_from_dict_item<NpArray<complex_t>>(py_global_data, "pulse_array");
-    auto pulse_indices = get_value_from_dict_item<NpArray<int>>(py_global_data, "pulse_indices");
-    auto reg = get_value<NpArray<uint8_t>>(py_register);
+    auto vec = static_cast<complex_t *>(the_vec.request().ptr);
+    auto num_rows = the_vec.size();
+    py::array_t <complex_t> out_arr(num_rows);
+    auto out = static_cast<complex_t *>(out_arr.request().ptr);
+    memset(&out[0], 0, num_rows * sizeof(complex_t));
 
     std::unordered_map<std::string, complex_t> chan_values;
-    chan_values.reserve(pulses.size());
-    for(const auto& elem : enumerate(pulses)){
+    chan_values.reserve(rhs_data.pulses.size());
+    for (const auto &elem : enumerate(rhs_data.pulses)) {
         /**
          * eleme is map of string as key type, and vector of vectors of doubles.
          * elem["D0"] = [[0.,1.,2.][0.,1.,2.]]
@@ -157,55 +175,78 @@ py::array_t<complex_t> td_ode_rhs(double t,
         auto channel = elem.second.first;
         auto pulse = elem.second.second;
 
-        auto val = chan_value(t, i, freqs[i], pulse[0], pulse_array,
-                              pulse_indices, pulse[1], reg);
+        auto val = chan_value(t, i, rhs_data.freqs[i], pulse[0], rhs_data.pulse_array,
+                              rhs_data.pulse_indices, pulse[1], rhs_data.reg);
         chan_values.emplace(channel, val);
     }
 
     // 4. Eval the time-dependent terms and do SPMV.
-    auto systems = get_value<std::vector<TermExpression>>(py_system);
-    auto vars = get_vec_from_dict_item<double>(py_global_data, "vars");
-    auto vars_names = get_vec_from_dict_item<std::string>(py_global_data, "vars_names");
-    auto num_h_terms = get_value_from_dict_item<long>(py_global_data, "num_h_terms");
-    auto datas = get_vec_from_dict_item<NpArray<complex_t>>(py_global_data, "h_ops_data");
-    auto idxs = get_vec_from_dict_item<NpArray<int>>(py_global_data, "h_ops_ind");
-    auto ptrs = get_vec_from_dict_item<NpArray<int>>(py_global_data, "h_ops_ptr");
-    auto energy = get_value_from_dict_item<NpArray<double>>(py_global_data, "h_diag_elems");
-    for(int h_idx = 0; h_idx < num_h_terms; h_idx++){
+    for (int h_idx = 0; h_idx < rhs_data.num_h_terms; h_idx++) {
         // TODO: Refactor
         std::string term;
-        if(h_idx == systems.size() && num_h_terms > systems.size()){
+        if (h_idx == rhs_data.systems.size() && rhs_data.num_h_terms > rhs_data.systems.size()) {
             term = "1.0";
-        }else if(h_idx < systems.size()){
-            term = systems[h_idx].term;
-        }else{
+        } else if (h_idx < rhs_data.systems.size()) {
+            term = rhs_data.systems[h_idx].term;
+        } else {
             continue;
         }
 
-        auto td = evaluate_hamiltonian_expression(term, vars, vars_names, chan_values);
-        if(std::abs(td) > 1e-15){
-            for(auto i=0; i<num_rows; i++){
+        auto td = evaluate_hamiltonian_expression(term, rhs_data.vars, rhs_data.vars_names, chan_values);
+        if (std::abs(td) > 1e-15) {
+            for (auto i = 0; i < num_rows; i++) {
                 complex_t dot = {0., 0.};
-                auto row_start = ptrs[h_idx][i];
-                auto row_end = ptrs[h_idx][i+1];
-                for(auto j = row_start; j<row_end; ++j){
-                    auto tmp_idx = idxs[h_idx][j];
+                auto row_start = rhs_data.ptrs[h_idx][i];
+                auto row_end = rhs_data.ptrs[h_idx][i + 1];
+                for (auto j = row_start; j < row_end; ++j) {
+                    auto tmp_idx = rhs_data.idxs[h_idx][j];
                     auto osc_term =
                         std::exp(
-                            complex_t(0.,1.) * (energy[i] - energy[tmp_idx]) * t
+                            complex_t(0., 1.) * (rhs_data.energy[i] - rhs_data.energy[tmp_idx]) * t
                         );
                     complex_t coef = (i < tmp_idx ? std::conj(td) : td);
-                    dot += coef * osc_term * datas[h_idx][j] * vec[tmp_idx];
-
+                    dot += coef * osc_term * rhs_data.datas[h_idx][j] * vec[tmp_idx];
                 }
                 out[i] += dot;
             }
         }
     } /* End of systems */
 
-    for(auto i=0; i < num_rows; ++i){
-        out[i] += complex_t(0.,1.) * energy[i] * vec[i];
+    for (auto i = 0; i < num_rows; ++i) {
+        out[i] += complex_t(0., 1.) * rhs_data.energy[i] * vec[i];
     }
 
-    return py::array(num_rows, out);
+    return out_arr;
+}
+
+RhsFunctor::RhsFunctor(py::object the_global_data, py::object the_exp, py::object the_system,
+                       py::object the_channels, py::object the_reg)
+    : rhs_data_(
+    std::make_shared<RhsData>(the_global_data, the_exp, the_system, the_channels, the_reg)) {}
+
+py::array_t <complex_t> RhsFunctor::operator()(double t, py::array_t <complex_t> the_vec) {
+    return inner_ode_rhs(t, the_vec, *rhs_data_);
+}
+
+py::array_t <complex_t> td_ode_rhs(double t,
+                                   py::array_t <complex_t> the_vec,
+                                   py::object the_global_data,
+                                   py::object the_exp,
+                                   py::object the_system,
+                                   py::object the_channels,
+                                   py::object the_reg) {
+#ifdef DEBUG
+    CALLGRIND_START_INSTRUMENTATION;
+#endif
+
+    // I left this commented on porpose so we can use logging eventually
+    // This is just a RAII for the logger
+    // const Unregister unregister;
+    // auto file_logger = spdlog::basic_logger_mt("basic_logger", "logs/td_ode_rhs.txt");
+    // spdlog::set_default_logger(file_logger);
+    // spdlog::set_level(spdlog::level::debug); // Set global log level to debug
+    // spdlog::flush_on(spdlog::level::debug);
+
+    auto rhs_data = RhsData(the_global_data, the_exp, the_system, the_channels, the_reg);
+    return inner_ode_rhs(t, the_vec, rhs_data);
 }

--- a/src/open_pulse/numeric_integrator.hpp
+++ b/src/open_pulse/numeric_integrator.hpp
@@ -26,6 +26,8 @@
 
 namespace py = pybind11;
 
+struct RhsData;
+
 py::array_t<complex_t> td_ode_rhs(double t,
                                   py::array_t<complex_t> vec,
                                   py::object global_data,
@@ -33,5 +35,19 @@ py::array_t<complex_t> td_ode_rhs(double t,
                                   py::object system,
                                   py::object channels,
                                   py::object reg);
+
+class RhsFunctor {
+public:
+    RhsFunctor(py::object the_global_data,
+               py::object the_exp,
+               py::object the_system,
+               py::object the_channels,
+               py::object the_reg);
+
+    py::array_t <complex_t> operator()(double t, py::array_t <complex_t> the_vec);
+
+private:
+    std::shared_ptr<RhsData> rhs_data_;
+};
 
 #endif // _NUMERIC_INTEGRATOR_HPP

--- a/src/open_pulse/ordered_map.hpp
+++ b/src/open_pulse/ordered_map.hpp
@@ -15,116 +15,103 @@
 #ifndef _ORDERED_MAP_HPP
 #define _ORDERED_MAP_HPP
 
-#include <unordered_map>
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 
-template<
-	class Key,
-    class T,
-    class Hash = std::hash<Key>,
-    class KeyEqual = std::equal_to<Key>,
-    class Allocator = std::allocator<std::pair<const Key, T>>
-> class ordered_map {
+template <class Key, class T, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>,
+          class Allocator = std::allocator<std::pair<const Key, T>>>
+class ordered_map {
+public:
+  using unordered_map_t = std::unordered_map<Key, T, Hash, KeyEqual, Allocator>;
+  using vector_t = std::vector<Key>;
+
+  ordered_map(){}
+  ordered_map(const ordered_map& other) : internal_map(other.internal_map), order(other.order){
+    it.reset(new ordered_map_iterator_t<unordered_map_t, vector_t>(internal_map, order));
+  }
+
+  ordered_map& operator=(const ordered_map& other){
+    internal_map = other.internal_map;
+    order = other.order;
+    it.reset(new ordered_map_iterator_t<unordered_map_t, vector_t>(internal_map, order));
+    return *this;
+  }
+
+  auto reserve(size_t size) {
+    order.reserve(size);
+    return internal_map.reserve(size);
+  }
+
+  template <class... Args> decltype(auto) emplace(Args &&... args) {
+    const auto first = std::get<0>(std::forward_as_tuple(args...));
+    order.emplace_back(first);
+    return internal_map.emplace(std::forward<Args>(args)...);
+  }
+
+  size_t size() const { return internal_map.size(); }
+
+  const T &operator[](const std::string &index) const { return internal_map[index]; }
+
+  // This is needed so we can use the container in an iterator context like ranged fors.
+  template <class _map_t, class _vec_t> class ordered_map_iterator_t {
+    using unordered_map_iter_t = typename _map_t::iterator;
+    using vec_iter_t = typename _vec_t::iterator;
+
+    _map_t &map;
+    _vec_t &vec;
+
+    unordered_map_iter_t map_iter;
+    vec_iter_t vec_iter;
+
   public:
+    using reference = typename unordered_map_iter_t::reference;
+    using difference_type = typename unordered_map_iter_t::difference_type;
+    using value_type = typename unordered_map_iter_t::value_type;
+    using pointer = typename unordered_map_iter_t::reference;
+    using iterator_category = typename unordered_map_iter_t::iterator_category;
 
-    using unordered_map_t = std::unordered_map<Key, T, Hash, KeyEqual, Allocator>;
-    using vector_t = std::vector<Key>;
+    ordered_map_iterator_t(_map_t &map, _vec_t &vec) : map(map), vec(vec) {}
 
-	auto reserve(size_t size){
-		order.reserve(size);
-		return internal_map.reserve(size);
-	}
-
-	template<class... Args>
-	decltype(auto) emplace(Args&&... args) {
-		const auto first = std::get<0>(std::forward_as_tuple(args...));
-		order.emplace_back(first);
-		return internal_map.emplace(std::forward<Args>(args)...);
-	}
-
-	size_t size(){
-		return internal_map.size();
-	}
-
-	const T& operator[](const std::string& index) const {
-        return internal_map[index];
+    ordered_map_iterator_t begin() {
+      vec_iter = vec.begin();
+      map_iter = map.find(*vec_iter);
+      return *this;
     }
 
-	// This is needed so we can use the container in an iterator context like ranged fors.
-    template<class _map_t, class _vec_t>
-    class ordered_map_iterator_t {
-		using unordered_map_iter_t = typename _map_t::iterator;
-    	using vec_iter_t = typename _vec_t::iterator;
-
-		_map_t& map;
-		_vec_t& vec;
-
-        unordered_map_iter_t map_iter;
-        vec_iter_t vec_iter;
-
-	  public:
-
-    	using reference = typename unordered_map_iter_t::reference;
-        using difference_type = typename unordered_map_iter_t::difference_type;
-        using value_type = typename unordered_map_iter_t::value_type;
-        using pointer = typename unordered_map_iter_t::reference;
-        using iterator_category = typename unordered_map_iter_t::iterator_category;
-
-        ordered_map_iterator_t(_map_t& map,
-                 _vec_t& vec) : map(map), vec(vec){
-        }
-
-        ordered_map_iterator_t begin() {
-            vec_iter = vec.begin();
-            map_iter = map.find(*vec_iter);
-            return *this;
-        }
-
-        ordered_map_iterator_t end() {
-            vec_iter = vec.end();
-            map_iter = map.find(*(vec_iter - 1));
-            return *this;
-        }
-
-        ordered_map_iterator_t operator ++(){
-            auto tmp = ++vec_iter;
-            tmp = (tmp == vec.end()? --tmp: tmp);
-            map_iter = map.find(*tmp);
-            return *this;
-        }
-
-        bool operator ==(const ordered_map_iterator_t& rhs) const {
-            return vec_iter == rhs.vec_iter;
-        }
-
-        bool operator !=(const ordered_map_iterator_t& rhs) const {
-            return vec_iter != rhs.vec_iter;
-        }
-
-        reference operator *() const {
-            return *map_iter;
-        }
-    };
-
-    using iterator = ordered_map_iterator_t<unordered_map_t, vector_t>;
-    using const_iterator = ordered_map_iterator_t<unordered_map_t, vector_t>;
-
-    iterator it{internal_map, order};
-
-    const_iterator begin() {
-        return it.begin();
+    ordered_map_iterator_t end() {
+      vec_iter = vec.end();
+      map_iter = map.find(*(vec_iter - 1));
+      return *this;
     }
 
-    const_iterator end() {
-        return it.end();
+    ordered_map_iterator_t operator++() {
+      auto tmp = ++vec_iter;
+      tmp = (tmp == vec.end() ? --tmp : tmp);
+      map_iter = map.find(*tmp);
+      return *this;
     }
 
-  private:
-    unordered_map_t internal_map;
-	vector_t order;
+    bool operator==(const ordered_map_iterator_t &rhs) const { return vec_iter == rhs.vec_iter; }
 
+    bool operator!=(const ordered_map_iterator_t &rhs) const { return vec_iter != rhs.vec_iter; }
+
+    const reference operator*() const { return *map_iter; }
+  };
+
+  using iterator = ordered_map_iterator_t<unordered_map_t, vector_t>;
+  using const_iterator = ordered_map_iterator_t<unordered_map_t, vector_t>;
+
+  std::unique_ptr<iterator> it = std::make_unique<iterator>(internal_map, order);
+
+  const_iterator begin() const { return it->begin(); }
+
+  const_iterator end() const { return it->end(); }
+
+private:
+  unordered_map_t internal_map;
+  vector_t order;
 };
 
 #endif //_ORDERED_MAP_HPP

--- a/src/open_pulse/pulse_utils_bindings.cpp
+++ b/src/open_pulse/pulse_utils_bindings.cpp
@@ -15,6 +15,13 @@
 #include "numeric_integrator.hpp"
 #include "pulse_utils.hpp"
 
+#include <pybind11/functional.h>
+
+RhsFunctor get_ode_rhs_functor(py::object the_global_data, py::object the_exp,
+                               py::object the_system, py::object the_channels, py::object the_reg) {
+  return RhsFunctor(the_global_data, the_exp, the_system, the_channels, the_reg);
+}
+
 PYBIND11_MODULE(pulse_utils, m) {
     m.doc() = "Utility functions for pulse simulator"; // optional module docstring
 
@@ -24,4 +31,9 @@ PYBIND11_MODULE(pulse_utils, m) {
     m.def("write_shots_memory", &write_shots_memory, "Converts probabilities back into shots");
     m.def("oplist_to_array", &oplist_to_array, "Insert list of complex numbers into numpy complex array");
     m.def("spmv_csr", &spmv_csr, "Sparse matrix, dense vector multiplication.");
+
+    py::class_<RhsFunctor>(m, "OdeRhsFunctor")
+        .def("__call__", &RhsFunctor::operator());
+
+    m.def("get_ode_rhs_functor", &get_ode_rhs_functor, "Get ode_rhs functor to allow caching of parameters");
 }

--- a/src/open_pulse/python_to_cpp.hpp
+++ b/src/open_pulse/python_to_cpp.hpp
@@ -330,13 +330,6 @@ class NpArray {
         return data[index];
     }
 
-    NpArray& operator=(const NpArray<VecType>& other){
-		data = reinterpret_cast<VecType *>(other.data);
-        size = other.size;
-		shape = other.shape;
-		return *this;
-	}
-
     bool operator==(const NpArray<VecType>& other) const {
         if(other.size != size ||
            other.shape.size() != shape.size())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In normal ODE solving execution RHS function is called hundred of thousands of times. Conversion of function parameters from python to C++ are quite expensive and take most of the time. In this PR a functor is created to cache the converted parameters to C++ that do not change from call to call within the solver.

Testing with the tutorial [8_pulse_simulator_duffing_model](https://github.com/Qiskit/qiskit-tutorials/blob/master/legacy_tutorials/aer/8_pulse_simulator_duffing_model.ipynb):
- In the first simulation run (section 4.2), execution time goes down from **~10s** to **~2s**.
- In the second simulation (section 5.3, cell 15), execution times goes down from **~17s** to **~3.5s**.
- And finally, in the last simulation (section 5.3, cell 18), time goes down from **~40s** to **~8s**.

### Details and comments


