### PR TITLE
Add missing basis gates

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -246,12 +246,13 @@ class QasmSimulator(AerBackend):
         'description': 'A C++ simulator with realistic noise for QASM Qobj files',
         'coupling_map': None,
         'basis_gates': [
-            'u1', 'u2', 'u3', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
-            't', 'tdg', 'swap', 'ccx', 'r', 'rx', 'ry', 'rz', 'rxx', 'ryy',
-            'rzz', 'rzx', 'unitary', 'diagonal', 'initialize', 'cu1', 'cu2',
-            'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcrx', 'mcry', 'mcrz', 'mcr',
-            'mcu1', 'mcu2', 'mcu3', 'mcswap', 'p', 'cp', 'mcp', 'sx', 'csx', 'mcsx',
-            'multiplexer', 'kraus', 'roerror'
+            'u1', 'u2', 'u3', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x', 'y',
+            'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx', 'cy',
+            'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy', 'rzz',
+            'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx', 'mcp',
+            'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz', 'mcr',
+            'mcswap', 'unitary', 'diagonal', 'multiplexer', 'initialize',
+            'kraus', 'superop', 'roerror', 'delay'
         ],
         'gates': []
     }

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -88,12 +88,13 @@ class StatevectorSimulator(AerBackend):
         'description': 'A C++ statevector simulator for QASM Qobj files',
         'coupling_map': None,
         'basis_gates': [
-            'u1', 'u2', 'u3', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
-            't', 'tdg', 'swap', 'ccx', 'r', 'rx', 'ry', 'rz', 'rxx', 'ryy',
-            'rzz', 'rzx', 'unitary', 'diagonal', 'initialize', 'cu1', 'cu2',
-            'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcrx', 'mcry', 'mcrz', 'mcr',
-            'mcu1', 'mcu2', 'mcu3', 'mcswap', 'p', 'cp', 'mcp', 'sx', 'csx', 'mcsx',
-            'multiplexer',
+            'u1', 'u2', 'u3', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x', 'y',
+            'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx', 'cy',
+            'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy', 'rzz',
+            'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx', 'mcp',
+            'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz', 'mcr',
+            'mcswap', 'unitary', 'diagonal', 'multiplexer', 'initialize',
+            'kraus', 'roerror', 'delay'
         ],
         'gates': []
     }

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -96,12 +96,12 @@ class UnitarySimulator(AerBackend):
         'description': 'A C++ unitary simulator for QASM Qobj files',
         'coupling_map': None,
         'basis_gates': [
-            'u1', 'u2', 'u3', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg',
-            't', 'tdg', 'swap', 'ccx', 'r', 'rx', 'ry', 'rz', 'rxx', 'ryy',
-            'rzz', 'rzx', 'unitary', 'diagonal', 'cu1', 'cu2',
-            'cu3', 'cswap', 'mcx', 'mcy', 'mcz', 'mcrx', 'mcry', 'mcrz', 'mcr',
-            'mcu1', 'mcu2', 'mcu3', 'mcswap', 'p', 'cp', 'mcp', 'sx', 'csx', 'mcsx',
-            'multiplexer'
+            'u1', 'u2', 'u3', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x', 'y',
+            'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx', 'cy',
+            'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy', 'rzz',
+            'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx', 'mcp',
+            'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz', 'mcr',
+            'mcswap', 'unitary', 'diagonal', 'multiplexer', 'delay'
         ],
         'gates': []
     }

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -41,7 +41,7 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::diagonal_matrix, Operations::OpType::kraus,
      Operations::OpType::superop},
     // Gates
