### PR TITLE
Remove compiler warnings on the 1 shifts when compiling with windows.

### DIFF
--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -696,7 +696,7 @@ QasmController::Method QasmController::simulation_method(
       // times slow than a single shot of statevector due the increased
       // dimension
       if (noise_model.has_quantum_errors() &&
-          circ.shots > (1 << circ.num_qubits) &&
+          circ.shots > (1ULL << circ.num_qubits) &&
           validate_memory_requirements(DensityMatrix::State<>(), circ, false) &&
           validate_state(DensityMatrix::State<>(), circ, noise_model, false) &&
           check_measure_sampling_opt(circ, Method::density_matrix)) {

--- a/src/noise/quantum_error.hpp
+++ b/src/noise/quantum_error.hpp
@@ -222,7 +222,7 @@ void QuantumError::set_from_kraus(const std::vector<cmatrix_t> &mats) {
   size_t mat_dim = mats[0].GetRows();
   auto num_qubits = static_cast<unsigned>(std::log2(mat_dim));
   set_num_qubits(num_qubits);
-  if (mat_dim != 1UL << num_qubits)
+  if (mat_dim != 1ULL << num_qubits)
     throw std::invalid_argument("QuantumError: Kraus channel input is a multi-qubit channel.");
 
   // Check if each matrix is a:
@@ -325,7 +325,7 @@ const cmatrix_t& QuantumError::superoperator() const {
 
 void QuantumError::compute_superoperator() {
   // Initialize superoperator matrix to correct size
-  size_t dim = 1 << (2 * get_num_qubits());
+  size_t dim = 1ULL << (2 * get_num_qubits());
   superoperator_.initialize(dim, dim);
   // We use the superoperator simulator state to do this
   QubitSuperoperator::State<> superop;

--- a/src/simulators/extended_stabilizer/chlib/core.hpp
+++ b/src/simulators/extended_stabilizer/chlib/core.hpp
@@ -611,7 +611,7 @@ void Print(uint_fast64_t x, unsigned n)
 {
   for (unsigned i=0; i<n; i++)
   {
-    std::cout<<( (x & (1UL << i) ) >0);
+    std::cout<<( (x & (1ULL << i) ) >0);
   }
   std::cout<<std::endl;
 }

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -147,7 +147,7 @@ uint_t reorder_qubits(const reg_t qubits, uint_t index) {
   uint_t num_qubits = qubits.size();
   for (uint_t i=0; i<num_qubits; i++) {
     current_pos = num_qubits-1-qubits[i];
-    current_val = 0x1 << current_pos;
+    current_val = 1ULL << current_pos;
     new_pos = num_qubits-1-i;
     shift = new_pos - current_pos;
     if (index & current_val) {

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -1081,7 +1081,7 @@ void QubitVector<data_t, Derived>::apply_diagonal_matrix(const reg_t &qubits,
       int_t iv = 0;
       for (int_t j = 0; j < qubits.size(); j++)
         if ((k & (1ULL << qubits[j])) != 0)
-          iv += (1 << j);
+          iv += (1ULL << j);
       if (_diag[iv] != (data_t) 1.0)
         data_[k] *= _diag[iv];
     }

--- a/src/simulators/statevector/qv_avx2.cpp
+++ b/src/simulators/statevector/qv_avx2.cpp
@@ -52,9 +52,9 @@ inline void fill_indices(uint64_t index0,
     indexes[i] = index0;
 
   for (size_t n = 0; n < num_qubits; ++n)
-    for (size_t i = 0; i < indexes_size; i += (1 << (n + 1)))
+    for (size_t i = 0; i < indexes_size; i += (1ULL << (n + 1)))
       for (size_t j = 0; j < (1ULL << n); ++j)
-        indexes[i + j + (1U << n)] += (1ULL << qregs[n]);
+        indexes[i + j + (1ULL << n)] += (1ULL << qregs[n]);
 }
 
 const uint64_t MASKS[] = {0ULL,
@@ -388,7 +388,7 @@ inline void reorder(const uint64_t* qreg_orig, uint64_t* qreg, FloatType* mat) {
     for (size_t i = 0; i < num_qubits; ++i)
       for (size_t j = 0; j < num_qubits; ++j)
         if (qreg_orig[i] == qreg[j])
-          masks[i] = 1U << j;
+          masks[i] = 1ULL << j;
   };
   size_t masks[num_qubits];
   build_mask(masks);
@@ -397,7 +397,7 @@ inline void reorder(const uint64_t* qreg_orig, uint64_t* qreg, FloatType* mat) {
     for (size_t i = 0; i < DIMENSION; ++i) {
       size_t index = 0U;
       for (size_t j = 0; j < num_qubits; ++j) {
-        if (i & (1U << j))
+        if (i & (1ULL << j))
           index |= masks[j];
       }
       indexes[i] = index;


### PR DESCRIPTION
### Summary
Replaced the 1 << to 1ULL << to fix compiler warnings.

### Details and comments
Replaced the 1 << uint_t to 1ULL << uint_t, because uint_t is a 64 bit type.
1 << therefore does a shift on a 32 bit number, which then is converted to a 64 bit number.
Only simulation with more than 33 qubits would notice.
