### PR TITLE
Clustermanager

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -223,7 +223,7 @@ class AerBackend(BaseBackend, ABC):
             pending_jobs=0,
             status_msg='')
 
-    def _run_job(self, job_id, qobj, backend_options, noise_model, validate):
+    def _run_job(self, job_id, qobj, backend_options, noise_model, validate=False):
         """Run a qobj job"""
         warnings.warn(
             'The `_run_job` method has been deprecated. Use `_run` instead.',

--- a/qiskit/providers/aer/cluster/__init__.py
+++ b/qiskit/providers/aer/cluster/__init__.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+===========================================================
+Cluster Manager (:mod:`qiskit.providers.aer.managed`)
+===========================================================
+
+.. currentmodule:: qiskit.providers.aer.cluster
+
+High level mechanism for handling cluster jobs.
+
+Classes
+==========================
+.. autosummary::
+   :toctree: ../stubs/
+
+   ClusterManager
+"""
+
+from .clustermanager import AerClusterManager
+from .clusterjobset import JobSet
+from .clusterjob import CJob
+from .clusterresults import CResults
+from .exceptions import *

--- a/qiskit/providers/aer/cluster/clusterjob.py
+++ b/qiskit/providers/aer/cluster/clusterjob.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Job managed by the Job Manager."""
+
+import warnings
+import logging
+import functools
+from typing import Optional, Any
+from concurrent import futures
+
+from qiskit.providers.aer.backends.aerbackend import AerBackend
+from qiskit.qobj import QasmQobj
+from qiskit.result import Result
+from qiskit.providers import JobStatus, JobError
+
+logger = logging.getLogger(__name__)
+
+
+class CJob:
+    """Job managed by the Cluster Manager.
+
+    Attributes:
+       _executor (futures.Executor): default executor to handle asynchronous jobs
+    """
+
+    _executor = futures.ThreadPoolExecutor(max_workers=1)
+
+    def __init__(self, backend: AerBackend, qobj: QasmQobj, *run_args: Any, **run_kwargs: Any):
+        """ManagedJob constructor.
+
+        Args:
+            backend: Backend to execute the experiments on.
+            qobj: Assembled qobj object.
+            *run_args: Positional args passed through to backend.run
+            **run_kwargs: Keyword args passed through to backend.run
+        """
+        self._qobj = qobj
+        self._id = self._qobj.qobj_id
+        self._backend = backend
+        self._run_args = run_args
+        self._run_kwargs = run_kwargs
+        self._future = None
+        self._result = None
+        # Properties that may be populated by the future.
+        self.submit_error = None
+
+    def submit(self, executor: Optional[futures.Executor] = None) -> None:
+        """Submit the job.
+
+        Args:
+            executor: The executor to be used to submit the job.
+        """
+
+        # Submit the job in its own future.
+        logger.debug("Submitting job %s in future", self._id)
+        if executor:
+            self._future = executor.submit(self._backend._run_job, self._id, self._qobj,
+                                           *self._run_args, **self._run_kwargs)
+        else:
+            self._future = self._executor.submit(self._backend._run_job, self._id, self._qobj,
+                                                 *self._run_args, **self._run_kwargs)
+        logger.debug("Job %s future obtained", self._id)
+
+    def requires_submit(func):
+        """
+        Decorator to ensure that a submit has been performed before
+        calling the method.
+
+        Args:
+            func (callable): test function to be decorated.
+
+        Returns:
+            callable: the decorated function.
+        """
+        @functools.wraps(func)
+        def _wrapper(self, *args, **kwargs):
+            if self._future is None:
+                raise JobError("Job not submitted yet!. You have to .submit() first!")
+            return func(self, *args, **kwargs)
+        return _wrapper
+
+    @property
+    @requires_submit
+    def future(self) -> futures.Future:
+        """Return this job's associated future.
+
+        Returns:
+            Future: A future-like object
+        """
+        return self._future
+
+    @requires_submit
+    def result(self, timeout: Optional[float] = None, raises: Optional[bool] = False) -> Result:
+        """Return the result of the job.
+
+        Args:
+           timeout: Number of seconds to wait for job.
+           raises: if True and the job raised an exception
+                   this will raise the same exception
+        Returns:
+            Job result or ``None`` if result could not be retrieved.
+
+        Raises:
+            JobError: If the job does not return results before a
+                specified timeout.
+        """
+        if self._result:
+            return self._result
+        result = None
+        if self._future is not None:
+            try:
+                result = self._future.result(timeout=timeout)
+            except JobError as err:
+                warnings.warn(
+                    "Unable to retrieve job result for job {}".format(self._id))
+                if raises:
+                    raise err
+        self._result = result
+        return result
+
+    @requires_submit
+    def status(self) -> JobStatus:
+        """Query the future for it's status
+
+        Returns:
+            Current job status, or ``None`` if an error occurred.
+        """
+        _status = None
+        if self._future.running():
+            _status = JobStatus.RUNNING
+        elif self._future.cancelled():
+            _status = JobStatus.CANCELLED
+        elif self._future.done():
+            _status = JobStatus.DONE if self._future.exception() is None else JobStatus.ERROR
+        else:
+            # Note: There is an undocumented Future state: PENDING, that seems to show up when
+            # the job is enqueued, waiting for someone to pick it up. We need to deal with this
+            # state but there's no public API for it, so we are assuming that if the job is not
+            # in any of the previous states, is PENDING, ergo INITIALIZING for us.
+            _status = JobStatus.INITIALIZING
+        return _status
+
+    @requires_submit
+    def cancel(self) -> bool:
+        """Attempt to cancel the Job.
+
+        Returns:
+            False if the call cannot be cancelled, True otherwise"""
+        return self._future.cancel()
+
+    def qobj(self) -> QasmQobj:
+        """Return the Qobj submitted for this job.
+
+        Returns:
+            Qobj: the Qobj submitted for this job.
+        """
+        return self._qobj
+
+    def name(self) -> str:
+        """Return this job's name.
+
+        Returns:
+            Name: str name of this job.
+        """
+        return self._id

--- a/qiskit/providers/aer/cluster/clusterjob.py
+++ b/qiskit/providers/aer/cluster/clusterjob.py
@@ -19,10 +19,10 @@ import logging
 from typing import Optional, Any
 from concurrent import futures
 
-from qiskit.providers.aer.backends.aerbackend import AerBackend
 from qiskit.qobj import QasmQobj
 from qiskit.result import Result
 from qiskit.providers import JobStatus, JobError
+from ..backends.aerbackend import AerBackend
 from .utils import requires_submit
 
 logger = logging.getLogger(__name__)

--- a/qiskit/providers/aer/cluster/clusterjob.py
+++ b/qiskit/providers/aer/cluster/clusterjob.py
@@ -16,7 +16,6 @@
 
 import warnings
 import logging
-import functools
 from typing import Optional, Any
 from concurrent import futures
 
@@ -24,6 +23,7 @@ from qiskit.providers.aer.backends.aerbackend import AerBackend
 from qiskit.qobj import QasmQobj
 from qiskit.result import Result
 from qiskit.providers import JobStatus, JobError
+from .utils import requires_submit
 
 logger = logging.getLogger(__name__)
 
@@ -72,24 +72,6 @@ class CJob:
             self._future = self._executor.submit(self._backend._run_job, self._id, self._qobj,
                                                  *self._run_args, **self._run_kwargs)
         logger.debug("Job %s future obtained", self._id)
-
-    def requires_submit(func):
-        """
-        Decorator to ensure that a submit has been performed before
-        calling the method.
-
-        Args:
-            func (callable): test function to be decorated.
-
-        Returns:
-            callable: the decorated function.
-        """
-        @functools.wraps(func)
-        def _wrapper(self, *args, **kwargs):
-            if self._future is None:
-                raise JobError("Job not submitted yet!. You have to .submit() first!")
-            return func(self, *args, **kwargs)
-        return _wrapper
 
     @property
     @requires_submit

--- a/qiskit/providers/aer/cluster/clusterjobset.py
+++ b/qiskit/providers/aer/cluster/clusterjobset.py
@@ -19,12 +19,10 @@ from concurrent import futures
 import time
 import logging
 import uuid
-import functools
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.pulse import Schedule
 from qiskit.qobj import QasmQobj
-from qiskit.providers import JobError
 from qiskit.providers.jobstatus import JobStatus
 
 from ..backends.aerbackend import AerBackend
@@ -46,9 +44,6 @@ class JobSet:
     for all of the jobs using :meth:`results()` and cancel all jobs using
     :meth:`cancel()`.
     """
-
-    _id_prefix = "cluster_jobset_"
-    _id_suffix = "_"
 
     def __init__(self, experiments: List[QasmQobj], name: Optional[str] = None):
         """JobSet constructor.
@@ -89,7 +84,6 @@ class JobSet:
         self._future = True
         total_jobs = len(self._experiments)
         for i, exp in enumerate(self._experiments):
-            job_name = f'{self._name}_{i}'
             cjob = CJob(backend, exp, *run_args, **run_kwargs)
             cjob.submit(executor=executor)
             logger.debug("Job %s submitted", i + 1)
@@ -142,7 +136,7 @@ class JobSet:
             try:
                 result = cjob.result(timeout=timeout, raises=raises)
                 if result is None or not result.success:
-                    logger.warning('ClusterJob {} failed.'.format(cjob.name()))
+                    logger.warning('ClusterJob %s failed.', cjob.name())
                     success = False
             except AerClusterTimeoutError as ex:
                 raise AerClusterTimeoutError(

--- a/qiskit/providers/aer/cluster/clusterjobset.py
+++ b/qiskit/providers/aer/cluster/clusterjobset.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A set of jobs being managed by the :class:`AerClusterManager`."""
+
+from typing import List, Optional, Union, Any, Tuple
+from concurrent import futures
+import time
+import logging
+import uuid
+import functools
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.pulse import Schedule
+from qiskit.qobj import QasmQobj
+from qiskit.providers import JobError
+from qiskit.providers.jobstatus import JobStatus
+
+from ..backends.aerbackend import AerBackend
+from .clusterjob import CJob
+from .clusterresults import CResults
+from .exceptions import AerClusterTimeoutError, AerClusterJobNotFound
+
+logger = logging.getLogger(__name__)
+
+
+class JobSet:
+    """A set of cluster jobs.
+
+    An instance of this class is returned when you submit experiments using
+    :meth:`AerClusterManager.run()`.
+    It provides methods that allow you to interact
+    with the jobs as a single entity. For example, you can retrieve the results
+    for all of the jobs using :meth:`results()` and cancel all jobs using
+    :meth:`cancel()`.
+    """
+
+    _id_prefix = "cluster_jobset_"
+    _id_suffix = "_"
+
+    def __init__(self, experiments: List[QasmQobj], name: Optional[str] = None):
+        """JobSet constructor.
+
+        Args:
+            experiments: List[QasmQobjs] to execute.
+            name: Name for this set of jobs.
+        """
+        self._name = name or str(uuid.uuid4())
+        self._experiments = experiments
+
+        # Used for caching
+        self._futures = []
+        self._results = None
+        self._error_msg = None
+
+    def requires_submit(func):
+        """
+        Decorator to ensure that a submit has been performed before
+        calling the method.
+
+        Args:
+            func (callable): test function to be decorated.
+
+        Returns:
+            callable: the decorated function.
+        """
+        @functools.wraps(func)
+        def _wrapper(self, *args, **kwargs):
+            if not self._futures:
+                raise JobError("JobSet not submitted yet!. You have to .run() first!")
+            return func(self, *args, **kwargs)
+        return _wrapper
+
+    def run(self,
+            executor: futures.Executor,
+            backend: AerBackend,
+            *run_args: Any,
+            **run_kwargs: Any) -> None:
+        """Execute this set of jobs on an executor.
+
+        Args:
+            executor: The executor used to submit jobs asynchronously.
+            backend: The backend to run the jobs on.
+            *run_args: Positional arguments passed through to backend.run.
+            **run_kwargs: Keyword arguments passed through to backend.run.
+
+        Raises:
+            RuntimeError: If the jobs were already submitted.
+        """
+        if self._futures:
+            raise RuntimeError(
+                'The jobs for this managed job set have already been submitted.')
+
+        total_jobs = len(self._experiments)
+        for i, exp in enumerate(self._experiments):
+            job_name = f'{self._name}_{i}'
+            cjob = CJob(backend, exp, *run_args, **run_kwargs)
+            cjob.submit(executor=executor)
+            logger.debug("Job %s submitted", i + 1)
+            self._futures.append(cjob)
+
+    @requires_submit
+    def statuses(self) -> List[Union[JobStatus]]:
+        """Return the status of each job in this set.
+
+        Returns:
+            A list of job statuses.
+        """
+        return [cjob.status() for cjob in self._futures]
+
+    @requires_submit
+    def results(
+            self,
+            timeout: Optional[float] = None,
+            raises: Optional[bool] = False
+    ) -> CResults:
+        """Return the results of the jobs.
+
+        This call will block until all job results become available or
+        the timeout is reached. Analogous to dask.client.gather()
+
+        Args:
+           timeout: Number of seconds to wait for job results.
+           raises: whether or not to re-raise exceptions thrown by jobs
+
+        Returns:
+            A :class:`CResults`
+            instance that can be used to retrieve results
+            for individual experiments.
+
+        Raises:
+            AerClusterTimeoutError: if unable to retrieve all job results before the
+                specified timeout.
+        """
+        if self._results is not None:
+            return self._results
+
+        success = True
+        start_time = time.time()
+        original_timeout = timeout
+
+        # We'd like to use futures.as_completed or futures.wait
+        #   however this excludes the use of dask as executor
+        #   because dask's futures are not ~exactly~ the same.
+        for cjob in self._futures:
+            try:
+                result = cjob.result(timeout=timeout, raises=raises)
+                if result is None or not result.success:
+                    logger.warning('ClusterJob {} failed.'.format(cjob.name()))
+                    success = False
+            except AerClusterTimeoutError as ex:
+                raise AerClusterTimeoutError(
+                    'Timeout while waiting for the results of experiment {}'.format(
+                        cjob.name())) from ex
+            if timeout:
+                timeout = original_timeout - (time.time() - start_time)
+                if timeout <= 0:
+                    raise AerClusterTimeoutError(
+                        "Timeout while waiting for JobSet results")
+
+        self._results = CResults(self, success)
+
+        return self._results
+
+    @requires_submit
+    def cancel(self) -> None:
+        """Cancel all jobs in this job set."""
+        for cjob in self._futures:
+            cjob.cancel()
+
+    @requires_submit
+    def job(self, experiment: Union[str, QuantumCircuit, Schedule]) -> Tuple[CJob, int]:
+        """Retrieve the job used to submit the specified experiment and its index.
+
+        Args:
+            experiment: Retrieve the job used to submit this experiment. Several
+                types are accepted for convenience:
+
+                    * str: The name of the experiment.
+                    * QuantumCircuit: The name of the circuit instance will be used.
+                    * Schedule: The name of the schedule instance will be used.
+
+        Returns:
+            A tuple of the job used to submit the experiment and the experiment index.
+
+        Raises:
+            AerClusterJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        if isinstance(experiment, (QuantumCircuit, Schedule)):
+            experiment = experiment.name
+        for job in self.jobs():
+            for i, exp in enumerate(job.qobj().experiments):
+                if hasattr(exp.header, 'name') and exp.header.name == experiment:
+                    return job, i
+
+        raise AerClusterJobNotFound(
+            'Unable to find the job for experiment {}.'.format(experiment))
+
+    @requires_submit
+    def jobs(self) -> List[Union[CJob, None]]:
+        """Return jobs in this job set.
+
+        Returns:
+            A list of :class:`~qiskit.providers.aer.cluster.CJob`
+            instances that represents the submitted jobs.
+            An entry in the list is ``None`` if the job failed to be submitted.
+        """
+        return self._futures
+
+    def name(self) -> str:
+        """Return the name of this job set.
+
+        Returns:
+            Name of this job set.
+        """
+        return self._name
+
+    def managed_jobs(self) -> List[CJob]:
+        """Return the managed jobs in this set.
+
+        Returns:
+            A list of managed jobs.
+        """
+        return self._futures

--- a/qiskit/providers/aer/cluster/clustermanager.py
+++ b/qiskit/providers/aer/cluster/clustermanager.py
@@ -1,0 +1,161 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=invalid-name, bad-continuation
+
+"""Manager for Qiskit Aer cluster-backed simulations."""
+from typing import Any, Union, List
+from concurrent import futures
+
+from qiskit import assemble, QuantumCircuit
+from qiskit.qobj import QasmQobj
+from qiskit.pulse import Schedule
+from ..backends.aerbackend import AerBackend
+from .clusterjobset import JobSet
+from .utils import methdispatch, split
+
+
+class AerClusterManager:
+    """Manager for Qiskit Aer cluster-backed simulations.
+
+    The AerClusterManager is a higher level mechanism for running
+    multiple circuits or pulse schedules. It connects to an existing
+    cluster (or creates a local one) and submits circuits individually
+    rather than building a single qobj to be submitted. When the jobs are
+    finished, it collects and presents the results in a unified view.
+
+    You can use the :meth:`run()` method to submit multiple experiments
+    with the Manager::
+
+        from qiskit import Aer, transpile
+        from qiskit.providers.aer.cluster import AerClusterManager
+        from qiskit.circuit.random import random_circuit
+
+        backend = Aer.get_backend('qasm_simulator')
+
+        # Build a thousand circuits.
+        circs = []
+        for _ in range(1000):
+            circs.append(random_circuit(num_qubits=5, depth=4, measure=True))
+
+        # Need to transpile the circuits first.
+        circs = transpile(circs, backend=backend)
+
+        # Use Job Manager to break the circuits into multiple jobs.
+        job_manager = AerClusterManager(shots=4000)
+        job_set_foo = job_manager.run(circs, backend=backend, name='foo')
+
+    The :meth:`run()` method returns a :class:`JobSet` instance, which
+    represents the set of jobs for the experiments. You can use the
+    :class:`JobSet` methods, such as :meth:`statuses()<JobSet.statuses>`,
+    :meth:`results()<JobSet.results>`, and
+    :meth:`error_messages()<JobSet.error_messages>` to get a combined
+    view of the jobs in the set.
+    For example::
+
+        results = job_set_foo.results()
+        results.get_counts(5)  # Counts for experiment 5.
+
+    """
+
+    def __init__(self, executor: futures.Executor, **assemble_config: Any) -> None:
+        """ClusterManager Constructor."""
+        self._exec = executor
+        self._assemble_config = assemble_config
+
+        self._job_sets = []
+
+    def set_assemble_config(self, **assemble_config: Any) -> None:
+        """Set the arguments passed to assemble on subsequent calls to run."""
+        self._assemble_config = assemble_config
+        return self
+
+    @methdispatch
+    def run(self,
+            backend: AerBackend,
+            exp: Union[List[Union[QuantumCircuit, Schedule]], QasmQobj],
+            *run_args: Any,
+            **run_kwargs: Any) -> JobSet:
+        """Execute a qobj on a backend."""
+        raise NotImplementedError(
+            "run() is not implemented for this type of experiment ({})".format(str(type(exp))))
+
+    @run.register(QasmQobj)
+    def _run_qobj(self,
+                  backend: AerBackend,
+                  qobj: QasmQobj,
+                  *run_args: Any,
+                  **run_kwargs: Any) -> JobSet:
+        """Execute a qobj on a backend.
+
+        Args:
+            backend: Backend to execute the experiments on.
+            qobj: QasmQobj to be executed
+            *run_args: Positional arguments passed through to the backend.run
+            **run_kwargs: Keyword arguments to be passed through to the backend.run
+
+        Returns:
+            A :class:`JobSet` instance representing the set of simulation jobs.
+
+        Raises:
+            ValueError: If the qobj/backend are incompatible
+        """
+        if not isinstance(backend, AerBackend):
+            raise ValueError(
+                "AerClusterManager only supports AerBackends. "
+                "{} is not an AerBackend.".format(backend))
+
+        experiments = split(qobj)
+
+        job_set = JobSet(experiments)
+        job_set.run(self._exec, backend, *run_args, **run_kwargs)
+        self._job_sets.append(job_set)
+
+        return job_set
+
+    @run.register(list)
+    def _run_multi(self,
+                   backend: AerBackend,
+                   experiments: List[QuantumCircuit],
+                   *run_args: Any,
+                   **run_kwargs: Any) -> JobSet:
+        """Execute a list of circuits on a backend.
+
+        Args:
+            backend: Backend to execute the experiments on.
+            experiments: List of QuantumCircuits to be executed
+            *run_args: Positional arguments passed through to the backend.run
+            **run_kwargs: Keyword arguments to be passed through to the backend.run
+
+        Returns:
+            A :class:`JobSet` instance representing the set of simulation jobs.
+
+        Raises:
+            ValueError: If the backend/experiments are incompatible
+        """
+        if not isinstance(backend, AerBackend):
+            raise ValueError(
+                "AerClusterManager only supports AerBackends. "
+                "{} is not an AerBackend.".format(backend))
+
+        if (any(isinstance(exp, Schedule) for exp in experiments) and
+                not backend.configuration().open_pulse):
+            raise ValueError(
+                'Pulse schedules found, but the backend does not support pulse schedules.')
+
+        exps = [assemble(exp, backend, **self._assemble_config) for exp in experiments]
+
+        job_set = JobSet(exps)
+        job_set.run(self._exec, backend, *run_args, **run_kwargs)
+        self._job_sets.append(job_set)
+
+        return job_set

--- a/qiskit/providers/aer/cluster/clusterresults.py
+++ b/qiskit/providers/aer/cluster/clusterresults.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Results managed by the Job Manager."""
+
+from typing import List, Optional, Union, Tuple, Dict
+import copy
+
+# TODO Use TYPE_CHECKING instead of pylint disable after dropping python 3.5
+import numpy  # pylint: disable=unused-import
+from qiskit.result import Result
+from qiskit.circuit import QuantumCircuit
+from qiskit.pulse import Schedule
+
+from qiskit.providers import JobError
+from .exceptions import AerClusterResultDataNotAvailable, AerClusterResultDataNotAvailable
+
+
+class CResults:
+    """A CResults instance is returned by CJobSet by the Job Manager.
+
+    This class is a wrapper around the :class:`~qiskit.result.Result` class and
+    provides the same methods. Please refer to the
+    :class:`~qiskit.result.Result` class for more information on the methods.
+    """
+
+    def __init__(
+            self,
+            job_set: 'clusterjobset.JobSet',
+            success: bool
+    ):
+        """ClusterResults constructor.
+
+        Args:
+            job_set: Cluster job set for these results.
+            success: ``True`` if all experiments were successful and results
+                available. ``False`` otherwise.
+
+        Attributes:
+            success: Whether all experiments were successful.
+        """
+        self._job_set = job_set
+        self.success = success
+        self._combined_results = None  # type: Result
+
+    def data(self, experiment: Union[str, QuantumCircuit, Schedule, int]) -> Dict:
+        """Get the raw data for an experiment.
+
+        Args:
+            experiment: Retrieve result for this experiment. Several types are
+                accepted for convenience:
+
+                    * str: The name of the experiment.
+                    * QuantumCircuit: The name of the circuit instance will be used.
+                    * Schedule: The name of the schedule instance will be used.
+                    * int: The position of the experiment.
+
+        Returns:
+            Refer to the :meth:`Result.data()<qiskit.result.Result.data()>` for
+            information on return data.
+
+        Raises:
+            AerClusterResultDataNotAvailable: If data for the experiment could not be retrieved.
+            AerClusterJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.data(exp_index)
+
+    def get_memory(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int]
+    ) -> Union[list, 'numpy.ndarray']:
+        """Get the sequence of memory states (readouts) for each shot.
+        The data from the experiment is a list of format
+        ['00000', '01000', '10100', '10100', '11101', '11100', '00101', ..., '01010']
+
+        Args:
+            experiment: Retrieve result for this experiment, as specified by :meth:`data()`.
+
+        Returns:
+            Refer to the :meth:`Result.get_memory()<qiskit.result.Result.get_memory()>`
+            for information on return data.
+
+        Raises:
+            AerClusterResultDataNotAvailable: If data for the experiment could not be retrieved.
+            AerClusterJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.get_memory(exp_index)
+
+    def get_counts(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int]
+    ) -> Dict[str, int]:
+        """Get the histogram data of an experiment.
+
+        Args:
+            experiment: Retrieve result for this experiment, as specified by :meth:`data()`.
+
+        Returns:
+            Refer to the :meth:`Result.get_counts()<qiskit.result.Result.get_counts()>`
+            for information on return data.
+
+        Raises:
+            AerClusterResultDataNotAvailable: If data for the experiment could not be retrieved.
+            AerClusterJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.get_counts(exp_index)
+
+    def get_statevector(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int],
+            decimals: Optional[int] = None
+    ) -> List[complex]:
+        """Get the final statevector of an experiment.
+
+        Args:
+            experiment: Retrieve result for this experiment, as specified by :meth:`data()`.
+            decimals: The number of decimals in the statevector.
+                If ``None``, skip rounding.
+
+        Returns:
+            Refer to the :meth:`Result.get_statevector()<qiskit.result.Result.get_statevector()>`
+            for information on return data.
+
+        Raises:
+            AerClusterResultDataNotAvailable: If data for the experiment could not be retrieved.
+            AerClusterJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.get_statevector(experiment=exp_index, decimals=decimals)
+
+    def get_unitary(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int],
+            decimals: Optional[int] = None
+    ) -> List[List[complex]]:
+        """Get the final unitary of an experiment.
+
+        Args:
+            experiment: Retrieve result for this experiment, as specified by :meth:`data()`.
+            decimals: The number of decimals in the unitary.
+                If ``None``, skip rounding.
+
+        Returns:
+            Refer to the :meth:`Result.get_unitary()<qiskit.result.Result.get_unitary()>`
+            for information on return data.
+
+        Raises:
+            AerClusterResultDataNotAvailable: If data for the experiment could not be retrieved.
+            AerClusterJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.get_unitary(experiment=exp_index, decimals=decimals)
+
+    def combine_results(self) -> Result:
+        """Combine results from all jobs into a single `Result`.
+
+        Note:
+            Since the order of the results must match the order of the initial
+            experiments, job results can only be combined if all jobs succeeded.
+
+        Returns:
+            A :class:`~qiskit.result.Result` object that contains results from
+                all jobs.
+        Raises:
+            AerClusterResultDataNotAvailable: If results cannot be combined
+                because some jobs failed.
+        """
+        if self._combined_results:
+            return self._combined_results
+
+        if not self.success:
+            raise AerClusterResultDataNotAvailable(
+                "Results cannot be combined since one or more jobs failed.")
+
+        jobs = self._job_set.jobs()
+        combined_result = copy.deepcopy(jobs[0].result())
+        for idx in range(1, len(jobs)):
+            combined_result.results.extend(jobs[idx].result().results)
+
+        self._combined_results = combined_result
+        return combined_result
+
+    def _get_result(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule]
+    ) -> Tuple[Result, int]:
+        """Get the result of the job used to submit the experiment.
+
+        Args:
+            experiment: Retrieve result for this experiment, as specified by :meth:`data()`.
+
+        Returns:
+            A tuple of the result of the job used to submit the experiment and
+                the experiment index within the job.
+
+        Raises:
+            AerClusterResultDataNotAvailable: If data for the experiment could not be retrieved.
+        """
+
+        (job, exp_index) = self._job_set.job(experiment)
+        try:
+            result = job.result()
+            return result, exp_index
+        except JobError as err:
+            raise AerClusterResultDataNotAvailable(
+                'Result data for experiment {} is not available.'.format(experiment)) from err

