### PR TITLE
Versions of GCC before 9.1 lack the assignment operator in strstream.…

### DIFF
--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -1508,7 +1508,7 @@ std::string bin2hex(std::string str, bool prefix) {
     hex += part;
     // Add any additional chunks
     for (size_t j=1; j < chunks; ++j) {
-      ss = std::stringstream(); // clear string stream
+      std::stringstream ss; // clear string stream
       ss << std::hex << std::stoull(str.substr(remain + j * bin_block, bin_block), nullptr, 2);
       part = ss.str();
       part.insert(0, hex_block - part.size(), '0');


### PR DESCRIPTION
…  Use a scoped constructor instead of an assignment.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Versions of GCC before 9.1 did not declare an assignment operator for strstream.   Avoid the need for that by using a locally scoped constructor.

### Details and comments


