### PR TITLE
Fix test failures due to qiskit-terra #5125

### DIFF
--- a/test/terra/backends/statevector_simulator/statevector_basics.py
+++ b/test/terra/backends/statevector_simulator/statevector_basics.py
@@ -133,7 +133,10 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        self.compare_statevector(result, circuits, targets)
+        # TODO: check phase when terra fixes global phase bug
+        #       See Terra issue #5125 for details
+        #       https://github.com/Qiskit/qiskit-terra/issues/5125
+        self.compare_statevector(result, circuits, targets, ignore_phase=True)
 
     def test_conditional_gate_2bit(self):
         """Test conditional gates on 2-bit conditional register."""
@@ -146,6 +149,7 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
+        
         self.compare_statevector(result, circuits, targets)
 
     def test_conditional_unitary_2bit(self):
@@ -159,7 +163,10 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        self.compare_statevector(result, circuits, targets)
+        # TODO: check phase when terra fixes global phase bug
+        #       See Terra issue #5125 for details
+        #       https://github.com/Qiskit/qiskit-terra/issues/5125
+        self.compare_statevector(result, circuits, targets, ignore_phase=True)
 
     # ---------------------------------------------------------------------
     # Test h-gate
@@ -1072,7 +1079,10 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        self.compare_statevector(result, circuits, targets)
+        # TODO: check phase when terra fixes global phase bug
+        #       See Terra issue #5125 for details
+        #       https://github.com/Qiskit/qiskit-terra/issues/5125
+        self.compare_statevector(result, circuits, targets, ignore_phase=True)
 
     def test_diagonal_gate(self):
         """Test simulation with diagonal gate circuit instructions."""
@@ -1282,4 +1292,4 @@ class StatevectorSimulatorTests:
             targets[i] = exp(1j * global_phase) * targets[i]
         result = self.SIMULATOR.run(qobj).result()
         self.assertSuccess(result)
-        self.compare_statevector(result, circuits, targets, global_phase=True)
+        self.compare_statevector(result, circuits, targets, ignore_phase=False)

--- a/test/terra/backends/unitary_simulator/unitary_basics.py
+++ b/test/terra/backends/unitary_simulator/unitary_basics.py
@@ -1048,7 +1048,10 @@ class UnitarySimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        self.compare_unitary(result, circuits, targets)
+        # TODO: check phase when terra fixes global phase bug
+        #       See Terra issue #5125 for details
+        #       https://github.com/Qiskit/qiskit-terra/issues/5125
+        self.compare_unitary(result, circuits, targets, ignore_phase=True)
 
     def test_diagonal_gate(self):
         """Test simulation with diagonal gate circuit instructions."""
@@ -1152,4 +1155,4 @@ class UnitarySimulatorTests:
             targets[i] = exp(1j * global_phase) * targets[i]
         result = self.SIMULATOR.run(qobj).result()
         self.assertSuccess(result)
-        self.compare_unitary(result, circuits, targets, global_phase=True)
+        self.compare_unitary(result, circuits, targets, ignore_phase=False)

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -25,9 +25,9 @@ from itertools import repeat
 from random import choice, sample
 from math import pi
 import numpy as np
-from numpy.linalg import norm
 
-from qiskit.quantum_info import state_fidelity
+from qiskit.quantum_info import Operator, Statevector
+from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.providers.aer import __path__ as main_path
 
@@ -140,44 +140,34 @@ class QiskitAerTestCase(unittest.TestCase):
             items.pop(pos)
 
     def compare_statevector(self, result, circuits, targets,
-                            global_phase=True, places=None):
+                            ignore_phase=False, atol=1e-8, rtol=1e-5):
         """Compare final statevectors to targets."""
         for pos, test_case in enumerate(zip(circuits, targets)):
             circuit, target = test_case
-            output = result.get_statevector(circuit)
+            target = Statevector(target)
+            output = Statevector(result.get_statevector(circuit))
             test_msg = "Circuit ({}/{}):".format(pos + 1, len(circuits))
             with self.subTest(msg=test_msg):
                 msg = " {} != {}".format(output, target)
-                if global_phase:
-                    # Test equal including global phase
-                    self.assertAlmostEqual(
-                        norm(output - target), 0, places=places,
-                        msg=msg)
-                else:
-                    # Test equal ignorning global phase
-                    self.assertAlmostEqual(
-                        state_fidelity(output, target) - 1, 0, places=places,
-                        msg=msg + " up to global phase")
+                delta = matrix_equal(output.data, target.data,
+                                     ignore_phase=ignore_phase,
+                                     atol=atol, rtol=rtol)
+                self.assertTrue(delta, msg=msg)
 
     def compare_unitary(self, result, circuits, targets,
-                        global_phase=True, places=None):
+                        ignore_phase=False, atol=1e-8, rtol=1e-5):
         """Compare final unitary matrices to targets."""
         for pos, test_case in enumerate(zip(circuits, targets)):
             circuit, target = test_case
-            output = result.get_unitary(circuit)
+            target = Operator(target)
+            output = Operator(result.get_unitary(circuit))
             test_msg = "Circuit ({}/{}):".format(pos + 1, len(circuits))
             with self.subTest(msg=test_msg):
