### PR TITLE
Add git sha1 to version string on dev builds

### DIFF
--- a/qiskit/providers/aer/version.py
+++ b/qiskit/providers/aer/version.py
@@ -17,6 +17,8 @@ Helper tools for getting Terra addon version information
 import os
 import subprocess
 
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 def _minimal_ext_cmd(cmd):
     # construct minimal environment

--- a/qiskit/providers/aer/version.py
+++ b/qiskit/providers/aer/version.py
@@ -15,7 +15,63 @@ Helper tools for getting Terra addon version information
 """
 
 import os
+import subprocess
 
-ROOT_DIR = os.path.dirname(__file__)
+
+def _minimal_ext_cmd(cmd):
+    # construct minimal environment
+    env = {}
+    for k in ['SYSTEMROOT', 'PATH']:
+        v = os.environ.get(k)
+        if v is not None:
+            env[k] = v
+    # LANGUAGE is used on win32
+    env['LANGUAGE'] = 'C'
+    env['LANG'] = 'C'
+    env['LC_ALL'] = 'C'
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, env=env,
+                            cwd=os.path.join(os.path.dirname(ROOT_DIR)))
+    out = proc.communicate()[0]
+    if proc.returncode > 0:
+        raise OSError
+    return out
+
+
+def git_version():
+    """Get the current git head sha1."""
+    # Determine if we're at master
+    try:
+        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        git_revision = out.strip().decode('ascii')
+    except OSError:
+        git_revision = "Unknown"
+
+    return git_revision
+
+
 with open(os.path.join(ROOT_DIR, "VERSION.txt"), "r") as version_file:
-    __version__ = version_file.read().strip()
+    VERSION = version_file.read().strip()
+
+
+def get_version_info():
+    """Get the full version string."""
+    # Adding the git rev number needs to be done inside
+    # write_version_py(), otherwise the import of scipy.version messes
+    # up the build under Python 3.
+    full_version = VERSION
+
+    if not os.path.exists(os.path.join(os.path.dirname(os.path.dirname(
+            os.path.dirname(ROOT_DIR))), '.git')):
+        return full_version
+    try:
+        release = _minimal_ext_cmd(['git', 'tag', '-l', '--points-at', 'HEAD'])
+    except Exception:  # pylint: disable=broad-except
+        return full_version
+    if not release:
+        git_revision = git_version()
+        full_version += '.dev0+' + git_revision[:7]
+
+    return full_version
+
+__version__ = get_version_info()

--- a/qiskit/providers/aer/version.py
+++ b/qiskit/providers/aer/version.py
@@ -76,4 +76,5 @@ def get_version_info():
 
     return full_version
 
+
 __version__ = get_version_info()


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support to the aer version file for adding the git
sha1s to dev builds so that users can know which version of the code
they built against. This exists in the other qiskit elements but was
missing from aer.

### Details and comments