### PR TITLE
Add timeout fixture to test setup

### DIFF
--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -42,14 +42,8 @@ class TestPulseSimulator(common.QiskitAerTestCase):
     r"""PulseSimulator tests."""
 
     def setUp(self):
-        """ Set configuration settings for pulse simulator
-        WARNING: We do not support Python 3.5 because the digest algorithm relies on dictionary insertion order.
-        This "feature" was introduced later on Python 3.6 and there's no official support for OrderedDict in the C API so
-        Python 3.5 support has been disabled while looking for a propper fix.
-        """
-        if sys.version_info.major == 3 and sys.version_info.minor == 5:
-           self.skipTest("We don't support Python 3.5 for Pulse simulator")
-
+        """ Set configuration settings for pulse simulator"""
+        super().setUp()
         # Get pulse simulator backend
         self.backend_sim = PulseSimulator()
 

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -25,11 +25,13 @@ from itertools import repeat
 from random import choice, sample
 from math import pi
 import numpy as np
+import fixtures
 
 from qiskit.quantum_info import Operator, Statevector
 from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.providers.aer import __path__ as main_path
+from qiskit.test import QiskitTestCase
 
 
 class Path(Enum):
@@ -40,8 +42,12 @@ class Path(Enum):
     EXAMPLES = os.path.join(MAIN, '../examples')
 
 
-class QiskitAerTestCase(unittest.TestCase):
+class QiskitAerTestCase(QiskitTestCase):
     """Helper class that contains common functionality."""
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(fixtures.Timeout(120, gentle=True))
 
     @classmethod
     def setUpClass(cls):

--- a/test/terra/extensions/test_snapshot_density_matrix.py
+++ b/test/terra/extensions/test_snapshot_density_matrix.py
@@ -10,15 +10,16 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-
 import unittest
 
 from qiskit import QuantumCircuit, assemble
 from qiskit.extensions.exceptions import ExtensionError
 from qiskit.providers.aer.extensions.snapshot_density_matrix import SnapshotDensityMatrix
 
+from ..common import QiskitAerTestCase
 
-class TestSnapshotDensityMatrixExtension(unittest.TestCase):
+
+class TestSnapshotDensityMatrixExtension(QiskitAerTestCase):
     """SnapshotDensityMatrix extension tests"""
 
     @staticmethod

--- a/test/terra/extensions/test_snapshot_expectation_value.py
+++ b/test/terra/extensions/test_snapshot_expectation_value.py
@@ -10,17 +10,20 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-
 import unittest
 
+
 import numpy
+
 from qiskit import QuantumCircuit, assemble
 from qiskit.extensions.exceptions import ExtensionError
 from qiskit.providers.aer.extensions.snapshot_expectation_value import SnapshotExpectationValue
 from qiskit.quantum_info.operators import Pauli, Operator
 
+from ..common import QiskitAerTestCase
 
-class TestSnapshotExpectationValueExtension(unittest.TestCase):
+
+class TestSnapshotExpectationValueExtension(QiskitAerTestCase):
     """SnapshotExpectationValue extension tests"""
 
     @staticmethod

--- a/test/terra/extensions/test_snapshot_probabilities.py
+++ b/test/terra/extensions/test_snapshot_probabilities.py
@@ -17,8 +17,10 @@ from qiskit import QuantumCircuit, assemble
 from qiskit.extensions.exceptions import ExtensionError
 from qiskit.providers.aer.extensions.snapshot_probabilities import SnapshotProbabilities
 
+from ..common import QiskitAerTestCase
 
-class TestSnapshotProbabilitiesExtension(unittest.TestCase):
+
+class TestSnapshotProbabilitiesExtension(QiskitAerTestCase):
     """SnapshotProbabilities extension tests"""
 
     @staticmethod

--- a/test/terra/extensions/test_snapshot_stabilizer.py
+++ b/test/terra/extensions/test_snapshot_stabilizer.py
@@ -17,8 +17,10 @@ from qiskit import QuantumCircuit, assemble
 from qiskit.extensions.exceptions import ExtensionError
 from qiskit.providers.aer.extensions.snapshot_stabilizer import SnapshotStabilizer
 
+from ..common import QiskitAerTestCase
 
-class TestSnapshotStabilizerExtension(unittest.TestCase):
+
+class TestSnapshotStabilizerExtension(QiskitAerTestCase):
     """SnapshotStbilizer extension tests"""
 
     @staticmethod

--- a/test/terra/extensions/test_snapshot_statevector.py
+++ b/test/terra/extensions/test_snapshot_statevector.py
@@ -17,8 +17,10 @@ from qiskit import QuantumCircuit, assemble
 from qiskit.extensions.exceptions import ExtensionError
 from qiskit.providers.aer.extensions.snapshot_statevector import SnapshotStatevector
 
+from ..common import QiskitAerTestCase
 
-class TestSnapshotStatevectorExtension(unittest.TestCase):
+
+class TestSnapshotStatevectorExtension(QiskitAerTestCase):
     """SnapshotStatevector extension tests"""
 
     @staticmethod

--- a/test/terra/noise/test_noise_inserter.py
+++ b/test/terra/noise/test_noise_inserter.py
@@ -20,7 +20,10 @@ from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 from qiskit.qasm import pi
 import unittest
 
