### PR TITLE
Add available memory checks for Statevector and Unitary simulators

### DIFF
--- a/releasenotes/notes/validate-memory-statevector-d1b4fc48b002856f.yaml
+++ b/releasenotes/notes/validate-memory-statevector-d1b4fc48b002856f.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Add missing available memory checks for the
+    :class:`~qiskit.providers.aer.StatevectorSimulator` and
+    :class:`~qiskit.providers.aer.UnitarySimulator`. This throws an exception if
+    the memory required to simulate the number of qubits in a circuit exceeds the
+    available memory of the system.

--- a/src/controllers/statevector_controller.hpp
+++ b/src/controllers/statevector_controller.hpp
@@ -280,6 +280,9 @@ void StatevectorController::run_circuit_helper(
   // Validate circuit and throw exception if invalid operations exist
   validate_state(state, circ, noise, true);
 
+  // Validate memory requirements and throw exception if not enough memory
+  validate_memory_requirements(state, circ, true);
+
   // Check for custom initial state, and if so check it matches num qubits
   if (!initial_state_.empty()) {
     if (initial_state_.size() != 1ULL << circ.num_qubits) {

--- a/src/controllers/unitary_controller.hpp
+++ b/src/controllers/unitary_controller.hpp
@@ -261,6 +261,9 @@ void UnitaryController::run_circuit_helper(
   // Validate circuit and throw exception if invalid operations exist
   validate_state(state, circ, noise, true);
 
+  // Validate memory requirements and throw exception if not enough memory
+  validate_memory_requirements(state, circ, true);
+
   // Check for custom initial state, and if so check it matches num qubits
   if (!initial_unitary_.empty()) {
     auto nrows = initial_unitary_.GetRows();


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #968 

Add missing available memory checks for the StatevectorController and UnitaryController in the C++ code. These throw an exception if the memory required to simulate the number of qubits in a circuit exceeds the  available memory of the system.

### Details and comments

This C++ memory check was only run for the QasmSimulator, while the other two simulators did the error checking in Python before running the C++ code. However the python checks are disabled if a qobj is run with `validate=False` which is the default setting.
