### PR TITLE
Set OMP thrust method and capture streams in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
+    env:
+      AER_THRUST_BACKEND: OMP
+      QISKIT_TEST_CAPTURE_STREAMS: 1
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit makes 2 minor changes to the CI configuration to re-enable
building and running tests with the thrust OMP CPU backend. This was lost
in the migration to GHA and means we're not testing the thrust
simulation methods in CI which is a coverage hole. This fixes that
oversight. At the same time this commit adds the
QISKIT_TEST_CAPTURE_STREAMS env variable. Since Qiskit/qiskit-terra#3982
merged the base test class has had support for capturing STDOUT, STDERR,
and python logging as part of the test runs, which is especially
important for our CI configuration where we run tests in parallel. This
just enables this option so we'll have captured output streams
associated with each test method.

### Details and comments