-class TestNoiseInserter(unittest.TestCase):
+from ..common import QiskitAerTestCase
+
+
+class TestNoiseInserter(QiskitAerTestCase):
     def test_no_noise(self):
         qr = QuantumRegister(3, 'qr')
         circuit = QuantumCircuit(qr)

--- a/test/terra/noise/test_noise_transformation.py
+++ b/test/terra/noise/test_noise_transformation.py
@@ -13,7 +13,8 @@
 NoiseTransformer class tests
 """
 
-import unittest
+from ..common import QiskitAerTestCase
+
 import numpy
 from qiskit.providers.aer.noise.errors.errorutils import standard_gate_unitary
 from qiskit.providers.aer.noise import NoiseModel
@@ -26,8 +27,9 @@ from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 from qiskit.providers.aer.noise.errors.quantum_error import QuantumError
 
 
-class TestNoiseTransformer(unittest.TestCase):
+class TestNoiseTransformer(QiskitAerTestCase):
     def setUp(self):
+        super().setUp()
         self.ops = {
             'X': standard_gate_unitary('x'),
             'Y': standard_gate_unitary('y'),

--- a/test/terra/pulse/de/test_de_methods.py
+++ b/test/terra/pulse/de/test_de_methods.py
@@ -10,9 +10,13 @@ from qiskit.providers.aer.pulse.de.DE_Methods import (ODE_Method,
                                                       QiskitZVODE,
                                                       method_from_string)
 
-class TestDE_Methods(unittest.TestCase):
+from ...common import QiskitAerTestCase
+
+
+class TestDE_Methods(QiskitAerTestCase):
 
     def setUp(self):
+        super().setUp()
         # set up a 2d test problem
         self.t0 = 0.
         self.y0 = np.eye(2)

--- a/test/terra/pulse/de/test_type_utils.py
+++ b/test/terra/pulse/de/test_type_utils.py
@@ -1,15 +1,15 @@
 """tests for type_utils.py"""
 
-import unittest
 import numpy as np
 from qiskit.providers.aer.pulse.de.type_utils import (convert_state,
                                                       type_spec_from_instance,
                                                       StateTypeConverter)
 
-class TestTypeUtils(unittest.TestCase):
+from ...common import QiskitAerTestCase
 
-    def setUp(self):
-        pass
+
+class TestTypeUtils(QiskitAerTestCase):
+
 
     def test_convert_state(self):
         """Test convert_state"""

--- a/test/terra/pulse/test_duffing_model_generators.py
+++ b/test/terra/pulse/test_duffing_model_generators.py
@@ -25,9 +25,6 @@ from qiskit.providers.models.backendconfiguration import UchannelLO
 class TestDuffingModelGenerators(QiskitAerTestCase):
     """Tests for functions in duffing_model_generators.py"""
 
-    def setUp(self):
-        pass
-
     def test_duffing_system_model1(self):
         """First test of duffing_system_model, 2 qubits, 2 dimensional"""
 

--- a/test/terra/pulse/test_system_models.py
+++ b/test/terra/pulse/test_system_models.py
@@ -33,6 +33,7 @@ class BaseTestPulseSystemModel(QiskitAerTestCase):
     """Tests for PulseSystemModel"""
 
     def setUp(self):
+        super().setUp()
         self._default_qubit_lo_freq = [4.9, 5.0]
         self._u_channel_lo = []
         self._u_channel_lo.append([UchannelLO(0, 1.0+0.0j)])

--- a/test/terra/test_python_to_cpp.py
+++ b/test/terra/test_python_to_cpp.py
@@ -10,7 +10,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import sys
 import unittest
 import numpy as np
 from qiskit.providers.aer.pulse.qutip_extra_lite.qobj import Qobj
@@ -20,17 +19,12 @@ from qiskit.providers.aer.pulse.controllers.test_python_to_cpp import \
     test_py_dict_string_list_of_list_of_doubles_to_cpp_map_string_vec_of_vecs_of_doubles,\
     test_np_array_of_doubles, test_evaluate_hamiltonians, test_py_ordered_map
 
+from .common import QiskitAerTestCase
 
-class TestPythonToCpp(unittest.TestCase):
+
+class TestPythonToCpp(QiskitAerTestCase):
     """ Test Pyhton C API wrappers we have for dealing with Python data structures
         in C++ code. """
-    def setUp(self):
-        """ WARNING: We do not support Python 3.5 because the digest algorithm relies on dictionary insertion order.
-        This "feature" was introduced later on Python 3.6 and there's no official support for OrderedDict in the C API so
-        Python 3.5 support has been disabled while looking for a propper fix. """
-        if sys.version_info.major == 3 and sys.version_info.minor == 5:
-           self.skipTest("We don't support Python 3.5 for Pulse simulator")
-        pass
 
     def test_py_list_to_cpp_vec(self):
         arg = [1., 2., 3.]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We're currently facing periodic job timeouts in CI that appear to be
caused by a test method getting stuck and not finishing. To debug this
we first need to figure out which test is getting stuck. This commit
adds a test fixture to the base test class's setUp method. This will
signal to stop the method after 120 secs and raise a TimeoutException.

### Details and comments


