### PR TITLE
Fix a copy-paste-error in the noise model> it checks the wrong variable.

### DIFF
--- a/qiskit/providers/aer/noise/device/parameters.py
+++ b/qiskit/providers/aer/noise/device/parameters.py
@@ -174,7 +174,7 @@ def thermal_relaxation_values(properties):
             if hasattr(t2_params, 'unit'):
                 # Convert to nanoseconds
                 t2 *= _NANOSECOND_UNITS.get(t2_params.unit, 1)
-        if hasattr(t2_params, 'value'):
+        if hasattr(freq_params, 'value'):
             freq = freq_params.value
             if hasattr(freq_params, 'unit'):
                 # Convert to Gigahertz


### PR DESCRIPTION
### Summary

While working at a new provider and testing the possibility to use the noise model also for other devices, I found a copy-and-paste error in the value creation for the thermal relaxation routine. The problem is quite obvious when spotted and simply fixed too.

### Details and comments

The variable to check for the property `value` should for obvious reasons be `freq_params` instead of `t2_params`. 

I would have changed or added tests, but since this module is not tested at all, starting a test module would be a major change to the code instead of one simple modification of one line of code. I think it could be good to test this part too, but this should be a new issue / PR by itself.
