### PR TITLE
Fix bug where snapshots are returned by copy instead of reference

### DIFF
--- a/releasenotes/notes/fix-snapshot-copy-54ee685094d1e261.yaml
+++ b/releasenotes/notes/fix-snapshot-copy-54ee685094d1e261.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes a bug where snapshot data was always copied from C++ to Python rather
+    than moved where possible. This will halve memory usage and improve simulation
+    time when using large statevector or density matrix snapshots.

--- a/src/framework/results/data/average_snapshot.hpp
+++ b/src/framework/results/data/average_snapshot.hpp
@@ -61,7 +61,7 @@ class AverageSnapshot {
   json_t to_json();
 
   // Return data reference
-  stringmap_t<stringmap_t<AverageData<T>>> data() { return data_; }
+  stringmap_t<stringmap_t<AverageData<T>>> &data() { return data_; }
 
   // Return const data reference
   const stringmap_t<stringmap_t<AverageData<T>>> &data() const { return data_; }

--- a/src/framework/results/data/pershot_snapshot.hpp
+++ b/src/framework/results/data/pershot_snapshot.hpp
@@ -59,7 +59,7 @@ class PershotSnapshot {
   json_t to_json();
 
   // Return data reference
-  stringmap_t<PershotData<T>> data() { return data_; }
+  stringmap_t<PershotData<T>> &data() { return data_; }
 
   // Return const data reference
   const stringmap_t<PershotData<T>> &data() const { return data_; }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bug where snapshot data was always copied from C++ to Python rather than moved where possible. This will halve memory usage and improve simulation time when using large statevector or density matrix snapshots.

### Details and comments


