### PR TITLE
Only run GPU wheel jobs on tags and publish to pypi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 name: Build
-on: [push, pull_request]
-#  push:
-#    tags:
-#      - '*'
+on:
+  push:
+    tags:
+      - '*'
 jobs:
   build:
     name: Build qiskit-aer-gpu wheels
@@ -31,10 +31,10 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-#      - name: Publish Wheels
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: qiskit
-#        run : |
-#          pip install -U twine
-#          twine upload wheelhouse/*
+      - name: Publish Wheels
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: qiskit
+        run : |
+          pip install -U twine
+          twine upload wheelhouse/*


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The GPU wheel build job was added in #775, but merged a bit too early.
There was still a test commit merged on the PR branch which was being
used to switch the job to run on every PR and commit and disable the
push to pypi. This commit reverts that test commit so that we're only
running the 2+ hour wheel building job when we tag a release and also
uncomments the section to publish the built wheels to pypi.

### Details and comments