### PR TITLE
Reduce precision on test_qubit_lo_from_configurable_backend

### DIFF
--- a/test/terra/pulse/test_system_models.py
+++ b/test/terra/pulse/test_system_models.py
@@ -159,7 +159,7 @@ class TestPulseSystemModel(BaseTestPulseSystemModel):
         qubit_lo_from_hamiltonian = test_model.hamiltonian.get_qubit_lo_from_drift()
         freqs = test_model.calculate_channel_frequencies(qubit_lo_from_hamiltonian)
         expected = getattr(backend.configuration(), 'hamiltonian')['vars']['wq0'] / (2 * np. pi)
-        self.assertAlmostEqual(freqs['D0'], expected)
+        self.assertAlmostEqual(freqs['D0'], expected, places=6)
 
     def _compute_u_lo_freqs(self, qubit_lo_freq):
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

test_qubit_lo_from_configurable_backend has started failing recently
because of the fake backends in terra which caused the expectations to
be subtely off from the expected value. This commit reduces the
precision of the assertion between the expected value and the result to
only check 6 decimal places which should be sufficient for testing and
unblock the failure caused by the changes in terra.

### Details and comments