### PR TITLE
Fix test performance

### DIFF
--- a/test/terra/backends/qasm_simulator/qasm_delay_measure.py
+++ b/test/terra/backends/qasm_simulator/qasm_delay_measure.py
@@ -15,11 +15,12 @@ QasmSimulator Integration Tests
 """
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.circuit.library import QFT, QuantumVolume
 from qiskit.compiler import assemble, transpile
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors import ReadoutError, depolarizing_error
-from test.benchmark.tools import quantum_volume_circuit, qft_circuit
+
 
 class QasmDelayMeasureTests:
     """QasmSimulator delay measure sampling optimization tests."""

--- a/test/terra/backends/qasm_simulator/qasm_initialize.py
+++ b/test/terra/backends/qasm_simulator/qasm_initialize.py
@@ -72,12 +72,12 @@ class QasmInitializeTests:
         """Test QasmSimulator initialize"""
         # For statevector output we can combine deterministic and non-deterministic
         # count output circuits
-        shots = 4000
+        shots = 1000
         circuits = ref_initialize.initialize_circuits_1(final_measure=True)
         targets = ref_initialize.initialize_counts_1(shots)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        opts = self.BACKEND_OPTS.copy()
+        result = self.SIMULATOR.run(qobj, backend_options=opts).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
@@ -85,22 +85,22 @@ class QasmInitializeTests:
         """Test QasmSimulator initializes"""
         # For statevector output we can combine deterministic and non-deterministic
         # count output circuits
-        shots = 4000
+        shots = 1000
         circuits = ref_initialize.initialize_circuits_2(final_measure=True)
         targets = ref_initialize.initialize_counts_2(shots)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        opts = self.BACKEND_OPTS.copy()
+        result = self.SIMULATOR.run(qobj, backend_options=opts).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
     def test_initialize_sampling_opt(self):
         """Test sampling optimization"""
-        shots = 4000
+        shots = 1000
         circuits = ref_initialize.initialize_sampling_optimization()
         targets = ref_initialize.initialize_counts_sampling_optimization(shots)
         qobj = assemble(circuits, self.SIMULATOR, shots=shots)
-        result = self.SIMULATOR.run(
-            qobj, backend_options=self.BACKEND_OPTS).result()
+        opts = self.BACKEND_OPTS.copy()
+        result = self.SIMULATOR.run(qobj, backend_options=opts).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)

--- a/test/terra/backends/qasm_simulator/qasm_noise.py
+++ b/test/terra/backends/qasm_simulator/qasm_noise.py
@@ -56,7 +56,7 @@ class QasmPauliNoiseTests:
 
     def test_pauli_gate_noise(self):
         """Test simulation with Pauli gate error noise model."""
-        shots = 4000
+        shots = 1000
         circuits = ref_pauli_noise.pauli_gate_error_circuits()
         noise_models = ref_pauli_noise.pauli_gate_error_noise_models()
         targets = ref_pauli_noise.pauli_gate_error_counts(shots)
@@ -73,7 +73,7 @@ class QasmPauliNoiseTests:
 
     def test_pauli_reset_noise(self):
         """Test simulation with Pauli reset error noise model."""
-        shots = 4000
+        shots = 1000
         circuits = ref_pauli_noise.pauli_reset_error_circuits()
         noise_models = ref_pauli_noise.pauli_reset_error_noise_models()
         targets = ref_pauli_noise.pauli_reset_error_counts(shots)
@@ -90,7 +90,7 @@ class QasmPauliNoiseTests:
 
     def test_pauli_measure_noise(self):
         """Test simulation with Pauli measure error noise model."""
-        shots = 4000
+        shots = 1000
         circuits = ref_pauli_noise.pauli_measure_error_circuits()
         noise_models = ref_pauli_noise.pauli_measure_error_noise_models()
         targets = ref_pauli_noise.pauli_measure_error_counts(shots)
@@ -114,7 +114,7 @@ class QasmResetNoiseTests:
 
     def test_reset_gate_noise(self):
         """Test simulation with reset gate error noise model."""
-        shots = 4000
+        shots = 1000
         circuits = ref_reset_noise.reset_gate_error_circuits()
         noise_models = ref_reset_noise.reset_gate_error_noise_models()
         targets = ref_reset_noise.reset_gate_error_counts(shots)
@@ -138,7 +138,7 @@ class QasmKrausNoiseTests:
 
     def test_kraus_gate_noise(self):
         """Test simulation with Kraus gate error noise model."""
-        shots = 4000
+        shots = 1000
         circuits = ref_kraus_noise.kraus_gate_error_circuits()
         noise_models = ref_kraus_noise.kraus_gate_error_noise_models()
         targets = ref_kraus_noise.kraus_gate_error_counts(shots)

--- a/test/terra/backends/qasm_simulator/qasm_thread_management.py
+++ b/test/terra/backends/qasm_simulator/qasm_thread_management.py
@@ -17,12 +17,13 @@ QasmSimulator Integration Tests
 import multiprocessing
 import psutil
 
-from test.benchmark.tools import quantum_volume_circuit
 from qiskit import execute, QuantumCircuit
+from qiskit.circuit.library import QuantumVolume
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 from test.terra.decorators import requires_omp, requires_multiprocessing
+
 
 # pylint: disable=no-member
 class QasmThreadManagementTests:
@@ -30,6 +31,25 @@ class QasmThreadManagementTests:
 
     SIMULATOR = QasmSimulator()
     BACKEND_OPTS = {}
+
+    def backend_options_parallel(self,
+                                 total_threads=None,
+                                 state_threads=None,
+                                 shot_threads=None,
+                                 exp_threads=None):
+        """Backend options with thread manangement."""
+        opts = self.BACKEND_OPTS.copy()
+        if total_threads:
+            opts['max_parallel_threads'] = total_threads
+        else:
+            opts['max_parallel_threads'] = 0
+        if shot_threads:
+            opts['max_parallel_shots'] = shot_threads
+        if state_threads:
+            opts['max_parallel_state_update'] = state_threads
+        if exp_threads:
+            opts['max_parallel_experiments'] = exp_threads
+        return opts
 
     def dummy_noise_model(self):
         """Return dummy noise model for dummy circuit"""
@@ -72,13 +92,14 @@ class QasmThreadManagementTests:
     def test_max_memory_settings(self):
         """test max memory configuration"""
 
-        # 4-qubit quantum volume test circuit
+        # 4-qubit quantum circuit
         shots = 100
-        circuit = quantum_volume_circuit(4, 1, measure=True, seed=0)
+        circuit = QuantumVolume(4, 1, seed=0)
+        circuit.measure_all()
         system_memory = int(psutil.virtual_memory().total / 1024 / 1024)
 
         # Test defaults
-        opts = self.BACKEND_OPTS.copy()
+        opts = self.backend_options_parallel()
         result = execute(circuit, self.SIMULATOR, shots=shots,
                          backend_options=opts).result()
         max_mem_result = result.metadata.get('max_memory_mb')
@@ -89,6 +110,7 @@ class QasmThreadManagementTests:
 
         # Test custom value
         max_mem_target = 128
+        opts = self.backend_options_parallel()
         opts['max_memory_mb'] = max_mem_target
         result = execute(circuit, self.SIMULATOR, shots=shots,
                          backend_options=opts).result()
@@ -98,10 +120,11 @@ class QasmThreadManagementTests:
 
     def available_threads(self):
         """"Return the threads reported by the simulator"""
