### PR TITLE
Turn off gentle timeout and use common test class everywhere

### DIFF
--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -47,7 +47,7 @@ class QiskitAerTestCase(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.useFixture(fixtures.Timeout(120, gentle=True))
+        self.useFixture(fixtures.Timeout(120, gentle=False))
 
     @classmethod
     def setUpClass(cls):

--- a/test/terra/extensions/test_wrappers.py
+++ b/test/terra/extensions/test_wrappers.py
@@ -23,9 +23,10 @@ from qiskit.providers.aer.backends.controller_wrappers import (qasm_controller_e
                                                                statevector_controller_execute,
                                                                unitary_controller_execute)
 from test.terra.reference import ref_algorithms, ref_measure, ref_1q_clifford
+from test.terra.common import QiskitAerTestCase
 
 
-class TestControllerExecuteWrappers(unittest.TestCase):
+class TestControllerExecuteWrappers(QiskitAerTestCase):
     """Basic functionality tests for pybind-generated wrappers"""
 
     CFUNCS = [qasm_controller_execute(), statevector_controller_execute(), unitary_controller_execute()]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a few issues in #955 in the hopes of further debugging
our test job timeouts in CI. The first change made is the timeout
fixture is changed from gentle=True to gentle=False. The true case is
generally preferable because it sets the signal handler to raise an
exception which doesn't interrupt test execution however, if a runner
process is stuck it might not work because the signal handling never
gets invoked. gentle=false will just have the sigalarm kill the process.
Additionally, in #955 one test class was missed and was using
unittest.TestCase instead of QiskitAerTestCase, which meant that the
tests in those classes could still get stuck since the fixture was not
initialized for that class.

### Details and comments