### PR TITLE
Move stestr to top of requirements list

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+stestr>=2.5.0
 cmake!=3.17.1,!=3.17.0
 conan>=1.22.2
 scikit-build
@@ -11,5 +12,4 @@ sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-automodapi
 jupyter-sphinx;python_version<'3.8'
-stestr>=2.5.0
 reno>=3.1.0;python_version>'3.5'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The latest stevedore version 3.0.0 was released on July 10, 2020 and
introduced a new minimum version of importlib-metadata. Stevedore gets
pulled in as a 3rd level transitive dependency from stestr. However,
because of the lack of a pip dependency solver the version of
importlib-metadata is not getting updated. We started running pip check
in #668 to catch issues like this because pip will be introducing a
dependency solver at some point later this year so we wanted to be
prepared for this. To attempt to solve this issue this commit moves
stestr to the top of the requirements list to try and make pip behave
correctly and upgrade importlib-metadata before other dependencies
(which have a lower requirement). If this does not work a follow will
just pin stevedore in the constraints file (which is what the
constraints file is for).

### Details and comments