### PR TITLE
Fix fusion thresholds and defaults

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 
 # Generic rule for the repository. This pattern is actually the one that will
 # apply unless specialized by a later rule
-* @chriseclectic @atilag
+* @chriseclectic @vvilpas @atilag
 
 # Individual folders on root directory
 /qiskit         @chriseclectic @atilag @vvilpas

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -109,7 +109,7 @@ class AerBackend(BaseBackend, ABC):
     def run(self,
             qobj,
             backend_options=None,  # DEPRECATED
-            validate=True,
+            validate=False,
             **run_options):
         """Run a qobj on the backend.
 
@@ -117,7 +117,7 @@ class AerBackend(BaseBackend, ABC):
             qobj (QasmQobj): The Qobj to be executed.
             backend_options (dict or None): DEPRECATED dictionary of backend options
                                             for the execution (default: None).
-            validate (bool): validate the Qobj before running (default: True).
+            validate (bool): validate the Qobj before running (default: False).
             run_options (kwargs): additional run time backend options.
 
         Returns:

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -171,7 +171,7 @@ class PulseSimulator(AerBackend):
             qobj,
             *args,
             backend_options=None,  # DEPRECATED
-            validate=False,
+            validate=True,
             **run_options):
         """Run a qobj on the backend.
 
@@ -179,7 +179,7 @@ class PulseSimulator(AerBackend):
             qobj (QasmQobj): The Qobj to be executed.
             backend_options (dict or None): DEPRECATED dictionary of backend options
                                             for the execution (default: None).
-            validate (bool): validate the Qobj before running (default: False).
+            validate (bool): validate the Qobj before running (default: True).
             run_options (kwargs): additional run time backend options.
 
         Returns:

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -171,7 +171,7 @@ class PulseSimulator(AerBackend):
             qobj,
             *args,
             backend_options=None,  # DEPRECATED