--- a/qiskit/providers/aer/cluster/clusterresults.py
+++ b/qiskit/providers/aer/cluster/clusterresults.py
@@ -24,7 +24,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.pulse import Schedule
 
 from qiskit.providers import JobError
-from .exceptions import AerClusterResultDataNotAvailable, AerClusterResultDataNotAvailable
+from .exceptions import AerClusterResultDataNotAvailable
 
 
 class CResults:

--- a/qiskit/providers/aer/cluster/exceptions.py
+++ b/qiskit/providers/aer/cluster/exceptions.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Exception for the Job Manager modules."""
+
+from ..aererror import AerError
+
+
+class AerClusterError(AerError):
+    """Base class for errors raise by the Job Manager."""
+    pass
+
+
+class AerClusterInvalidStateError(AerClusterError):
+    """Errors raised when an operation is invoked in an invalid state."""
+    pass
+
+
+class AerClusterTimeoutError(AerClusterError):
+    """Errors raised when a Job Manager operation times out."""
+    pass
+
+
+class AerClusterJobNotFound(AerClusterError):
+    """Errors raised when a job cannot be found."""
+    pass
+
+
+class AerClusterResultDataNotAvailable(AerClusterError):
+    """Errors raised when result data is not available."""
+    pass
+
+
+class AerClusterUnknownJobSet(AerClusterError):
+    """Errors raised when the job set ID is unknown."""
+    pass

--- a/qiskit/providers/aer/cluster/utils.py
+++ b/qiskit/providers/aer/cluster/utils.py
@@ -1,0 +1,64 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Disassemble function for a qobj into a list of circuits and its config"""
+import uuid
+from typing import Optional, List
+from functools import singledispatch, update_wrapper
+
+from qiskit.qobj import QasmQobj, QasmQobjConfig
+
+
+def methdispatch(func):
+    """returns a wrapper function that selects which registered function
+    to call based on the type of args[2]"""
+    dispatcher = singledispatch(func)
+
+    def wrapper(*args, **kw):
+        return dispatcher.dispatch(args[2].__class__)(*args, **kw)
+    wrapper.register = dispatcher.register
+    update_wrapper(wrapper, func)
+    return wrapper
+
+
+def split(qobj: QasmQobj, _id: Optional[str] = None) -> List[QasmQobj]:
+    """Split a qobj and return a list of qobjs each with a single experiment.
+
+    Args:
+        qobj (Qobj): The input qobj object to split
+        _id (str): All generated qobjs will have this ID
+
+    Returns:
+        A list of qobjs.
+    """
+    if qobj.type == 'PULSE':
+        return None
+    else:
+        return _split_qasm_qobj(qobj, _id)
+
+
+def _split_qasm_qobj(qobj: QasmQobj, _id: Optional[str] = None):
+    qobjs = []
+    if len(qobj.experiments) <= 1:
+        return [qobj]
+    elif getattr(qobj.config, 'parameterizations', None):
+        params = getattr(qobj.config, 'parameterizations', None)
+        delattr(qobj.config, 'parameterizations')
+        for exp, par in zip(qobj.experiments, params):
+            _qid = _id or str(uuid.uuid4())
+            _config = QasmQobjConfig(parameterizations=[par], **qobj.config.__dict__)
+            qobjs.append(QasmQobj(_qid, _config, [exp], qobj.header))
+    else:
+        for exp in qobj.experiments:
+            _qid = _id or str(uuid.uuid4())
+            qobjs.append(QasmQobj(_qid, qobj.config, [exp], qobj.header))
+    return qobjs

