### PR TITLE
Revert "Fix test failures due to qiskit-terra #5125 (#949)"

### DIFF
--- a/test/terra/backends/statevector_simulator/statevector_basics.py
+++ b/test/terra/backends/statevector_simulator/statevector_basics.py
@@ -133,10 +133,7 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        # TODO: check phase when terra fixes global phase bug
-        #       See Terra issue #5125 for details
-        #       https://github.com/Qiskit/qiskit-terra/issues/5125
-        self.compare_statevector(result, circuits, targets, ignore_phase=True)
+        self.compare_statevector(result, circuits, targets)
 
     def test_conditional_gate_2bit(self):
         """Test conditional gates on 2-bit conditional register."""
@@ -149,7 +146,6 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        
         self.compare_statevector(result, circuits, targets)
 
     def test_conditional_unitary_2bit(self):
@@ -163,10 +159,7 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        # TODO: check phase when terra fixes global phase bug
-        #       See Terra issue #5125 for details
-        #       https://github.com/Qiskit/qiskit-terra/issues/5125
-        self.compare_statevector(result, circuits, targets, ignore_phase=True)
+        self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
     # Test h-gate
@@ -1079,10 +1072,7 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        # TODO: check phase when terra fixes global phase bug
-        #       See Terra issue #5125 for details
-        #       https://github.com/Qiskit/qiskit-terra/issues/5125
-        self.compare_statevector(result, circuits, targets, ignore_phase=True)
+        self.compare_statevector(result, circuits, targets)
 
     def test_diagonal_gate(self):
         """Test simulation with diagonal gate circuit instructions."""
@@ -1292,4 +1282,4 @@ class StatevectorSimulatorTests:
             targets[i] = exp(1j * global_phase) * targets[i]
         result = self.SIMULATOR.run(qobj).result()
         self.assertSuccess(result)
-        self.compare_statevector(result, circuits, targets, ignore_phase=False)
+        self.compare_statevector(result, circuits, targets, global_phase=True)

--- a/test/terra/backends/unitary_simulator/unitary_basics.py
+++ b/test/terra/backends/unitary_simulator/unitary_basics.py
@@ -1048,10 +1048,7 @@ class UnitarySimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        # TODO: check phase when terra fixes global phase bug
-        #       See Terra issue #5125 for details
-        #       https://github.com/Qiskit/qiskit-terra/issues/5125
-        self.compare_unitary(result, circuits, targets, ignore_phase=True)
+        self.compare_unitary(result, circuits, targets)
 
     def test_diagonal_gate(self):
         """Test simulation with diagonal gate circuit instructions."""
@@ -1155,4 +1152,4 @@ class UnitarySimulatorTests:
             targets[i] = exp(1j * global_phase) * targets[i]
         result = self.SIMULATOR.run(qobj).result()
         self.assertSuccess(result)
-        self.compare_unitary(result, circuits, targets, ignore_phase=False)
+        self.compare_unitary(result, circuits, targets, global_phase=True)

--- a/tools/verify_wheels.py
+++ b/tools/verify_wheels.py
@@ -6,14 +6,13 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 import numpy as np
+from numpy.linalg import norm
 
 from qiskit import ClassicalRegister
 from qiskit.compiler import assemble, transpile
 from qiskit import execute
 from qiskit import QuantumCircuit
 from qiskit import QuantumRegister
-from qiskit.quantum_info import Operator, Statevector
-from qiskit.quantum_info.operators.predicates import matrix_equal
 
 from qiskit.providers.aer.pulse.system_models.duffing_model_generators import duffing_system_model
 from qiskit.pulse import (Schedule, Play, Acquire, SamplePulse, DriveChannel, AcquireChannel,
@@ -383,38 +382,34 @@ def cx_gate_unitary_deterministic():
 
 
 def compare_statevector(result, circuits, targets,
-                        ignore_phase=False, atol=1e-8, rtol=1e-5):
+                        global_phase=True, places=None):
     """Compare final statevectors to targets."""
     for pos, test_case in enumerate(zip(circuits, targets)):
         circuit, target = test_case
-        target = Statevector(target)
-        output = Statevector(result.get_statevector(circuit))
-        equiv = matrix_equal(output.data, target.data,
-                             ignore_phase=ignore_phase,
-                             atol=atol, rtol=rtol)
-        if equiv:
-            return
-        msg = "Circuit ({}/{}): {} != {}".format(
-            pos + 1, len(circuits), output.data, target.data)
-        raise Exception(msg)
+        output = result.get_statevector(circuit)
+        msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
+               " {} != {}".format(output, target))
+        assertAlmostEqual(norm(output - target), 0, places=places,
+                          msg=msg)
 
 
 def compare_unitary(result, circuits, targets,
-                    ignore_phase=False, atol=1e-8, rtol=1e-5):
+                    global_phase=True, places=None):
     """Compare final unitary matrices to targets."""
     for pos, test_case in enumerate(zip(circuits, targets)):
         circuit, target = test_case
-        target = Operator(target)
-        output = Operator(result.get_unitary(circuit))
-        equiv = matrix_equal(output.data, target.data,
-                             ignore_phase=ignore_phase,
-                             atol=atol, rtol=rtol)
-        if equiv:
-            return
-        msg = "Circuit ({}/{}): {} != {}".format(
-            pos + 1, len(circuits), output.data, target.data)
-        raise Exception(msg)
-
+        output = result.get_unitary(circuit)
+        msg = ("Circuit ({}/{}):".format(pos + 1, len(circuits)) +
+               " {} != {}".format(output, target))
+        if (global_phase):
+            # Test equal including global phase
+            assertAlmostEqual(norm(output - target), 0,
+                              places=places, msg=msg)
+        else:
+            # Test equal ignorning global phase
+            delta = np.trace(
+                np.dot(np.conj(np.transpose(output)), target)) - len(output)
+            assertAlmostEqual(delta, 0, places=places)
 
 def model_and_pi_schedule():
     """Return a simple model and schedule for pulse simulation"""


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit/qiskit-terra#5125 has been closed as fixed by
Qiskit/qiskit-terra#5126. So we no longer need to disable checking the
results are phase equal. This commit adds back the phase checking so we
can test that global phase handling is correct again.

### Details and comments

This reverts commit a0274c33e3e5989d78fe67ffb7dd1332f3d71bd1.
