### PR TITLE
Add gate fusion to StatevectorSimulator and UnitarySimulator

### DIFF
--- a/releasenotes/notes/0.6/gate-fusion-4f208fd824ccaf3b.yaml
+++ b/releasenotes/notes/0.6/gate-fusion-4f208fd824ccaf3b.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Enable the gate-fusion circuit optimization from the 
+    :class:`qiskit.providers.aer.QasmSimulator` in both the
+    :class:`qiskit.providers.aer.StatevectorSimulator` and
+    :class:`qiskit.providers.aer.UnitarySimulator` backends.

--- a/src/controllers/statevector_controller.hpp
+++ b/src/controllers/statevector_controller.hpp
@@ -303,13 +303,11 @@ void StatevectorController::run_circuit_helper(
   data.set_config(config);
 
   // Optimize circuit
-  const std::vector<Operations::Op>* op_ptr = nullptr;
-  Circuit opt_circ;
-  Transpile::Fusion fusion_pass(5, 20);
+  const std::vector<Operations::Op>* op_ptr = &circ.ops;
+  Transpile::Fusion fusion_pass(5, 20); // 20-qubit default threshold
   fusion_pass.set_config(config);
-  if (circ.num_qubits < fusion_pass.threshold || !fusion_pass.active) {
-    op_ptr = &circ.ops;
-  } else {
+  Circuit opt_circ;
+  if (fusion_pass.active && circ.num_qubits >= fusion_pass.threshold) {
     opt_circ = circ; // copy circuit
     Noise::NoiseModel dummy_noise; // dummy object for transpile pass
     fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);

--- a/src/controllers/statevector_controller.hpp
+++ b/src/controllers/statevector_controller.hpp
@@ -18,6 +18,7 @@
 #include "controller.hpp"
 #include "simulators/statevector/statevector_state.hpp"
 #include "simulators/statevector/qubitvector_avx2.hpp"
+#include "transpile/fusion.hpp"
 
 namespace AER {
 namespace Simulator {
@@ -301,13 +302,28 @@ void StatevectorController::run_circuit_helper(
   // Output data container
   data.set_config(config);
 
+  // Optimize circuit
+  const std::vector<Operations::Op>* op_ptr = nullptr;
+  Circuit opt_circ;
+  Transpile::Fusion fusion_pass(5, 20);
+  fusion_pass.set_config(config);
+  if (circ.num_qubits < fusion_pass.threshold || !fusion_pass.active) {
+    op_ptr = &circ.ops;
+  } else {
+    opt_circ = circ; // copy circuit
+    Noise::NoiseModel dummy_noise; // dummy object for transpile pass
+    fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
+    op_ptr = &opt_circ.ops;
+  }
+
   // Run single shot collecting measure data or snapshots
-  if (initial_state_.empty())
+  if (initial_state_.empty()) {
     state.initialize_qreg(circ.num_qubits);
-  else
+  } else {
     state.initialize_qreg(circ.num_qubits, initial_state_);
+  }
   state.initialize_creg(circ.num_memory, circ.num_registers);
-  state.apply_ops(circ.ops, data, rng);
+  state.apply_ops(*op_ptr, data, rng);
   state.add_creg_to_data(data);
 
   // Add final state to the data

--- a/src/controllers/unitary_controller.hpp
+++ b/src/controllers/unitary_controller.hpp
@@ -17,6 +17,7 @@
 
 #include "controller.hpp"
 #include "simulators/unitary/unitary_state.hpp"
+#include "transpile/fusion.hpp"
 
 namespace AER {
 namespace Simulator {
@@ -290,13 +291,28 @@ void UnitaryController::run_circuit_helper(
   data.set_config(config);
   data.add_metadata("method", state.name());
 
+  // Optimize circuit
+  const std::vector<Operations::Op>* op_ptr = nullptr;
+  Circuit opt_circ;
+  Transpile::Fusion fusion_pass(5, 10); // 10-qubit default threshold
+  fusion_pass.set_config(config);
+  if (circ.num_qubits < fusion_pass.threshold || !fusion_pass.active) {
+    op_ptr = &circ.ops;
+  } else {
+    opt_circ = circ; // copy circuit
+    Noise::NoiseModel dummy_noise; // dummy object for transpile pass
+    fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
+    op_ptr = &opt_circ.ops;
+  }
+
   // Run single shot collecting measure data or snapshots
-  if (initial_unitary_.empty())
+  if (initial_unitary_.empty()) {
     state.initialize_qreg(circ.num_qubits);
-  else
+  } else {
     state.initialize_qreg(circ.num_qubits, initial_unitary_);
+  }
   state.initialize_creg(circ.num_memory, circ.num_registers);
-  state.apply_ops(circ.ops, data, rng);
+  state.apply_ops(*op_ptr, data, rng);
   state.add_creg_to_data(data);
 
   // Add final state unitary to the data

--- a/src/controllers/unitary_controller.hpp
+++ b/src/controllers/unitary_controller.hpp
@@ -292,13 +292,11 @@ void UnitaryController::run_circuit_helper(
   data.add_metadata("method", state.name());
 
   // Optimize circuit
-  const std::vector<Operations::Op>* op_ptr = nullptr;
-  Circuit opt_circ;
+  const std::vector<Operations::Op>* op_ptr = &circ.ops;
   Transpile::Fusion fusion_pass(5, 10); // 10-qubit default threshold
   fusion_pass.set_config(config);
-  if (circ.num_qubits < fusion_pass.threshold || !fusion_pass.active) {
-    op_ptr = &circ.ops;
-  } else {
+  Circuit opt_circ;
+  if (fusion_pass.active && circ.num_qubits >= fusion_pass.threshold) {
     opt_circ = circ; // copy circuit
     Noise::NoiseModel dummy_noise; // dummy object for transpile pass
     fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);

--- a/test/terra/backends/statevector_simulator/statevector_fusion.py
+++ b/test/terra/backends/statevector_simulator/statevector_fusion.py
@@ -1,0 +1,125 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+StatevectorSimulator Gate Fusion Tests
+"""
+from qiskit import assemble, transpile
+from qiskit.circuit.library import QuantumVolume
+from qiskit.quantum_info import Statevector
+from qiskit.providers.aer import StatevectorSimulator
+
+
+class StatevectorFusionTests:
+    """StatevectorSimulator fusion tests."""
+
+    SIMULATOR = StatevectorSimulator()
+
+    def fusion_options(self, enabled=None, threshold=None, verbose=None):
+        """Return default backend_options dict."""
+        backend_options = self.BACKEND_OPTS.copy()
+        if enabled is not None:
+            backend_options['fusion_enable'] = enabled
+        if verbose is not None:
+            backend_options['fusion_verbose'] = verbose
+        if threshold is not None:
+            backend_options['fusion_threshold'] = threshold
+        return backend_options
+
+    def fusion_metadata(self, result):
+        """Return fusion metadata dict"""
+        metadata = result.results[0].metadata
+        return metadata.get('fusion', {})
+
+    def test_fusion_theshold(self):
+        """Test fusion threhsold settings work."""
+        seed = 12345
+        threshold = 4
+        backend_options = self.fusion_options(enabled=True, threshold=threshold)
+
+        with self.subTest(msg='below fusion threshold'):
+            circuit = QuantumVolume(threshold - 1, seed=seed)
+            circuit = transpile(circuit, self.SIMULATOR)
+            qobj = assemble([circuit], shots=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertFalse(meta.get('applied'))
+
+        with self.subTest(msg='at fusion threshold'):
+            circuit = QuantumVolume(threshold, seed=seed)
+            circuit = transpile(circuit, self.SIMULATOR)
+            qobj = assemble([circuit], shots=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertTrue(meta.get('applied'))
+
+        with self.subTest(msg='above fusion threshold'):
+            circuit = QuantumVolume(threshold + 1, seed=seed)
+            circuit = transpile(circuit, self.SIMULATOR)
+            qobj = assemble([circuit], shots=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertTrue(meta.get('applied'))
+
+    def test_fusion_disable(self):
+        """Test Fusion enable/disable option"""
+        seed = 2233
+        circuit = QuantumVolume(4, seed=seed)
+        circuit = transpile(circuit, self.SIMULATOR)
+        qobj = assemble([circuit], shots=1)
+
+        with self.subTest(msg='test fusion enable'):
+            backend_options = self.fusion_options(enabled=True, threshold=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertTrue(meta.get('applied'))
+
+        with self.subTest(msg='test fusion disable'):
+            backend_options = self.fusion_options(enabled=False, threshold=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertFalse(meta.get('applied'))
+
+    def test_fusion_output(self):
+        """Test Fusion returns same final unitary"""
+        seed = 54321
+        circuit = QuantumVolume(4, seed=seed)
+        circuit = transpile(circuit, self.SIMULATOR)
+        qobj = assemble([circuit], shots=1)
+
+        options_disabled = self.fusion_options(enabled=False, threshold=1)
+        result_disabled = self.SIMULATOR.run(
+            qobj, backend_options=options_disabled).result()
+        self.assertSuccess(result_disabled)
+
+        options_enabled = self.fusion_options(enabled=True, threshold=1)
+        result_enabled = self.SIMULATOR.run(
+            qobj, backend_options=options_enabled).result()
+        self.assertSuccess(result_enabled)
+
+        sv_no_fusion = Statevector(result_disabled.get_statevector(0))
+        sv_fusion = Statevector(result_enabled.get_statevector(0))
+        self.assertEqual(sv_no_fusion, sv_fusion)

--- a/test/terra/backends/test_statevector_simulator.py
+++ b/test/terra/backends/test_statevector_simulator.py
@@ -18,10 +18,11 @@ from test.terra import common
 from test.terra.decorators import requires_method
 # Basic circuit instruction tests
 from test.terra.backends.statevector_simulator.statevector_basics import StatevectorSimulatorTests
-
+from test.terra.backends.statevector_simulator.statevector_fusion import StatevectorFusionTests
 
 class TestStatevectorSimulator(common.QiskitAerTestCase,
-                               StatevectorSimulatorTests):
+                               StatevectorSimulatorTests,
+                               StatevectorFusionTests):
     """StatevectorSimulator automatic method tests."""
 
     BACKEND_OPTS = {"seed_simulator": 10598}
@@ -29,7 +30,8 @@ class TestStatevectorSimulator(common.QiskitAerTestCase,
 
 @requires_method("statevector_simulator", "statevector_gpu")
 class TestStatevectorSimulatorThrustGPU(common.QiskitAerTestCase,
-                                        StatevectorSimulatorTests):
+                                        StatevectorSimulatorTests,
+                                        StatevectorFusionTests):
     """StatevectorSimulator automatic method tests."""
 
     BACKEND_OPTS = {"seed_simulator": 10598, "method": "statevector_gpu"}
@@ -37,7 +39,8 @@ class TestStatevectorSimulatorThrustGPU(common.QiskitAerTestCase,
 
 @requires_method("statevector_simulator", "statevector_thrust")
 class TestStatevectorSimulatorThrustCPU(common.QiskitAerTestCase,
-                                        StatevectorSimulatorTests):
+                                        StatevectorSimulatorTests,
+                                        StatevectorFusionTests):
     """StatevectorSimulator automatic method tests."""
 
     BACKEND_OPTS = {"seed_simulator": 10598, "method": "statevector_thrust"}

--- a/test/terra/backends/test_unitary_simulator.py
+++ b/test/terra/backends/test_unitary_simulator.py
@@ -16,11 +16,15 @@ UnitarySimulator Integration Tests
 import unittest
 from test.terra import common
 from test.terra.decorators import requires_method
-# Basic circuit instruction tests
+
 from test.terra.backends.unitary_simulator.unitary_basics import UnitarySimulatorTests
 from test.terra.backends.unitary_simulator.unitary_snapshot import UnitarySnapshotTests
+from test.terra.backends.unitary_simulator.unitary_fusion import UnitaryFusionTests
 
-class TestUnitarySimulator(common.QiskitAerTestCase, UnitarySimulatorTests, UnitarySnapshotTests):
+class TestUnitarySimulator(common.QiskitAerTestCase,
+                           UnitarySimulatorTests,
+                           UnitarySnapshotTests,
+                           UnitaryFusionTests):
     """UnitarySimulator automatic method tests."""
 
     BACKEND_OPTS = {"seed_simulator": 2113}
@@ -28,7 +32,8 @@ class TestUnitarySimulator(common.QiskitAerTestCase, UnitarySimulatorTests, Unit
 
 @requires_method("unitary_simulator", "unitary_gpu")
 class TestUnitarySimulatorThrustGPU(common.QiskitAerTestCase,
-                                    UnitarySimulatorTests):
+                                    UnitarySimulatorTests,
+                                    UnitaryFusionTests):
     """UnitarySimulator unitary_gpu method tests."""
 
     BACKEND_OPTS = {"seed_simulator": 2113, "method": "unitary_gpu"}
@@ -36,7 +41,8 @@ class TestUnitarySimulatorThrustGPU(common.QiskitAerTestCase,
 
 @requires_method("unitary_simulator", "unitary_thrust")
 class TestUnitarySimulatorThrustCPU(common.QiskitAerTestCase,
-                                    UnitarySimulatorTests):
+                                    UnitarySimulatorTests,
+                                    UnitaryFusionTests):
     """UnitarySimulator unitary_thrust method tests."""
 
     BACKEND_OPTS = {"seed_simulator": 2113, "method": "unitary_thrust"}

--- a/test/terra/backends/unitary_simulator/unitary_fusion.py
+++ b/test/terra/backends/unitary_simulator/unitary_fusion.py
@@ -1,0 +1,125 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+UnitarySimulator Gate Fusion Tests
+"""
+from qiskit import assemble, transpile
+from qiskit.circuit.library import QuantumVolume
+from qiskit.quantum_info import Operator
+from qiskit.providers.aer import UnitarySimulator
+
+
+class UnitaryFusionTests:
+    """UnitarySimulator fusion tests."""
+
+    SIMULATOR = UnitarySimulator()
+
+    def fusion_options(self, enabled=None, threshold=None, verbose=None):
+        """Return default backend_options dict."""
+        backend_options = self.BACKEND_OPTS.copy()
+        if enabled is not None:
+            backend_options['fusion_enable'] = enabled
+        if verbose is not None:
+            backend_options['fusion_verbose'] = verbose
+        if threshold is not None:
+            backend_options['fusion_threshold'] = threshold
+        return backend_options
+
+    def fusion_metadata(self, result):
+        """Return fusion metadata dict"""
+        metadata = result.results[0].metadata
+        return metadata.get('fusion', {})
+
+    def test_fusion_theshold(self):
+        """Test fusion threhsold settings work."""
+        seed = 12345
+        threshold = 4
+        backend_options = self.fusion_options(enabled=True, threshold=threshold)
+
+        with self.subTest(msg='below fusion threshold'):
+            circuit = QuantumVolume(threshold - 1, seed=seed)
+            circuit = transpile(circuit, self.SIMULATOR)
+            qobj = assemble([circuit], shots=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertFalse(meta.get('applied'))
+
+        with self.subTest(msg='at fusion threshold'):
+            circuit = QuantumVolume(threshold, seed=seed)
+            circuit = transpile(circuit, self.SIMULATOR)
+            qobj = assemble([circuit], shots=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertTrue(meta.get('applied'))
+
+        with self.subTest(msg='above fusion threshold'):
+            circuit = QuantumVolume(threshold + 1, seed=seed)
+            circuit = transpile(circuit, self.SIMULATOR)
+            qobj = assemble([circuit], shots=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertTrue(meta.get('applied'))
+
+    def test_fusion_disable(self):
+        """Test Fusion enable/disable option"""
+        seed = 2233
+        circuit = QuantumVolume(4, seed=seed)
+        circuit = transpile(circuit, self.SIMULATOR)
+        qobj = assemble([circuit], shots=1)
+
+        with self.subTest(msg='test fusion enable'):
+            backend_options = self.fusion_options(enabled=True, threshold=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertTrue(meta.get('applied'))
+
+        with self.subTest(msg='test fusion disable'):
+            backend_options = self.fusion_options(enabled=False, threshold=1)
+            result = self.SIMULATOR.run(
+                qobj, backend_options=backend_options).result()
+            meta = self.fusion_metadata(result)
+
+            self.assertSuccess(result)
+            self.assertFalse(meta.get('applied'))
+
+    def test_fusion_output(self):
+        """Test Fusion returns same final unitary"""
+        seed = 54321
+        circuit = QuantumVolume(4, seed=seed)
+        circuit = transpile(circuit, self.SIMULATOR)
+        qobj = assemble([circuit], shots=1)
+
+        options_disabled = self.fusion_options(enabled=False, threshold=1)
+        result_disabled = self.SIMULATOR.run(
+            qobj, backend_options=options_disabled).result()
+        self.assertSuccess(result_disabled)
+
+        options_enabled = self.fusion_options(enabled=True, threshold=1)
+        result_enabled = self.SIMULATOR.run(
+            qobj, backend_options=options_enabled).result()
+        self.assertSuccess(result_enabled)
+
+        unitary_no_fusion = Operator(result_disabled.get_unitary(0))
+        unitary_fusion = Operator(result_enabled.get_unitary(0))
+        self.assertEqual(unitary_no_fusion, unitary_fusion)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds the gate fusion circuit optimization used by the `QasmSimulator` to both the `StatevectorSimulator` and `UnitarySimulator` backends.

### Details and comments


