### PR TITLE
Remove terra from the setup_requirements list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,10 @@ except ImportError:
 
 import setuptools
 
-requirements = [
-    'qiskit-terra>=0.12.0',
+# These are requirements that are both runtime/install dependencies and
+# also build time/setup requirements and will be added to both lists
+# of requirements
+common_requirements = [
     'numpy>=1.16.3;python_version>"3.5"',
     'numpy>=1.16.3,<1.19.0;python_version<"3.6"',
     'scipy>=1.0;python_version>"3.5"',
@@ -40,11 +42,13 @@ requirements = [
                      # This should be fixed in the CMake build files.
 ]
 
-setup_requirements = requirements + [
+setup_requirements = common_requirements + [
     'scikit-build',
     'cmake!=3.17,!=3.17.0',
     'conan>=1.22.2'
 ]
+
+requirements = common_requirements + ['qiskit-terra>=0.12.0']
 
 if not hasattr(setuptools,
                'find_namespace_packages') or not inspect.ismethod(


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since qiskit-terra was added to the install time requirements list
in #593 we've been incorrectly listing qiskit-terra as a build time
dependency. That's because since #547 we've been listing our install
time requirements as also build time requirements (which at the time
that #547 was merged was true). This is still largely true as
qiskit-terra is the only install time requirement that isn't required
for building aer. However, forcing terra as a build time dependency
complicates the build process since it pulls in a large number of
external dependencies which may not be supported in a dedicated build
environment (see piwheels/packages#132 for an example of this). To
simplify the requirements for just building aer and to make it clear
what is actually required for building vs runtime dependencies this
commit splits out the common requirements into a shared list between
setup_requirements and install requirements. Then terra is explicitly
added to only the install requirements list.

### Details and comments