-            validate=True,
+            validate=False,
             **run_options):
         """Run a qobj on the backend.
 
@@ -179,7 +179,7 @@ class PulseSimulator(AerBackend):
             qobj (QasmQobj): The Qobj to be executed.
             backend_options (dict or None): DEPRECATED dictionary of backend options
                                             for the execution (default: None).
-            validate (bool): validate the Qobj before running (default: True).
+            validate (bool): validate the Qobj before running (default: False).
             run_options (kwargs): additional run time backend options.
 
         Returns:

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -231,7 +231,7 @@ class QasmSimulator(AerBackend):
     * ``fusion_max_qubit`` (int): Maximum number of qubits for a operation generated
       in a fusion optimization [Default: 5]
     * ``fusion_threshold`` (int): Threshold that number of qubits must be greater
-      than or equal to enable fusion optimization [Default: 20]
+      than or equal to enable fusion optimization [Default: 14]
     """
 
     _DEFAULT_CONFIGURATION = {

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -90,6 +90,17 @@ class StatevectorSimulator(AerBackend):
       this will only use unallocated CPU cores up to
       max_parallel_threads. Note that setting this too low can reduce
       performance (Default: 14).
+
+    These backend options apply in circuit optimization passes:
+
+    * ``fusion_enable`` (bool): Enable fusion optimization in circuit
+      optimization passes [Default: True]
+    * ``fusion_verbose`` (bool): Output gates generated in fusion optimization
+      into metadata [Default: False]
+    * ``fusion_max_qubit`` (int): Maximum number of qubits for a operation generated
+      in a fusion optimization [Default: 5]
+    * ``fusion_threshold`` (int): Threshold that number of qubits must be greater
+      than or equal to enable fusion optimization [Default: 14]
     """
 
     _DEFAULT_CONFIGURATION = {

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -96,6 +96,17 @@ class UnitarySimulator(AerBackend):
       this will only use unallocated CPU cores up to
       max_parallel_threads. Note that setting this too low can reduce
       performance (Default: 14).
+
+    These backend options apply in circuit optimization passes:
+
+    * ``fusion_enable`` (bool): Enable fusion optimization in circuit
+      optimization passes [Default: True]
+    * ``fusion_verbose`` (bool): Output gates generated in fusion optimization
+      into metadata [Default: False]
+    * ``fusion_max_qubit`` (int): Maximum number of qubits for a operation generated
+      in a fusion optimization [Default: 5]
+    * ``fusion_threshold`` (int): Threshold that number of qubits must be greater
+      than or equal to enable fusion optimization [Default: 7]
     """
 
     _DEFAULT_CONFIGURATION = {

--- a/releasenotes/notes/fusion-threshold-33127b9b4e219640.yaml
+++ b/releasenotes/notes/fusion-threshold-33127b9b4e219640.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Changes ``"fusion_threshold"`` backend option to apply fusion when the
+    number of qubits is above the threshold, not equal or above the threshold,
+    to match the behaviour of the OpenMP qubit threshold parameter.
+  - |
+    Changes the default value of ``"fusion_threshold"`` from 20 to 14 for the
+    :class:`~qiskit.providers.aer.QasmSimulator` and
+    :class:`~qiskit.providers.aer.StatevectorSimulator`, and from 10 to 7 for
+    the :class:`~qiskit.providers.aer.UnitarySimulator`.

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -48,7 +48,7 @@ namespace Simulator {
  *      zero in result data [Default: 1e-10]
  * - "statevector_parallel_threshold" (int): Threshold that number of qubits
  *      must be greater than to enable OpenMP parallelization at State
- *      level [Default: 13]
+ *      level [Default: 14]
  * - "statevector_sample_measure_opt" (int): Threshold that number of qubits
  *      must be greater than to enable indexing optimization during
  *      measure sampling [Default: 10]
@@ -117,7 +117,7 @@ namespace Simulator {
  * - fusion_max_qubit (int): Maximum number of qubits for a operation generated
  *       in a fusion optimization [Default: 5]
  * - fusion_threshold (int): Threshold that number of qubits must be greater
- *       than or equal to enable fusion optimization [Default: 20]
+ *       than or equal to enable fusion optimization [Default: 14]
  *
  **************************************************************************/
 
@@ -164,9 +164,6 @@ class QasmController : public Base::Controller {
   // Simulation precision
   enum class Precision { double_precision, single_precision };
 
-  // Fusion method
-  using FusionMethod = Transpile::Fusion::Method;
-
   //-----------------------------------------------------------------------
   // Base class abstract method override
   //-----------------------------------------------------------------------
@@ -207,8 +204,8 @@ class QasmController : public Base::Controller {
   // Return a fusion transpilation pass configured for the current
   // method, circuit and config
   Transpile::Fusion transpile_fusion(Method method,
-                                     const json_t& config,
-                                     FusionMethod fusion_method = FusionMethod::unitary) const;
+                                     const Operations::OpSet &opset,
+                                     const json_t& config) const;
 
   //----------------------------------------------------------------
   // Run circuit helpers
@@ -781,29 +778,44 @@ size_t QasmController::required_memory_mb(
 }
 
 Transpile::Fusion QasmController::transpile_fusion(Method method,
-                                                   const json_t& config,
-                                                   FusionMethod fusion_method) const {
+                                                   const Operations::OpSet &opset,
+                                                   const json_t& config) const {
   Transpile::Fusion fusion_pass;
+  if (opset.contains(Operations::OpType::superop)) {
+    fusion_pass.allow_superop = true;
+  }
+  if (opset.contains(Operations::OpType::kraus)) {
+    fusion_pass.allow_kraus = true;
+  }
   switch (method) {
-    case Method::statevector:
-    case Method::statevector_thrust_gpu:
-    case Method::statevector_thrust_cpu:
     case Method::density_matrix:
     case Method::density_matrix_thrust_gpu:
     case Method::density_matrix_thrust_cpu: {
-      if (fusion_method == FusionMethod::superop) {
-        fusion_pass.allow_superop = true;
-      } else if (fusion_method == FusionMethod::kraus) {
-        fusion_pass.allow_kraus = true;
+      // Halve the default threshold and max fused qubits for density matrix
+      fusion_pass.threshold /= 2;
+      fusion_pass.max_qubit /= 2;
+      break;
+    }
+    case Method::matrix_product_state: {
+      // Disable fusion by default, but allow it to be enabled by config settings
+      fusion_pass.active = false;
+    }
+    case Method::statevector:
+    case Method::statevector_thrust_gpu:
+    case Method::statevector_thrust_cpu: {
+      if (fusion_pass.allow_kraus) {
+        // Halve default max fused qubits for Kraus noise fusion
+        fusion_pass.max_qubit /= 2;
       }
-      fusion_pass.set_config(config);
       break;
     }
     default: {
       fusion_pass.active = false;
-      break;
+      return fusion_pass;
     }
   }
+  // Override default fusion settings with custom config
+  fusion_pass.set_config(config);
   return fusion_pass;
 }
 
@@ -885,9 +897,7 @@ void QasmController::run_circuit_helper(const Circuit& circ,
   result.add_metadata("measure_sampling", false);
 
   // Choose execution method based on noise and method
-
   Circuit opt_circ;
-  FusionMethod fusion_method = FusionMethod::unitary;
 
   // Ideal circuit
   if (noise.is_ideal()) {
@@ -904,7 +914,6 @@ void QasmController::run_circuit_helper(const Circuit& circ,
     // Sample noise using SuperOp method
     auto noise_superop = noise;
     noise_superop.activate_superop_method();
-    fusion_method = FusionMethod::superop;
     opt_circ = noise_superop.sample_noise(circ, rng);
   }
   // Kraus noise sampling
@@ -912,7 +921,6 @@ void QasmController::run_circuit_helper(const Circuit& circ,
            noise.opset().contains(Operations::OpType::superop)) {
     auto noise_kraus = noise;
     noise_kraus.activate_kraus_method();
-    fusion_method = FusionMethod::kraus;
     opt_circ = noise_kraus.sample_noise(circ, rng);
   }
   // General circuit noise sampling
@@ -927,8 +935,7 @@ void QasmController::run_circuit_helper(const Circuit& circ,
   Transpile::DelayMeasure measure_pass;
   measure_pass.set_config(config);
   measure_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), result);
-
-  auto fusion_pass = transpile_fusion(method, config, fusion_method);
+  auto fusion_pass = transpile_fusion(method, opt_circ.opset(), config);
   fusion_pass.optimize_circuit(opt_circ, dummy_noise, state.opset(), result);
 
   // Run simulation
@@ -995,7 +1002,7 @@ void QasmController::run_circuit_with_sampled_noise(const Circuit& circ,
                                                     RngEngine& rng) const {
 
   // Transpilation for circuit noise method
-  auto fusion_pass = transpile_fusion(method, config, FusionMethod::unitary);
+  auto fusion_pass = transpile_fusion(method, circ.opset(), config);
   Transpile::DelayMeasure measure_pass;
   measure_pass.set_config(config);
   Noise::NoiseModel dummy_noise;

--- a/src/controllers/statevector_controller.hpp
+++ b/src/controllers/statevector_controller.hpp
@@ -37,7 +37,7 @@ namespace Simulator {
  *      zero in result data [Default: 1e-10]
  * - "statevector_parallel_threshold" (int): Threshold that number of qubits
  *      must be greater than to enable OpenMP parallelization at State
- *      level [Default: 13]
+ *      level [Default: 14]
  * - "statevector_sample_measure_opt" (int): Threshold that number of qubits
  *      must be greater than to enable indexing optimization during
  *      measure sampling [Default: 10]
@@ -298,7 +298,7 @@ void StatevectorController::run_circuit_helper(
 
   // Optimize circuit
   const std::vector<Operations::Op>* op_ptr = &circ.ops;
-  Transpile::Fusion fusion_pass(5, 20); // 20-qubit default threshold
+  Transpile::Fusion fusion_pass;
   fusion_pass.set_config(config);
   Circuit opt_circ;
   if (fusion_pass.active && circ.num_qubits >= fusion_pass.threshold) {

--- a/src/controllers/unitary_controller.hpp
+++ b/src/controllers/unitary_controller.hpp
@@ -297,7 +297,8 @@ void UnitaryController::run_circuit_helper(
 
   // Optimize circuit
   const std::vector<Operations::Op>* op_ptr = &circ.ops;
-  Transpile::Fusion fusion_pass(5, 10); // 10-qubit default threshold
+  Transpile::Fusion fusion_pass;
+  fusion_pass.threshold /= 2;  // Halve default threshold for unitary simulator
   fusion_pass.set_config(config);
   Circuit opt_circ;
   if (fusion_pass.active && circ.num_qubits >= fusion_pass.threshold) {

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -13,6 +13,7 @@
 QasmSimulator Integration Tests
 """
 # pylint: disable=no-member
+import copy
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit.library import QuantumVolume, QFT
@@ -31,8 +32,8 @@ class QasmFusionTests:
 
     def create_statevector_circuit(self):
         """ Creates a simple circuit for running in the statevector """
-        qr = QuantumRegister(10)
-        cr = ClassicalRegister(10)
+        qr = QuantumRegister(5)
+        cr = ClassicalRegister(5)
         circuit = QuantumCircuit(qr, cr)
         circuit.u3(0.1, 0.1, 0.1, qr[0])
         circuit.barrier(qr)
@@ -105,7 +106,8 @@ class QasmFusionTests:
                 qobj, **backend_options).result()
             self.assertSuccess(result)
             meta = self.fusion_metadata(result)
-            self.assertFalse(meta.get('applied', False))
+            self.assertTrue(meta.get('enabled'))
+            self.assertFalse(meta.get('applied'))
 
         with self.subTest(msg='at fusion threshold'):
             circuit = transpile(QFT(threshold),
@@ -117,7 +119,8 @@ class QasmFusionTests:
                 qobj, **backend_options).result()
             self.assertSuccess(result)
             meta = self.fusion_metadata(result)
-            self.assertTrue(meta.get('applied', False))
+            self.assertTrue(meta.get('enabled'))
+            self.assertFalse(meta.get('applied'))
 
         with self.subTest(msg='above fusion threshold'):
             circuit = transpile(QFT(threshold + 1),
@@ -129,7 +132,8 @@ class QasmFusionTests:
                 qobj, **backend_options).result()
             self.assertSuccess(result)
             meta = self.fusion_metadata(result)
-            self.assertTrue(meta.get('applied', False))
+            self.assertTrue(meta.get('enabled'))
+            self.assertTrue(meta.get('applied'))
 
     def test_fusion_verbose(self):
         """Test Fusion with verbose option"""
@@ -192,10 +196,9 @@ class QasmFusionTests:
         result = self.SIMULATOR.run(qobj,
                                     noise_model=noise_model,
                                     **backend_options).result()
+        method = result.results[0].metadata.get('method')
         meta = self.fusion_metadata(result)
-        if backend_options.get('method') in ['density_matrix',
-                                             'density_matrix_thrust',
-                                             'density_matrix_gpu']:
+        if method in ['density_matrix', 'density_matrix_thrust', 'density_matrix_gpu']:
             target_method = 'superop'
         else:
             target_method = 'kraus'
@@ -223,9 +226,8 @@ class QasmFusionTests:
                                     noise_model=noise_model,
                                     **backend_options).result()
         meta = self.fusion_metadata(result)
-        if backend_options.get('method') in ['density_matrix',
-                                             'density_matrix_thrust',
-                                             'density_matrix_gpu']:
+        method = result.results[0].metadata.get('method')
+        if method in ['density_matrix', 'density_matrix_thrust', 'density_matrix_gpu']:
             target_method = 'superop'
         else:
             target_method = 'unitary'
@@ -249,30 +251,32 @@ class QasmFusionTests:
         with self.subTest(msg='fusion enabled'):
             backend_options = self.fusion_options(enabled=True, threshold=1)
             result = self.SIMULATOR.run(
-                qobj, **backend_options).result()
+                copy.deepcopy(qobj), **backend_options).result()
             meta = self.fusion_metadata(result)
 
             self.assertSuccess(result)
+            self.assertTrue(meta.get('enabled'))
             self.assertTrue(meta.get('applied', False))
 
         with self.subTest(msg='fusion disabled'):
             backend_options = backend_options = self.fusion_options(enabled=False, threshold=1)
             result = self.SIMULATOR.run(
-                qobj, **backend_options).result()
+                copy.deepcopy(qobj), **backend_options).result()
             meta = self.fusion_metadata(result)
 
             self.assertSuccess(result)
-            self.assertFalse(meta.get('applied', False))
+            self.assertFalse(meta.get('enabled'))
 
         with self.subTest(msg='fusion default'):
             backend_options = self.fusion_options()
 
             result = self.SIMULATOR.run(
-                qobj, **backend_options).result()
+                copy.deepcopy(qobj), **backend_options).result()
             meta = self.fusion_metadata(result)
 
             self.assertSuccess(result)
-            self.assertFalse(meta.get('applied', False))
+            self.assertTrue(meta.get('enabled'))
+            self.assertFalse(meta.get('applied', False), msg=meta)
 
     def test_fusion_operations(self):
         """Test Fusion enable/disable option"""
@@ -351,8 +355,9 @@ class QasmFusionTests:
 
         self.assertTrue(getattr(result_disabled, 'success', 'False'))
         self.assertTrue(getattr(result_enabled, 'success', 'False'))
-        self.assertEqual(meta_disabled, {})
-        self.assertTrue(meta_enabled.get('applied', False))
+        self.assertFalse(meta_disabled.get('enabled'))
+        self.assertTrue(meta_enabled.get('enabled'))
+        self.assertTrue(meta_enabled.get('applied'))
         self.assertDictAlmostEqual(result_enabled.get_counts(circuit),
                                    result_disabled.get_counts(circuit),
                                    delta=0.0,
@@ -361,30 +366,25 @@ class QasmFusionTests:
     def test_fusion_qv(self):
         """Test Fusion with quantum volume"""
         shots = 100
-        num_qubits = 8
+        num_qubits = 6
         depth = 2
         circuit = transpile(QuantumVolume(num_qubits, depth, seed=0),
                             backend=self.SIMULATOR,
                             optimization_level=0)
         circuit.measure_all()
-        qobj = assemble([circuit],
-                        self.SIMULATOR,
-                        shots=shots,
-                        seed_simulator=1)
-
-        backend_options = self.fusion_options(enabled=False, threshold=1)
-        result_disabled = self.SIMULATOR.run(
-            qobj, **backend_options).result()
+        qobj_disabled = assemble([circuit], self.SIMULATOR, shots=shots,
+                                 **self.fusion_options(enabled=False, threshold=1, verbose=True))
+        result_disabled = self.SIMULATOR.run(qobj_disabled).result()
         meta_disabled = self.fusion_metadata(result_disabled)
 
-        backend_options = self.fusion_options(enabled=True, threshold=1)
-        result_enabled = self.SIMULATOR.run(
-            qobj, **backend_options).result()
+        qobj_enabled = assemble([circuit], self.SIMULATOR, shots=shots,
+                                **self.fusion_options(enabled=True, threshold=1, verbose=True))
+        result_enabled = self.SIMULATOR.run(qobj_enabled).result()
         meta_enabled = self.fusion_metadata(result_enabled)
 
         self.assertTrue(getattr(result_disabled, 'success', 'False'))
         self.assertTrue(getattr(result_enabled, 'success', 'False'))
-        self.assertEqual(meta_disabled, {})
+        self.assertFalse(meta_disabled.get('applied', False))
         self.assertTrue(meta_enabled.get('applied', False))
         self.assertDictAlmostEqual(result_enabled.get_counts(circuit),
                                    result_disabled.get_counts(circuit),
@@ -417,8 +417,9 @@ class QasmFusionTests:
 
         self.assertTrue(getattr(result_disabled, 'success', 'False'))
         self.assertTrue(getattr(result_enabled, 'success', 'False'))
-        self.assertEqual(meta_disabled, {})
-        self.assertTrue(meta_enabled.get('applied', False))
+        self.assertFalse(meta_disabled.get('enabled'))
+        self.assertTrue(meta_enabled.get('enabled'))
+        self.assertTrue(meta_enabled.get('applied'))
         self.assertDictAlmostEqual(result_enabled.get_counts(circuit),
                                    result_disabled.get_counts(circuit),
                                    delta=0.0,

--- a/test/terra/backends/statevector_simulator/statevector_fusion.py
+++ b/test/terra/backends/statevector_simulator/statevector_fusion.py
@@ -65,7 +65,7 @@ class StatevectorFusionTests:
             meta = self.fusion_metadata(result)
 
             self.assertSuccess(result)
-            self.assertTrue(meta.get('applied'))
+            self.assertFalse(meta.get('applied'))
 
         with self.subTest(msg='above fusion threshold'):
             circuit = QuantumVolume(threshold + 1, seed=seed)

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -236,7 +236,7 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
                         shots=256)
 
         try:
-            test_sim.run(qobj).result()
+            test_sim.run(qobj, validate=True).result()
         except AerError as error:
             self.assertTrue('does not support multiple Acquire' in error.message)
 
@@ -249,7 +249,7 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
                         shots=256)
 
         try:
-            test_sim.run(qobj).result()
+            test_sim.run(qobj, validate=True).result()
         except AerError as error:
             self.assertTrue('requires at least one Acquire' in error.message)
 

--- a/test/terra/backends/unitary_simulator/unitary_fusion.py
+++ b/test/terra/backends/unitary_simulator/unitary_fusion.py
@@ -65,7 +65,7 @@ class UnitaryFusionTests:
             meta = self.fusion_metadata(result)
 
             self.assertSuccess(result)
-            self.assertTrue(meta.get('applied'))
+            self.assertFalse(meta.get('applied'))
 
         with self.subTest(msg='above fusion threshold'):
             circuit = QuantumVolume(threshold + 1, seed=seed)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changes default gate fusion thresholds for improved performance, and fixes default max qubit size for fusion bugs in density matrix and noise fusion introduced in #927 

This is more of a quick fix for the 0.7 release, and a more complete refactor of fusion logic can be tackled in #986 

### Details and comments

* Changes `"fusion_threshold"` backend option to apply fusion when the number of qubits is above the threshold, not equal or above the threshold, to match the behaviour of the OpenMP qubit threshold parameter.

* Changes the default value of "fusion_threshold" from 20 to 14 for the QasmSimulator (statevector) and StatevectorSimulator, and from 10 to 7 for the UnitarySimulator and QasmSimulator (density matrix).

* Allows fusion for MPS if fusion enabled is specified in config. Default for MPS is still fusion disabled.

* Fixes bug in fusion for density matrix method introduced in #927 which was preventing the max qubit size for fusion being halved for the density matrix method. This was resulting in the fused circuit being slower for density matrix simulations.