### PR TITLE
Try to fix aer lint failure by installing aer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
           pip install -U pip wheel
           pip install -U -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
           pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -U .
         shell: bash
       - name: Run Lint
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,11 @@ jobs:
             ${{ runner.os }}-pip-lint-
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+      - name: Install openblas
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
       - name: Install deps
         run: |
           set -e


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since Qiskit/qiskit-terra#5086 merged the aer CI jobs have been failing.
It looks like it's because pylint can't find the pybind modules. I'm not
sure how Qiskit/qiskit-terra#5086 changed things, but this commit tries
to fix it by installing aer in the pylint job.

### Details and comments