### PR TITLE
Fix Aer provider to return new backend instances with backends/get_backend.

### DIFF
--- a/releasenotes/notes/aer-provider-instance-38b472f3ea541977.yaml
+++ b/releasenotes/notes/aer-provider-instance-38b472f3ea541977.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixes bug with :class:`~qiskit.providers.aer.AerProvider` where options set
+    on the returned backends using
+    :meth:`~qiskit.providers.aer.QasmSimulator.set_options` were stored in the
+    provider and would persist for subsequent calls to
+    :meth:`~qiskit.providers.aer.AerProvider.get_backend` for the same named
+    backend. Now every call to 
+    and :meth:`~qiskit.providers.aer.AerProvider.backends` returns a new
+    instance of the simulator backend that can be configured.

--- a/test/terra/extensions/test_wrappers.py
+++ b/test/terra/extensions/test_wrappers.py
@@ -21,6 +21,7 @@ from qiskit.providers.aer.backends import QasmSimulator, StatevectorSimulator, U
 from qiskit.providers.aer.backends.controller_wrappers import (qasm_controller_execute,
                                                                statevector_controller_execute,
                                                                unitary_controller_execute)
+from qiskit.providers.aer.backends.backend_utils import LIBRARY_DIR
 from test.terra.reference import ref_algorithms, ref_measure, ref_1q_clifford
 from test.terra.common import QiskitAerTestCase
 
@@ -48,7 +49,8 @@ class TestControllerExecuteWrappers(QiskitAerTestCase):
         circuit = QuantumCircuit(num_qubits)
         circuit.x(list(range(num_qubits)))
         qobj = assemble(transpile(circuit, backend), backend)
-        opts = {'max_parallel_threads': 1}
+        opts = {'max_parallel_threads': 1,
+                'library_dir': LIBRARY_DIR}
         fqobj = backend._format_qobj(qobj, **opts, noise_model=noise_model)
         return fqobj.to_dict()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates AerProvider to return a new backend instance each time `backend` or `get_backend` is called. This is so that if the backend instance is modified with `set_options` it won't persist pass the scope of where that backend object is used.

### Details and comments


