### PR TITLE
Alternate try to fix aer lint failure by installing aer 

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -18,9 +18,9 @@ from math import log2
 from qiskit.util import local_hardware_info
 from qiskit.providers.models import QasmBackendConfiguration
 from .aerbackend import AerBackend
-# pylint: disable=import-error
-from .controller_wrappers import qasm_controller_execute
 from ..version import __version__
+# pylint: disable=import-error,no-name-in-module
+from .controller_wrappers import qasm_controller_execute
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -19,10 +19,10 @@ from math import log2
 from qiskit.util import local_hardware_info
 from qiskit.providers.models import QasmBackendConfiguration
 from .aerbackend import AerBackend
-# pylint: disable=import-error
-from .controller_wrappers import statevector_controller_execute
 from ..aererror import AerError
 from ..version import __version__
+# pylint: disable=import-error,no-name-in-module
+from .controller_wrappers import statevector_controller_execute
 
 # Logger
 logger = logging.getLogger(__name__)

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -22,9 +22,9 @@ from qiskit.providers.models import QasmBackendConfiguration
 
 from .aerbackend import AerBackend
 from ..aererror import AerError
-# pylint: disable=import-error
-from .controller_wrappers import unitary_controller_execute
 from ..version import __version__
+# pylint: disable=import-error,no-name-in-module
+from .controller_wrappers import unitary_controller_execute
 
 # Logger
 logger = logging.getLogger(__name__)

--- a/qiskit/providers/aer/extensions/snapshot_density_matrix.py
+++ b/qiskit/providers/aer/extensions/snapshot_density_matrix.py
@@ -15,7 +15,7 @@ Simulator command to snapshot internal simulator representation.
 """
 
 from qiskit import QuantumCircuit
-from qiskit.providers.aer.extensions import Snapshot
+from .snapshot import Snapshot
 
 
 class SnapshotDensityMatrix(Snapshot):

--- a/qiskit/providers/aer/extensions/snapshot_expectation_value.py
+++ b/qiskit/providers/aer/extensions/snapshot_expectation_value.py
@@ -21,7 +21,7 @@ from qiskit.circuit import Instruction
 from qiskit.extensions.exceptions import ExtensionError
 from qiskit.qobj import QasmQobjInstruction
 from qiskit.quantum_info.operators import Pauli, Operator
-from qiskit.providers.aer.extensions import Snapshot
+from .snapshot import Snapshot
 
 
 class SnapshotExpectationValue(Snapshot):

--- a/qiskit/providers/aer/extensions/snapshot_probabilities.py
+++ b/qiskit/providers/aer/extensions/snapshot_probabilities.py
@@ -16,7 +16,7 @@ Simulator command to snapshot internal simulator representation.
 
 from warnings import warn
 from qiskit import QuantumCircuit
-from qiskit.providers.aer.extensions import Snapshot
+from .snapshot import Snapshot
 
 
 class SnapshotProbabilities(Snapshot):

--- a/qiskit/providers/aer/extensions/snapshot_stabilizer.py
+++ b/qiskit/providers/aer/extensions/snapshot_stabilizer.py
@@ -15,7 +15,7 @@ Simulator command to snapshot internal simulator representation.
 """
 
 from qiskit import QuantumCircuit
-from qiskit.providers.aer.extensions import Snapshot
+from .snapshot import Snapshot
 
 
 class SnapshotStabilizer(Snapshot):

--- a/qiskit/providers/aer/extensions/snapshot_statevector.py
+++ b/qiskit/providers/aer/extensions/snapshot_statevector.py
@@ -15,7 +15,7 @@ Simulator command to snapshot internal simulator representation.
 """
 
 from qiskit import QuantumCircuit
-from qiskit.providers.aer.extensions import Snapshot
+from .snapshot import Snapshot
 
 
 class SnapshotStatevector(Snapshot):

--- a/qiskit/providers/aer/noise/device/basic_device_model.py
+++ b/qiskit/providers/aer/noise/device/basic_device_model.py
@@ -116,7 +116,7 @@ def basic_device_noise_model(properties,
     # This wrapper is for the deprecated function
     # We need to import noise model here to avoid cyclic import errors
     # pylint: disable=import-outside-toplevel
-    from qiskit.providers.aer.noise.noise_model import NoiseModel
+    from ..noise_model import NoiseModel
     return NoiseModel.from_backend(properties,
                                    gate_error=gate_error,
                                    readout_error=readout_error,

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -21,8 +21,8 @@ from qiskit.circuit import Instruction
 from qiskit.providers import BaseBackend
 from qiskit.providers.models import BackendProperties
 
-from qiskit.providers.aer.backends.aerbackend import AerJSONEncoder
-from qiskit.providers.aer.backends.qasm_simulator import QasmSimulator
+from ..backends.aerbackend import AerJSONEncoder
+from ..backends.qasm_simulator import QasmSimulator
 
 from .noiseerror import NoiseError
 from .errors.quantum_error import QuantumError

--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -18,7 +18,7 @@
 
 from collections import OrderedDict
 import numpy as np
-from qiskit.providers.aer.aererror import AerError
+from ...aererror import AerError
 # pylint: disable=no-name-in-module
 from .pulse_utils import oplist_to_array
 

--- a/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
+++ b/qiskit/providers/aer/pulse/system_models/hamiltonian_model.py
@@ -18,7 +18,7 @@
 from collections import OrderedDict
 import numpy as np
 import numpy.linalg as la
-from qiskit.providers.aer.aererror import AerError
+from ...aererror import AerError
 from .string_model_parser.string_model_parser import HamiltonianParser
 
 

--- a/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
@@ -18,7 +18,7 @@
 from warnings import warn
 from collections import OrderedDict
 from qiskit.providers import BaseBackend
-from qiskit.providers.aer.aererror import AerError
+from ...aererror import AerError
 from .hamiltonian_model import HamiltonianModel
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit/qiskit-terra#5086 seemd to break pylint testing by preventing the Aer package from being found by pylint without building and installing.

This tries to fix the issue by replacing all absolute imports in Aer with relative module imports. This is a work around until general namespace packaging issues are implemented to move all of Aer into its own namespace.

### Details and comments

#979 fixes the issue by building and installing Aer in the lint module, however this means lint passing is dependent on Aer being built via sdist, which is a separate test usually run after linting.
