### PR TITLE
[WIP] MPS: Added support for snapshot_density_matrix 

### DIFF
--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -55,13 +55,14 @@ const Operations::OpSet StateOpSet(
     "expectation_value_pauli", "expectation_value_pauli_with_variance",
     "expectation_value_pauli_single_shot", "expectation_value_matrix",
     "expectation_value_matrix_with_variance",
-    "expectation_value_matrix_single_shot"}
+      "expectation_value_matrix_single_shot",
+      "density_matrix", "density_matrix_with_variance"}
 );
 
 // Allowed snapshots enum class
 enum class Snapshots {
   statevector, cmemory, cregister,
-    probs, probs_var,
+    probs, probs_var, densmat, densmat_var,
     expval_pauli, expval_pauli_var, expval_pauli_shot,
     expval_matrix, expval_matrix_var, expval_matrix_shot
 };
@@ -137,7 +138,7 @@ public:
   std::vector<reg_t> 
   sample_measure_using_probabilities(const reg_t &qubits,
 				     uint_t shots,
-				     RngEngine &rng) const;
+				     RngEngine &rng);
 
   // Computes sample_measure by copying the MPS to a temporary structure, and
   // applying a measurement on the temporary MPS. This is done for every shot,
@@ -207,7 +208,7 @@ protected:
   // Return vector of measure probabilities for specified qubits
   // If a state subclass supports this function, then "measure"
   // must be contained in the set defined by 'allowed_ops'
-  rvector_t measure_probs(const reg_t &qubits) const;
+  rvector_t measure_probs(const reg_t &qubits);
 
   // Sample the measurement outcome for qubits
   // return a pair (m, p) of the outcome m, and its corresponding
@@ -238,6 +239,10 @@ protected:
                               ExperimentData &data,
                               SnapshotDataType type);
 