+        opts = self.backend_options_parallel()
         result = execute(self.dummy_circuit(1),
                          self.SIMULATOR,
                          shots=1,
-                         backend_options=self.BACKEND_OPTS).result()
+                         backend_options=opts).result()
         return self.threads_used(result)[0]['total']
 
     @requires_omp
@@ -109,7 +132,7 @@ class QasmThreadManagementTests:
     def test_parallel_thread_defaults(self):
         """Test parallel thread assignment defaults"""
 
-        opts = self.BACKEND_OPTS
+        opts = self.backend_options_parallel()
         max_threads = self.available_threads()
 
         # Test single circuit, no noise
@@ -219,7 +242,7 @@ class QasmThreadManagementTests:
         # We intentionally set the max shot and experiment threads to
         # twice the max threads to check they are limited correctly
         for custom_max_threads in [0, 1, 2, 4]:
-            opts = self.BACKEND_OPTS.copy()
+            opts = self.backend_options_parallel()
             opts['max_parallel_threads'] = custom_max_threads
             opts['max_parallel_experiments'] = 2 * custom_max_threads
             opts['max_parallel_shots'] = 2 * custom_max_threads
@@ -333,8 +356,7 @@ class QasmThreadManagementTests:
         """Test parallel experiment thread assignment"""
 
         max_threads = self.available_threads()
-        opts = self.BACKEND_OPTS.copy()
-        opts['max_parallel_experiments'] = max_threads
+        opts = self.backend_options_parallel(exp_threads=max_threads)
 
         # Test single circuit
         # Parallel experiments and shots should always be 1
@@ -402,7 +424,9 @@ class QasmThreadManagementTests:
         # NOTE: this assumes execution on statevector simulator
         # which required approx 2 MB for 16 qubit circuit.
         opts['max_memory_mb'] = 1
