### PR TITLE
Deprecate snapshot variance

### DIFF
--- a/qiskit/providers/aer/extensions/snapshot_expectation_value.py
+++ b/qiskit/providers/aer/extensions/snapshot_expectation_value.py
@@ -40,8 +40,10 @@ class SnapshotExpectationValue(Snapshot):
             ExtensionError: if snapshot is invalid.
         """
         if variance:
-            warn('The snapshot `variance` kwarg has been deprecated and will be removed'
-                 ' in qiskit-aer 0.8.', DeprecationWarning)
+            warn('The snapshot `variance` kwarg has been deprecated and will'
+                 ' be removed in qiskit-aer 0.8. To compute variance use'
+                 ' `single_shot=True` and compute manually in post-processing',
+                 DeprecationWarning)
         pauli_op = self._format_pauli_op(op)
         if pauli_op:
             # Pauli expectation value

--- a/qiskit/providers/aer/extensions/snapshot_expectation_value.py
+++ b/qiskit/providers/aer/extensions/snapshot_expectation_value.py
@@ -13,6 +13,7 @@
 """
 Simulator command to snapshot internal simulator representation.
 """
+from warnings import warn
 import math
 import numpy
 from qiskit import QuantumCircuit
@@ -38,6 +39,9 @@ class SnapshotExpectationValue(Snapshot):
         Raises:
             ExtensionError: if snapshot is invalid.
         """
+        if variance:
+            warn('The snapshot `variance` kwarg has been deprecated and will be removed'
+                 ' in qiskit-aer 0.8.', DeprecationWarning)
         pauli_op = self._format_pauli_op(op)
         if pauli_op:
             # Pauli expectation value

--- a/qiskit/providers/aer/extensions/snapshot_probabilities.py
+++ b/qiskit/providers/aer/extensions/snapshot_probabilities.py
@@ -14,6 +14,7 @@
 Simulator command to snapshot internal simulator representation.
 """
 
+from warnings import warn
 from qiskit import QuantumCircuit
 from qiskit.providers.aer.extensions import Snapshot
 
@@ -32,6 +33,9 @@ class SnapshotProbabilities(Snapshot):
         Raises:
             ExtensionError: if snapshot is invalid.
         """
+        if variance:
+            warn('The snapshot `variance` kwarg has been deprecated and will be removed'
+                 ' in qiskit-aer 0.8.', DeprecationWarning)
         snapshot_type = 'probabilities_with_variance' if variance else 'probabilities'
         super().__init__(label, snapshot_type=snapshot_type,
                          num_qubits=num_qubits)

--- a/releasenotes/notes/deprecate-snapshot-variance-7d02188deacf9a08.yaml
+++ b/releasenotes/notes/deprecate-snapshot-variance-7d02188deacf9a08.yaml
@@ -1,0 +1,9 @@
+---
+deprecations:
+  - |
+    The `variance` kwarg of Snapshot instructions has been deprecated. This
+    function computed the sample variance in the snapshot due to noise model
+    sampling, not the variance due to measurement statistics so was often
+    being used incorrectly. If noise modeling variance is required single shot
+    snapshots should be used so variance can be computed manually in
+    post-processing.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `variance` kwarg of Snapshot instructions has been deprecated. This function computed the sample variance in the snapshot due to noise model
    sampling, not the variance due to measurement statistics so was often
    being used incorrectly. If noise modeling variance is required single shot
    snapshots should be used so variance can be computed manually in
    post-processing.

### Details and comments

Deprecation will allow closing #903 in future release.
