### PR TITLE
Add missing standard gate basis gates

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -429,8 +429,8 @@ class QasmSimulator(AerBackend):
             config.n_qubits = 63  # TODO: estimate from memory
             config.description = 'A C++ QasmQobj ranked stabilizer simulator with noise'
             config.basis_gates = [
-                'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'swap',
-                'u0', 'u1', 'ccx', 'ccz', 'roerror', 'delay'
+                'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'swap',
+                'u0', 'u1', 'p', 'ccx', 'ccz', 'roerror', 'delay'
             ]
 
         return config

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -248,7 +248,7 @@ class QasmSimulator(AerBackend):
         'description': 'A C++ QasmQobj simulator with noise',
         'coupling_map': None,
         'basis_gates': [
-            'u1', 'u2', 'u3', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
+            'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
             'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
             'cy', 'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy',
             'rzz', 'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx',
@@ -400,7 +400,7 @@ class QasmSimulator(AerBackend):
             config.n_qubits = config.n_qubits // 2
             config.description = 'A C++ QasmQobj density matrix simulator with noise'
             config.basis_gates = [
-                'u1', 'u2', 'u3', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
+                'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
                 'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
                 'cy', 'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy',
                 'rzz', 'rzx', 'ccx', 'unitary', 'diagonal', 'kraus', 'superop'
@@ -411,7 +411,7 @@ class QasmSimulator(AerBackend):
         elif method == 'matrix_product_state':
             config.description = 'A C++ QasmQobj matrix product state simulator with noise'
             config.basis_gates = [
-                'u1', 'u2', 'u3', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
+                'u1', 'u2', 'u3', 'u', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
                 'sdg', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay'
             ]
 

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -411,8 +411,8 @@ class QasmSimulator(AerBackend):
         elif method == 'matrix_product_state':
             config.description = 'A C++ QasmQobj matrix product state simulator with noise'
             config.basis_gates = [
-                'u1', 'u2', 'u3', 'u', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
-                'sdg', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay'
+                'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
+                'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay'
             ]
 
         # Stabilizer method
@@ -420,7 +420,7 @@ class QasmSimulator(AerBackend):
             config.n_qubits = 5000  # TODO: estimate from memory
             config.description = 'A C++ QasmQobj Clifford stabilizer simulator with noise'
             config.basis_gates = [
-                'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'cx', 'cy', 'cz',
+                'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'cx', 'cy', 'cz',
                 'swap', 'roerror', 'delay'
             ]
 

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -110,7 +110,7 @@ class StatevectorSimulator(AerBackend):
         'description': 'A C++ statevector simulator for QASM Qobj files',
         'coupling_map': None,
         'basis_gates': [
-            'u1', 'u2', 'u3', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
+            'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
             'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
             'cy', 'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy',
             'rzz', 'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx',

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -116,7 +116,7 @@ class UnitarySimulator(AerBackend):
         'description': 'A C++ unitary simulator for QASM Qobj files',
         'coupling_map': None,
         'basis_gates': [
-            'u1', 'u2', 'u3', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
+            'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
             'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
             'cy', 'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy',
             'rzz', 'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx',

--- a/releasenotes/notes/basis-gates-acbc8a1a52a49413.yaml
+++ b/releasenotes/notes/basis-gates-acbc8a1a52a49413.yaml
@@ -1,28 +1,49 @@
 ---
 features:
   - |
-    Adds support for parameterized delay gate ``"delay"`` to the
-    :class:`~qiskit.providers.aer.StatevectorSimulator`,
+    Adds basis gate support for the :class:`qiskit.circuit.Delay`
+    instruction to the :class:`~qiskit.providers.aer.StatevectorSimulator`,
     :class:`~qiskit.providers.aer.UnitarySimulator`, and
     :class:`~qiskit.providers.aer.QasmSimulator`.
-    By default this gate is treated as an identity gate during simulation.
+    Note that this gate is treated as an identity gate during simulation
+    and the delay length parameter is ignored.
   - |
-    Adds support for parameterized phase gate ``"p"`` and controlled-phase
-    gate ``"cp"`` to the :class:`~qiskit.providers.aer.StatevectorSimulator`,
+    Adds basis gate support for the single-qubit gate
+    :class:`qiskit.circuit.library.UGate` to the
+    :class:`~qiskit.providers.aer.StatevectorSimulator`,
+    :class:`~qiskit.providers.aer.UnitarySimulator`, and the 
+    ``"statevector"``, ``"density_matrix"``, ``"matrix_product_state"``,
+    and ``"extended_stabilizer"`` methods of the
+    :class:`~qiskit.providers.aer.QasmSimulator`.
+  - |
+    Adds basis gate support for the phase gate
+    :class:`qiskit.circuit.library.PhaseGate` to the
+    :class:`~qiskit.providers.aer.StatevectorSimulator`,
+    :class:`~qiskit.providers.aer.StatevectorSimulator`,
+    :class:`~qiskit.providers.aer.UnitarySimulator`, and the 
+    ``"statevector"``, ``"density_matrix"``, ``"matrix_product_state"``,
+    and ``"extended_stabilizer"`` methods of the
+    :class:`~qiskit.providers.aer.QasmSimulator`.
+  - |
+    Adds basis gate support for the controlled-phase gate
+    :class:`qiskit.circuit.library.CPhaseGate` to the
+    :class:`~qiskit.providers.aer.StatevectorSimulator`,
+    :class:`~qiskit.providers.aer.StatevectorSimulator`,
     :class:`~qiskit.providers.aer.UnitarySimulator`, and the 
     ``"statevector"`` and ``"density_matrix"`` methods of the
     :class:`~qiskit.providers.aer.QasmSimulator`.
   - |
-    Adds support for the multi-controlled phase gate ``"mcphase"`` to the
+    Adds support for the multi-controlled phase gate
+    :class:`qiskit.circuit.library.MCPhaseGate` to the
     :class:`~qiskit.providers.aer.StatevectorSimulator`,
     :class:`~qiskit.providers.aer.UnitarySimulator`, and the 
     ``"statevector"`` method of the
     :class:`~qiskit.providers.aer.QasmSimulator`.
   - |
-    Adds support for the :math:`\sqrt(X)` gate ``"sx"`` to the 
+    Adds support for the :math:`\sqrt(X)` gate
+    :class:`qiskit.circuit.library.SXGate` to the
     class:`~qiskit.providers.aer.StatevectorSimulator`,
-    :class:`~qiskit.providers.aer.UnitarySimulator`, and the
-    ``"statevector"`` and ``"density_matrix"`` methods of the
+    :class:`~qiskit.providers.aer.UnitarySimulator`, and
     :class:`~qiskit.providers.aer.QasmSimulator`.
 deprecations:
   - |

--- a/releasenotes/notes/basis-gates-acbc8a1a52a49413.yaml
+++ b/releasenotes/notes/basis-gates-acbc8a1a52a49413.yaml
@@ -30,7 +30,8 @@ features:
     :class:`~qiskit.providers.aer.StatevectorSimulator`,
     :class:`~qiskit.providers.aer.StatevectorSimulator`,
     :class:`~qiskit.providers.aer.UnitarySimulator`, and the 
-    ``"statevector"`` and ``"density_matrix"`` methods of the
+    ``"statevector"``, ``"density_matrix"``, and
+    ``"matrix_product_state"`` methods of the
     :class:`~qiskit.providers.aer.QasmSimulator`.
   - |
     Adds support for the multi-controlled phase gate

--- a/src/noise/noise_model.hpp
+++ b/src/noise/noise_model.hpp
@@ -260,6 +260,7 @@ private:
 
 const stringmap_t<NoiseModel::ParamGate>
 NoiseModel::param_gate_table_ = {
+  {"u", ParamGate::u3},
   {"u3", ParamGate::u3},
   {"u2", ParamGate::u2},
   {"u1", ParamGate::u1},

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -41,10 +41,10 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::diagonal_matrix, Operations::OpType::kraus,
      Operations::OpType::superop},
     // Gates
-    {"U", "CX", "u1", "u2", "u3",  "cx",  "cy", "cz",  "swap", "id",
-     "x", "y",  "z",  "h",  "s",   "sdg", "t",   "tdg",  "ccx",
-     "r", "rx", "ry", "rz", "rxx", "ryy", "rzz", "rzx",  "p",
-     "cp","cu1", "sx", "x90", "delay"},
+    {"U",    "CX",  "u1", "u2",  "u3", "u",   "cx",   "cy",  "cz",
+     "swap", "id",  "x",  "y",   "z",  "h",   "s",    "sdg", "t",
+     "tdg",  "ccx", "r",  "rx",  "ry", "rz",  "rxx",  "ryy", "rzz",
+     "rzx",  "p",   "cp", "cu1", "sx", "x90", "delay"},
     // Snapshots
     {"density_matrix", "memory", "register", "probabilities",
      "probabilities_with_variance", "expectation_value_pauli",
@@ -277,6 +277,7 @@ const stringmap_t<Gates> State<densmat_t>::gateset_({
     {"u1", Gates::u1}, // zero-X90 pulse waltz gate
     {"u2", Gates::u2}, // single-X90 pulse waltz gate
     {"u3", Gates::u3}, // two X90 pulse waltz gate
+    {"u", Gates::u3}, // two X90 pulse waltz gate
     {"U", Gates::u3},  // two X90 pulse waltz gate
     // Two-qubit gates
     {"CX", Gates::cx},     // Controlled-X gate (CNOT)

--- a/src/simulators/extended_stabilizer/ch_runner.hpp
+++ b/src/simulators/extended_stabilizer/ch_runner.hpp
@@ -104,6 +104,7 @@ public:
   void apply_cz(uint_t control, uint_t target, uint_t rank);
   void apply_swap(uint_t qubit_1, uint_t qubit_2, uint_t rank);
   void apply_h(uint_t qubit, uint_t rank);
+  void apply_sx(uint_t qubit, uint_t rank);
   void apply_s(uint_t qubit, uint_t rank);
   void apply_sdag(uint_t qubit, uint_t rank);
   void apply_x(uint_t qubit, uint_t rank);
@@ -251,6 +252,13 @@ void Runner::apply_s(uint_t qubit, uint_t rank)
 
 void Runner::apply_sdag(uint_t qubit, uint_t rank)
 {
+  states_[rank].Sdag(qubit);
+}
+
+void Runner::apply_sx(uint_t qubit, uint_t rank)
+{
+  states_[rank].Sdag(qubit);
+  states_[rank].Z(qubit);
   states_[rank].Sdag(qubit);
 }
 

--- a/src/simulators/extended_stabilizer/ch_runner.hpp
+++ b/src/simulators/extended_stabilizer/ch_runner.hpp
@@ -258,7 +258,7 @@ void Runner::apply_sdag(uint_t qubit, uint_t rank)
 void Runner::apply_sx(uint_t qubit, uint_t rank)
 {
   states_[rank].Sdag(qubit);
-  states_[rank].Z(qubit);
+  states_[rank].H(qubit);
   states_[rank].Sdag(qubit);
 }
 

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -38,7 +38,7 @@ const Operations::OpSet StateOpSet(
     Operations::OpType::roerror, Operations::OpType::bfunc,
     Operations::OpType::snapshot},
   // Gates
-  {"CX", "u0", "u1", "cx", "cz", "swap", "id", "x", "y", "z", "h",
+  {"CX", "u0", "u1", "p", "cx", "cz", "swap", "id", "x", "y", "z", "h",
     "s", "sdg", "t", "tdg", "ccx", "ccz", "delay"},
   // Snapshots
   {"statevector", "probabilities", "memory", "register"}
@@ -188,11 +188,13 @@ const stringmap_t<Gates> State::gateset_({
   {"s", Gates::s},       // Phase gate (aka sqrt(Z) gate)
   {"sdg", Gates::sdg},   // Conjugate-transpose of Phase gate
   {"h", Gates::h},       // Hadamard gate (X + Z / sqrt(2))
+  {"sx", Gates::sx},     // sqrt(X) gate
   {"t", Gates::t},       // T-gate (sqrt(S))
   {"tdg", Gates::tdg},   // Conjguate-transpose of T gate
   // Waltz Gates
   {"u0", Gates::u0},     // idle gate in multiples of X90
   {"u1", Gates::u1},     // zero-X90 pulse waltz gate
+  {"p", Gates::u1},      // zero-X90 pulse waltz gate
   // Two-qubit gates
   {"CX", Gates::cx},     // Controlled-X gate (CNOT)
   {"cx", Gates::cx},     // Controlled-X gate (CNOT)
@@ -597,6 +599,9 @@ void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank)
       break;
     case Gates::h:
       BaseState::qreg_.apply_h(op.qubits[0], rank);
+      break;
+    case Gates::sx:
+      BaseState::qreg_.apply_sx(op.qubits[0], rank);
       break;
     case Gates::cx:
       BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);

--- a/src/simulators/extended_stabilizer/gates.hpp
+++ b/src/simulators/extended_stabilizer/gates.hpp
@@ -30,7 +30,7 @@ namespace CHSimulator
   using complex_t = std::complex<double>;
 
   enum class Gates {
-    u0, u1, id, x, y, z, h, s, sdg, t, tdg,
+    u0, u1, id, x, y, z, h, s, sdg, sx, t, tdg,
     cx, cz, swap,
     ccx, ccz
   };
@@ -48,12 +48,14 @@ namespace CHSimulator
     {"z", Gatetypes::pauli},       // Pauli-Z gate
     {"s", Gatetypes::clifford},       // Phase gate (aka sqrt(Z) gate)
     {"sdg", Gatetypes::clifford},   // Conjugate-transpose of Phase gate
+    {"sx", Gatetypes::clifford},    // Sqrt(X) gate
     {"h", Gatetypes::clifford},       // Hadamard gate (X + Z / sqrt(2))
     {"t", Gatetypes::non_clifford},       // T-gate (sqrt(S))
     {"tdg", Gatetypes::non_clifford},   // Conjguate-transpose of T gate
     // Waltz Gates
     {"u0", Gatetypes::pauli},     // idle gate in multiples of X90
     {"u1", Gatetypes::non_clifford},     // zero-X90 pulse waltz gate
+    {"p", Gatetypes::non_clifford},     // zero-X90 pulse waltz gate
     // Two-qubit gates
     {"CX", Gatetypes::clifford},     // Controlled-X gate (CNOT)
     {"cx", Gatetypes::clifford},     // Controlled-X gate (CNOT)

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -49,8 +49,8 @@ const Operations::OpSet StateOpSet(
   Operations::OpType::bfunc, Operations::OpType::roerror,
   Operations::OpType::matrix, Operations::OpType::kraus},
   // Gates
-  {"id", "x",  "y", "z", "s",  "sdg", "h",  "t",   "tdg",  "u1",
-   "u2", "u3", "u", "U", "CX", "cx",  "cz", "cu1", "swap", "ccx"},
+  {"id", "x",  "y", "z", "s",  "sdg", "h",  "t",   "tdg",  "p", "u1",
+   "u2", "u3", "u", "U", "CX", "cx",  "cz", "cp", "cu1", "swap", "ccx"},
   // Snapshots
   {"statevector", "memory", "register", "probabilities",
     "expectation_value_pauli", "expectation_value_pauli_with_variance",
@@ -297,22 +297,25 @@ const stringmap_t<Gates> State::gateset_({
   {"s", Gates::s},       // Phase gate (aka sqrt(Z) gate)
   {"sdg", Gates::sdg},   // Conjugate-transpose of Phase gate
   {"h", Gates::h},       // Hadamard gate (X + Z / sqrt(2))
+  {"sx", Gates::sx},     // Sqrt(X) gate
   {"t", Gates::t},       // T-gate (sqrt(S))
   {"tdg", Gates::tdg},   // Conjguate-transpose of T gate
   // Waltz Gates
+  {"p", Gates::u1},      // zero-X90 pulse waltz gate
   {"u1", Gates::u1},     // zero-X90 pulse waltz gate
   {"u2", Gates::u2},     // single-X90 pulse waltz gate
   {"u3", Gates::u3},     // two X90 pulse waltz gate
-  {"u", Gates::u3},     // two X90 pulse waltz gate
+  {"u", Gates::u3},      // two X90 pulse waltz gate
   {"U", Gates::u3},      // two X90 pulse waltz gate
   // Two-qubit gates
   {"CX", Gates::cx},     // Controlled-X gate (CNOT)
   {"cx", Gates::cx},     // Controlled-X gate (CNOT)
   {"cz", Gates::cz},     // Controlled-Z gate
-  {"cu1", Gates::cu1},     // Controlled-U1 gate
+  {"cu1", Gates::cu1},   // Controlled-U1 gate
+  {"cp", Gates::cu1},    // Controlled-U1 gate
   {"swap", Gates::swap}, // SWAP gate
   // Three-qubit gates
-   {"ccx", Gates::mcx}    // Controlled-CX gate (Toffoli)
+   {"ccx", Gates::mcx}   // Controlled-CX gate (Toffoli)
 });
 
 const stringmap_t<Snapshots> State::snapshotset_({
@@ -663,6 +666,9 @@ void State::apply_gate(const Operations::Op &op) {
       break;
     case Gates::sdg:
       qreg_.apply_sdg(op.qubits[0]);
+      break;
+    case Gates::sx:
+      qreg_.apply_sx(op.qubits[0]);
       break;
     case Gates::t:
       qreg_.apply_t(op.qubits[0]);

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -49,8 +49,8 @@ const Operations::OpSet StateOpSet(
   Operations::OpType::bfunc, Operations::OpType::roerror,
   Operations::OpType::matrix, Operations::OpType::kraus},
   // Gates
-  {"id", "x", "y", "z", "s", "sdg", "h", "t", "tdg", "u1", "u2", "u3",
-    "U", "CX", "cx", "cz", "cu1", "swap", "ccx"},
+  {"id", "x",  "y", "z", "s",  "sdg", "h",  "t",   "tdg",  "u1",
+   "u2", "u3", "u", "U", "CX", "cx",  "cz", "cu1", "swap", "ccx"},
   // Snapshots
   {"statevector", "memory", "register", "probabilities",
     "expectation_value_pauli", "expectation_value_pauli_with_variance",
@@ -303,6 +303,7 @@ const stringmap_t<Gates> State::gateset_({
   {"u1", Gates::u1},     // zero-X90 pulse waltz gate
   {"u2", Gates::u2},     // single-X90 pulse waltz gate
   {"u3", Gates::u3},     // two X90 pulse waltz gate
+  {"u", Gates::u3},     // two X90 pulse waltz gate
   {"U", Gates::u3},      // two X90 pulse waltz gate
   // Two-qubit gates
   {"CX", Gates::cx},     // Controlled-X gate (CNOT)

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -318,6 +318,12 @@ void MPS::apply_h(uint_t index)
   get_qubit(index).apply_matrix(h_matrix);
 }
 
+void MPS::apply_sx(uint_t index)
+{
+  cmatrix_t sx_matrix = AER::Linalg::Matrix::SX;
+  get_qubit(index).apply_matrix(sx_matrix);
+}
+
 void MPS::apply_u1(uint_t index, double lambda)
 {
   cmatrix_t u1_matrix = AER::Linalg::Matrix::u1(lambda);
@@ -335,6 +341,8 @@ void MPS::apply_u3(uint_t index, double theta, double phi, double lambda)
   cmatrix_t u3_matrix = AER::Linalg::Matrix::u3(theta, phi, lambda);
   get_qubit(index).apply_matrix(u3_matrix);
 }
+
+
 
 void MPS::apply_cnot(uint_t index_A, uint_t index_B)
 {

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -314,32 +314,27 @@ reg_t MPS::get_internal_qubits(const reg_t &qubits) const {
  
 void MPS::apply_h(uint_t index) 
 {
-  cmatrix_t h_matrix = AER::Linalg::Matrix::H;
-  get_qubit(index).apply_matrix(h_matrix);
+  get_qubit(index).apply_matrix(AER::Linalg::Matrix::H);
 }
 
 void MPS::apply_sx(uint_t index)
 {
-  cmatrix_t sx_matrix = AER::Linalg::Matrix::SX;
-  get_qubit(index).apply_matrix(sx_matrix);
+  get_qubit(index).apply_matrix(AER::Linalg::Matrix::SX);
 }
 
 void MPS::apply_u1(uint_t index, double lambda)
 {
-  cmatrix_t u1_matrix = AER::Linalg::Matrix::u1(lambda);
-  get_qubit(index).apply_matrix(u1_matrix);
+  get_qubit(index).apply_matrix(AER::Linalg::Matrix::u1(lambda));
 }
 
 void MPS::apply_u2(uint_t index, double phi, double lambda)
 {
-  cmatrix_t u2_matrix = AER::Linalg::Matrix::u2(phi, lambda);
-  get_qubit(index).apply_matrix(u2_matrix);
+  get_qubit(index).apply_matrix(AER::Linalg::Matrix::u2(phi, lambda));
 }
 
 void MPS::apply_u3(uint_t index, double theta, double phi, double lambda)
 {
-  cmatrix_t u3_matrix = AER::Linalg::Matrix::u3(theta, phi, lambda);
-  get_qubit(index).apply_matrix(u3_matrix);
+  get_qubit(index).apply_matrix(AER::Linalg::Matrix::u3(theta, phi, lambda));
 }
 
 

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -26,7 +26,7 @@ namespace MatrixProductState {
 
 // Allowed gates enum class
 enum Gates {
-  id, h, x, y, z, s, sdg, t, tdg, u1, u2, u3, // single qubit
+  id, h, x, y, z, s, sdg, sx, t, tdg, u1, u2, u3, // single qubit
   cx, cz, cu1, swap, su4, // two qubit
   mcx // three qubit
 };
@@ -98,6 +98,7 @@ public:
   // Returns: none.
   //----------------------------------------------------------------
   void apply_h(uint_t index);
+  void apply_sx(uint_t index);
   void apply_x(uint_t index){ get_qubit(index).apply_x();}
   void apply_y(uint_t index){ get_qubit(index).apply_y();}
   void apply_z(uint_t index){ get_qubit(index).apply_z();}

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -40,12 +40,13 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
      Operations::OpType::multiplexer, Operations::OpType::kraus},
     // Gates
-    {"u1",   "u2",   "u3",   "cx",   "cz",   "cy",     "cp",      "cu1",
-     "cu2",  "cu3",  "swap", "id",   "p",    "x",      "y",       "z",
-     "h",    "s",    "sdg",  "t",    "tdg",  "r",      "rx",      "ry",
-     "rz",   "rxx",  "ryy",  "rzz",  "rzx",  "ccx",    "cswap",   "mcx",
-     "mcy",  "mcz",  "mcu1", "mcu2", "mcu3", "mcswap", "mcphase", "mcr",
-     "mcrx", "mcry", "mcry", "sx",   "csx",  "mcsx", "delay"},
+    {"u1",     "u2",      "u3",  "u",    "U",    "CX",   "cx",   "cz",
+     "cy",     "cp",      "cu1", "cu2",  "cu3",  "swap", "id",   "p",
+     "x",      "y",       "z",   "h",    "s",    "sdg",  "t",    "tdg",
+     "r",      "rx",      "ry",  "rz",   "rxx",  "ryy",  "rzz",  "rzx",
+     "ccx",    "cswap",   "mcx", "mcy",  "mcz",  "mcu1", "mcu2", "mcu3",
+     "mcswap", "mcphase", "mcr", "mcrx", "mcry", "mcry", "sx",   "csx",
+     "mcsx",   "delay"},
     // Snapshots
     {"statevector", "memory", "register", "probabilities",
      "probabilities_with_variance", "expectation_value_pauli", "density_matrix",
@@ -319,7 +320,10 @@ const stringmap_t<Gates> State<statevec_t>::gateset_({
     {"u1", Gates::mcp},  // zero-X90 pulse waltz gate
     {"u2", Gates::mcu2}, // single-X90 pulse waltz gate
     {"u3", Gates::mcu3}, // two X90 pulse waltz gate
+    {"u", Gates::mcu3}, // two X90 pulse waltz gate
+    {"U", Gates::mcu3}, // two X90 pulse waltz gate
     // 2-qubit gates
+    {"CX", Gates::mcx},      // Controlled-X gate (CNOT)
     {"cx", Gates::mcx},      // Controlled-X gate (CNOT)
     {"cy", Gates::mcy},      // Controlled-Y gate
     {"cz", Gates::mcz},      // Controlled-Z gate

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -35,10 +35,10 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
      Operations::OpType::kraus, Operations::OpType::superop},
     // Gates
-    {"U",   "CX", "u1",  "u2", "u3",  "cx",   "cy",  "cz",  "swap",
-     "id",  "x",  "y",   "z",  "h",   "s",    "sdg", "t",   "tdg",
-     "ccx", "r",  "rx",  "ry", "rz",  "rxx",  "ryy", "rzz", "rzx",
-     "p",   "cp", "cu1", "sx", "x90", "delay"},
+    {"U",    "CX",  "u1", "u2",  "u3", "u",   "cx",   "cy",  "cz",
+     "swap", "id",  "x",  "y",   "z",  "h",   "s",    "sdg", "t",
+     "tdg",  "ccx", "r",  "rx",  "ry", "rz",  "rxx",  "ryy", "rzz",
+     "rzx",  "p",   "cp", "cu1", "sx", "x90", "delay"},
     // Snapshots
     {"superoperator"});
 
@@ -186,6 +186,7 @@ const stringmap_t<Gates> State<data_t>::gateset_({
     {"u1", Gates::u1}, // zero-X90 pulse waltz gate
     {"u2", Gates::u2}, // single-X90 pulse waltz gate
     {"u3", Gates::u3}, // two X90 pulse waltz gate
+    {"u", Gates::u3}, // two X90 pulse waltz gate
     {"U", Gates::u3},  // two X90 pulse waltz gate
     // Two-qubit gates
     {"CX", Gates::cx},     // Controlled-X gate (CNOT)

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -37,12 +37,13 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
      Operations::OpType::snapshot},
     // Gates
-    {"u1",   "u2",   "u3",   "cx",   "cz",   "cy",     "cp",      "cu1",
-     "cu2",  "cu3",  "swap", "id",   "p",    "x",      "y",       "z",
-     "h",    "s",    "sdg",  "t",    "tdg",  "r",      "rx",      "ry",
-     "rz",   "rxx",  "ryy",  "rzz",  "rzx",  "ccx",    "cswap",   "mcx",
-     "mcy",  "mcz",  "mcu1", "mcu2", "mcu3", "mcswap", "mcphase", "mcr",
-     "mcrx", "mcry", "mcry", "sx",   "csx",  "mcsx", "delay"},
+    {"u1",     "u2",      "u3",  "u",    "U",    "CX",   "cx",   "cz",
+     "cy",     "cp",      "cu1", "cu2",  "cu3",  "swap", "id",   "p",
+     "x",      "y",       "z",   "h",    "s",    "sdg",  "t",    "tdg",
+     "r",      "rx",      "ry",  "rz",   "rxx",  "ryy",  "rzz",  "rzx",
+     "ccx",    "cswap",   "mcx", "mcy",  "mcz",  "mcu1", "mcu2", "mcu3",
+     "mcswap", "mcphase", "mcr", "mcrx", "mcry", "mcry", "sx",   "csx",
+     "mcsx",   "delay"},
     // Snapshots
     {"unitary"});
 
@@ -189,7 +190,10 @@ const stringmap_t<Gates> State<unitary_matrix_t>::gateset_({
     {"u1", Gates::mcp}, // zero-X90 pulse waltz gate
     {"u2", Gates::mcu2}, // single-X90 pulse waltz gate
     {"u3", Gates::mcu3}, // two X90 pulse waltz gate
+    {"u", Gates::mcu3}, // two X90 pulse waltz gate
+    {"U", Gates::mcu3}, // two X90 pulse waltz gate
     // Two-qubit gates
+    {"CX", Gates::mcx},      // Controlled-X gate (CNOT)
     {"cx", Gates::mcx},      // Controlled-X gate (CNOT)
     {"cy", Gates::mcy},      // Controlled-Z gate
     {"cz", Gates::mcz},      // Controlled-Z gate

--- a/test/terra/backends/qasm_simulator/qasm_standard_gates.py
+++ b/test/terra/backends/qasm_simulator/qasm_standard_gates.py
@@ -80,26 +80,6 @@ GATES = [
     (UGate, 3)
 ]
 
-STATEVECTOR_BG = QasmSimulator().configuration().basis_gates
-DENSITY_MATRIX_BG = [
-    "u1", "u2", "u3", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s",
-    "sdg", "t", "tdg", "ccx", "r", "rx", "ry", "rz", "rxx", "ryy", "rzz",
-    "rzx", "p", "cp", "cu1", "sx", "delay",
-]
-MATRIX_PRODUCT_STATE_BG = [
-    "id", "x", "y", "z", "s", "sdg", "h", "t", "tdg", "u1", "u2", "u3",
-    "cx", "cz", "cu1", "swap", "ccx", "delay",
-]
-BASIS_GATES = {
-    'statevector': STATEVECTOR_BG,
-    'statevector_gpu': STATEVECTOR_BG,
-    'statevector_thrust': STATEVECTOR_BG,
-    'density_matrix': DENSITY_MATRIX_BG,
-    'density_matrix_gpu': DENSITY_MATRIX_BG,
-    'density_matrix_thrust': DENSITY_MATRIX_BG,
-    'matrix_product_state': MATRIX_PRODUCT_STATE_BG
-}
-
 
 @ddt
 class QasmStandardGateStatevectorTests:
@@ -128,13 +108,10 @@ class QasmStandardGateStatevectorTests:
         # Add snapshot and execute
         circuit.snapshot_statevector('final')
         backend_options = self.BACKEND_OPTS
-        method = backend_options.get('method', 'automatic')
-        basis_gates = BASIS_GATES.get(method)
-        result = execute(circuit,
-                         self.SIMULATOR,
-                         basis_gates=basis_gates,
-                         shots=1,
-                         **backend_options).result()
+        method = backend_options.pop('method', 'automatic')
+        backend = self.SIMULATOR
+        backend.set_options(method=method)
+        result = execute(circuit, backend, shots=1, **backend_options).result()
 
         # Check results
         success = getattr(result, 'success', False)
@@ -175,13 +152,10 @@ class QasmStandardGateDensityMatrixTests:
         # Add snapshot and execute
         circuit.snapshot_density_matrix('final')
         backend_options = self.BACKEND_OPTS
-        method = backend_options.get('method', 'automatic')
-        basis_gates = BASIS_GATES.get(method)
-        result = execute(circuit,
-                         self.SIMULATOR,
-                         basis_gates=basis_gates,
-                         shots=1,
-                         **backend_options).result()
+        method = backend_options.pop('method', 'automatic')
+        backend = self.SIMULATOR
+        backend.set_options(method=method)
+        result = execute(circuit, backend, shots=1, **backend_options).result()
 
         # Check results
         success = getattr(result, 'success', False)

--- a/test/terra/backends/statevector_simulator/statevector_gates.py
+++ b/test/terra/backends/statevector_simulator/statevector_gates.py
@@ -89,8 +89,14 @@ class StatevectorGateTests:
         (U3Gate, 3),
         (UGate, 3)
     ]
-    BASIS_GATES = [None, ['id', 'u3', 'cx'], ['id', 'r', 'cz'],
-                   ['id', 'rz', 'rx', 'cz'], ['id', 'p', 'sx', 'cx']]
+    BASIS_GATES = [
+        None,
+        ['id', 'u1', 'u2', 'u3', 'cx'],
+        ['id', 'u', 'cx'],
+        ['id', 'r', 'cz'],
+        ['id', 'rz', 'rx', 'cz'],
+        ['id', 'p', 'sx', 'cx']
+    ]
 
     @data(*[(gate_params[0], gate_params[1], basis_gates)
             for gate_params, basis_gates in product(GATES, BASIS_GATES)])

--- a/test/terra/backends/unitary_simulator/unitary_gates.py
+++ b/test/terra/backends/unitary_simulator/unitary_gates.py
@@ -89,8 +89,14 @@ class UnitaryGateTests:
         (U3Gate, 3),
         (UGate, 3)
     ]
-    BASIS_GATES = [None, ['id', 'u3', 'cx'], ['id', 'r', 'cz'],
-                   ['id', 'rz', 'rx', 'cz'], ['id', 'p', 'sx', 'cx']]
+    BASIS_GATES = [
+        None,
+        ['id', 'u1', 'u2', 'u3', 'cx'],
+        ['id', 'u', 'cx'],
+        ['id', 'r', 'cz'],
+        ['id', 'rz', 'rx', 'cz'],
+        ['id', 'p', 'sx', 'cx']
+    ]
 
     @data(*[(gate_params[0], gate_params[1], basis_gates)
             for gate_params, basis_gates in product(GATES, BASIS_GATES)])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds `UGate` to basis gate of simulators that support it (Closes #988)
* Adds `SXGate` and `PGate` support to MPS simulator and extended stabilizer simulator, so they now can be run on all simulators except stabilizer.

### Details and comments


