### PR TITLE
Enable building 32bit binaries in wheel jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,33 +151,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-  win32_wheel:
-    name: compile-wheel-win32
-    runs-on: "windows-latest"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-          architecture: 'x86'
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-      - name: Install deps
-        run: python -m pip install -U virtualenv setuptools wheel numpy
-      - name: Build Wheels
-        run: python setup.py bdist_wheel -- -G 'Visual Studio 16 2019' -A 'Win32'
-      - name: Install and test wheel
-        run: |
-          set -e
-          virtualenv test-wheel
-          test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
-          test-wheel/Scripts/pip install -c constraints.txt dist/*whl
-          test-wheel/Scripts/python tools/verify_wheels.py
-        shell: bash
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./dist/*.whl
   tests:
     name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Install deps
         run: python -m pip install -U virtualenv setuptools wheel numpy
       - name: Build Wheels
-        run: python setup.py bdist_wheel -- -G 'Visual Studio 16 2019'
+        run: python setup.py bdist_wheel -- -G 'Visual Studio 16 2019' -A 'Win32'
       - name: Install and test wheel
         run: |
           set -e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,6 +151,33 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+  win32_wheel:
+    name: compile-wheel-win32
+    runs-on: "windows-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+          architecture: 'x86'
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+      - name: Install deps
+        run: python -m pip install -U virtualenv setuptools wheel numpy
+      - name: Build Wheels
+        run: python setup.py bdist_wheel -- -G 'Visual Studio 16 2019'
+      - name: Install and test wheel
+        run: |
+          set -e
+          virtualenv test-wheel
+          test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
+          test-wheel/Scripts/pip install -c constraints.txt dist/*whl
+          test-wheel/Scripts/python tools/verify_wheels.py
+        shell: bash
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*.whl
   tests:
     name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U Cython virtualenv pybind11"
-          CIBW_SKIP: "cp27-* cp34-* cp35-* *-manylinux_i686 pp*"
+          CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
           CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
           CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11"
-          CIBW_SKIP: "cp27-* cp34-* cp35-* *-manylinux_i686 pp*"
+          CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
           CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
           CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,9 +98,9 @@ stages:
             mkdir wheelhouse
             for version in 3.6 3.7 3.8 ; do
                 source activate qiskit-aer-$version
-
                 conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
-                python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
+                python -m pip install -U setuptools wheel
+                python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win32"
                 virtualenv test-$version
                 test-$version/Scripts/pip install -c constraints.txt dist/*whl
                 test-$version/Scripts/python tools/verify_wheels.py
@@ -217,7 +217,8 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
-              python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
+              pip install -U setuptools wheel
+              python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win32"
             displayName: Build wheels
             env:
               CONDA_FORCE_32BIT: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ stages:
                 source activate qiskit-aer-$version
                 conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
                 python -m pip install -U setuptools wheel
-                python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win32"
+                python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64" -A "Win32"
                 virtualenv test-$version
                 test-$version/Scripts/pip install -c constraints.txt dist/*whl
                 test-$version/Scripts/python tools/verify_wheels.py
@@ -218,7 +218,7 @@ stages:
               set -e
               source activate qiskit-aer
               pip install -U setuptools wheel
-              python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win32"
+              python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64" -A "Win32"
             displayName: Build wheels
             env:
               CONDA_FORCE_32BIT: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,6 @@ stages:
 #      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
         TWINE_USERNAME: qiskit
-        CONDA_FORCE_32BIT: 1
       steps:
         - checkout: self
           submodules: true
@@ -81,18 +80,25 @@ stages:
         - bash: |
             set -x
             set -e
+            conda update --yes -n base conda
+            conda config --add channels conda-forge
+          displayName: Update Conda
+        - bash: |
+            set -x
+            set -e
             for version in 3.6 3.7 3.8 ; do
                 conda create --yes --quiet --name qiskit-aer-$version python=$version
             done
           displayName: Create Anaconda environments
+          env:
+            CONDA_FORCE_32BIT: 1
         - bash: |
             set -x
             set -e
             mkdir wheelhouse
             for version in 3.6 3.7 3.8 ; do
                 source activate qiskit-aer-$version
-                conda update --yes -n base conda
-                conda config --add channels conda-forge
+
                 conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
                 python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
                 virtualenv test-$version
@@ -105,8 +111,9 @@ stages:
                 rm -rf qiskit_aer.egg-info
                 rm -rf contrib/standalone/version.hpp
             done
-
           displayName: Build wheels
+          env:
+            CONDA_FORCE_32BIT: 1
         - task: PublishBuildArtifacts@1
           inputs: {pathtoPublish: 'wheelhouse'}
           condition: succeededOrFailed()
@@ -177,7 +184,6 @@ stages:
               python.version: '3.7'
         variables:
           PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-          CONDA_FORCE_32BIT: 1
         steps:
           - checkout: self
             submodules: true
@@ -195,18 +201,26 @@ stages:
           - bash: |
               set -x
               set -e
-              conda create --yes --quiet --name qiskit-aer python=$(python.version)
-              source activate qiskit-aer
               conda update --yes -n base conda
               conda config --add channels conda-forge
+            displayName: Update Conda
+          - bash: |
+              set -x
+              set -e
+              conda create --yes --quiet --name qiskit-aer python=$(python.version)
+              source activate qiskit-aer
               conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
             displayName: Create Anaconda environments
+            env:
+              CONDA_FORCE_32BIT: 1
           - bash: |
               set -x
               set -e
               source activate qiskit-aer
               python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
             displayName: Build wheels
+            env:
+              CONDA_FORCE_32BIT: 1
           - bash: |
               set -x
               set -e
@@ -216,6 +230,8 @@ stages:
               test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
               test-wheel/Scripts/python tools/verify_wheels.py
             displayName: Verify wheels
+            env:
+              CONDA_FORCE_32BIT: 1
 
       - job: 'Windows_sdist_Builds'
         pool: {vmImage: 'vs2017-win2016'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,55 @@ stages:
             twine upload wheelhouse/*
           env:
             TWINE_PASSWORD: $(TWINE_PASSWORD)
+    - job: 'Windows_win32_Wheel_Builds'
+      pool: {vmImage: 'vs2017-win2016'}
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      variables:
+        TWINE_USERNAME: qiskit
+        CONDA_FORCE_32BIT: 1
+      steps:
+        - checkout: self
+          submodules: true
+        - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+          displayName: Add conda to PATH
+        - bash: |
+            set -x
+            set -e
+            for version in 3.6 3.7 3.8 ; do
+                conda create --yes --quiet --name qiskit-aer-$version python=$version
+            done
+          displayName: Create Anaconda environments
+        - bash: |
+            set -x
+            set -e
+            mkdir wheelhouse
+            for version in 3.6 3.7 3.8 ; do
+                source activate qiskit-aer-$version
+                conda update --yes -n base conda
+                conda config --add channels conda-forge
+                conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
+                python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
+                virtualenv test-$version
+                test-$version/Scripts/pip install -c constraints.txt dist/*whl
+                test-$version/Scripts/python tools/verify_wheels.py
+                mv dist/*whl wheelhouse/.
+                rm -rf test-$version
+                rm -rf _skbuild
+                rm -rf .eggs
+                rm -rf qiskit_aer.egg-info
+                rm -rf contrib/standalone/version.hpp
+            done
+
+          displayName: Build wheels
+        - task: PublishBuildArtifacts@1
+          inputs: {pathtoPublish: 'wheelhouse'}
+          condition: succeededOrFailed()
+        - bash: |
+            pip install -U twine
+            twine upload wheelhouse/*
+          env:
+            TWINE_PASSWORD: $(TWINE_PASSWORD)
+
 
   - stage: 'Compile'
     dependsOn: []
@@ -122,6 +171,54 @@ stages:
               test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
               test-wheel/Scripts/python tools/verify_wheels.py
             displayName: Verify wheels
+      - job: 'Windows_win32_Wheel_Builds'
+        pool: {vmImage: 'vs2017-win2016'}
+        strategy:
+          matrix:
+            Python37:
+              python.version: '3.7'
+        variables:
+          PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+          CONDA_FORCE_32BIT: 1
+        steps:
+          - checkout: self
+            submodules: true
+          - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+            displayName: Add conda to PATH
+          - task: Cache@2
+            inputs:
+              key: 'pip | "$(Agent.OS)" | "$(python.version)" |"$(Build.BuildNumber)"'
+              restoreKeys: |
+                pip | "$(Agent.OS)" | "$(python.version)"
+                pip | "$(Agent.OS)"
+                pip
+              path: $(PIP_CACHE_DIR)
+            displayName: Cache pip
+          - bash: |
+              set -x
+              set -e
+              conda create --yes --quiet --name qiskit-aer python=$(python.version)
+              source activate qiskit-aer
+              conda update --yes -n base conda
+              conda config --add channels conda-forge
+              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
+            displayName: Create Anaconda environments
+          - bash: |
+              set -x
+              set -e
+              source activate qiskit-aer
+              python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
+            displayName: Build wheels
+          - bash: |
+              set -x
+              set -e
+              source activate qiskit-aer
+              virtualenv test-wheel
+              test-wheel/Scripts/pip install -c constraints.txt dist/*whl
+              test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
+              test-wheel/Scripts/python tools/verify_wheels.py
+            displayName: Verify wheels
+
       - job: 'Windows_sdist_Builds'
         pool: {vmImage: 'vs2017-win2016'}
         strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
     - '*'
 stages:
   - stage: 'Wheel_Builds'
-#    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     jobs:
     - job: 'Windows_Wheel_Builds'
       pool: {vmImage: 'vs2017-win2016'}
@@ -69,7 +69,7 @@ stages:
             TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'Windows_win32_Wheel_Builds'
       pool: {vmImage: 'vs2017-win2016'}
-#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
         TWINE_USERNAME: qiskit
       steps:
@@ -117,11 +117,13 @@ stages:
         - task: PublishBuildArtifacts@1
           inputs: {pathtoPublish: 'wheelhouse'}
           condition: succeededOrFailed()
-#        - bash: |
-#            pip install -U twine
-#            twine upload wheelhouse/*
-#          env:
-#            TWINE_PASSWORD: $(TWINE_PASSWORD)
+        - bash: |
+            pip install -U twine
+            twine upload wheelhouse/*
+          env:
+            TWINE_PASSWORD: $(TWINE_PASSWORD)
+
+
   - stage: 'Compile'
     dependsOn: []
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
     - '*'
 stages:
   - stage: 'Wheel_Builds'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+#    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     jobs:
     - job: 'Windows_Wheel_Builds'
       pool: {vmImage: 'vs2017-win2016'}
@@ -69,7 +69,7 @@ stages:
             TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'Windows_win32_Wheel_Builds'
       pool: {vmImage: 'vs2017-win2016'}
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
         TWINE_USERNAME: qiskit
         CONDA_FORCE_32BIT: 1
@@ -110,13 +110,11 @@ stages:
         - task: PublishBuildArtifacts@1
           inputs: {pathtoPublish: 'wheelhouse'}
           condition: succeededOrFailed()
-        - bash: |
-            pip install -U twine
-            twine upload wheelhouse/*
-          env:
-            TWINE_PASSWORD: $(TWINE_PASSWORD)
-
-
+#        - bash: |
+#            pip install -U twine
+#            twine upload wheelhouse/*
+#          env:
+#            TWINE_PASSWORD: $(TWINE_PASSWORD)
   - stage: 'Compile'
     dependsOn: []
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ stages:
                 source activate qiskit-aer-$version
                 conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
                 python -m pip install -U setuptools wheel
-                python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64" -A "Win32"
+                python setup.py bdist_wheel -- -G "Visual Studio 15 2017"
                 virtualenv test-$version
                 test-$version/Scripts/pip install -c constraints.txt dist/*whl
                 test-$version/Scripts/python tools/verify_wheels.py
@@ -218,7 +218,7 @@ stages:
               set -e
               source activate qiskit-aer
               pip install -U setuptools wheel
-              python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64" -A "Win32"
+              python setup.py bdist_wheel -- -G "Visual Studio 15 2017"
             displayName: Build wheels
             env:
               CONDA_FORCE_32BIT: 1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit is an attempt to start building 32bit binaries in CI for
publishing at release time (and the corresponding wheel compile jobs).
This is primarily an issue for windows were a large number of users are
running with a win32 python binary and aer fails to install from wheel
because there is not 32bit binary available.

### Details and comments