### PR TITLE
Fix CI failures because of azure image update

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -229,7 +229,7 @@ stages:
           - bash: |
               set -x
               set -e
-              conda create --yes --quiet --name qiskit-aer python=$(python.version)
+              conda create --yes --quiet --name test-wheel python=$(python.version)
               source activate test-wheel
               pip install -c constraints.txt dist/*whl
               pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,7 @@ stages:
                 conda config --add channels conda-forge
                 conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
                 python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
+                pip install -U virtualenv
                 virtualenv test-$version
                 test-$version/Scripts/pip install -c constraints.txt dist/*whl
                 test-$version/Scripts/python tools/verify_wheels.py
@@ -101,6 +102,7 @@ stages:
                 conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
                 python -m pip install -U setuptools wheel
                 python setup.py bdist_wheel -- -G "Visual Studio 15 2017"
+                pip install -U virtualenv
                 virtualenv test-$version
                 test-$version/Scripts/pip install -c constraints.txt dist/*whl
                 test-$version/Scripts/python tools/verify_wheels.py
@@ -173,6 +175,7 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
+              pip install -U virtualenv
               virtualenv test-wheel
               test-wheel/Scripts/pip install -c constraints.txt dist/*whl
               test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
@@ -228,6 +231,7 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
+              pip install -U virtualenv
               virtualenv test-wheel
               test-wheel/Scripts/pip install -c constraints.txt dist/*whl
               test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,12 +45,12 @@ stages:
                 source activate qiskit-aer-$version
                 conda update --yes -n base conda
                 conda config --add channels conda-forge
-                conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
+                conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake pip setuptools pybind11 cython scipy
                 python setup.py bdist_wheel -- -G "Visual Studio 15 2017 Win64"
-                pip install -U virtualenv
-                virtualenv test-$version
-                test-$version/Scripts/pip install -c constraints.txt dist/*whl
-                test-$version/Scripts/python tools/verify_wheels.py
+                conda create --yes --quiet python=$version --name test-$version
+                source activate test-$version
+                pip install -c constraints.txt dist/*whl
+                python tools/verify_wheels.py
                 mv dist/*whl wheelhouse/.
                 rm -rf test-$version
                 rm -rf _skbuild
@@ -99,13 +99,13 @@ stages:
             mkdir wheelhouse
             for version in 3.6 3.7 3.8 ; do
                 source activate qiskit-aer-$version
-                conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake virtualenv pip setuptools pybind11 cython scipy
+                conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake pip setuptools pybind11 cython scipy
                 python -m pip install -U setuptools wheel
                 python setup.py bdist_wheel -- -G "Visual Studio 15 2017"
-                pip install -U virtualenv
-                virtualenv test-$version
-                test-$version/Scripts/pip install -c constraints.txt dist/*whl
-                test-$version/Scripts/python tools/verify_wheels.py
+                conda create --yes --quiet python=$version --name test-$version
+                source activate test-$version
+                pip install -c constraints.txt dist/*whl
+                python tools/verify_wheels.py
                 mv dist/*whl wheelhouse/.
                 rm -rf test-$version
                 rm -rf _skbuild
@@ -163,7 +163,7 @@ stages:
               source activate qiskit-aer
               conda update --yes -n base conda
               conda config --add channels conda-forge
-              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
+              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake pip setuptools pybind11 cython scipy
             displayName: Create Anaconda environments
           - bash: |
               set -x
@@ -174,12 +174,11 @@ stages:
           - bash: |
               set -x
               set -e
-              source activate qiskit-aer
-              pip install -U virtualenv
-              virtualenv test-wheel
-              test-wheel/Scripts/pip install -c constraints.txt dist/*whl
-              test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
-              test-wheel/Scripts/python tools/verify_wheels.py
+              conda create --yes --quiet --name test-wheel python=$(python.version)
+              source activate test-wheel
+              pip install -c constraints.txt dist/*whl
+              pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
+              python tools/verify_wheels.py
             displayName: Verify wheels
       - job: 'Windows_win32_Wheel_Builds'
         pool: {vmImage: 'vs2017-win2016'}
@@ -214,7 +213,7 @@ stages:
               set -e
               conda create --yes --quiet --name qiskit-aer python=$(python.version)
               source activate qiskit-aer
-              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
+              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake pip setuptools pybind11 cython scipy
             displayName: Create Anaconda environments
             env:
               CONDA_FORCE_32BIT: 1
@@ -230,12 +229,11 @@ stages:
           - bash: |
               set -x
               set -e
-              source activate qiskit-aer
-              pip install -U virtualenv
-              virtualenv test-wheel
-              test-wheel/Scripts/pip install -c constraints.txt dist/*whl
-              test-wheel/Scripts/pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
-              test-wheel/Scripts/python tools/verify_wheels.py
+              conda create --yes --quiet --name qiskit-aer python=$(python.version)
+              source activate test-wheel
+              pip install -c constraints.txt dist/*whl
+              pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
+              python tools/verify_wheels.py
             displayName: Verify wheels
             env:
               CONDA_FORCE_32BIT: 1
@@ -272,7 +270,7 @@ stages:
               source activate qiskit-aer
               conda update --yes -n base conda
               conda config --add channels conda-forge
-              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake virtualenv pip setuptools pybind11 cython scipy
+              conda install --yes --quiet --name qiskit-aer python=$(python.version) numpy cmake pip setuptools pybind11 cython scipy
             displayName: Create Anaconda environments
           - bash: |
               set -x
@@ -284,7 +282,7 @@ stages:
               set -x
               set -e
               source activate qiskit-aer
-              pip install -U setuptools virtualenv wheel
+              pip install -U setuptools wheel
               pip install dist/*tar.gz
               pip install git+https://github.com/Qiskit/qiskit-terra
               python tools/verify_wheels.py


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Azure pipelines recently updated their windows images with a newer
version of conda. This has started causing CI failures when the wheel
jobs run virtualenv to build an isolated python env to test that the
built wheels work for a user without any dependencies pre-installed.
This commit fixes this by abandoning the use of virtualenv and relying
on conda to create an isolated test environment.

### Details and comments

A follow up from here will be to investigate abandoning the use of conda
from the CI jobs. It adds needless complexity and was originally added
to ensure we could easily install cvxpy and cvxopt on windows which
hopefully shouldn't be a problem anymore.