### PR TITLE
MPS: Bug in apply_cu1

### DIFF
--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -350,7 +350,7 @@ void MPS::apply_cz(uint_t index_A, uint_t index_B)
 void MPS::apply_cu1(uint_t index_A, uint_t index_B, double lambda)
 {
   cmatrix_t u1_matrix = AER::Utils::Matrix::u1(lambda);
-  apply_2_qubit_gate(index_A, index_B, cu1, u1_matrix);
+  apply_2_qubit_gate(get_qubit_index(index_A), get_qubit_index(index_B), cu1, u1_matrix);
 }
 
 void MPS::apply_ccx(const reg_t &qubits)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
In ``MPS::apply_cu1``, the operation was done on the input qubits instead of on the internal qubits.


### Details and comments
This change was made in all other interface function following the change in PR #665.

