### PR TITLE
Add AVX with separation of binaries of AVX and non-AVX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,12 @@ else()
 	message(STATUS "No Thrust support enabled")
 endif()
 
+if(SKBUILD) # Terra Addon build
+	enable_cxx_compiler_flag_if_supported("-DQV_AVX_ISOLATION")
+else() # Standalone build
+	enable_cxx_compiler_flag_if_supported("-mfma")
+	enable_cxx_compiler_flag_if_supported("-mavx2")
+endif()
 
 # Set dependent libraries
 set(AER_LIBRARIES
@@ -236,7 +242,10 @@ if(SKBUILD) # Terra Addon build
 	add_subdirectory(qiskit/providers/aer/pulse/qutip_extra_lite/cy)
 	add_subdirectory(qiskit/providers/aer/backends/wrappers)
 	add_subdirectory(src/open_pulse)
+	enable_cxx_compiler_flag_if_supported("-DQV_AVX_ISOLATION")
 else() # Standalone build
+	enable_cxx_compiler_flag_if_supported("-mfma")
+	enable_cxx_compiler_flag_if_supported("-mavx2")
 	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 	if(CUDA_FOUND)
 		cuda_add_executable(qasm_simulator ${AER_SIMULATOR_CPP_MAIN})

--- a/qiskit/providers/aer/backends/wrappers/CMakeLists.txt
+++ b/qiskit/providers/aer/backends/wrappers/CMakeLists.txt
@@ -7,11 +7,31 @@ find_package(Pybind11 REQUIRED)
 # shared library.
 string(REPLACE " -static " "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
+set_source_files_properties(bindings.cc PROPERTIES COMPILE_FLAGS "-DQV_AVX_ISOLATION")
+
 # Controllers
 if(CUDA_FOUND)
     set_source_files_properties(bindings.cc PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ)
 endif()
-basic_pybind11_add_module(controller_wrappers bindings.cc)
+
+# We build SIMD filed separately, because they will be reached only if the
+# machine running the code has SIMD support
+set(SIMD_SOURCE_FILE "../../../../../src/simulators/statevector/qvintrin.cpp")
+
+if(APPLE OR UNIX)
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
+	    set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "-DQV_AVX_ISOLATION")
+	elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+	    set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "-DQV_AVX_ISOLATION")
+	else()
+	    set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "-mfma -mavx2 -DQV_AVX_ISOLATION")
+	endif()
+elseif(MSVC)
+    set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "/arch:AVX2 /DQV_AVX_ISOLATION")
+endif()
+
+basic_pybind11_add_module(controller_wrappers bindings.cc ${SIMD_SOURCE_FILE})
+
 target_include_directories(controller_wrappers PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR}
                                                PRIVATE ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
 target_link_libraries(controller_wrappers ${AER_LIBRARIES})

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -522,12 +522,23 @@ Result Controller::execute(std::vector<Circuit> &circuits,
     if (parallel_shots_ > 1 || parallel_state_update_ > 1)
       omp_set_nested(1);
 #endif
-    #pragma omp parallel for if (parallel_experiments_ > 1) num_threads(parallel_experiments_)
-    for (int j = 0; j < result.results.size(); ++j) {
-      // Make a copy of the noise model for each circuit execution
-      // so that it can be modified if required
-      auto circ_noise_model = noise_model;
-      execute_circuit(circuits[j], circ_noise_model, config, result.results[j]);
+    // then- and else-blocks have intentionally duplication.
+    // Nested omp has significant overheads even though a guard condition exists.
+    if (parallel_experiments_ > 1) {
+      #pragma omp parallel for if (parallel_experiments_ > 1) num_threads(parallel_experiments_)
+      for (int j = 0; j < result.results.size(); ++j) {
+        // Make a copy of the noise model for each circuit execution
+        // so that it can be modified if required
+        auto circ_noise_model = noise_model;
+        execute_circuit(circuits[j], circ_noise_model, config, result.results[j]);
+      }
+    } else {
+      for (int j = 0; j < result.results.size(); ++j) {
+        // Make a copy of the noise model for each circuit execution
+        // so that it can be modified if required
+        auto circ_noise_model = noise_model;
+        execute_circuit(circuits[j], circ_noise_model, config, result.results[j]);
+      }
     }
 
     // Check each experiment result for completed status.

--- a/src/simulators/statevector/qvintrin.cpp
+++ b/src/simulators/statevector/qvintrin.cpp
@@ -1,0 +1,89 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+#define QV_ISOLATED_AVX
+#include "qvintrin.hpp"
+
+#if defined(__PPC__)  || defined(__PPC64__)
+// PPC
+#elif defined(__arm__) || defined(__arm64__)
+// ARM
+#else
+// INTEL
+#ifdef _MSC_VER
+#include <intrin.h>
+#elif defined(__GNUC__)
+#include <cpuid.h>
+#endif
+#include "qvintrin_avx.hpp"
+#endif
+
+namespace QV {
+
+bool is_intrinsics () {
+#if defined(__PPC__) | defined(__PPC64__)
+  return false;
+#elif defined(__arm__) || defined(__arm64__)
+  return false;
+#else //Intel
+#ifdef __AVX2__
+  return is_avx2_supported();
+#else
+  return false;
+#endif //Intel
+#endif
+}
+
+bool apply_matrix_opt(
+    float* qv_data,
+    const uint64_t data_size,
+    const uint64_t* qregs,
+    const uint64_t qregs_size,
+    const float* fmat,
+    const uint64_t omp_threads) {
+#if defined(__PPC__)  || defined(__PPC64__)
+  return false;
+#elif defined(__arm__) || defined(__arm64__)
+  return false;
+#else //Intel
+#ifdef __AVX2__
+  return apply_matrix_avx <float> (
+      qv_data, data_size, qregs, qregs_size, fmat, omp_threads);
+#else
+  return false;
+#endif // Intel
+#endif
+}
+
+bool apply_matrix_opt(
+    double* qv_data,
+    const uint64_t data_size,
+    const uint64_t* qregs,
+    const uint64_t qregs_size,
+    const double* dmat,
+    const uint64_t omp_threads) {
+#if defined(__PPC__)  || defined(__PPC64__)
+  return false;
+#elif defined(__arm__) || defined(__arm64__)
+  return false;
+#else //Intel
+#ifdef __AVX2__
+  return apply_matrix_avx <double> (
+      qv_data, data_size, qregs, qregs_size, dmat, omp_threads);
+#else
+  return false;
+#endif // Intel
+#endif
+}
+}
+

--- a/src/simulators/statevector/qvintrin.hpp
+++ b/src/simulators/statevector/qvintrin.hpp
@@ -1,0 +1,120 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+
+
+#ifndef _qv_qvintrin_hpp_
+#define _qv_qvintrin_hpp_
+
+#include <cstdint>
+#include <utility>
+
+#if defined(__PPC__) | defined(__PPC64__)
+
+#elif defined(__arm__) || defined(__arm64__)
+
+#else
+
+#if !defined(QV_ISOLATED_AVX) && defined (__AVX2__)
+#include <cpuid.h>
+// only if x86
+#include "qvintrin_avx.hpp"
+#endif
+
+#endif
+
+namespace QV {
+
+#ifndef QV_AVX_ISOLATION
+bool is_intrinsics () {
+#if defined(__PPC__) | defined(__PPC64__)
+  return false;
+#elif defined(__arm__) || defined(__arm64__)
+  return false;
+#else //Intel
+#ifdef __AVX2__
+  return is_avx2_supported();
+#else
+  return false;
+#endif //Intel
+
+#endif
+}
+
+bool apply_matrix_opt(
+    float* qv_data,
+    const uint64_t data_size,
+    const uint64_t* qregs,
+    const uint64_t qregs_size,
+    const float* fmat,
+    const uint64_t omp_threads) {
+#if defined(__PPC__) | defined(__PPC64__)
+  return false;
+#elif defined(__arm__) || defined(__arm64__)
+  return false;
+#else //Intel
+#ifdef __AVX2__
+  return apply_matrix_avx <float> (
+      (void *) qv_data, data_size, qregs, qregs_size, fmat, omp_threads);
+#else
+  return false;
+#endif //Intel
+
+#endif
+}
+
+bool apply_matrix_opt(
+    double* qv_data,
+    const uint64_t data_size,
+    const uint64_t* qregs,
+    const uint64_t qregs_size,
+    const double* dmat,
+    const uint64_t omp_threads) {
+
+#if defined(__PPC__) | defined(__PPC64__)
+  return false;
+#elif defined(__arm__) || defined(__arm64__)
+  return false;
+#else //Intel
+#ifdef __AVX2__
+  return apply_matrix_avx <double> (
+      qv_data, data_size, qregs, qregs_size, dmat, omp_threads);
+#else
+  return false;
+#endif //Intel
+
+#endif
+}
+#else
+bool is_intrinsics();
+
+bool apply_matrix_opt(
+    float* qv_data,
+    const uint64_t data_size,
+    const uint64_t* qregs,
+    const uint64_t qregs_size,
+    const float* mat,
+    const uint64_t omp_threads);
+
+bool apply_matrix_opt(
+    double* qv_data,
+    const uint64_t data_size,
+    const uint64_t* qregs,
+    const uint64_t qregs_size,
+    const double* mat,
+    const uint64_t omp_threads);
+#endif
+}
+//------------------------------------------------------------------------------
+#endif // end module

--- a/src/simulators/statevector/qvintrin_avx.hpp
+++ b/src/simulators/statevector/qvintrin_avx.hpp
@@ -1,0 +1,890 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2020.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _qv_intrinsics_avx_hpp_
+#define _qv_intrinsics_avx_hpp_
+
+#include <immintrin.h>
+#include <type_traits>
+
+namespace {
+inline void ccpuid(int cpu_info[4], int function_id) {
+#ifdef _MSC_VER
+  __cpuid(cpu_info, function_id);
+#elif defined(__GNUC__)
+  __cpuid(function_id,
+    cpu_info[0],
+    cpu_info[1],
+    cpu_info[2],
+    cpu_info[3]);
+#else // We don't support this platform intrinsics
+  cpu_info[0] = cpu_info[1] = cpu_info[2] = cpu_info[3] = 0;
+#endif
+}
+}
+
+inline void cpuidex(int cpu_info[4], int function_id, int subfunction_id) {
+#ifdef _MSC_VER
+  __cpuidex(cpu_info, function_id, subfunction_id);
+#elif defined(__GNUC__)
+  __cpuid_count(function_id, subfunction_id, cpu_info[0], cpu_info[1], cpu_info[2], cpu_info[3]);
+#else // We don't support this platform intrinsics
+  cpu_info[0] = cpu_info[1] = cpu_info[2] = cpu_info[3] = 0;
+#endif
+}
+
+namespace QV {
+
+#define _mm_complex_multiply_pd(real_ret, imag_ret, real_left, imag_left, real_right, imag_right)\
+{\
+  real_ret = _mm256_mul_pd(real_left, real_right);\
+  imag_ret = _mm256_mul_pd(real_left, imag_right);\
+  real_ret = _mm256_fnmadd_pd(imag_left, imag_right, real_ret);\
+  imag_ret = _mm256_fmadd_pd(imag_left, real_right, imag_ret);\
+}
+
+#define _mm_complex_multiply_add_pd(real_ret, imag_ret, real_left, imag_left, real_right, imag_right)\
+{\
+  real_ret = _mm256_fmadd_pd(real_left, real_right, real_ret);\
+  imag_ret = _mm256_fmadd_pd(real_left, imag_right, imag_ret);\
+  real_ret = _mm256_fnmadd_pd(imag_left, imag_right, real_ret);\
+  imag_ret = _mm256_fmadd_pd(imag_left, real_right, imag_ret);\
+}
+
+#define _mm_complex_inner_product_pd(\
+    dim, vreals, vimags, cmplxs, vret_real, vret_imag, vtmp_0, vtmp_1)\
+{\
+  vtmp_0 = _mm256_set1_pd(cmplxs[0]);\
+  vtmp_1 = _mm256_set1_pd(cmplxs[1]);\
+  _mm_complex_multiply_pd(vret_real, vret_imag, vreals[0], vimags[0], vtmp_0, vtmp_1);\
+  for (unsigned ____i = 1; ____i < dim; ++____i) {\
+    vtmp_0 = _mm256_set1_pd(cmplxs[____i * 2]);\
+    vtmp_1 = _mm256_set1_pd(cmplxs[____i * 2 + 1]);\
+    _mm_complex_multiply_add_pd(vret_real, vret_imag, vreals[____i], vimags[____i], vtmp_0, vtmp_1);\
+  }\
+}
+
+#define _mm_complex_multiply_ps(real_ret, imag_ret, real_left, imag_left, real_right, imag_right)\
+{\
+  real_ret = _mm256_mul_ps(real_left, real_right);\
+  imag_ret = _mm256_mul_ps(real_left, imag_right);\
+  real_ret = _mm256_fnmadd_ps(imag_left, imag_right, real_ret);\
+  imag_ret = _mm256_fmadd_ps(imag_left, real_right, imag_ret);\
+}
+
+#define _mm_complex_multiply_add_ps(real_ret, imag_ret, real_left, imag_left, real_right, imag_right)\
+{\
+  real_ret = _mm256_fmadd_ps(real_left, real_right, real_ret);\
+  imag_ret = _mm256_fmadd_ps(real_left, imag_right, imag_ret);\
+  real_ret = _mm256_fnmadd_ps(imag_left, imag_right, real_ret);\
+  imag_ret = _mm256_fmadd_ps(imag_left, real_right, imag_ret);\
+}
+
+#define _mm_complex_inner_product_ps(\
+    dim, vreals, vimags, cmplxs, vret_real, vret_imag, vtmp_0, vtmp_1)\
+{\
+  vtmp_0 = _mm256_set1_ps(cmplxs[0]);\
+  vtmp_1 = _mm256_set1_ps(cmplxs[1]);\
+  _mm_complex_multiply_ps(vret_real, vret_imag, vreals[0], vimags[0], vtmp_0, vtmp_1);\
+  for (unsigned ____i = 1; ____i < dim; ++____i) {\
+    vtmp_0 = _mm256_set1_ps(cmplxs[____i * 2]);\
+    vtmp_1 = _mm256_set1_ps(cmplxs[____i * 2 + 1]);\
+    _mm_complex_multiply_add_ps(vret_real, vret_imag, vreals[____i], vimags[____i], vtmp_0, vtmp_1);\
+  }\
+}
+
+#define _mm_altload_complex_ps(cmplx_addr_0, cmplx_addr_1, real_ret, imag_ret)\
+{\
+  real_ret = _mm256_load_ps(cmplx_addr_0);\
+  imag_ret = _mm256_load_ps(cmplx_addr_1);\
+  tmp0 = _mm256_permutevar8x32_ps(real_ret, _mm256_set_epi32(6, 7, 4, 5, 2, 3, 0, 1));\
+  tmp1 = _mm256_permutevar8x32_ps(imag_ret, _mm256_set_epi32(6, 7, 4, 5, 2, 3, 0, 1));\
+  real_ret = _mm256_blend_ps(real_ret, tmp1, 0b10101010);\
+  imag_ret = _mm256_blend_ps(tmp0, imag_ret, 0b10101010);\
+  real_ret = _mm256_permutevar8x32_ps(real_ret, _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0));\
+  imag_ret = _mm256_permutevar8x32_ps(imag_ret, _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0));\
+}
+
+#define _mm_altstore_complex_ps(real_ret, imag_ret, cmplx_addr_0, cmplx_addr_1)\
+{\
+  real_ret = _mm256_permutevar8x32_ps(real_ret, _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0));\
+  imag_ret = _mm256_permutevar8x32_ps(imag_ret, _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0));\
+  tmp0 = _mm256_permutevar8x32_ps(real_ret, _mm256_set_epi32(6, 7, 4, 5, 2, 3, 0, 1));\
+  tmp1 = _mm256_permutevar8x32_ps(imag_ret, _mm256_set_epi32(6, 7, 4, 5, 2, 3, 0, 1));\
+  real_ret = _mm256_blend_ps(real_ret, tmp1, 0b10101010);\
+  imag_ret = _mm256_blend_ps(tmp0, imag_ret, 0b10101010);\
+  _mm256_store_ps(cmplx_addr_0, real_ret);\
+  _mm256_store_ps(cmplx_addr_1, imag_ret);\
+}
+
+#define _mm_altload_complex_pd(cmplx_addr_0, cmplx_addr_1, real_ret, imag_ret)\
+{\
+  real_ret = _mm256_load_pd(cmplx_addr_0);\
+  imag_ret = _mm256_load_pd(cmplx_addr_1);\
+  tmp0 = _mm256_permute4x64_pd(real_ret, 2 * 64 + 3 * 16 + 0 * 4 + 1 * 1);\
+  tmp1 = _mm256_permute4x64_pd(imag_ret, 2 * 64 + 3 * 16 + 0 * 4 + 1 * 1);\
+  real_ret = _mm256_blend_pd(real_ret, tmp1, 0b1010);\
+  imag_ret = _mm256_blend_pd(tmp0, imag_ret, 0b1010);\
+  real_ret = _mm256_permute4x64_pd(real_ret, 3 * 64 + 1 * 16 + 2 * 4 + 0 * 1);\
+  imag_ret = _mm256_permute4x64_pd(imag_ret, 3 * 64 + 1 * 16 + 2 * 4 + 0 * 1);\
+}
+
+#define _mm_altstore_complex_pd(real_ret, imag_ret, cmplx_addr_0, cmplx_addr_1)\
+{\
+  real_ret = _mm256_permute4x64_pd(real_ret, 3 * 64 + 1 * 16 + 2 * 4 + 0 * 1);\
+  imag_ret = _mm256_permute4x64_pd(imag_ret, 3 * 64 + 1 * 16 + 2 * 4 + 0 * 1);\
+  tmp0 = _mm256_permute4x64_pd(real_ret, 2 * 64 + 3 * 16 + 0 * 4 + 1 * 1);\
+  tmp1 = _mm256_permute4x64_pd(imag_ret, 2 * 64 + 3 * 16 + 0 * 4 + 1 * 1);\
+  real_ret = _mm256_blend_pd(real_ret, tmp1, 0b1010);\
+  imag_ret = _mm256_blend_pd(tmp0, imag_ret, 0b1010);\
+  _mm256_store_pd(cmplx_addr_0, real_ret);\
+  _mm256_store_pd(cmplx_addr_1, imag_ret);\
+}
+
+#define perm_d_q0q1_0   3 * 64 + 2 * 16 + 0 * 4 + 1 * 1
+#define perm_d_q0q1_1   3 * 64 + 0 * 16 + 1 * 4 + 2 * 1
+#define perm_d_q0q1_2   0 * 64 + 2 * 16 + 1 * 4 + 3 * 1
+#define perm_d_q0       2 * 64 + 3 * 16 + 0 * 4 + 1 * 1
+#define perm_d_q1       1 * 64 + 0 * 16 + 3 * 4 + 2 * 1
+
+template<size_t N>
+inline void _fill_indices(uint64_t ind0, uint64_t* inds, const uint64_t ids_size, const uint64_t* qregs) {
+  for (unsigned i = 0; i < ids_size; ++i)
+    inds[i] = ind0;
+  for (unsigned n = 0; n < N; ++n)
+    for (unsigned i = 0; i < ids_size; i += (1 << (n + 1)))
+      for (unsigned j = 0; j < (1U << n); ++j)
+        inds[i + j + (1U << n)] += (1ULL << qregs[n]);
+}
+
+
+template<size_t N>
+inline void _apply_matrix_float_avx_q0q1q2(  //
+    void* data, //
+    void* mat, //
+    const uint64_t* qregs, // sorted
+    const uint64_t ind0 //
+    ) {
+
+  auto ids_size = (1ULL << N);
+  uint64_t inds[1ULL << N];
+  _fill_indices<N>(ind0, inds, ids_size, qregs);
+
+  __m256i masks[7];
+  __m256 real_ret, imag_ret, real_ret1, imag_ret1;
+  __m256 vreals[1ULL << N], vimags[1ULL << N];
+  __m256 tmp0, tmp1;
+
+  float* fdata = (float*) data;
+  float* fmat = (float*) mat;
+
+  masks[0] = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 0, 1);
+  masks[1] = _mm256_set_epi32(7, 6, 5, 4, 3, 0, 1, 2);
+  masks[2] = _mm256_set_epi32(7, 6, 5, 4, 0, 2, 1, 3);
+  masks[3] = _mm256_set_epi32(7, 6, 5, 0, 3, 2, 1, 4);
+  masks[4] = _mm256_set_epi32(7, 6, 0, 4, 3, 2, 1, 5);
+  masks[5] = _mm256_set_epi32(7, 0, 5, 4, 3, 2, 1, 6);
+  masks[6] = _mm256_set_epi32(0, 6, 5, 4, 3, 2, 1, 7);
+
+  for (unsigned i = 0; i < ids_size; i += 8) {
+    auto idx = inds[i];
+    _mm_altload_complex_ps(&fdata[idx * 2], &fdata[idx * 2 + 8], vreals[i], vimags[i]);
+
+    for (unsigned j = 1; j < 8; ++j) {
+      vreals[i + j] = _mm256_permutevar8x32_ps(vreals[i], masks[j - 1]);
+      vimags[i + j] = _mm256_permutevar8x32_ps(vimags[i], masks[j - 1]);
+    }
+  }
+
+  unsigned midx = 0;
+  for (unsigned i = 0; i < ids_size; i += 8) {
+    auto idx = inds[i];
+    _mm_complex_inner_product_ps((1ULL << N), vreals, vimags, (&fmat[midx]), real_ret, imag_ret, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+
+    for (unsigned j = 1; j < 8; ++j) {
+      _mm_complex_inner_product_ps((1ULL << N), vreals, vimags, (&fmat[midx]), real_ret1, imag_ret1, tmp0, tmp1);
+      midx += (1ULL << (N + 1));
+
+      real_ret1 = _mm256_permutevar8x32_ps(real_ret1, masks[j - 1]);
+      imag_ret1 = _mm256_permutevar8x32_ps(imag_ret1, masks[j - 1]);
+
+      switch (j) {
+      case 1:
+        real_ret = _mm256_blend_ps(real_ret, real_ret1, 0b00000010);
+        imag_ret = _mm256_blend_ps(imag_ret, imag_ret1, 0b00000010);
+        break;
+      case 2:
+        real_ret = _mm256_blend_ps(real_ret, real_ret1, 0b00000100);
+        imag_ret = _mm256_blend_ps(imag_ret, imag_ret1, 0b00000100);
+        break;
+      case 3:
+        real_ret = _mm256_blend_ps(real_ret, real_ret1, 0b00001000);
+        imag_ret = _mm256_blend_ps(imag_ret, imag_ret1, 0b00001000);
+        break;
+      case 4:
+        real_ret = _mm256_blend_ps(real_ret, real_ret1, 0b00010000);
+        imag_ret = _mm256_blend_ps(imag_ret, imag_ret1, 0b00010000);
+        break;
+      case 5:
+        real_ret = _mm256_blend_ps(real_ret, real_ret1, 0b00100000);
+        imag_ret = _mm256_blend_ps(imag_ret, imag_ret1, 0b00100000);
+        break;
+      case 6:
+        real_ret = _mm256_blend_ps(real_ret, real_ret1, 0b01000000);
+        imag_ret = _mm256_blend_ps(imag_ret, imag_ret1, 0b01000000);
+        break;
+      case 7:
+        real_ret = _mm256_blend_ps(real_ret, real_ret1, 0b10000000);
+        imag_ret = _mm256_blend_ps(imag_ret, imag_ret1, 0b10000000);
+        break;
+      }
+    }
+
+    _mm_altstore_complex_ps(real_ret, imag_ret, &fdata[idx * 2], &fdata[idx * 2 + 8]);
+  }
+}
+
+template<size_t N>
+inline void _apply_matrix_float_avx_qLqL( //
+    void* data, //
+    void* mat, //
+    const uint64_t* qregs, // sorted
+    const uint64_t ind0 //
+    ) {
+
+  auto ids_size = (1ULL << N);
+  uint64_t inds[1ULL << N];
+  _fill_indices<N>(ind0, inds, ids_size, qregs);
+
+  __m256i masks[3];
+  __m256 real_ret, imag_ret, real_ret1, imag_ret1;
+  __m256 vreals[1ULL << N], vimags[1ULL << N];
+  __m256 tmp0, tmp1;
+
+  if (qregs[1] == 1) {
+    masks[0] = _mm256_set_epi32(7, 6, 4, 5, 3, 2, 0, 1);
+    masks[1] = _mm256_set_epi32(7, 4, 5, 6, 3, 0, 1, 2);
+    masks[2] = _mm256_set_epi32(4, 6, 5, 7, 0, 2, 1, 3);
+  } else if (qregs[0] == 0) {
+    masks[0] = _mm256_set_epi32(7, 6, 5, 4, 2, 3, 0, 1);
+    masks[1] = _mm256_set_epi32(7, 2, 5, 0, 3, 6, 1, 4);
+    masks[2] = _mm256_set_epi32(2, 6, 0, 4, 3, 7, 1, 5);
+  } else { //if (q0 == 1 && q1 == 2) {
+    masks[0] = _mm256_set_epi32(7, 6, 5, 4, 1, 0, 3, 2);
+    masks[1] = _mm256_set_epi32(7, 6, 1, 0, 3, 2, 5, 4);
+    masks[2] = _mm256_set_epi32(1, 0, 5, 4, 3, 2, 7, 6);
+  }
+
+  float* fdata = (float*) data;
+  float* fmat = (float*) mat;
+
+  for (unsigned i = 0; i < (1ULL << N); i += 4) {
+    auto idx = inds[i];
+    _mm_altload_complex_ps(&fdata[idx * 2], &fdata[idx * 2 + 8], vreals[i], vimags[i]);
+    for (unsigned j = 0; j < 3; ++j) {
+      vreals[i + j + 1] = _mm256_permutevar8x32_ps(vreals[i], masks[j]);
+      vimags[i + j + 1] = _mm256_permutevar8x32_ps(vimags[i], masks[j]);
+    }
+  }
+
+  unsigned midx = 0;
+  for (unsigned i = 0; i < (1ULL << N); i += 4) {
+    auto idx = inds[i];
+    _mm_complex_inner_product_ps((1ULL << N), vreals, vimags, (&fmat[midx]), real_ret, imag_ret, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+
+    for (unsigned j = 0; j < 3; ++j) {
+      _mm_complex_inner_product_ps((1ULL << N), vreals, vimags, (&fmat[midx]), real_ret1, imag_ret1, tmp0, tmp1);
+      midx += (1ULL << (N + 1));
+
+      real_ret1 = _mm256_permutevar8x32_ps(real_ret1, masks[j]);
+      imag_ret1 = _mm256_permutevar8x32_ps(imag_ret1, masks[j]);
+
+      switch (j) {
+      case 0:
+        real_ret = (qregs[1] == 1) ? _mm256_blend_ps(real_ret, real_ret1, 0b00100010) : // (0,1)
+                   (qregs[0] == 0) ? _mm256_blend_ps(real_ret, real_ret1, 0b00001010) : // (0,2)
+                                     _mm256_blend_ps(real_ret, real_ret1, 0b00001100); //  (1,2)
+        imag_ret = (qregs[1] == 1) ? _mm256_blend_ps(imag_ret, imag_ret1, 0b00100010) : // (0,1)
+                   (qregs[0] == 0) ? _mm256_blend_ps(imag_ret, imag_ret1, 0b00001010) : // (0,2)
+                                     _mm256_blend_ps(imag_ret, imag_ret1, 0b00001100); //  (1,2)
+        break;
+      case 1:
+        real_ret = (qregs[1] == 1) ? _mm256_blend_ps(real_ret, real_ret1, 0b01000100) :  // (0,1)
+                   (qregs[0] == 0) ? _mm256_blend_ps(real_ret, real_ret1, 0b01010000) :  // (0,2)
+                                     _mm256_blend_ps(real_ret, real_ret1, 0b00110000); //   (1,2)
+        imag_ret = (qregs[1] == 1) ? _mm256_blend_ps(imag_ret, imag_ret1, 0b01000100) :  // (0,1)
+                   (qregs[0] == 0) ? _mm256_blend_ps(imag_ret, imag_ret1, 0b01010000) :  // (0,2)
+                                     _mm256_blend_ps(imag_ret, imag_ret1, 0b00110000); //   (1,2)
+        break;
+      case 2:
+        real_ret = (qregs[1] == 1) ? _mm256_blend_ps(real_ret, real_ret1, 0b10001000) : // (0,1)
+                   (qregs[0] == 0) ? _mm256_blend_ps(real_ret, real_ret1, 0b10100000) : // (0,2)
+                                     _mm256_blend_ps(real_ret, real_ret1, 0b11000000); //  (1,2)
+        imag_ret = (qregs[1] == 1) ? _mm256_blend_ps(imag_ret, imag_ret1, 0b10001000) : // (0,1)
+                   (qregs[0] == 0) ? _mm256_blend_ps(imag_ret, imag_ret1, 0b10100000) : // (0,2)
+                                     _mm256_blend_ps(imag_ret, imag_ret1, 0b11000000); //  (1,2)
+        break;
+      }
+    }
+    _mm_altstore_complex_ps(real_ret, imag_ret, &fdata[idx * 2], &fdata[idx * 2 + 8]);
+  }
+}
+
+template<size_t N>
+inline void _apply_matrix_float_avx_qL( //
+    void* data, //
+    void* mat, //
+    const uint64_t* qregs, // sorted
+    const uint64_t ind0 //
+    ) {
+
+  auto ids_size = (1ULL << N);
+  uint64_t inds[1ULL << N];
+  _fill_indices<N>(ind0, inds, ids_size, qregs);
+
+  __m256i mask;
+  __m256 real_ret, imag_ret, real_ret1, imag_ret1;
+  __m256 vreals[1ULL << N], vimags[1ULL << N];
+  __m256 tmp0, tmp1;
+
+  if (qregs[0] == 0) {
+    mask = _mm256_set_epi32(6, 7, 4, 5, 2, 3, 0, 1);
+  } else if (qregs[0] == 1) {
+    mask = _mm256_set_epi32(5, 4, 7, 6, 1, 0, 3, 2);
+  } else { //if (q0 == 2) {
+    mask = _mm256_set_epi32(3, 2, 1, 0, 7, 6, 5, 4);
+  }
+
+  float* fdata = (float*) data;
+  float* fmat = (float*) mat;
+
+  for (unsigned i = 0; i < (1ULL << N); i += 2) {
+    auto idx = inds[i];
+    _mm_altload_complex_ps(&fdata[idx * 2], &fdata[idx * 2 + 8], vreals[i], vimags[i]);
+    vreals[i + 1] = _mm256_permutevar8x32_ps(vreals[i], mask);
+    vimags[i + 1] = _mm256_permutevar8x32_ps(vimags[i], mask);
+  }
+
+  unsigned midx = 0;
+  for (unsigned i = 0; i < (1ULL << N); i += 2) {
+    auto idx = inds[i];
+    _mm_complex_inner_product_ps((1ULL << N), vreals, vimags, (&fmat[midx]), real_ret, imag_ret, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+
+    _mm_complex_inner_product_ps((1ULL << N), vreals, vimags, (&fmat[midx]), real_ret1, imag_ret1, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+
+    real_ret1 = _mm256_permutevar8x32_ps(real_ret1, mask);
+    imag_ret1 = _mm256_permutevar8x32_ps(imag_ret1, mask);
+
+    real_ret = (qregs[0] == 0) ? _mm256_blend_ps(real_ret, real_ret1, 0b10101010) : // (0,H,H)
+               (qregs[0] == 1) ? _mm256_blend_ps(real_ret, real_ret1, 0b11001100) : // (1,H,H)
+                                 _mm256_blend_ps(real_ret, real_ret1, 0b11110000); //  (2,H,H)
+    imag_ret = (qregs[0] == 0) ? _mm256_blend_ps(imag_ret, imag_ret1, 0b10101010) : // (0,H,H)
+               (qregs[0] == 1) ? _mm256_blend_ps(imag_ret, imag_ret1, 0b11001100) : // (1,H,H)
+                                 _mm256_blend_ps(imag_ret, imag_ret1, 0b11110000); //  (2,H,H)
+
+    _mm_altstore_complex_ps(real_ret, imag_ret, &fdata[idx * 2], &fdata[idx * 2 + 8]);
+  }
+}
+
+template<size_t N>
+inline void _apply_matrix_float_avx( //
+    void* data, //
+    void* mat, //
+    const uint64_t* qregs, // sorted
+    const uint64_t ind0 //
+    ) {
+
+  auto ids_size = (1ULL << N);
+  uint64_t inds[1ULL << N];
+  _fill_indices<N>(ind0, inds, ids_size, qregs);
+
+  __m256 real_ret, imag_ret;
+  __m256 vreals[1ULL << N], vimags[1ULL << N];
+  __m256 tmp0, tmp1;
+
+  float* fdata = (float*) data;
+  float* fmat = (float*) mat;
+
+  for (unsigned i = 0; i < (1ULL << N); ++i) {
+    auto idx = inds[i];
+    _mm_altload_complex_ps(&fdata[idx * 2], &fdata[idx * 2 + 8], vreals[i], vimags[i]);
+  }
+
+  unsigned midx = 0;
+  for (unsigned i = 0; i < (1ULL << N); ++i) {
+    auto idx = inds[i];
+    _mm_complex_inner_product_ps((1ULL << N), vreals, vimags, (&fmat[midx]), real_ret, imag_ret, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+    _mm_altstore_complex_ps(real_ret, imag_ret, &fdata[idx * 2], &fdata[idx * 2 + 8]);
+  }
+}
+
+template<size_t N>
+inline void _apply_matrix_double_avx_q0q1( //
+    void* data, //
+    void* mat, //
+    const uint64_t* qregs, // sorted
+    const uint64_t ind0 //
+    ) {
+
+  auto ids_size = (1ULL << N);
+  uint64_t inds[1ULL << N];
+  _fill_indices<N>(ind0, inds, ids_size, qregs);
+
+  __m256d real_ret, imag_ret, real_ret1, imag_ret1;
+  __m256d vreals[1ULL << N], vimags[1ULL << N];
+  __m256d tmp0, tmp1;
+
+  double* ddata = (double*) data;
+  double* dmat = (double*) mat;
+
+  for (unsigned i = 0; i < ids_size; i += 4) {
+    auto idx = inds[i];
+    _mm_altload_complex_pd(&ddata[idx * 2], &ddata[idx * 2 + 4], vreals[i], vimags[i]);
+    for (unsigned j = 1; j < 4; ++j) {
+      switch (j) {
+      case 1:
+        vreals[i + j] = _mm256_permute4x64_pd(vreals[i], perm_d_q0q1_0);
+        vimags[i + j] = _mm256_permute4x64_pd(vimags[i], perm_d_q0q1_0);
+        break;
+      case 2:
+        vreals[i + j] = _mm256_permute4x64_pd(vreals[i], perm_d_q0q1_1);
+        vimags[i + j] = _mm256_permute4x64_pd(vimags[i], perm_d_q0q1_1);
+        break;
+      case 3:
+        vreals[i + j] = _mm256_permute4x64_pd(vreals[i], perm_d_q0q1_2);
+        vimags[i + j] = _mm256_permute4x64_pd(vimags[i], perm_d_q0q1_2);
+        break;
+      }
+    }
+  }
+
+  unsigned midx = 0;
+  for (unsigned i = 0; i < ids_size; i += 4) {
+    auto idx = inds[i];
+    _mm_complex_inner_product_pd((1ULL << N), vreals, vimags, (&dmat[midx]), real_ret, imag_ret, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+    for (unsigned j = 1; j < 4; ++j) {
+      _mm_complex_inner_product_pd((1ULL << N), vreals, vimags, (&dmat[midx]), real_ret1, imag_ret1, tmp0, tmp1);
+      midx += (1ULL << (N + 1));
+      switch (j) {
+      case 1:
+        real_ret1 = _mm256_permute4x64_pd(real_ret1, perm_d_q0q1_0);
+        imag_ret1 = _mm256_permute4x64_pd(imag_ret1, perm_d_q0q1_0);
+        real_ret = _mm256_blend_pd(real_ret, real_ret1, 0b0010);
+        imag_ret = _mm256_blend_pd(imag_ret, imag_ret1, 0b0010);
+        break;
+      case 2:
+        real_ret1 = _mm256_permute4x64_pd(real_ret1, perm_d_q0q1_1);
+        imag_ret1 = _mm256_permute4x64_pd(imag_ret1, perm_d_q0q1_1);
+        real_ret = _mm256_blend_pd(real_ret, real_ret1, 0b0100);
+        imag_ret = _mm256_blend_pd(imag_ret, imag_ret1, 0b0100);
+        break;
+      case 3:
+        real_ret1 = _mm256_permute4x64_pd(real_ret1, perm_d_q0q1_2);
+        imag_ret1 = _mm256_permute4x64_pd(imag_ret1, perm_d_q0q1_2);
+        real_ret = _mm256_blend_pd(real_ret, real_ret1, 0b1000);
+        imag_ret = _mm256_blend_pd(imag_ret, imag_ret1, 0b1000);
+        break;
+      }
+    }
+    _mm_altstore_complex_pd(real_ret, imag_ret, &ddata[idx * 2], &ddata[idx * 2 + 4]);
+  }
+}
+
+template<size_t N>
+inline void _apply_matrix_double_avx_qL( //
+    void* data, //
+    void* mat, //
+    const uint64_t* qregs, // sorted
+    const uint64_t ind0 //
+    ) {
+
+  auto ids_size = (1ULL << N);
+  uint64_t inds[1ULL << N];
+  _fill_indices<N>(ind0, inds, ids_size, qregs);
+
+  __m256d real_ret, imag_ret, real_ret1, imag_ret1;
+  __m256d vreals[1ULL << N], vimags[1ULL << N];
+  __m256d tmp0, tmp1;
+
+  double* ddata = (double*) data;
+  double* dmat = (double*) mat;
+
+  for (unsigned i = 0; i < ids_size; i += 2) {
+    auto idx = inds[i];
+    _mm_altload_complex_pd(&ddata[idx * 2], &ddata[idx * 2 + 4], vreals[i], vimags[i]);
+    if (qregs[0] == 0) {
+      vreals[i + 1] = _mm256_permute4x64_pd(vreals[i], perm_d_q0);
+      vimags[i + 1] = _mm256_permute4x64_pd(vimags[i], perm_d_q0);
+    } else {
+      vreals[i + 1] = _mm256_permute4x64_pd(vreals[i], perm_d_q1);
+      vimags[i + 1] = _mm256_permute4x64_pd(vimags[i], perm_d_q1);
+    }
+  }
+
+  unsigned midx = 0;
+  for (unsigned i = 0; i < ids_size; i += 2) {
+    auto idx = inds[i];
+    _mm_complex_inner_product_pd(ids_size, vreals, vimags, (&dmat[midx]), real_ret, imag_ret, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+
+    _mm_complex_inner_product_pd(ids_size, vreals, vimags, (&dmat[midx]), real_ret1, imag_ret1, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+
+    if (qregs[0] == 0) {
+      real_ret1 = _mm256_permute4x64_pd(real_ret1, perm_d_q0);
+      imag_ret1 = _mm256_permute4x64_pd(imag_ret1, perm_d_q0);
+      real_ret = _mm256_blend_pd(real_ret, real_ret1, 0b1010);
+      imag_ret = _mm256_blend_pd(imag_ret, imag_ret1, 0b1010);
+    } else {
+      real_ret1 = _mm256_permute4x64_pd(real_ret1, perm_d_q1);
+      imag_ret1 = _mm256_permute4x64_pd(imag_ret1, perm_d_q1);
+      real_ret = _mm256_blend_pd(real_ret, real_ret1, 0b1100);
+      imag_ret = _mm256_blend_pd(imag_ret, imag_ret1, 0b1100);
+    }
+
+    _mm_altstore_complex_pd(real_ret, imag_ret, &ddata[idx * 2], &ddata[idx * 2 + 4]);
+  }
+}
+
+template<size_t N>
+inline void _apply_matrix_double_avx( //
+    void* data, //
+    void* mat, //
+    const uint64_t* qregs, // sorted
+    const uint64_t ind0 //
+    ) {
+
+  auto ids_size = (1ULL << N);
+  uint64_t inds[1ULL << N];
+  _fill_indices<N>(ind0, inds, ids_size, qregs);
+
+  __m256d real_ret, imag_ret;
+  __m256d vreals[1ULL << N], vimags[1ULL << N];
+  __m256d tmp0, tmp1;
+
+  double* ddata = (double*) data;
+  double* dmat = (double*) mat;
+
+  for (unsigned i = 0; i < ids_size; ++i) {
+    auto idx = inds[i];
+    _mm_altload_complex_pd(&ddata[idx * 2], &ddata[idx * 2 + 4], vreals[i], vimags[i]);
+  }
+
+  unsigned midx = 0;
+  for (unsigned i = 0; i < ids_size; ++i) {
+    auto idx = inds[i];
+    _mm_complex_inner_product_pd(ids_size, vreals, vimags, (&dmat[midx]), real_ret, imag_ret, tmp0, tmp1);
+    midx += (1ULL << (N + 1));
+    _mm_altstore_complex_pd(real_ret, imag_ret, &ddata[idx * 2], &ddata[idx * 2 + 4]);
+  }
+}
+
+const uint64_t _MASKS[] = {  //
+    0ULL, 1ULL, 3ULL, 7ULL,  //
+        15ULL, 31ULL, 63ULL, 127ULL,  //
+        255ULL, 511ULL, 1023ULL, 2047ULL,  //
+        4095ULL, 8191ULL, 16383ULL, 32767ULL,  //
+        65535ULL, 131071ULL, 262143ULL, 524287ULL,  //
+        1048575ULL, 2097151ULL, 4194303ULL, 8388607ULL,  //
+        16777215ULL, 33554431ULL, 67108863ULL, 134217727ULL,  //
+        268435455ULL, 536870911ULL, 1073741823ULL, 2147483647ULL,  //
+        4294967295ULL, 8589934591ULL, 17179869183ULL, 34359738367ULL,  //
+        68719476735ULL, 137438953471ULL, 274877906943ULL, 549755813887ULL,  //
+        1099511627775ULL, 2199023255551ULL, 4398046511103ULL, 8796093022207ULL,  //
+        17592186044415ULL, 35184372088831ULL, 70368744177663ULL, 140737488355327ULL,  //
+        281474976710655ULL, 562949953421311ULL, 1125899906842623ULL, 2251799813685247ULL,  //
+        4503599627370495ULL, 9007199254740991ULL, 18014398509481983ULL, 36028797018963967ULL,  //
+        72057594037927935ULL, 144115188075855871ULL, 288230376151711743ULL, 576460752303423487ULL,  //
+        1152921504606846975ULL, 2305843009213693951ULL, 4611686018427387903ULL, 9223372036854775807ULL  //
+    };
+
+template<size_t N>
+inline uint64_t index0(  //
+    const uint64_t* qubits, // sorted
+    const uint64_t k) {
+  uint64_t lowbits, retval = k;
+  for (size_t j = 0; j < N; j++) {
+    lowbits = retval & _MASKS[qubits[j]];
+    retval >>= qubits[j];
+    retval <<= qubits[j] + 1;
+    retval |= lowbits;
+  }
+  return retval;
+}
+
+template<size_t N, typename Lambda, typename param_t>
+void _apply_lambda( //
+    uint64_t data_size, //
+    const uint64_t skip, //
+    Lambda&& func, //
+    const uint64_t* qubits, // sorted
+    const unsigned omp_threads, //
+    const param_t &params) {
+
+  const int64_t END = data_size >> N;
+
+#pragma omp parallel for if (omp_threads > 1) num_threads(omp_threads)
+  for (int64_t k = 0; k < END; k += skip) {
+    const auto idx = index0<N>(qubits, k);
+    std::forward <Lambda> (func)(idx, params);
+  }
+}
+
+template<size_t N, typename data_t>
+inline void _reorder(const uint64_t* qreg_orig, uint64_t* qreg, data_t* fmat) {
+  auto dim = (1ULL << N);
+
+  // sort qreg_org
+  for (unsigned i = 0; i < N; ++i) {
+    for (unsigned j = 0; j < N - 1 - i; ++j) {
+      if (qreg[j] > qreg[j + 1]) {
+        auto tmp = qreg[j];
+        qreg[j] = qreg[j + 1];
+        qreg[j + 1] = tmp;
+      }
+    }
+  }
+
+  unsigned masks[N];
+
+  for (size_t i = 0; i < N; ++i)
+    for (size_t j = 0; j < N; ++j)
+      if (qreg_orig[i] == qreg[j])
+        masks[i] = 1U << j;
+
+  size_t indexes[1U << N];
+  for (size_t i = 0; i < dim; ++i) {
+    size_t index = 0U;
+    for (size_t j = 0; j < N; ++j) {
+      if (i & (1U << j))
+        index |= masks[j];
+    }
+    indexes[i] = index;
+  }
+
+  data_t fmat_org[1 << (N * 2 + 1)];
+  for (size_t i = 0; i < dim * dim * 2; ++i)
+    fmat_org[i] = fmat[i];
+
+  for (unsigned i = 0; i < dim; ++i) {
+    for (unsigned j = 0; j < dim; ++j) {
+      unsigned oldidx = i * dim + j;
+      unsigned newidx = indexes[i] * dim + indexes[j];
+      fmat[newidx * 2] = fmat_org[oldidx * 2];
+      fmat[newidx * 2 + 1] = fmat_org[oldidx * 2 + 1];
+    }
+  }
+}
+
+template<size_t N>
+inline bool _apply_matrix_float(  //
+    void * _data, //
+    uint64_t data_size, //
+    const uint64_t* qregs_,
+    const void* mat, //
+    const unsigned omp_threads //
+    ) {
+  if (data_size <= 8)
+    return false;
+
+  float* data = (float*) _data;
+  float* fmat_orig = (float*) mat;
+
+  float fmat[(1 << (N * 2 + 1))];
+  // memcpy(fmat, mat, sizeof(float) * (1 << (N * 2 + 1)));
+  for (auto i = 0; i < (1 << (N * 2 + 1)); ++i)
+    fmat[i] = fmat_orig[i];
+
+// transpose
+  for (size_t i = 0; i < (1U << N); ++i) {
+    for (size_t j = 0; j < (1U << N); ++j) {
+      fmat[(i * (1U << N) + j) * 2] = fmat_orig[(j * (1U << N) + i) * 2];
+      fmat[(i * (1U << N) + j) * 2 + 1] = fmat_orig[(j * (1U << N) + i) * 2 + 1];
+    }
+  }
+
+  uint64_t qregs[N];
+  // memcpy(qregs, qregs_, sizeof(uint64_t) * N);
+  for (size_t i = 0; i < N; ++i)
+    qregs[i] = qregs_[i];
+
+  if (N > 1) {
+    _reorder<N>(qregs_, qregs, fmat);
+  }
+
+  if (N > 2 && qregs[2] == 2) {
+    auto lambda = [&](const uint64_t ids0, float* _fmat)->void {
+      _apply_matrix_float_avx_q0q1q2<N>(data, _fmat, qregs, ids0);
+    };
+    _apply_lambda<N>(data_size, 1, lambda, qregs, omp_threads, (float*) fmat);
+  } else if (N > 1 && qregs[1] < 3) {
+    auto lambda = [&](const uint64_t ids0, float* _fmat)->void {
+      _apply_matrix_float_avx_qLqL<N>(data, _fmat, qregs, ids0);
+    };
+    _apply_lambda<N>(data_size, 2, lambda, qregs, omp_threads, (float*) fmat);
+  } else if (qregs[0] < 3) {
+    auto lambda = [&](const uint64_t ids0, float* _fmat)->void {
+      _apply_matrix_float_avx_qL<N>(data, _fmat, qregs, ids0);
+    };
+    _apply_lambda<N>(data_size, 4, lambda, qregs, omp_threads, (float*) fmat);
+  } else {
+    auto lambda = [&](const uint64_t ids0, float* _fmat)->void {
+      _apply_matrix_float_avx<N>(data, _fmat, qregs, ids0);
+    };
+    _apply_lambda<N>(data_size, 8, lambda, qregs, omp_threads, (float*) fmat);
+  }
+  return true;
+}
+
+template<size_t N>
+inline bool _apply_matrix_double(  //
+    void * _data, //
+    uint64_t data_size, //
+    const uint64_t* qregs_,
+    const void* mat, //
+    const unsigned omp_threads //
+    ) {
+  if (data_size <= 4)
+    return false;
+
+  double* dmat_orig = (double*) mat;
+
+  double dmat[(1 << (N * 2 + 1))];
+  // memcpy(dmat, mat, sizeof(uint64_t) * (1 << (N * 2 + 1)));
+  for (auto i = 0; i < (1 << (N * 2 + 1)); ++i)
+    dmat[i] = dmat_orig[i];
+
+// transpose
+  for (size_t i = 0; i < (1U << N); ++i) {
+    for (size_t j = 0; j < (1U << N); ++j) {
+      dmat[(i * (1U << N) + j) * 2] = dmat_orig[(j * (1U << N) + i) * 2];
+      dmat[(i * (1U << N) + j) * 2 + 1] = dmat_orig[(j * (1U << N) + i) * 2 + 1];
+    }
+  }
+
+  uint64_t qregs[N];
+  // memcpy(qregs, qregs_, sizeof(uint64_t) * N);
+  for (size_t i = 0; i < N; ++i)
+    qregs[i] = qregs_[i];
+  if (N > 1) {
+    _reorder<N>(qregs_, qregs, dmat);
+  }
+
+  double* data = (double*) _data;
+
+  if (N > 1 && qregs[1] == 1) {
+    auto lambda = [&](const uint64_t ids0, double* _dmat)->void {
+      _apply_matrix_double_avx_q0q1<N>(data, _dmat, qregs, ids0);
+    };
+    _apply_lambda<N>(data_size, 1, lambda, qregs, omp_threads, (double*) dmat);
+  } else if (qregs[0] < 2) {
+    auto lambda = [&](const uint64_t ids0, double* _dmat)->void {
+      _apply_matrix_double_avx_qL<N>(data, _dmat, qregs, ids0);
+    };
+    _apply_lambda<N>(data_size, 2, lambda, qregs, omp_threads, (double*) dmat);
+  } else {
+    auto lambda = [&](const uint64_t ids0, double* _dmat)->void {
+      _apply_matrix_double_avx<N>(data, _dmat, qregs, ids0);
+    };
+    _apply_lambda<N>(data_size, 4, lambda, qregs, omp_threads, (double*) dmat);
+  }
+  return true;
+}
+
+template<typename data_t, size_t N>
+inline bool apply_matrix_avx( //
+    void * qv_data, //
+    uint64_t data_size, //
+    const uint64_t* qregs,
+    const void* mat, //
+    const unsigned omp_threads //
+    ) {
+  if (sizeof(data_t) == sizeof(float)) {
+    return _apply_matrix_float<N>(qv_data, data_size, qregs, mat, omp_threads);
+  } else {
+    return _apply_matrix_double<N>(qv_data, data_size, qregs, mat, omp_threads);
+  }
+}
+
+template<typename data_t>
+inline bool apply_matrix_avx( //
+    void * qv_data, //
+    uint64_t data_size, //
+    const uint64_t* qregs, //
+    const uint64_t qregs_size, //
+    const void* mat, //
+    const unsigned omp_threads //
+    ) {
+  switch (qregs_size) {
+  case 1:
+    return apply_matrix_avx<data_t, 1>(qv_data, data_size, qregs, mat, omp_threads);
+  case 2:
+    return apply_matrix_avx<data_t, 2>(qv_data, data_size, qregs, mat, omp_threads);
+  case 3:
+    return apply_matrix_avx<data_t, 3>(qv_data, data_size, qregs, mat, omp_threads);
+  case 4:
+    return apply_matrix_avx<data_t, 4>(qv_data, data_size, qregs, mat, omp_threads);
+  case 5:
+    return apply_matrix_avx<data_t, 5>(qv_data, data_size, qregs, mat, omp_threads);
+  case 6:
+    return apply_matrix_avx<data_t, 6>(qv_data, data_size, qregs, mat, omp_threads);
+  default:
+    return false;
+  }
+}
+
+inline bool is_avx2_supported() {
+  static bool cached = false;
+  static bool is_supported = false;
+  if (cached)
+    return is_supported;
+
+  int cpui[4] = {0};
+  ccpuid(cpui, 0);
+  auto num_ids = cpui[0];
+  if (num_ids < 7) {
+    cached = true;
+    is_supported = false;
+    return false;
+  }
+
+  //check fma
+  cpuidex(cpui, 1, 0);
+  if (!(cpui[2] & (1 << 1))) {
+    cached = true;
+    is_supported = false;
+    return false;
+  }
+
+  //check AVX2
+  cpuidex(cpui, 7, 0);
+  if (!(cpui[1] & (1 << 5))) {
+    cached = true;
+    is_supported = false;
+    return false;
+  }
+
+  cached = true;
+  is_supported = true;
+  return is_supported;
+}
+
+} // namespace QV
+#endif


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is a revised version of #684 .

### Details and comments
Python:
`src/simulators/statevector/qvintrin.cpp` is compiled with `-mfma -favx2 -DQV_AVX_ISOLATION`.
`qiskit/providers/aer/backends/wrappers/bindings.cc` is compiled with `-DQV_AVX_ISOLATION`
Then, `bindings.cc` does not call any AVX and FMA if platform does not support them by checking CPU types.

Standalone:
`contrib/standalone/qasm_simulator.cpp` is compled with `-mfma -favx2` because standalone will be compiled on machines that run them.

If `__AVX2__` is not defined, AVX impl is not called in Intel platform and is not compiled in other platform.