+   void snapshot_density_matrix(const Operations::Op &op,
+			     ExperimentData &data,
+	     		     SnapshotDataType type);
+
   // Snapshot the expectation value of a Pauli operator
   void snapshot_pauli_expval(const Operations::Op &op,
                              ExperimentData &data,
@@ -252,6 +257,9 @@ protected:
   void snapshot_state(const Operations::Op &op,
 		      ExperimentData &data,
 		      std::string name = "");
+
+  // Return the reduced density matrix for the simulator
+  cmatrix_t density_matrix(const reg_t &qubits);
 
   //-----------------------------------------------------------------------
   // Single-qubit gate helpers
@@ -313,6 +321,8 @@ const stringmap_t<Snapshots> State::snapshotset_({
   {"expectation_value_pauli", Snapshots::expval_pauli},
   {"expectation_value_matrix", Snapshots::expval_matrix},
   {"probabilities_with_variance", Snapshots::probs_var},
+  {"density_matrix", Snapshots::densmat},
+  {"density_matrix_with_variance", Snapshots::densmat_var},
   {"expectation_value_pauli_with_variance", Snapshots::expval_pauli_var},
   {"expectation_value_matrix_with_variance", Snapshots::expval_matrix_var},
   {"expectation_value_pauli_single_shot", Snapshots::expval_pauli_shot},
@@ -574,6 +584,33 @@ void State::snapshot_probabilities(const Operations::Op &op,
 
 }
 
+void State::snapshot_density_matrix(const Operations::Op &op,
+			     ExperimentData &data,
+			     SnapshotDataType type) {
+  cmatrix_t reduced_state;
+  if (op.qubits.empty()) {
+    reduced_state = cmatrix_t(1, 1);
+    reduced_state[0] = qreg_.norm();
+  } else {
+    reduced_state = qreg_.density_matrix(op.qubits);
+  }
+
+  // Add density matrix to result data
+  switch (type) {
+    case SnapshotDataType::average:
+      data.add_average_snapshot("density_matrix", op.string_params[0],
+                            BaseState::creg_.memory_hex(), std::move(reduced_state), false);
+      break;
+    case SnapshotDataType::average_var:
+      data.add_average_snapshot("density_matrix", op.string_params[0],
+                            BaseState::creg_.memory_hex(), std::move(reduced_state), true);
+      break;
+    case SnapshotDataType::pershot:
+      data.add_pershot_snapshot("density_matrix", op.string_params[0], std::move(reduced_state));
+      break;
+  }
+}
+
 void State::apply_gate(const Operations::Op &op) {
   // Look for gate name in gateset
   auto it = gateset_.find(op.name);
@@ -692,7 +729,7 @@ void State::apply_measure(const reg_t &qubits,
   creg_.store_measure(outcome, cmemory, cregister);
 }
 
-rvector_t State::measure_probs(const reg_t &qubits) const {
+rvector_t State::measure_probs(const reg_t &qubits) {
   rvector_t probvector;
   qreg_.get_probabilities_vector(probvector, qubits);
   return probvector;
@@ -718,7 +755,7 @@ std::vector<reg_t> State::sample_measure(const reg_t &qubits,
 std::vector<reg_t> State::
 sample_measure_using_probabilities(const reg_t &qubits,
 				   uint_t shots,
-				   RngEngine &rng) const {
+				   RngEngine &rng) {
 
   // Generate flat register for storing
   rvector_t rnds;
@@ -786,6 +823,9 @@ void State::apply_snapshot(const Operations::Op &op, ExperimentData &data) {
       snapshot_probabilities(op, data, SnapshotDataType::average);
       break;
   }
+  case Snapshots::densmat: {
+      snapshot_density_matrix(op, data, SnapshotDataType::average);
+  } break;
   case Snapshots::expval_pauli: {
     snapshot_pauli_expval(op, data, SnapshotDataType::average);
   } break;
@@ -795,6 +835,9 @@ void State::apply_snapshot(const Operations::Op &op, ExperimentData &data) {
   case Snapshots::probs_var: {
     // get probs as hexadecimal
     snapshot_probabilities(op, data, SnapshotDataType::average_var);
+  } break;
+  case Snapshots::densmat_var: {
+      snapshot_density_matrix(op, data, SnapshotDataType::average_var);
   } break;
   case Snapshots::expval_pauli_var: {
     snapshot_pauli_expval(op, data, SnapshotDataType::average_var);

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -126,7 +126,7 @@ public:
 
   void apply_diagonal_matrix(const AER::reg_t &qubits, const cvector_t &vmat);
 
-  cmatrix_t density_matrix(const reg_t &qubits) ;
+  cmatrix_t density_matrix(const reg_t &qubits);
 
   //---------------------------------------------------------------
   // Function: expectation_value
@@ -297,7 +297,7 @@ private:
 			      const cmatrix_t &mat);
   void apply_matrix_to_target_qubits(const reg_t &target_qubits,
 				     const cmatrix_t &mat);
-  cmatrix_t density_matrix_internal(const reg_t &qubits);
+  cmatrix_t density_matrix_internal(const reg_t &qubits, bool reverse_order=true);
 
   rvector_t diagonal_of_density_matrix(const reg_t &qubits);
 
@@ -328,7 +328,7 @@ private:
   // This function computes the state vector for all the consecutive qubits 
   // between first_index and last_index
   MPS_Tensor state_vec_as_MPS(uint_t first_index, uint_t last_index) const;
-  void full_state_vector_internal(cvector_t &state_vector, const reg_t &qubits) ;
+  void full_state_vector_internal(cvector_t &state_vector, const reg_t &qubits, bool reverse_order=true) ;
 
   void get_probabilities_vector_internal(rvector_t& probvector, const reg_t &qubits);
 

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -126,7 +126,7 @@ public:
 
   void apply_diagonal_matrix(const AER::reg_t &qubits, const cvector_t &vmat);
 
-  cmatrix_t density_matrix(const reg_t &qubits) const;
+  cmatrix_t density_matrix(const reg_t &qubits) ;
 
   //---------------------------------------------------------------
   // Function: expectation_value
@@ -135,7 +135,7 @@ public:
   //             M - the matrix
   // Returns: The expectation value. 
   //------------------------------------------------------------------
-  double expectation_value(const reg_t &qubits, const cmatrix_t &M) const;
+  double expectation_value(const reg_t &qubits, const cmatrix_t &M);
 
   //---------------------------------------------------------------
   // Function: expectation_value_pauli
@@ -170,7 +170,7 @@ public:
 
   void full_state_vector(cvector_t &state_vector);
 
-  void get_probabilities_vector(rvector_t& probvector, const reg_t &qubits) const;
+  void get_probabilities_vector(rvector_t& probvector, const reg_t &qubits);
 
   //----------------------------------------------------------------
   // Function name: get_accumulated_probabilities_vector
@@ -186,7 +186,7 @@ public:
 
   void get_accumulated_probabilities_vector(rvector_t& acc_probvector, 
 					    reg_t& index_vec,
-					    const reg_t &qubits) const;
+					    const reg_t &qubits);
 
   static void set_omp_threads(uint_t threads) {
     if (threads > 0)
@@ -230,19 +230,21 @@ public:
     return enable_gate_opt_;
   }
 
-  double norm(const uint_t qubit, const cvector_t &vmat) const {
+  double norm();
+
+  double norm(const uint_t qubit, const cvector_t &vmat) {
     cmatrix_t mat = AER::Utils::devectorize_matrix(vmat);
     reg_t qubits = {qubit};
     return expectation_value(qubits, mat);
   }
 
-  double norm(const reg_t &qubits, const cvector_t &vmat) const {
+  double norm(const reg_t &qubits, const cvector_t &vmat) {
     cmatrix_t mat = AER::Utils::devectorize_matrix(vmat);
     return expectation_value(qubits, mat);
   }
 
   reg_t sample_measure_using_probabilities(const rvector_t &rnds, 
-					   const reg_t &qubits) const;
+					   const reg_t &qubits);
 
   reg_t apply_measure(const reg_t &qubits,
 		      RngEngine &rng);
@@ -295,11 +297,11 @@ private:
 			      const cmatrix_t &mat);
   void apply_matrix_to_target_qubits(const reg_t &target_qubits,
 				     const cmatrix_t &mat);
-  cmatrix_t density_matrix_internal(const reg_t &qubits) const;
+  cmatrix_t density_matrix_internal(const reg_t &qubits);
 
-  rvector_t trace_of_density_matrix(const reg_t &qubits) const;
+  rvector_t diagonal_of_density_matrix(const reg_t &qubits);
 
-  double expectation_value_internal(const reg_t &qubits, const cmatrix_t &M) const;
+  double expectation_value_internal(const reg_t &qubits, const cmatrix_t &M);
   complex_t expectation_value_pauli_internal(const reg_t &qubits, const std::string &matrices,
 					     uint_t first_index, uint_t last_index,
 					     uint_t num_Is) const;
@@ -328,7 +330,7 @@ private:
   MPS_Tensor state_vec_as_MPS(uint_t first_index, uint_t last_index) const;
   void full_state_vector_internal(cvector_t &state_vector, const reg_t &qubits) ;
 
-  void get_probabilities_vector_internal(rvector_t& probvector, const reg_t &qubits) const;
+  void get_probabilities_vector_internal(rvector_t& probvector, const reg_t &qubits);
 
   void apply_measure_internal(const reg_t &qubits,
 			      RngEngine &rng, reg_t &outcome_vector_internal);

--- a/test/terra/backends/test_qasm_simulator_matrix_product_state.py
+++ b/test/terra/backends/test_qasm_simulator_matrix_product_state.py
@@ -43,6 +43,7 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
+from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStabilizerTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabilitiesTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
@@ -72,6 +73,7 @@ class TestQasmMatrixProductStateSimulator(
         QasmPauliNoiseTests,
         QasmResetNoiseTests,
         QasmSnapshotStatevectorTests,
+        QasmSnapshotDensityMatrixTests,
         QasmSnapshotProbabilitiesTests,
         QasmSnapshotStabilizerTests,
         QasmSnapshotExpValPauliTests,


### PR DESCRIPTION
…matrix and in diagonal_of_density_matrix

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added support for snapshot_density_matrix 


### Details and comments
Includes:
1. API for snapshot_density_matrix
2. Bug fix in `density_matrix` - order of qubits was not reversed to suit Qiskit ordering
This required change in implementation.
3. `trace_of_density_matrix` - changed name to `diagonal_of_density_matrix`
Also changed implementation to be similar to that of `density_matrix`
4. Enabled the suitable tests

