### PR TITLE
Fix bug in StatevectorSimulator preventing AVX2, GPU, and single-precision simulation

### DIFF
--- a/releasenotes/notes/fix-statevector-precision-24350e9fd7368c24.yaml
+++ b/releasenotes/notes/fix-statevector-precision-24350e9fd7368c24.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes bug in the :class:`qiskit.providers.aer.StatevectorSimulator` that
+    caused it to always run as CPU with double-precision without SIMD/AVX2
+    support even on systems with AVX2, or when single-precision or the GPU
+    method was specified in the backend options.

--- a/src/controllers/statevector_controller.hpp
+++ b/src/controllers/statevector_controller.hpp
@@ -275,7 +275,7 @@ void StatevectorController::run_circuit_helper(
     const Circuit& circ, const Noise::NoiseModel& noise, const json_t& config,
     uint_t shots, uint_t rng_seed, ExperimentData &data) const {
   // Initialize  state
-  Statevector::State<> state;
+  State_t state;
 
   // Validate circuit and throw exception if invalid operations exist
   validate_state(state, circ, noise, true);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes bug in the StatevectorSimulator that caused it to always run as CPU with double-precision without SIMD/AVX2 support even on systems with AVX2, or when single-precision or the GPU method was specified in the backend options.

### Details and comments

The template argument of the StatevectorController which specifies the simulator type was not being used. Instead the default double-precsion CPU qubitvector without AVX was always being used.