### PR TITLE
Refactor GHA config and attempt to fix pickle tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,7 @@ jobs:
     name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [standalone, sdist, lint, docs]
+    timeout-minutes: 25
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,19 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
       - name: Install deps
         run: |
           set -e
-          pip install -U pip
+          pip install -U pip wheel
           pip install -U -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
           pip install -U -c constraints.txt -r requirements-dev.txt
         shell: bash
@@ -36,10 +45,19 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+      - name: Pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-docs-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-docs-
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
       - name: Install Deps
         run: |
           set -e
-          pip install -U pip virtualenv
+          pip install -U pip virtualenv wheel
           pip install -U tox
           sudo apt-get update
           sudo apt-get install -y build-essential libopenblas-dev
@@ -105,6 +123,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-sdist-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-sdist-
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
       - name: Install Deps
         run: python -m pip install -U setuptools wheel virtualenv
       - name: Install openblas
@@ -171,11 +198,31 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-test-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-test-
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+        if: runner.os != 'Windows'
+      - name: Pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-test-
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+        if: runner.os == 'Windows'
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.1
         if: runner.os == 'Windows'
       - name: Install Deps
-        run: python -m pip install -U -r requirements-dev.txt git+https://github.com/Qiskit/qiskit-terra
+        run: python -m pip install -U -r requirements-dev.txt wheel git+https://github.com/Qiskit/qiskit-terra
       - name: Install openblas
         run: |
           set -e
@@ -222,11 +269,20 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+      - name: Pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-tutorials-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-tutorials-
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
       - name: Setup tutorials job
         run: |
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel
           pip install -U -r requirements-dev.txt -c constraints.txt
           pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
           pip install -c constraints.txt .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
   sdist:
     name: compile-sdist-python${{ matrix.python-version }}-${{ matrix.platform.os }}
     runs-on: ${{ matrix.platform.os }}
+    needs: ["lint"]
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
@@ -127,6 +128,7 @@ jobs:
   wheel:
     name: compile-wheel-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: ["lint"]
     strategy:
       matrix:
         os: ["macOS-latest", "ubuntu-latest"]
@@ -154,7 +156,7 @@ jobs:
   tests:
     name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: [standalone, wheel, sdist, lint, docs]
+    needs: [standalone, sdist, lint, docs]
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
@@ -212,7 +214,7 @@ jobs:
   tutorials:
     name: Tutorials
     runs-on: ubuntu-latest
-    needs: [standalone, wheel, sdist, lint, docs]
+    needs: [standalone, sdist, lint, docs]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7

--- a/test/terra/extensions/test_wrappers.py
+++ b/test/terra/extensions/test_wrappers.py
@@ -14,7 +14,6 @@
 import unittest
 import copy
 import pickle
-import os
 from multiprocessing import Pool
 
 from qiskit import assemble, transpile
@@ -49,8 +48,8 @@ class TestControllerExecuteWrappers(QiskitAerTestCase):
         return fqobj 
 
     def _map_and_test(self, cfunc, qobj):
-        n = max(os.cpu_count(), 2)
-        with Pool(processes=n) as p:
+        n = 2
+        with Pool(processes=1) as p:
             rs = p.map(cfunc, [copy.deepcopy(qobj) for _ in range(n)])
 
         self.assertEqual(len(rs), n)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changes the order of test dependencies in GHA to attempt to reduce bottlenecks. A local pip cache is also added to the job config.

### Details and comments

* The `wheel` and `sdist` tests were also set to require the `lint` test to pass
* The `wheel` test was removed as dependencies of the `tests` and `tutorial` actions since these tests takes a long time to run and block other tests running.