--- a/qiskit/providers/aer/cluster/utils.py
+++ b/qiskit/providers/aer/cluster/utils.py
@@ -16,6 +16,7 @@ from typing import Optional, List
 from functools import singledispatch, update_wrapper, wraps
 
 from qiskit.qobj import QasmQobj, QasmQobjConfig
+from qiskit.providers import JobError
 
 
 def requires_submit(func):

--- a/qiskit/providers/aer/cluster/utils.py
+++ b/qiskit/providers/aer/cluster/utils.py
@@ -10,12 +10,31 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Disassemble function for a qobj into a list of circuits and its config"""
+"""Utility functions for AerClusterManager."""
 import uuid
 from typing import Optional, List
-from functools import singledispatch, update_wrapper
+from functools import singledispatch, update_wrapper, wraps
 
 from qiskit.qobj import QasmQobj, QasmQobjConfig
+
+
+def requires_submit(func):
+    """
+    Decorator to ensure that a submit has been performed before
+    calling the method.
+
+    Args:
+        func (callable): test function to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+    @wraps(func)
+    def _wrapper(self, *args, **kwargs):
+        if self._future is None:
+            raise JobError("Job not submitted yet!. You have to .submit() first!")
+        return func(self, *args, **kwargs)
+    return _wrapper
 
 
 def methdispatch(func):

