### PR TITLE
Kraus noise gate fusion method

### DIFF
--- a/releasenotes/notes/kraus-noise-fusion-5577d4a38862e966.yaml
+++ b/releasenotes/notes/kraus-noise-fusion-5577d4a38862e966.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Improves general noisy statevector simulation performance by adding a Kraus
+    method to the gate fusion circuit optimization that allows applying gate
+    fusion to noisy statevector simulations with general Kraus noise.

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -166,6 +166,9 @@ class QasmController : public Base::Controller {
   // Simulation precision
   enum class Precision { double_precision, single_precision };
 
+  // Fusion method
+  using FusionMethod = Transpile::Fusion::Method;
+
   //-----------------------------------------------------------------------
   // Base class abstract method override
   //-----------------------------------------------------------------------
@@ -205,7 +208,9 @@ class QasmController : public Base::Controller {
 
   // Return a fusion transpilation pass configured for the current
   // method, circuit and config
-  Transpile::Fusion transpile_fusion(Method method, const json_t& config) const;
+  Transpile::Fusion transpile_fusion(Method method,
+                                     const json_t& config,
+                                     FusionMethod fusion_method = FusionMethod::unitary) const;
 
   //----------------------------------------------------------------
   // Run circuit helpers
@@ -232,32 +237,28 @@ class QasmController : public Base::Controller {
                        ExperimentData& data,
                        RngEngine& rng) const;
 
-  // Execute a n-shots of a circuit without noise.
-  // If possible this is done using measure sampling to only simulate
-  // a single shot up to the first measurement, then sampling measure
-  // outcomes for each shot.
+  // Execute multiple shots a of circuit by initializing the state vector
+  // to initial_state, running all ops in circ, and updating data with
+  // simulation output. Will use measurement sampling if possible
   template <class State_t, class Initstate_t>
-  void run_circuit_without_noise(const Circuit& circ,
-                                 const json_t& config,
-                                 uint_t shots,
-                                 State_t& state,
-                                 const Initstate_t& initial_state,
-                                 const Method method,
-                                 ExperimentData& data,
-                                 RngEngine& rng) const;
+  void run_multi_shot(const Circuit& circ,
+                      uint_t shots,
+                      State_t& state,
+                      const Initstate_t& initial_state,
+                      const Method method,
+                      ExperimentData& data,
+                      RngEngine& rng) const;
 
-  // Execute n-shots of a circuit with noise by sampling a new noisy
-  // instance of the circuit for each shot.
   template <class State_t, class Initstate_t>
-  void run_circuit_with_noise(const Circuit& circ,
-                              const Noise::NoiseModel& noise,
-                              const json_t& config,
-                              uint_t shots,
-                              State_t& state,
-                              const Initstate_t& initial_state,
-                              const Method method,
-                              ExperimentData& data,
-                              RngEngine& rng) const;
+  void run_circuit_with_sampled_noise(const Circuit& circ,
+                                      const Noise::NoiseModel& noise,
+                                      const json_t& config,
+                                      uint_t shots,
+                                      State_t& state,
+                                      const Initstate_t& initial_state,
+                                      const Method method,
+                                      ExperimentData& data,
+                                      RngEngine& rng) const;
 
   //----------------------------------------------------------------
   // Measure sampling optimization
@@ -797,7 +798,8 @@ size_t QasmController::required_memory_mb(
 }
 
 Transpile::Fusion QasmController::transpile_fusion(Method method,
-                                                   const json_t& config) const {
+                                                   const json_t& config,
+                                                   FusionMethod fusion_method) const {
   Transpile::Fusion fusion_pass;
   switch (method) {
     case Method::statevector:
@@ -806,6 +808,11 @@ Transpile::Fusion QasmController::transpile_fusion(Method method,
     case Method::density_matrix:
     case Method::density_matrix_thrust_gpu:
     case Method::density_matrix_thrust_cpu: {
+      if (fusion_method == FusionMethod::superop) {
+        fusion_pass.allow_superop = true;
+      } else if (fusion_method == FusionMethod::kraus) {
+        fusion_pass.allow_kraus = true;
+      }
       fusion_pass.set_config(config);
       break;
     }
@@ -894,31 +901,54 @@ void QasmController::run_circuit_helper(const Circuit& circ,
   data.add_metadata("measure_sampling", false);
 
   // Choose execution method based on noise and method
+
+  Circuit opt_circ;
+  FusionMethod fusion_method = FusionMethod::unitary;
+
+  // Ideal circuit
   if (noise.is_ideal()) {
-    run_circuit_without_noise(circ, config, shots, state, initial_state, method,
-                              data, rng);
-  } else if ((method == Method::density_matrix ||
-              method == Method::density_matrix_thrust_gpu ||
-              method == Method::density_matrix_thrust_cpu) &&
-             noise.has_quantum_errors()) {
-    // We can sample the noise model using superoperator method
-    // and then execute the resulting circuit containing superoperators
-    Noise::NoiseModel noise_cpy = noise;
-    noise_cpy.activate_superop_method();
-    Circuit noise_circ = noise_cpy.sample_noise(circ, rng);
-    run_circuit_without_noise(noise_circ, config, shots, state, initial_state,
-                              method, data, rng);
-  } else if (noise.has_quantum_errors() == false) {
-    // We can insert the readout errors from the noise model and then
-    // execute the resulting circuit
-    Circuit noise_circ = noise.sample_noise(circ, rng);
-    run_circuit_without_noise(noise_circ, config, shots, state, initial_state,
-                              method, data, rng);
-  } else {
-    // Run sampling a noisy instance of the circuit for each shot
-    run_circuit_with_noise(circ, noise, config, shots, state, initial_state,
-                           method, data, rng);
+    opt_circ = circ;
   }
+  // Readout error only
+  else if (noise.has_quantum_errors() == false) {
+    opt_circ = noise.sample_noise(circ, rng);
+  }
+  // Superop noise sampling
+  else if (method == Method::density_matrix ||
+           method == Method::density_matrix_thrust_gpu ||
+           method == Method::density_matrix_thrust_cpu) {
+    // Sample noise using SuperOp method
+    auto noise_superop = noise;
+    noise_superop.activate_superop_method();
+    fusion_method = FusionMethod::superop;
+    opt_circ = noise_superop.sample_noise(circ, rng);
+  }
+  // Kraus noise sampling
+  else if (noise.opset().contains(Operations::OpType::kraus) ||
+           noise.opset().contains(Operations::OpType::superop)) {
+    auto noise_kraus = noise;
+    noise_kraus.activate_kraus_method();
+    fusion_method = FusionMethod::kraus;
+    opt_circ = noise_kraus.sample_noise(circ, rng);
+  }
+  // General circuit noise sampling
+  else {
+    run_circuit_with_sampled_noise(circ, noise, config, shots, state,
+                                   initial_state, method, data, rng);
+    return;
+  }
+
+  // Optimize circuit
+  Noise::NoiseModel dummy_noise;
+  Transpile::DelayMeasure measure_pass;
+  measure_pass.set_config(config);
+  measure_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
+
+  auto fusion_pass = transpile_fusion(method, config, fusion_method);
+  fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
+
+  // Run simulation
+  run_multi_shot(opt_circ, shots, state, initial_state, method, data, rng);
 }
 
 template <class State_t, class Initstate_t>
@@ -933,68 +963,27 @@ void QasmController::run_single_shot(const Circuit& circ,
 }
 
 template <class State_t, class Initstate_t>
-void QasmController::run_circuit_with_noise(const Circuit& circ,
-                                            const Noise::NoiseModel& noise,
-                                            const json_t& config,
-                                            uint_t shots,
-                                            State_t& state,
-                                            const Initstate_t& initial_state,
-                                            const Method method,
-                                            ExperimentData& data,
-                                            RngEngine& rng) const {
-  // Transpile passes
-  auto fusion_pass = transpile_fusion(method, config);
-  Transpile::DelayMeasure measure_pass;
-  measure_pass.set_config(config);
-  Noise::NoiseModel dummy_noise;
-
-  while (shots-- > 0) {
-    Circuit noise_circ = noise.sample_noise(circ, rng);
-    noise_circ.shots = 1;
-    fusion_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(), data);
-    measure_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(), data);
-    run_single_shot(noise_circ, state, initial_state, data, rng);
-  }
-}
-
-template <class State_t, class Initstate_t>
-void QasmController::run_circuit_without_noise(const Circuit& circ,
-                                               const json_t& config,
-                                               uint_t shots,
-                                               State_t& state,
-                                               const Initstate_t& initial_state,
-                                               const Method method,
-                                               ExperimentData& data,
-                                               RngEngine& rng) const {
-  // Optimize circuit for state type
-  Circuit opt_circ = circ;
-
-  // Dummy noise model for transpiler passes
-  Noise::NoiseModel dummy_noise;
-
-  // Apply fusion transpilation pass
-  auto fusion_pass = transpile_fusion(method, config);
-  fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
-
-  // Apply delay measure transpilation pass
-  Transpile::DelayMeasure measure_pass;
-  measure_pass.set_config(config);
-  measure_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), data);
-
+void QasmController::run_multi_shot(const Circuit& circ,
+                                    uint_t shots,
+                                    State_t& state,
+                                    const Initstate_t& initial_state,
+                                    const Method method,
+                                    ExperimentData& data,
+                                    RngEngine& rng) const {
   // Check if measure sampler and optimization are valid
-  if (check_measure_sampling_opt(opt_circ, method)) {
+  if (check_measure_sampling_opt(circ, method)) {
     // Implement measure sampler
-    auto pos = opt_circ.first_measure_pos;  // Position of first measurement op
+    auto pos = circ.first_measure_pos;  // Position of first measurement op
 
     // Run circuit instructions before first measure
-    std::vector<Operations::Op> ops(opt_circ.ops.begin(),
-                                    opt_circ.ops.begin() + pos);
-    initialize_state(opt_circ, state, initial_state);
+    std::vector<Operations::Op> ops(circ.ops.begin(),
+                                    circ.ops.begin() + pos);
+    initialize_state(circ, state, initial_state);
     state.apply_ops(ops, data, rng);
 
     // Get measurement operations and set of measured qubits
-    ops = std::vector<Operations::Op>(opt_circ.ops.begin() + pos,
-                                      opt_circ.ops.end());
+    ops = std::vector<Operations::Op>(circ.ops.begin() + pos,
+                                      circ.ops.end());
     measure_sampler(ops, shots, state, data, rng);
 
     // Add measure sampling metadata
@@ -1003,8 +992,36 @@ void QasmController::run_circuit_without_noise(const Circuit& circ,
     // Perform standard execution if we cannot apply the
     // measurement sampling optimization
     while (shots-- > 0) {
-      run_single_shot(opt_circ, state, initial_state, data, rng);
+      run_single_shot(circ, state, initial_state, data, rng);
     }
+  }
+}
+
+
+template <class State_t, class Initstate_t>
+void QasmController::run_circuit_with_sampled_noise(const Circuit& circ,
+                                                    const Noise::NoiseModel& noise,
+                                                    const json_t& config,
+                                                    uint_t shots,
+                                                    State_t& state,
+                                                    const Initstate_t& initial_state,
+                                                    const Method method,
+                                                    ExperimentData& data,
+                                                    RngEngine& rng) const {
+
+  // Transpilation for circuit noise method
+  auto fusion_pass = transpile_fusion(method, config, FusionMethod::unitary);
+  Transpile::DelayMeasure measure_pass;
+  measure_pass.set_config(config);
+  Noise::NoiseModel dummy_noise;
+
+  // Sample noise using circuit method
+  while (shots-- > 0) {
+    Circuit noise_circ = noise.sample_noise(circ, rng);
+    noise_circ.shots = 1;
+    measure_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(), data);
+    fusion_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(), data);
+    run_single_shot(noise_circ, state, initial_state, data, rng);
   }
 }
 

--- a/src/framework/noise_utils.hpp
+++ b/src/framework/noise_utils.hpp
@@ -110,9 +110,9 @@ choi2kraus(const matrix<std::complex<T>>& choi, size_t dim, double threshold) {
     if (eval > 0.0 && !Linalg::almost_equal(eval, 0.0, threshold)) {
       std::complex<T> coeff(std::sqrt(eval), 0.0); 
       matrix<std::complex<T>> kmat(dim, dim);
-      for (size_t j = 0; j < dim; j++)
-        for (size_t k = 0; k < dim; k++) {
-          kmat(j, k) = coeff * evecs(j + dim * k, idx);
+      for (size_t col = 0; col < dim; col++)
+        for (size_t row = 0; row < dim; row++) {
+          kmat(row, col) = coeff * evecs(row + dim * col, idx);
         }
       kraus.push_back(kmat);
     }

--- a/src/framework/noise_utils.hpp
+++ b/src/framework/noise_utils.hpp
@@ -1,0 +1,140 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2020.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_noise_utils_hpp_
+#define _aer_noise_utils_hpp_
+
+#include "framework/utils.hpp"
+
+namespace AER {
+namespace Utils {
+
+//=========================================================================
+// Noise Transformation Functions
+//=========================================================================
+
+// Transform a superoperator matrix to a Choi matrix
+template <class T>
+matrix<T> superop2choi(const matrix<T>& superop, size_t dim);
+
+// Transform a superoperator matrix to a set of Kraus matrices
+template <class T>
+std::vector<matrix<T>> superop2kraus(const matrix<T>& superop, size_t dim, double threshold = 1e-10);
+
+// Transform a Choi matrix to a superoperator matrix
+template <class T>
+matrix<T> choi2superop(const matrix<T>& choi, size_t dim);
+
+// Transform a Choi matrix to a set of Kraus matrices
+template <class T>
+std::vector<matrix<std::complex<T>>>
+choi2kraus(const matrix<std::complex<T>>& choi, size_t dim, double threshold = 1e-10);
+
+// Transform a set of Kraus matrices to a Choi matrix
+template <class T>
+matrix<T> kraus2choi(const std::vector<matrix<T>>& kraus, size_t dim);
+
+// Transform a set of Kraus matrices to a superoperator matrix
+template <class T>
+matrix<T> kraus2superop(const std::vector<matrix<T>>& kraus, size_t dim);
+
+// Reshuffle transformation
+// Transforms a matrix with dimension (d0 * d1, d2 * d3)
+// into a matrix with dimension (d3 * d1, d2 * d0)
+// by transposition of bipartite indices
+// M[(i, j), (k, l)] -> M[(i, j), (k, i)]
+template <class T>
+matrix<T> reshuffle(const matrix<T> &mat, size_t d0, size_t d1, size_t d2, size_t d3);
+
+
+//=========================================================================
+// Implementations
+//=========================================================================
+
+template <class T>
+matrix<T> kraus2superop(const std::vector<matrix<T>>& kraus, size_t dim) {
+  matrix<T> superop(dim * dim, dim * dim);
+  for (const auto mat : kraus) {
+    superop += Utils::tensor_product(Utils::conjugate(mat), mat);
+  }
+  return superop;
+}
+
+template <class T>
+matrix<T> kraus2choi(const std::vector<matrix<T>>& kraus, size_t dim) {
+  return superop2choi(kraus2superop(kraus, dim), dim);
+}
+
+template <class T>
+matrix<T> superop2choi(const matrix<T>& superop, size_t dim) {
+  return reshuffle(superop, dim, dim, dim, dim);
+}
+
+template <class T>
+std::vector<matrix<T>> superop2kraus(const matrix<T>& superop, size_t dim, double threshold) {
+  return choi2kraus(superop2choi(superop, dim), dim, threshold);
+}
+
+template <class T>
+matrix<T> choi2superop(const matrix<T>& choi, size_t dim) {
+  return reshuffle(choi, dim, dim, dim, dim);
+}
+
+template <class T>
+std::vector<matrix<std::complex<T>>>
+choi2kraus(const matrix<std::complex<T>>& choi, size_t dim, double threshold) {
+  size_t dim2 = dim * dim;
+
+  std::vector<T> evals;
+  matrix<std::complex<T>> evecs;
+
+  eigensystem_hermitian(choi, evals, evecs);
+
+  // Convert eigensystem to Kraus operators
+  std::vector<matrix<std::complex<T>>> kraus;
+  for (size_t i = 0; i < dim2; i++) {
+    // Eigenvalues sorted smallest to largest so we index from the back
+    const size_t idx = dim2 - 1 - i;
+    const T eval = evals[idx];
+    if (eval > 0.0 && !Linalg::almost_equal(eval, 0.0, threshold)) {
+      std::complex<T> coeff(std::sqrt(eval), 0.0); 
+      matrix<std::complex<T>> kmat(dim, dim);
+      for (size_t j = 0; j < dim; j++)
+        for (size_t k = 0; k < dim; k++) {
+          kmat(j, k) = coeff * evecs(j + dim * k, idx);
+        }
+      kraus.push_back(kmat);
+    }
+  }
+  return kraus;
+}
+
+template <class T>
+matrix<T> reshuffle(const matrix<T> &mat, size_t d0, size_t d1, size_t d2, size_t d3) {
+  matrix<T> ret(d1 * d3, d0 * d2);
+  for (size_t i0 = 0; i0 < d0; ++i0)
+    for (size_t i1 = 0; i1 < d1; ++i1)
+      for (size_t i2 = 0; i2 < d2; ++i2)
+        for (size_t i3 = 0; i3 < d3; ++i3) {
+          ret(d1 * i3 + i1, d0 * i2 +  i0) = mat(d1 * i0 + i1, d3 * i2 + i3);
+        }
+  return ret;
+}
+
+//-------------------------------------------------------------------------
+} // end namespace Noise
+//-------------------------------------------------------------------------
+} // end namespace AER
+//-------------------------------------------------------------------------
+#endif

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -219,12 +219,70 @@ inline Op make_unitary(const reg_t &qubits, const cmatrix_t &mat, std::string la
   return op;
 }
 
+inline Op make_unitary(const reg_t &qubits, cmatrix_t &&mat, std::string label = "") {
+  Op op;
+  op.type = OpType::matrix;
+  op.name = "unitary";
+  op.qubits = qubits;
+  op.mats.resize(1);
+  op.mats[0] = std::move(mat);
+  if (label != "")
+    op.string_params = {label};
+  return op;
+}
+
 inline Op make_superop(const reg_t &qubits, const cmatrix_t &mat) {
   Op op;
   op.type = OpType::superop;
   op.name = "superop";
   op.qubits = qubits;
   op.mats = {mat};
+  return op;
+}
+
+inline Op make_superop(const reg_t &qubits, cmatrix_t &&mat) {
+  Op op;
+  op.type = OpType::superop;
+  op.name = "superop";
+  op.qubits = qubits;
+  op.mats.resize(1);
+  op.mats[0] = std::move(mat);
+  return op;
+}
+
+inline Op make_kraus(const reg_t &qubits, const std::vector<cmatrix_t> &mats) {
+  Op op;
+  op.type = OpType::kraus;
+  op.name = "kraus";
+  op.qubits = qubits;
+  op.mats = mats;
+  return op;
+}
+
+inline Op make_kraus(const reg_t &qubits, std::vector<cmatrix_t> &&mats) {
+  Op op;
+  op.type = OpType::kraus;
+  op.name = "kraus";
+  op.qubits = qubits;
+  op.mats = std::move(mats);
+  return op;
+}
+
+inline Op make_roerror(const reg_t &memory, const std::vector<rvector_t> &probs) {
+  Op op;
+  op.type = OpType::roerror;
+  op.name = "roerror";
+  op.memory = memory;
+  op.probs = probs;
+  return op;
+}
+
+inline Op make_roerror(const reg_t &memory, std::vector<rvector_t> &&probs) {
+  Op op;
+  op.type = OpType::roerror;
+  op.name = "roerror";
+  op.memory = memory;
+  op.probs = std::move(probs);
   return op;
 }
 
@@ -316,24 +374,6 @@ inline Op make_multiplexer(const reg_t &qubits,
   check_empty_qubits(op);
   check_duplicate_qubits(op);
 
-  return op;
-}
-
-inline Op make_kraus(const reg_t &qubits, const std::vector<cmatrix_t> &mats) {
-  Op op;
-  op.type = OpType::kraus;
-  op.name = "kraus";
-  op.qubits = qubits;
-  op.mats = mats;
-  return op;
-}
-
-inline Op make_roerror(const reg_t &memory, const std::vector<rvector_t> &probs) {
-  Op op;
-  op.type = OpType::roerror;
-  op.name = "roerror";
-  op.memory = memory;
-  op.probs = probs;
   return op;
 }
 

--- a/src/noise/noise_model.hpp
+++ b/src/noise/noise_model.hpp
@@ -56,11 +56,22 @@ public:
   Circuit sample_noise(const Circuit &circ,
                        RngEngine &rng) const;
 
+  // Set sample mode to circuit
+  // This is the default method for noise sampling that can work for
+  // any simulator that supports the sampled noise instructions
+  void activate_circuit_method();
+
   // Set sample mode to superoperator
   // This will cause all QuantumErrors stored in the noise model
   // to calculate their superoperator representations and raise
   // an exception if they cannot be converted.
   void activate_superop_method();
+
+  // Set sample mode to kraus
+  // This will cause all QuantumErrors stored in the noise model
+  // to calculate their canonical Kraus representations and raise
+  // an exception if they cannot be converted.
+  void activate_kraus_method();
 
   //-----------------------------------------------------------------------
   // Checking if errors types are in noise model
@@ -235,7 +246,7 @@ private:
   Operations::OpSet opset_;
 
   // Sampling method
-  Method method_ = Method::standard;
+  Method method_ = Method::circuit;
 };
 
 
@@ -331,6 +342,9 @@ Circuit NoiseModel::sample_noise(const Circuit &circ,
     return noisy_circ;
 }
 
+void NoiseModel::activate_circuit_method() {
+  method_ = Method::circuit;
+}
 
 void NoiseModel::activate_superop_method() {
   // Set internal sampling method
@@ -338,6 +352,16 @@ void NoiseModel::activate_superop_method() {
   // Compute superoperators
   for (auto& qerror : quantum_errors_) {
     qerror.compute_superoperator();
+  }
+}
+
+
+void NoiseModel::activate_kraus_method() {
+  // Set internal sampling method
+  method_ = Method::kraus;
+  // Compute kraus
+  for (auto& qerror : quantum_errors_) {
+    qerror.compute_kraus();
   }
 }
 

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -71,7 +71,8 @@ public:
   double cost_factor;
   bool verbose = false;
   bool active = true;
-  bool allow_noise = true;
+  bool allow_superop = false;
+  bool allow_kraus = false;
 
 private:
   bool can_ignore(const op_t& op) const;
@@ -140,8 +141,11 @@ void Fusion::set_config(const json_t &config) {
   if (JSON::check_key("fusion_cost_factor", config))
     JSON::get_value(cost_factor, "fusion_cost_factor", config);
   
-  if (JSON::check_key("fusion_allow_noise", config))
-    JSON::get_value(allow_noise, "fusion_allow_noise", config);
+  if (JSON::check_key("fusion_allow_kraus", config))
+    JSON::get_value(allow_kraus, "fusion_allow_kraus", config);
+
+  if (JSON::check_key("fusion_allow_superop", config))
+    JSON::get_value(allow_superop, "fusion_allow_superop", config);
 }
 
 
@@ -160,11 +164,15 @@ void Fusion::optimize_circuit(Circuit& circ,
   // Determine fusion method
   // TODO: Support Kraus fusion method
   Method method = Method::unitary;
-  if (allow_noise && allowed_opset.contains(optype_t::superop) &&
+  if (allow_superop && allowed_opset.contains(optype_t::superop) &&
       (circ.opset().contains(optype_t::kraus)
        || circ.opset().contains(optype_t::superop)
        || circ.opset().contains(optype_t::reset))) {
     method = Method::superop;
+  } else if (allow_kraus && allowed_opset.contains(optype_t::kraus) &&
+      (circ.opset().contains(optype_t::kraus)
+       || circ.opset().contains(optype_t::superop))) {
+    method = Method::kraus;
   }
   uint_t qubit_threshold = (method==Method::unitary) ? threshold : threshold / 2;
   uint_t max_fused_qubits = (method==Method::unitary) ? max_qubit : max_qubit / 2;
@@ -256,8 +264,7 @@ bool Fusion::can_apply_fusion(const op_t& op, uint_t max_fused_qubits, Method me
     case optype_t::kraus:
     case optype_t::reset:
     case optype_t::superop: {
-      // TODO: Add support for Method::kraus
-      return method == Method::superop && op.qubits.size() <= max_fused_qubits;
+      return method != Method::unitary && op.qubits.size() <= max_fused_qubits;
     }
     case optype_t::gate: {
       if (op.qubits.size() > max_fused_qubits)
@@ -299,18 +306,21 @@ op_t Fusion::generate_fusion_operation(const std::vector<op_t>& fusioned_ops,
     return Operations::make_unitary(qubits, unitary_simulator.qreg().move_to_matrix(),
                                     std::string("fusion"));
   }
+
   // For both Kraus and SuperOp method we simulate using superoperator
   // simulator
   QubitSuperoperator::State<> superop_simulator;
   superop_simulator.initialize_qreg(qubits.size());
   superop_simulator.apply_ops(fusioned_ops, dummy_data, dummy_rng);
+  auto superop = superop_simulator.qreg().move_to_matrix();
+
   if (method == Method::superop) {
-    return Operations::make_superop(qubits, superop_simulator.qreg().move_to_matrix());
+    return Operations::make_superop(qubits, std::move(superop));
   }
-  
-  // TODO: Add support for Kraus method
-  // For Kraus method we must convert superoperator to a Kraus op
-  throw std::runtime_error("Kraus fusion method is not supported yet");
+
+  // If Kraus method we convert superop to canonical Kraus representation
+  size_t dim = 1 << qubits.size();
+  return Operations::make_kraus(qubits, Utils::superop2kraus(superop, dim));
 }
 
 

--- a/test/terra/backends/test_qasm_simulator_density_matrix.py
+++ b/test/terra/backends/test_qasm_simulator_density_matrix.py
@@ -46,6 +46,7 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
 # Other tests
 from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
+from test.terra.backends.qasm_simulator.qasm_fusion import QasmFusionTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -57,7 +58,7 @@ from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValM
 
 
 class DensityMatrixTests(
-        QasmMethodTests, QasmMeasureTests, QasmMultiQubitMeasureTests,
+        QasmMethodTests, QasmFusionTests, QasmMeasureTests, QasmMultiQubitMeasureTests,
         QasmResetTests, QasmConditionalGateTests, QasmConditionalUnitaryTests,
         QasmConditionalKrausTests, QasmConditionalSuperOpTests,
         QasmCliffordTests, QasmCliffordTestsWaltzBasis,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

~Depends on #889~

Adds a Kraus method to NoiseModel and gate fusion that allows applying the gate fusion optimization to noisy statevector simulations with Kraus noise.

### Details and comments

Initial benchmarks show this gives a 3-9x performance improvement for noisy statevector simulations using the device noise model for 10-20 qubits.

![kraus_fusion_perf](https://user-images.githubusercontent.com/2235104/92787754-620e8d00-f377-11ea-926c-390ffd832e83.png)

Benchmarks run on Ubuntu desktop w/ AMD Ryzen 3700X and Geforce 1070.