### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ sudo: false
 stage_generic: &stage_generic
   install:
     - pip install -U pip
-    - pip install cython
+    - pip install cython packaging
     # Install terra from master on aer master else use the most recent release
     - |
       if [[ $TRAVIS_BRANCH == "master" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ sudo: false
 stage_generic: &stage_generic
   install:
     - pip install -U pip
-    - pip install cython packaging
+    - pip install -U cython packaging
     # Install terra from master on aer master else use the most recent release
     - |
       if [[ $TRAVIS_BRANCH == "master" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ sudo: false
 #   * stage_osx
 stage_generic: &stage_generic
   install:
-    - pip install -U 'pip<20.0.0'
+    - pip install -U pip
     - pip install cython
     # Install terra from master on aer master else use the most recent release
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ jobs:
         - docker
       env:
         - CIBW_BEFORE_BUILD="pip install -U Cython pip virtualenv pybind11 && yum install -y openblas-devel"
-        - CIBW_SKIP="cp27-* cp34-* *-manylinux_i686 pp*"
+        - CIBW_SKIP="cp27-* cp34-* cp35-* *-manylinux_i686 pp*"
         - CIBW_MANYLINUX_X86_64_IMAGE="manylinux2010"
         - CIBW_MANYLINUX_I686_IMAGE="manylinux2010"
         - CIBW_TEST_COMMAND="python3 {project}/tools/verify_wheels.py"
@@ -223,13 +223,6 @@ jobs:
       <<: *stage_linux
       python: 3.6
 
-    # GNU/Linux, Python 3.5
-    - stage: test
-      if: type = cron
-      name: Python 3.5 Tests Linux
-      <<: *stage_linux
-      python: 3.5
-
     # MacOS, Python 3.8 (via pyenv)
     - stage: test
       if: type = cron
@@ -261,16 +254,6 @@ jobs:
         - PYTHON_VERSION=3.6.5
         - QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 
-    # MacOS, Python 3.5 (via pyenv)
-    - stage: test
-      if: type = cron
-      name: Python 3.5 Tests MacOS
-      <<: *stage_osx
-      python: 3.5
-      env:
-        - MPLBACKEND=ps
-        - PYTHON_VERSION=3.5.6
-        - QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
     # "deploy" stage
     ##########################################################################
     #
@@ -284,7 +267,7 @@ jobs:
       env:
         - CIBW_BEFORE_ALL="yum install -y openblas-devel"
         - CIBW_BEFORE_BUILD="pip install -U Cython pip virtualenv pybind11"
-        - CIBW_SKIP="cp27-* cp34-* *-manylinux_i686 pp*"
+        - CIBW_SKIP="cp27-* cp34-* cp35-* *-manylinux_i686 pp*"
         - CIBW_MANYLINUX_X86_64_IMAGE="manylinux2010"
         - CIBW_MANYLINUX_I686_IMAGE="manylinux2010"
         - TWINE_USERNAME=qiskit
@@ -315,7 +298,7 @@ jobs:
       if: tag IS present
       env:
         - CIBW_BEFORE_BUILD="pip install -U Cython pip virtualenv pybind11"
-        - CIBW_SKIP="cp27-* cp34-* pp*"
+        - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python3 {project}/tools/verify_wheels.py"
         - CIBW_TEST_REQUIRES="git+https://github.com/Qiskit/qiskit-terra.git"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
         - bash: |
             set -x
             set -e
-            for version in 3.5 3.6 3.7 3.8 ; do
+            for version in 3.6 3.7 3.8 ; do
                 conda create --yes --quiet --name qiskit-aer-$version python=$version
             done
           displayName: Create Anaconda environments
@@ -41,7 +41,7 @@ stages:
             set -x
             set -e
             mkdir wheelhouse
-            for version in 3.5 3.6 3.7 3.8 ; do
+            for version in 3.6 3.7 3.8 ; do
                 source activate qiskit-aer-$version
                 conda update --yes -n base conda
                 conda config --add channels conda-forge
@@ -76,8 +76,6 @@ stages:
         strategy:
           maxParallel: 2
           matrix:
-            Python35:
-              python.version: '3.5'
             Python36:
               python.version: '3.6'
             Python37:
@@ -109,12 +107,6 @@ stages:
               conda config --add channels conda-forge
               conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
             displayName: Create Anaconda environments
-          - bash: |
-              set -e
-              source activate qiskit-aer
-              pip install -U -c constraints.txt numpy scipy
-            displayName: "Install 3.5 constrained dependencies"
-            condition: eq(variables['python.version'], '3.5')
           - bash: |
               set -x
               set -e
@@ -259,8 +251,6 @@ stages:
         strategy:
           maxParallel: 3
           matrix:
-            Python35:
-              python.version: '3.5'
             Python36:
               python.version: '3.6'
             Python37:
@@ -313,18 +303,6 @@ stages:
               fi
             displayName: "Install dependencies py3.8"
             condition: eq(variables['python.version'], '3.8')
-          - bash: |
-              set -e
-              source activate qiskit-aer-$(Build.BuildNumber)
-              pip install -U pip setuptools wheel virtualenv
-              pip install -c constraints.txt -r requirements-dev.txt
-              if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH == *"master"* || $BUILD_SOURCEBRANCH == *"master"* ]] ; then
-                  pip install git+https://github.com/Qiskit/qiskit-terra.git
-              else
-                  pip install qiskit-terra
-              fi
-            displayName: "Install dependencies"
-            condition: eq(variables['python.version'], '3.5')
           - bash: |
               set -e
               source activate qiskit-aer-$(Build.BuildNumber)

--- a/releasenotes/notes/drop-py35-814876e9d7354a39.yaml
+++ b/releasenotes/notes/drop-py35-814876e9d7354a39.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The deprecated support for running qiskit-aer with Python 3.5 has
+    been removed. To use qiskit-aer >=0.7.0 you will now need at
+    least Python 3.6. If you are using Python 3.5 the last version which will
+    work is qiskit-aer 0.6.x.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-automodapi
 jupyter-sphinx;python_version<'3.8'
-reno>=3.1.0;python_version>'3.5'
+reno>=3.1.0

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,8 @@ import setuptools
 # also build time/setup requirements and will be added to both lists
 # of requirements
 common_requirements = [
-    'numpy>=1.16.3;python_version>"3.5"',
-    'numpy>=1.16.3,<1.19.0;python_version<"3.6"',
-    'scipy>=1.0;python_version>"3.5"',
-    'scipy>=1.0,<1.5.0;python_version<"3.6"',
+    'numpy>=1.16.3',
+    'scipy>=1.0',
     'cython>=0.27.1',
     'pybind11>=2.4'  # This isn't really an install requirement,
                      # Pybind11 is required to be pre-installed for
@@ -92,12 +90,12 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering",
     ],
+    python_requires=">=3.6",
     install_requires=requirements,
     setup_requires=setup_requirements,
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py35, py36, py37, lint
+envlist = py36, py37, py38, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit drops support for running with python 3.5. It marks the
minimum supported version of the package as python 3.6, removes python
3.5 package pins, removes the 3.5 CI jobs, and removes the warning on
python 3.5. Looking at the PyPI stats since the deprecation period
started the number of users on Python 3.5 has diminished significantly,
but not disappeared. There were 359 downloads with pip from pypi out of
total of 18,980 total pip downloads in the last 30 days. Compared to the
roughly 10% figure when we deprecated Python 3.5.

Merging this means we can not release until after the documented EoL
date for Python 3.5 support of September 13. This shouldn't be a problem
because with Qiskit/qiskit-terra#4767 we will need to coordinate the
release of all the qiskit elements and are planning to do that after
09/13/2020.

It's worth noting that we should start planning to deprecate python 3.6
support sooner rather than later it goes EoL upstream at the end of
next year [1] and some of our other upstream dependencies (mainly numpy
et al) are going to remove support before the upstream Python EoL date
[2].

### Details and comments

[1] https://devguide.python.org/#branchstatus
[2] https://numpy.org/neps/nep-0029-deprecation_policy.html