-        result = execute(2 * [quantum_volume_circuit(16, 1, measure=True, seed=0)],
+        circuit = QuantumVolume(16, 1, seed=0)
+        circuit.measure_all()
+        result = execute(2 * [circuit],
                          self.SIMULATOR,
                          shots=10*max_threads,
                          backend_options=opts).result()
@@ -421,8 +445,7 @@ class QasmThreadManagementTests:
         """Test parallel shot thread assignment"""
 
         max_threads = self.available_threads()
-        opts = self.BACKEND_OPTS.copy()
-        opts['max_parallel_shots'] = max_threads
+        opts = self.backend_options_parallel(shot_threads=max_threads)
 
         # Test single circuit
         # Parallel experiments and shots should always be 1
@@ -490,7 +513,9 @@ class QasmThreadManagementTests:
         # NOTE: this assumes execution on statevector simulator
         # which required approx 2 MB for 16 qubit circuit.
         opts['max_memory_mb'] = 1
-        result = execute(2 * [quantum_volume_circuit(16, 1, measure=True, seed=0)],
+        circuit = QuantumVolume(16, 1, seed=0)
+        circuit.measure_all()
+        result = execute(2 * [circuit],
                          self.SIMULATOR,
                          shots=10*max_threads,
                          backend_options=opts).result()
@@ -509,11 +534,10 @@ class QasmThreadManagementTests:
         """test disabling parallel shots because max_parallel_shots is 1"""
         # Test circuit
         shots = multiprocessing.cpu_count()
-        circuit = quantum_volume_circuit(16, 1, measure=True, seed=0)
+        circuit = QuantumVolume(16, 1, seed=0)
+        circuit.measure_all()
 
-        backend_opts = self.BACKEND_OPTS.copy()
-        backend_opts['max_parallel_shots'] = 1
-        backend_opts['max_parallel_experiments'] = 1
+        backend_opts = self.backend_options_parallel(shot_threads=1, exp_threads=1)
         backend_opts['noise_model'] = self.dummy_noise_model()
         backend_opts['_parallel_experiments'] = 2
         backend_opts['_parallel_shots'] = 3

--- a/test/terra/backends/qasm_simulator/qasm_truncate.py
+++ b/test/terra/backends/qasm_simulator/qasm_truncate.py
@@ -9,7 +9,6 @@
 QasmSimulator Integration Tests
 """
 import json
-from test.benchmark.tools import quantum_volume_circuit
 from qiskit import execute, QuantumRegister, ClassicalRegister, QuantumCircuit, Aer
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer import noise

--- a/test/terra/backends/statevector_simulator/statevector_basics.py
+++ b/test/terra/backends/statevector_simulator/statevector_basics.py
@@ -133,10 +133,7 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        # TODO: check phase when terra fixes global phase bug
-        #       See Terra issue #5125 for details
-        #       https://github.com/Qiskit/qiskit-terra/issues/5125
-        self.compare_statevector(result, circuits, targets, ignore_phase=True)
+        self.compare_statevector(result, circuits, targets)
 
     def test_conditional_gate_2bit(self):
         """Test conditional gates on 2-bit conditional register."""
@@ -163,10 +160,7 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        # TODO: check phase when terra fixes global phase bug
-        #       See Terra issue #5125 for details
-        #       https://github.com/Qiskit/qiskit-terra/issues/5125
-        self.compare_statevector(result, circuits, targets, ignore_phase=True)
+        self.compare_statevector(result, circuits, targets)
 
     # ---------------------------------------------------------------------
     # Test h-gate
@@ -1079,10 +1073,7 @@ class StatevectorSimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        # TODO: check phase when terra fixes global phase bug
-        #       See Terra issue #5125 for details
-        #       https://github.com/Qiskit/qiskit-terra/issues/5125
-        self.compare_statevector(result, circuits, targets, ignore_phase=True)
+        self.compare_statevector(result, circuits, targets)
 
     def test_diagonal_gate(self):
         """Test simulation with diagonal gate circuit instructions."""

--- a/test/terra/backends/test_qasm_simulator.py
+++ b/test/terra/backends/test_qasm_simulator.py
@@ -110,7 +110,8 @@ class TestQasmSimulator(common.QiskitAerTestCase,
     """QasmSimulator automatic method tests."""
 
     BACKEND_OPTS = {
-        "seed_simulator": 2113
+        "seed_simulator": 2113,
+        "max_parallel_threads": 1
     }
 
 

--- a/test/terra/backends/test_qasm_simulator_density_matrix.py
+++ b/test/terra/backends/test_qasm_simulator_density_matrix.py
@@ -81,14 +81,22 @@ class DensityMatrixTests(
 class TestQasmSimulatorDensityMatrix(common.QiskitAerTestCase,
                                      DensityMatrixTests):
     """QasmSimulator density_matrix method tests."""
-    BACKEND_OPTS = {"seed_simulator": 314159, "method": "density_matrix"}
+    BACKEND_OPTS = {
+        "seed_simulator": 314159,
+        "method": "density_matrix",
+        "max_parallel_threads": 1
+    }
 
 
 @requires_method("qasm_simulator", "density_matrix_gpu")
 class TestQasmSimulatorDensityMatrixThrustGPU(common.QiskitAerTestCase,
                                               DensityMatrixTests):
     """QasmSimulator density_matrix_gpu method tests."""
-    BACKEND_OPTS = {"seed_simulator": 314159, "method": "density_matrix_gpu"}
+    BACKEND_OPTS = {
+        "seed_simulator": 314159,
+        "method": "density_matrix_gpu",
+        "max_parallel_threads": 1
+    }
 
 
 @requires_method("qasm_simulator", "density_matrix_thrust")
@@ -97,7 +105,8 @@ class TestQasmSimulatorDensityMatrixThrustCPU(common.QiskitAerTestCase,
     """QasmSimulator density_matrix_thrust method tests."""
     BACKEND_OPTS = {
         "seed_simulator": 314159,
-        "method": "density_matrix_thrust"
+        "method": "density_matrix_thrust",
+        "max_parallel_threads": 1
     }
 
 

--- a/test/terra/backends/test_qasm_simulator_matrix_product_state.py
+++ b/test/terra/backends/test_qasm_simulator_matrix_product_state.py
@@ -51,6 +51,7 @@ from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValP
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliNCTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValMatrixTests
 
+
 class TestQasmMatrixProductStateSimulator(
         common.QiskitAerTestCase,
         QasmMeasureTests,
@@ -89,6 +90,7 @@ class TestQasmMatrixProductStateSimulator(
         "method": "matrix_product_state",
         "max_parallel_threads": 1
     }
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/backends/test_qasm_simulator_stabilizer.py
+++ b/test/terra/backends/test_qasm_simulator_stabilizer.py
@@ -61,7 +61,8 @@ class TestQasmStabilizerSimulator(common.QiskitAerTestCase,
 
     BACKEND_OPTS = {
         "seed_simulator": 1337,
-        "method": "stabilizer"
+        "method": "stabilizer",
+        "max_parallel_threads": 1
     }
 
 

--- a/test/terra/backends/test_qasm_simulator_statevector.py
+++ b/test/terra/backends/test_qasm_simulator_statevector.py
@@ -89,7 +89,11 @@ class StatevectorTests(
 class TestQasmSimulatorStatevector(common.QiskitAerTestCase, StatevectorTests):
     """QasmSimulator statevector method tests."""
 
-    BACKEND_OPTS = {"seed_simulator": 271828, "method": "statevector"}
+    BACKEND_OPTS = {
+        "seed_simulator": 271828,
+        "method": "statevector",
+        "max_parallel_threads": 1
+    }
 
 
 @requires_method("qasm_simulator", "statevector_gpu")
@@ -97,7 +101,11 @@ class TestQasmSimulatorStatevectorThrustGPU(common.QiskitAerTestCase,
                                             StatevectorTests):
     """QasmSimulator statevector_gpu method tests."""
 
-    BACKEND_OPTS = {"seed_simulator": 271828, "method": "statevector_gpu"}
+    BACKEND_OPTS = {
+        "seed_simulator": 271828,
+        "method": "statevector_gpu",
+        "max_parallel_threads": 1
+    }
 
 
 @requires_method("qasm_simulator", "statevector_thrust")
@@ -105,7 +113,11 @@ class TestQasmSimulatorStatevectorThrustCPU(common.QiskitAerTestCase,
                                             StatevectorTests):
     """QasmSimulator statevector_thrust method tests."""
 
-    BACKEND_OPTS = {"seed_simulator": 271828, "method": "statevector_thrust"}
+    BACKEND_OPTS = {
+        "seed_simulator": 271828,
+        "method": "statevector_thrust",
+        "max_parallel_threads": 1
+    }
 
 
 if __name__ == '__main__':

--- a/test/terra/backends/unitary_simulator/unitary_basics.py
+++ b/test/terra/backends/unitary_simulator/unitary_basics.py
@@ -1048,10 +1048,7 @@ class UnitarySimulatorTests:
                       backend_options=self.BACKEND_OPTS)
         result = job.result()
         self.assertSuccess(result)
-        # TODO: check phase when terra fixes global phase bug
-        #       See Terra issue #5125 for details
-        #       https://github.com/Qiskit/qiskit-terra/issues/5125
-        self.compare_unitary(result, circuits, targets, ignore_phase=True)
+        self.compare_unitary(result, circuits, targets)
 
     def test_diagonal_gate(self):
         """Test simulation with diagonal gate circuit instructions."""

--- a/test/terra/reference/ref_multiplexer.py
+++ b/test/terra/reference/ref_multiplexer.py
@@ -200,78 +200,10 @@ def multiplexer_ccx_gate_circuits_deterministic(final_measure=True):
         circuit.measure(qr, cr)
     circuits.append(circuit)
 
-    # (X^I^X).CCX(0,1,2).(X^I^X) -> |000>
-    circuit = QuantumCircuit(*regs)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
-                   [qr[0], qr[1], qr[2]])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (X^X^I).CCX(0,1,2).(X^X^I) -> |000>
-    circuit = QuantumCircuit(*regs)
-    circuit.x(qr[1])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
-                   [qr[0], qr[1], qr[2]])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
     # CCX(2,1,0)
     circuit = QuantumCircuit(*regs)
     circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
                    [qr[2], qr[1], qr[0]])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (I^X^X).CCX(2,1,0).(I^X^X) -> |000>
-    circuit = QuantumCircuit(*regs)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
-                   [qr[2], qr[1], qr[0]])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (X^I^X).CCX(2,1,0).(X^I^X) -> |000>
-    circuit = QuantumCircuit(*regs)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
-                   [qr[2], qr[1], qr[0]])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
     if final_measure:
         circuit.barrier(qr)
         circuit.measure(qr, cr)
@@ -318,36 +250,6 @@ def multiplexer_ccx_gate_circuits_nondeterministic(final_measure=True):
     circuit.barrier(qr)
     circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
                    [qr[0], qr[1], qr[2]])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (I^I^X).CCX(0,1,2).(I^H^X) -> |000> + |110>
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
-                   [qr[0], qr[1], qr[2]])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (I^X^I).CCX(2,1,0).(H^X^I) -> |000> + |101>
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[2])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    circuit.barrier(qr)
-    circuit.append(multiplexer_multi_controlled_x(num_control_qubits),
-                   [qr[2], qr[1], qr[0]])
     circuit.barrier(qr)
     circuit.x(qr[1])
     if final_measure:

--- a/test/terra/reference/ref_non_clifford.py
+++ b/test/terra/reference/ref_non_clifford.py
@@ -39,39 +39,11 @@ def t_gate_circuits_deterministic(final_measure=True):
         circuit.measure(qr, cr)
     circuits.append(circuit)
 
-    # T.T = S
-    circuit = QuantumCircuit(*regs)
-    circuit.t(qr)
-    circuit.barrier(qr)
-    circuit.t(qr)
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
     # T.X
     circuit = QuantumCircuit(*regs)
     circuit.x(qr)
     circuit.barrier(qr)
     circuit.t(qr)
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # H.T.T.T.T.H = H.Z.H = X
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr)
-    circuit.barrier(qr)
-    circuit.t(qr)
-    circuit.barrier(qr)
-    circuit.t(qr)
-    circuit.barrier(qr)
-    circuit.t(qr)
-    circuit.barrier(qr)
-    circuit.t(qr)
-    circuit.barrier(qr)
-    circuit.h(qr)
     if final_measure:
         circuit.barrier(qr)
         circuit.measure(qr, cr)
@@ -86,20 +58,12 @@ def t_gate_counts_deterministic(shots, hex_counts=True):
     if hex_counts:
         # T
         targets.append({'0x0': shots})
-        # T.T = S
-        targets.append({'0x0': shots})
         # T.X
-        targets.append({'0x1': shots})
-        # H.T.T.T.TH = H.Z.H = X
         targets.append({'0x1': shots})
     else:
         # T
         targets.append({'0': shots})
-        # T.T = S
-        targets.append({'0': shots})
         # T.X
-        targets.append({'1': shots})
-        # H.T.T.T.TH = H.Z.H = X
         targets.append({'1': shots})
     return targets
 
@@ -109,12 +73,8 @@ def t_gate_statevector_deterministic():
     targets = []
     # T
     targets.append(np.array([1, 0]))
-    # T.T = S
-    targets.append(np.array([1, 0]))
     # T.X
     targets.append(np.array([0, 1 + 1j]) / np.sqrt(2))
-    # H.T.T.T.T.H = H.Z.H = X
-    targets.append(np.array([0, 1]))
     return targets
 
 
@@ -123,12 +83,8 @@ def t_gate_unitary_deterministic():
     targets = []
     # T
     targets.append(np.diag([1, (1 + 1j) / np.sqrt(2)]))
-    # T.T = S
-    targets.append(np.diag([1, 1j]))
     # T.X
     targets.append(np.array([[0, 1], [(1 + 1j) / np.sqrt(2), 0]]))
-    # H.T.T.T.TH = H.Z.H = X
-    targets.append(np.array([[0, 1], [1, 0]]))
     return targets
 
 
@@ -265,23 +221,6 @@ def tdg_gate_circuits_deterministic(final_measure=True):
         circuit.measure(qr, cr)
     circuits.append(circuit)
 
-    # H.Tdg.Tdg.Tdg.Tdg.H = H.Z.H = X
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr)
-    circuit.barrier(qr)
-    circuit.tdg(qr)
-    circuit.barrier(qr)
-    circuit.tdg(qr)
-    circuit.barrier(qr)
-    circuit.tdg(qr)
-    circuit.barrier(qr)
-    circuit.tdg(qr)
-    circuit.barrier(qr)
-    circuit.h(qr)
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
     return circuits
 
 
@@ -293,15 +232,11 @@ def tdg_gate_counts_deterministic(shots, hex_counts=True):
         targets.append({'0x0': shots})
         # H.Tdg.T.H = I
         targets.append({'0x0': shots})
-        # H.Tdg.Tdg.Tdg.Tdg.H = H.Z.H = X
-        targets.append({'0x1': shots})
     else:
         # Tdg
         targets.append({'0': shots})
         # H.Tdg.T.H = I
         targets.append({'0': shots})
-        # H.Tdg.Tdg.Tdg.Tdg.H = H.Z.H = X
-        targets.append({'1': shots})
     return targets
 
 
@@ -312,8 +247,6 @@ def tdg_gate_statevector_deterministic():
     targets.append(np.array([1, 0]))
     # H.Tdg.T.H = I
     targets.append(np.array([1, 0]))
-    # H.Tdg.Tdg.Tdg.Tdg.H = H.Z.H = X
-    targets.append(np.array([0, 1]))
     return targets
 
 
@@ -324,8 +257,6 @@ def tdg_gate_unitary_deterministic():
     targets.append(np.diag([1, (1 - 1j) / np.sqrt(2)]))
     # H.Tdg.T.H = I
     targets.append(np.eye(2))
-    # H.Tdg.Tdg.Tdg.Tdg.H = H.Z.H = X
-    targets.append(np.array([[0, 1], [1, 0]]))
     return targets
 
 
@@ -465,73 +396,9 @@ def ccx_gate_circuits_deterministic(final_measure=True):
         circuit.measure(qr, cr)
     circuits.append(circuit)
 
-    # (X^I^X).CCX(0,1,2).(X^I^X) -> |000>
-    circuit = QuantumCircuit(*regs)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    circuit.barrier(qr)
-    circuit.ccx(qr[0], qr[1], qr[2])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (X^X^I).CCX(0,1,2).(X^X^I) -> |000>
-    circuit = QuantumCircuit(*regs)
-    circuit.x(qr[1])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    circuit.barrier(qr)
-    circuit.ccx(qr[0], qr[1], qr[2])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
     # CCX(2,1,0)
     circuit = QuantumCircuit(*regs)
     circuit.ccx(qr[2], qr[1], qr[0])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (I^X^X).CCX(2,1,0).(I^X^X) -> |000>
-    circuit = QuantumCircuit(*regs)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    circuit.barrier(qr)
-    circuit.ccx(qr[2], qr[1], qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (X^I^X).CCX(2,1,0).(X^I^X) -> |000>
-    circuit = QuantumCircuit(*regs)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
-    circuit.barrier(qr)
-    circuit.ccx(qr[2], qr[1], qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[2])
     if final_measure:
         circuit.barrier(qr)
         circuit.measure(qr, cr)
@@ -564,15 +431,7 @@ def ccx_gate_counts_deterministic(shots, hex_counts=True):
         targets.append({'0x0': shots})
         # (I^X^X).CCX(0,1,2).(I^X^X) -> |100>
         targets.append({'0x4': shots})
-        # (X^I^X).CCX(0,1,2).(X^I^X) -> |000>
-        targets.append({'0x0': shots})
-        # (X^X^I).CCX(0,1,2).(X^X^I) -> |000>
-        targets.append({'0x0': shots})
         # CCX(2,1,0)
-        targets.append({'0x0': shots})
-        # (I^X^X).CCX(2,1,0).(I^X^X) -> |000>
-        targets.append({'0x0': shots})
-        # (X^I^X).CCX(2,1,0).(X^I^X) -> |000>
         targets.append({'0x0': shots})
         # (X^X^I).CCX(2,1,0).(X^X^I) -> |001>
         targets.append({'0x1': shots})
@@ -580,16 +439,8 @@ def ccx_gate_counts_deterministic(shots, hex_counts=True):
         # CCX(0,1,2)
         targets.append({'000': shots})
         # (I^X^X).CCX(0,1,2).(I^X^X) -> |100>
-        targets.append({'100': shots})
-        # (X^I^X).CCX(0,1,2).(X^I^X) -> |000>
-        targets.append({'000': shots})
-        # (X^X^I).CCX(0,1,2).(X^X^I) -> |000>
         targets.append({'000': shots})
         # CCX(2,1,0)
-        targets.append({'000': shots})
-        # (I^X^X).CCX(2,1,0).(I^X^X) -> |000>
-        targets.append({'000': shots})
-        # (X^I^X).CCX(2,1,0).(X^I^X) -> |000>
         targets.append({'000': shots})
         # (X^X^I).CCX(2,1,0).(X^X^I) -> |001>
         targets.append({'001': shots})
@@ -604,15 +455,7 @@ def ccx_gate_statevector_deterministic():
     targets.append(zero_state)
     # (I^X^X).CCX(0,1,2).(I^X^X) -> |100>
     targets.append(np.array([0, 0, 0, 0, 1, 0, 0, 0]))
-    # (X^I^X).CCX(0,1,2).(X^I^X) -> |000>
-    targets.append(zero_state)
-    # (X^X^I).CCX(0,1,2).(X^X^I) -> |000>
-    targets.append(zero_state)
     # CCX(2,1,0)
-    targets.append(zero_state)
-    # (I^X^X).CCX(2,1,0).(I^X^X) -> |000>
-    targets.append(zero_state)
-    # (X^I^X).CCX(2,1,0).(X^I^X) -> |000>
     targets.append(zero_state)
     # (X^X^I).CCX(2,1,0).(X^X^I) -> |001>
     targets.append(np.array([0, 1, 0, 0, 0, 0, 0, 0]))
@@ -635,36 +478,12 @@ def ccx_gate_unitary_deterministic():
                   [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
                   [1, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
                   [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
-    # (X^I^X).CCX(0,1,2).(X^I^X) -> |000>
-    targets.append(
-        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
-                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
-    # (X^X^I).CCX(0,1,2).(X^X^I) -> |000>
-    targets.append(
-        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
-                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     # CCX(2,1,0)
     targets.append(
         np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
                   [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
                   [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
                   [0, 0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 1, 0]]))
-    # (I^X^X).CCX(2,1,0).(I^X^X) -> |000>
-    targets.append(
-        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
-                  [0, 0, 1, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0],
-                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
-    # (X^I^X).CCX(2,1,0).(X^I^X) -> |000>
-    targets.append(
-        np.array([[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0],
-                  [0, 0, 0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, 0],
-                  [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1]]))
     # (X^X^I).CCX(2,1,0).(X^X^I) -> |001>
     targets.append(
         np.array([[0, 1, 0, 0, 0, 0, 0, 0], [1, 0, 0, 0, 0, 0, 0, 0],
@@ -698,34 +517,6 @@ def ccx_gate_circuits_nondeterministic(final_measure=True):
         circuit.measure(qr, cr)
     circuits.append(circuit)
 
-    # (I^I^X).CCX(0,1,2).(I^H^X) -> |000> + |110>
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[1])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    circuit.barrier(qr)
-    circuit.ccx(qr[0], qr[1], qr[2])
-    circuit.barrier(qr)
-    circuit.x(qr[0])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
-    # (I^X^I).CCX(2,1,0).(H^X^I) -> |000> + |101>
-    circuit = QuantumCircuit(*regs)
-    circuit.h(qr[2])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    circuit.barrier(qr)
-    circuit.ccx(qr[2], qr[1], qr[0])
-    circuit.barrier(qr)
-    circuit.x(qr[1])
-    if final_measure:
-        circuit.barrier(qr)
-        circuit.measure(qr, cr)
-    circuits.append(circuit)
-
     # (X^I^I).CCX(2,1,0).(X^H^I) -> |000> + |011>
     circuit = QuantumCircuit(*regs)
     circuit.h(qr[1])
@@ -749,18 +540,10 @@ def ccx_gate_counts_nondeterministic(shots, hex_counts=True):
     if hex_counts:
         # (I^X^I).CCX(0,1,2).(I^X^H) -> |000> + |101>
         targets.append({'0x0': shots / 2, '0x5': shots / 2})
-        # (I^I^X).CCX(0,1,2).(I^H^X) -> |000> + |110>
-        targets.append({'0x0': shots / 2, '0x6': shots / 2})
-        # (I^X^I).CCX(2,1,0).(H^X^I) -> |000> + |101>
-        targets.append({'0x0': shots / 2, '0x5': shots / 2})
         # (X^I^I).CCX(2,1,0).(X^H^I) -> |000> + |011>
         targets.append({'0x0': shots / 2, '0x3': shots / 2})
     else:
         # (I^X^I).CCX(0,1,2).(I^X^H) -> |000> + |101>
-        targets.append({'000': shots / 2, '101': shots / 2})
-        # (I^I^X).CCX(0,1,2).(I^H^X) -> |000> + |110>
-        targets.append({'000': shots / 2, '110': shots / 2})
-        # (I^X^I).CCX(2,1,0).(H^X^I) -> |000> + |101>
         targets.append({'000': shots / 2, '101': shots / 2})
         # (X^I^I).CCX(2,1,0).(X^H^I) -> |000> + |011>
         targets.append({'000': shots / 2, '011': shots / 2})
@@ -771,10 +554,6 @@ def ccx_gate_statevector_nondeterministic():
     """CCX-gate circuits reference statevectors."""
     targets = []
     # (I^X^I).CCX(0,1,2).(I^X^H) -> |000> + |101>
-    targets.append(np.array([1, 0, 0, 0, 0, 1, 0, 0]) / np.sqrt(2))
-    # (I^I^X).CCX(0,1,2).(I^H^X) -> |000> + |110>
-    targets.append(np.array([1, 0, 0, 0, 0, 0, 1, 0]) / np.sqrt(2))
-    # (I^X^I).CCX(2,1,0).(H^X^I) -> |000> + |101>
     targets.append(np.array([1, 0, 0, 0, 0, 1, 0, 0]) / np.sqrt(2))
     # (X^I^I).CCX(2,1,0).(X^H^I) -> |000> + |011>
     targets.append(np.array([1, 0, 0, 1, 0, 0, 0, 0]) / np.sqrt(2))
@@ -790,20 +569,6 @@ def ccx_gate_unitary_nondeterministic():
                   [0, 0, 1, 1, 0, 0, 0, 0], [0, 0, 1, -1, 0, 0, 0, 0],
                   [0, 0, 0, 0, 1, 1, 0, 0], [1, -1, 0, 0, 0, 0, 0, 0],
                   [0, 0, 0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 0, 0, 1, -1]]) /
-        np.sqrt(2))
-    # (I^I^X).CCX(0,1,2).(I^H^X) -> |000> + |110>
-    targets.append(
-        np.array([[1, 0, 1, 0, 0, 0, 0, 0], [0, 1, 0, 1, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 1, 0, -1, 0], [0, 1, 0, -1, 0, 0, 0, 0],
-                  [0, 0, 0, 0, 1, 0, 1, 0], [0, 0, 0, 0, 0, 1, 0, 1],
-                  [1, 0, -1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 0, -1]]) /
-        np.sqrt(2))
-    # (I^X^I).CCX(2,1,0).(H^X^I) -> |000> + |101>
-    targets.append(
-        np.array([[1, 0, 0, 0, 1, 0, 0, 0], [0, 1, 0, 0, 0, 1, 0, 0],
-                  [0, 0, 1, 0, 0, 0, 1, 0], [0, 0, 0, 1, 0, 0, 0, 1],
-                  [0, 1, 0, 0, 0, -1, 0, 0], [1, 0, 0, 0, -1, 0, 0, 0],
-                  [0, 0, 1, 0, 0, 0, -1, 0], [0, 0, 0, 1, 0, 0, 0, -1]]) /
         np.sqrt(2))
     # (X^I^I).CCX(2,1,0).(X^H^I) -> |000> + |011>
     targets.append(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes certain tests were causing the GHA CI tests to fail to complete. 

### Details and comments

* Removes some redundant CCX and T gate tests that were slow for the extended stabilzier simulator
* Sets tests to run single threaded (except for thread management tests) to not conflict with thread usage of test library
* Reduces shot number of certain tests that don't use measurement sampling
* Reduces the number of qubits in fusion tests now that they must also be run on the density matrix simulator.
* Changes tests to to use terra circuit library QFT and QV functions instead of custom ones.