--- a/test/terra/extensions/test_cluster.py
+++ b/test/terra/extensions/test_cluster.py
@@ -1,0 +1,186 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+import unittest
+import logging
+import concurrent.futures
+
+from qiskit import Aer
+from qiskit.providers.aer.cluster import AerClusterManager
+from qiskit.providers.aer.cluster.utils import split
+from qiskit.circuit.random import random_circuit
+from qiskit import execute, transpile, assemble
+from qiskit.assembler.disassemble import disassemble
+
+from test.terra import common
+from test.terra.reference import ref_algorithms
+from test.terra.reference import ref_pauli_noise
+from test.terra.reference.ref_snapshot_expval import (
+    snapshot_expval_circuits, snapshot_expval_counts, snapshot_expval_labels,
+    snapshot_expval_pre_meas_values, snapshot_expval_circuit_parameterized,
+    snapshot_expval_final_statevecs)
+
+DASK_TESTS=False
+try:
+    from dask.distributed import LocalCluster, Client
+    DASK_TESTS=True
+except ImportError:
+    logging.warn('Dask not installed: skipping Dask tests')
+
+def dump(obj):
+    for attr in dir(obj):
+        if hasattr( obj, attr ):
+            print( "obj.%s = %s" % (attr, getattr(obj, attr)))
+            print()
+
+class ClusterManagerFixtor(common.QiskitAerTestCase):
+    """ClusterManager extension tests"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Override me with an executor init."""
+        cls._test_executor = None
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._test_executor:
+            cls._test_executor.shutdown()
+
+    @staticmethod
+    def parameterized_circuits(shots=1000, measure=True, snapshot=False):
+        """Return ParameterizedQobj for settings."""
+        single_shot = shots == 1
+        pcirc1, param1 = snapshot_expval_circuit_parameterized(single_shot=single_shot,
+                                                               measure=measure,
+                                                               snapshot=snapshot)
+        circuits2to4 = snapshot_expval_circuits(pauli=True,
+                                                skip_measure=(not measure),
+                                                single_shot=single_shot)
+        pcirc2, param2 = snapshot_expval_circuit_parameterized(single_shot=single_shot,
+                                                               measure=measure,
+                                                               snapshot=snapshot)
+        circuits = [pcirc1] + circuits2to4 + [pcirc2]
+        params = [param1, [], [], [], param2]
+        return circuits, params
+
+    def test_grovers_default_basis_gates(self):
+        shots=4000
+        circuits = ref_algorithms.grovers_circuit(
+            final_measure=True, allow_sampling=True)
+        targets = ref_algorithms.grovers_counts(shots)
+        backend = Aer.get_backend('qasm_simulator')
+
+        job = execute(circuits, backend, shots=shots,
+                         backend_options=None)
+        result = job.result()
+        self.assertTrue(result.success)
+
+    def test_cluster_qasm(self):
+        """Test snapshot label must be str"""
+        shots=4000
+        backend = Aer.get_backend('qasm_simulator')
+        circs = [random_circuit(num_qubits=3, depth=4, measure=True) for _ in range(2)]
+        circs = transpile(circs, backend)
+
+        backend_options = None
+        noise_model = None
+
+        cman = AerClusterManager(self._test_executor, shots=shots)
+        combined_result = cman.run(backend, circs, backend_options, noise_model).results(raises=True).combine_results()
+        self.assertTrue(combined_result.success)
+
+    def test_set_assemble_config(self):
+        """Test snapshot label must be str"""
+        shots=4000
+        backend = Aer.get_backend('qasm_simulator')
+        circs = [random_circuit(num_qubits=3, depth=4, measure=True) for _ in range(2)]
+        circs = transpile(circs, backend)
+        
+        backend_options = None
+        noise_model = None
+        cman = AerClusterManager(self._test_executor)
+        combined_result = cman.set_assemble_config(shots=shots).run(backend, circs, backend_options, noise_model).results(raises=True).combine_results()
+        self.assertTrue(combined_result.success)
+
+    def split_compare(self, circs, parameterizations=None, **shared_assemble_args):
+        qobj = assemble(circs, parameterizations=parameterizations, qobj_id='testing', **shared_assemble_args)
+        if parameterizations:
+            qobjs = [assemble(c, parameterizations=[p], qobj_id='testing', **shared_assemble_args) for (c,p) in zip(circs, parameterizations)]
+        else:
+            qobjs = [assemble(c, qobj_id='testing', **shared_assemble_args) for c in circs]
+
+        test_qobjs = split(qobj, _id='testing')
+        self.assertEqual(len(test_qobjs), len(qobjs))
+        for ref, test in zip(qobjs, test_qobjs):
+            self.assertEqual(ref, test)
+
+    def test_split(self):
+        backend = Aer.get_backend('qasm_simulator')
+        circs = [random_circuit(num_qubits=3, depth=4, measure=True) for _ in range(2)]
+        circs = transpile(circs, backend)
+        backend_options = {'shots': 4000}
+        self.split_compare(circs, backend=backend, **backend_options)
+
+    def test_parameterized_split(self):
+        backend = Aer.get_backend('qasm_simulator')
+        backend_options = {'shots': 4000}
+        noise_model = None
+        circs, params = self.parameterized_circuits(shots=backend_options['shots'], measure=True, snapshot=True)
+        self.split_compare(circs, parameterizations=params, backend=backend, **backend_options)
+
+    def test_cluster_dispatch(self):
+        """Test snapshot label must be str"""
+        shots=4000
+        backend = Aer.get_backend('qasm_simulator')
+        circuits = ref_pauli_noise.pauli_gate_error_circuits()
+        noise_models = ref_pauli_noise.pauli_gate_error_noise_models()
+        targets = ref_pauli_noise.pauli_gate_error_counts(shots)
+ 
+        backend_options = None
+        noise_model = None
+        qobj = assemble(circuits, backend, shots=shots)
+        cman = AerClusterManager(self._test_executor, shots=shots)
+        combined_result_list = cman.run(backend, circuits, backend_options, noise_models[0]).results(raises=True).combine_results()
+        combined_result_qobj = cman.run(backend, qobj, backend_options, noise_models[0]).results(raises=True).combine_results()
+        self.assertSuccess(combined_result_list)
+        self.assertSuccess(combined_result_qobj)
+        self.compare_counts(combined_result_list, [circuits[0]], [targets[0]], delta=0.05*shots)
+        self.compare_counts(combined_result_qobj, [circuits[0]], [targets[0]], delta=0.05*shots)
+
+
+class TestThreadPoolExecutor(ClusterManagerFixtor):
+    @classmethod
+    def setUpClass(cls):
+        super(TestThreadPoolExecutor, cls).setUpClass()
+        cls._test_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+class TestDaskExecutor(ClusterManagerFixtor):
+    @classmethod
+    def setUpClass(cls):
+        super(TestDaskExecutor, cls).setUpClass()
+        if DASK_TESTS:
+            cls._test_executor = Client(address=LocalCluster(n_workers=1, processes=True))
+
+    def setUp(self):
+        super(TestDaskExecutor, self).setUp()
+        if not DASK_TESTS:
+            self.skipTest('Dask not installed, skipping ClusterManager-dask tests')
+
+#class TestProcessPoolExecutor(ClusterManagerFixtor):
+#    @classmethod
+#    def setUpClass(cls):
+#        super(TestProcessPoolExecutor, cls).setUpClass()
+#        cls._test_executor = concurrent.futures.ProcessPoolExecutor(max_workers=1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds AerClusterManager - a thin wrapper around a dask.distributed Client which allows users to use a local or remote cluster for submitting and managing jobs. 

### Details and comments

Example usage (see tests):

```
cman = AerClusterManager()
backend = Aer.get_backend('qasm_simulator')
circs = transpile([random_circuit(num_qubits=3, depth=4, measure=True) for _ in range(5)], backend)
backend_options = None
noise_model = None
jobset = cman.set_assemble_config(shots=shots).run(circs, backend)
result = jobset.results(raises=True).combine_results()
```