### PR TITLE
Remove pip upgrade from windows sdist job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,7 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
-              pip install -U pip setuptools virtualenv wheel
+              pip install -U setuptools virtualenv wheel
               pip install dist/*tar.gz
               pip install git+https://github.com/Qiskit/qiskit-terra
               python tools/verify_wheels.py


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The windows sdist install jobs have started failing on a permission
issue when trying to upgrade pip prior to installing from sdist. This
commit removes the pip upgrade because the base windows azure pipelines
image is now including pip 20.2.1 which is sufficiently new (being >19)
and upgrading isn't explicitly needed. This should avoid the potential
permissions issue replacing the pip.exe file on disk already.

### Details and comments