-    {"U", "CX", "u1", "u2", "u3",  "cx",  "cz",  "swap", "id",
+    {"U", "CX", "u1", "u2", "u3",  "cx",  "cy", "cz",  "swap", "id",
      "x", "y",  "z",  "h",  "s",   "sdg", "t",   "tdg",  "ccx",
      "r", "rx", "ry", "rz", "rxx", "ryy", "rzz", "rzx",  "p",
      "cp","cu1", "sx", "x90", "delay"},
@@ -53,7 +53,7 @@ const Operations::OpSet StateOpSet(
 // Allowed gates enum class
 enum class Gates {
   u1, u2, u3, r, rx,ry, rz, id, x, y, z, h, s, sdg, sx, t, tdg,
-  cx, cz, swap, rxx, ryy, rzz, rzx, ccx, cp
+  cx, cy, cz, swap, rxx, ryy, rzz, rzx, ccx, cp
 };
 
 // Allowed snapshots enum class
@@ -275,6 +275,7 @@ const stringmap_t<Gates> State<densmat_t>::gateset_({
     // Two-qubit gates
     {"CX", Gates::cx},     // Controlled-X gate (CNOT)
     {"cx", Gates::cx},     // Controlled-X gate (CNOT)
+    {"cy", Gates::cy},     // Controlled-Y gate
     {"cz", Gates::cz},     // Controlled-Z gate
     {"cp", Gates::cp},     // Controlled-Phase gate
     {"cu1", Gates::cp},    // Controlled-Phase gate
@@ -671,6 +672,9 @@ void State<densmat_t>::apply_gate(const Operations::Op &op) {
       break;
     case Gates::cx:
       BaseState::qreg_.apply_cnot(op.qubits[0], op.qubits[1]);
+      break;
+    case Gates::cy:
+      BaseState::qreg_.apply_unitary_matrix(op.qubits, Linalg::VMatrix::CY);
       break;
     case Gates::cz:
       BaseState::qreg_.apply_cphase(op.qubits[0], op.qubits[1], -1);

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -35,7 +35,8 @@ const Operations::OpSet StateOpSet(
     Operations::OpType::barrier, Operations::OpType::bfunc,
     Operations::OpType::roerror},
   // Gates
-  {"CX", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s", "sdg", "delay"},
+  {"CX", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s", "sdg",
+   "sx", "delay"},
   // Snapshots
   {"stabilizer", "memory", "register", "probabilities",
     "probabilities_with_variance", "expectation_value_pauli",
@@ -43,7 +44,7 @@ const Operations::OpSet StateOpSet(
     "expectation_value_pauli_single_shot"}
 );
 
-enum class Gates {id, x, y, z, h, s, sdg, cx, cy, cz, swap};
+enum class Gates {id, x, y, z, h, s, sdg, sx, cx, cy, cz, swap};
 
 // Allowed snapshots enum class
 enum class Snapshots {
@@ -193,17 +194,18 @@ const stringmap_t<Gates> State::gateset_({
   // Single qubit gates
   {"delay", Gates::id},// Delay gate
   {"id", Gates::id},   // Pauli-Identity gate
-  {"x", Gates::x},    // Pauli-X gate
-  {"y", Gates::y},    // Pauli-Y gate
-  {"z", Gates::z},    // Pauli-Z gate
-  {"s", Gates::s},    // Phase gate (aka sqrt(Z) gate)
+  {"x", Gates::x},     // Pauli-X gate
+  {"y", Gates::y},     // Pauli-Y gate
+  {"z", Gates::z},     // Pauli-Z gate
+  {"s", Gates::s},     // Phase gate (aka sqrt(Z) gate)
   {"sdg", Gates::sdg}, // Conjugate-transpose of Phase gate
-  {"h", Gates::h},    // Hadamard gate (X + Z / sqrt(2))
+  {"h", Gates::h},     // Hadamard gate (X + Z / sqrt(2))
+  {"sx", Gates::sx},   // Sqrt X gate.
   // Two-qubit gates
-  {"CX", Gates::cx},  // Controlled-X gate (CNOT)
-  {"cx", Gates::cx},  // Controlled-X gate (CNOT),
-  {"cy", Gates::cy},   // Controlled-Y gate
-  {"cz", Gates::cz},   // Controlled-Z gate
+  {"CX", Gates::cx},    // Controlled-X gate (CNOT)
+  {"cx", Gates::cx},    // Controlled-X gate (CNOT),
+  {"cy", Gates::cy},    // Controlled-Y gate
+  {"cz", Gates::cz},    // Controlled-Z gate
   {"swap", Gates::swap} // SWAP gate
 });
 
@@ -332,6 +334,13 @@ void State::apply_gate(const Operations::Op &op) {
       BaseState::qreg_.append_s(op.qubits[0]);
       break;
     case Gates::sdg:
+      BaseState::qreg_.append_z(op.qubits[0]);
+      BaseState::qreg_.append_s(op.qubits[0]);
+      break;
+    case Gates::sx:
+      BaseState::qreg_.append_z(op.qubits[0]);
+      BaseState::qreg_.append_s(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[0]);
       BaseState::qreg_.append_z(op.qubits[0]);
       BaseState::qreg_.append_s(op.qubits[0]);
       break;

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -35,17 +35,17 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
      Operations::OpType::kraus, Operations::OpType::superop},
     // Gates
-    {"U", "CX", "u1", "u2", "u3",  "cx",  "cz",  "swap", "id",
-     "x", "y",  "z",  "h",  "s",   "sdg", "t",   "tdg",  "ccx",
-     "r", "rx", "ry", "rz", "rxx", "ryy", "rzz", "rzx",  "p",
-     "cp", "cu1", "sx", "x90", "delay"},
+    {"U",   "CX", "u1",  "u2", "u3",  "cx",   "cy",  "cz",  "swap",
+     "id",  "x",  "y",   "z",  "h",   "s",    "sdg", "t",   "tdg",
+     "ccx", "r",  "rx",  "ry", "rz",  "rxx",  "ryy", "rzz", "rzx",
+     "p",   "cp", "cu1", "sx", "x90", "delay"},
     // Snapshots
     {"superoperator"});
 
 // Allowed gates enum class
 enum class Gates {
   u2, u1, u3, id, x, y, z, h, s, sdg, sx, t, tdg, r, rx, ry, rz,
-  cx, cz, cp, swap, rxx, ryy, rzz, rzx, ccx
+  cx, cy, cz, cp, swap, rxx, ryy, rzz, rzx, ccx
 };
 
 // Allowed snapshots enum class
@@ -188,6 +188,7 @@ const stringmap_t<Gates> State<data_t>::gateset_({
     // Two-qubit gates
     {"CX", Gates::cx},     // Controlled-X gate (CNOT)
     {"cx", Gates::cx},     // Controlled-X gate (CNOT)
+    {"cy", Gates::cy},     // Controlled-Y gate
     {"cz", Gates::cz},     // Controlled-Z gate
     {"cp", Gates::cp},     // Controlled-Phase gate
     {"cu1", Gates::cp},    // Controlled-Phase gate
@@ -379,6 +380,9 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
       break;
     case Gates::cx:
       BaseState::qreg_.apply_cnot(op.qubits[0], op.qubits[1]);
+      break;
+    case Gates::cy:
+      apply_matrix(op.qubits, Linalg::VMatrix::CY);
       break;
     case Gates::cz:
       BaseState::qreg_.apply_cphase(op.qubits[0], op.qubits[1], -1);

--- a/test/terra/backends/qasm_simulator/qasm_standard_gates.py
+++ b/test/terra/backends/qasm_simulator/qasm_standard_gates.py
@@ -82,7 +82,7 @@ GATES = [
 
 STATEVECTOR_BG = QasmSimulator().configuration().basis_gates
 DENSITY_MATRIX_BG = [
-    "u1", "u2", "u3", "cx", "cz", "swap", "id", "x", "y", "z", "h", "s",
+    "u1", "u2", "u3", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s",
     "sdg", "t", "tdg", "ccx", "r", "rx", "ry", "rz", "rxx", "ryy", "rzz",
     "rzx", "p", "cp", "cu1", "sx", "delay",
 ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds some things missed in #951 
* Adds missing delay to Backend basis gates to simulators
* Adds cy to density matrix and superop simulators


### Details and comments