-                msg = "\n{}\n {} != {}".format(circuit, output, target)
-                if global_phase:
-                    # Test equal including global phase
-                    self.assertAlmostEqual(
-                        norm(output - target), 0, places=places, msg=msg)
-                else:
-                    # Test equal ignorning global phase
-                    delta = np.trace(np.dot(
-                        np.conj(np.transpose(output)), target)) - len(output)
-                    self.assertAlmostEqual(
-                        delta, 0, places=places, msg=msg + " up to global phase")
+                msg = test_msg + " {} != {}".format(output.data, target.data)
+                delta = matrix_equal(output.data, target.data,
+                                     ignore_phase=ignore_phase,
+                                     atol=atol, rtol=rtol)
+                self.assertTrue(delta, msg=msg)
 
     def compare_counts(self, result, circuits, targets, hex_counts=True, delta=0):
         """Compare counts dictionary to targets."""
@@ -191,7 +181,7 @@ class QiskitAerTestCase(unittest.TestCase):
                 output = result.get_counts(circuit)
             test_msg = "Circuit ({}/{}):".format(pos + 1, len(circuits))
             with self.subTest(msg=test_msg):
-                msg = " {} != {}".format(output, target)
+                msg = test_msg + " {} != {}".format(output, target)
                 self.assertDictAlmostEqual(
                     output, target, delta=delta, msg=msg)
 

--- a/tools/verify_wheels.py
+++ b/tools/verify_wheels.py
@@ -6,13 +6,14 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 import numpy as np
-from numpy.linalg import norm
 
 from qiskit import ClassicalRegister
 from qiskit.compiler import assemble, transpile
 from qiskit import execute
 from qiskit import QuantumCircuit
 from qiskit import QuantumRegister
+from qiskit.quantum_info import Operator, Statevector
+from qiskit.quantum_info.operators.predicates import matrix_equal
 
 from qiskit.providers.aer.pulse.system_models.duffing_model_generators import duffing_system_model
 from qiskit.pulse import (Schedule, Play, Acquire, SamplePulse, DriveChannel, AcquireChannel,
@@ -381,35 +382,39 @@ def cx_gate_unitary_deterministic():
     return targets
 
 
-def compare_statevector(result, circuits, targets,
-                        global_phase=True, places=None):
+def compare_statevector(self, result, circuits, targets,
+                        ignore_phase=False, atol=1e-8, rtol=1e-5):
     """Compare final statevectors to targets."""
     for pos, test_case in enumerate(zip(circuits, targets)):
         circuit, target = test_case
-        output = result.get_statevector(circuit)
-        msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
-               " {} != {}".format(output, target))
-        assertAlmostEqual(norm(output - target), 0, places=places,
-                          msg=msg)
+        target = Statevector(target)
+        output = Statevector(result.get_statevector(circuit))
+        equiv = matrix_equal(output.data, target.data,
+                             ignore_phase=ignore_phase,
+                             atol=atol, rtol=rtol)
+        if equiv:
+            return
+        msg = "Circuit ({}/{}): {} != {}".format(
+            pos + 1, len(circuits), output.data, target.data)
+        raise Exception(msg)
 
 
-def compare_unitary(result, circuits, targets,
-                    global_phase=True, places=None):
+def compare_unitary(self, result, circuits, targets,
+                    ignore_phase=False, atol=1e-8, rtol=1e-5):
     """Compare final unitary matrices to targets."""
     for pos, test_case in enumerate(zip(circuits, targets)):
         circuit, target = test_case
-        output = result.get_unitary(circuit)
-        msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
-               " {} != {}".format(output, target))
-        if (global_phase):
-            # Test equal including global phase
-            assertAlmostEqual(norm(output - target), 0,
-                              places=places, msg=msg)
-        else:
-            # Test equal ignorning global phase
-            delta = np.trace(
-                np.dot(np.conj(np.transpose(output)), target)) - len(output)
-            assertAlmostEqual(delta, 0, places=places)
+        target = Operator(target)
+        output = Operator(result.get_unitary(circuit))
+        equiv = matrix_equal(output.data, target.data,
+                             ignore_phase=ignore_phase,
+                             atol=atol, rtol=rtol)
+        if equiv:
+            return
+        msg = "Circuit ({}/{}): {} != {}".format(
+            pos + 1, len(circuits), output.data, target.data)
+        raise Exception(msg)
+
 
 def model_and_pi_schedule():
     """Return a simple model and schedule for pulse simulation"""

--- a/tools/verify_wheels.py
+++ b/tools/verify_wheels.py
@@ -382,7 +382,7 @@ def cx_gate_unitary_deterministic():
     return targets
 
 
-def compare_statevector(self, result, circuits, targets,
+def compare_statevector(result, circuits, targets,
                         ignore_phase=False, atol=1e-8, rtol=1e-5):
     """Compare final statevectors to targets."""
     for pos, test_case in enumerate(zip(circuits, targets)):
@@ -399,7 +399,7 @@ def compare_statevector(self, result, circuits, targets,
         raise Exception(msg)
 
 
-def compare_unitary(self, result, circuits, targets,
+def compare_unitary(result, circuits, targets,
                     ignore_phase=False, atol=1e-8, rtol=1e-5):
     """Compare final unitary matrices to targets."""
     for pos, test_case in enumerate(zip(circuits, targets)):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A recent Terra PR caused an incorrect global_phase value to be set in qobj headers for some circuits. This was causing tests to fail which tested that output unitary and statevectors were phase equal. This PR changes the failing tests to only check that hte output is equal up to global phase until the Terra issue can be fixed.

### Details and comments

Related terra issue: https://github.com/Qiskit/qiskit-terra/issues/5125
