### PR TITLE
Allow `AerProvider.get_backend` to return configured backend

### DIFF
--- a/qiskit/providers/aer/aerprovider.py
+++ b/qiskit/providers/aer/aerprovider.py
@@ -35,8 +35,24 @@ class AerProvider(BaseProvider):
                           UnitarySimulator(provider=self),
                           PulseSimulator(provider=self)]
 
-    def get_backend(self, name=None, **kwargs):
-        return super().get_backend(name=name, **kwargs)
+    def get_backend(self, name=None, **backend_options):
+        """Return a configured simulator backend with the specified options.
+
+        Args:
+            name (str): name of the backend.
+            **backend_options: dict of options for backend ``set_options``.
+
+        Returns:
+            AerBackend: a configured backend.
+
+        Raises:
+            QiskitBackendNotFoundError: if no backend could be found or
+                more than one backend matches the filtering criteria.
+        """
+        backend = super().get_backend(name=name)
+        if backend_options:
+            backend.set_options(**backend_options)
+        return backend
 
     def backends(self, name=None, filters=None, **kwargs):
         # pylint: disable=arguments-differ

--- a/releasenotes/notes/aer-provider-config-backend-3a89b7587c34c6ee.yaml
+++ b/releasenotes/notes/aer-provider-config-backend-3a89b7587c34c6ee.yaml
@@ -1,0 +1,43 @@
+---
+upgrade:
+  - |
+    Allows setting configurable backend options when using
+    :meth:`~qiskit.providers.aer.AerProvider.get_backend` to return a backend
+    object. This is done via
+    ``provider.get_backend('qasm_simulator', **backend_options)``.
+    
+    For example returning a matrix product state method
+    :class:`~qiskit.providers.aer.QasmSimulator` from the Aer provider can now be
+    done using
+
+    Using the `Aer` provider
+
+    .. code-block:: python
+
+      from qiskit import Aer
+      backend = Aer.get_backend('qasm_simulator', method='matrix_product_state')
+
+    or 
+
+    .. code-block:: python
+
+      from qiskit import Aer
+      backend = Aer.get_backend('qasm_simulator')
+      backend.set_options(method='matrix_product_state')
+
+    This is equivalent to generating a configured simulator backend object directly
+
+    .. code-block:: python
+
+      from qiskit.providers.aer import QasmSimulator
+
+      backend = QasmSimulator(method='matrix_product_state')
+
+    or
+
+    .. code-block:: python
+
+      from qiskit.providers.aer import QasmSimulator
+
+      backend = QasmSimulator()
+      backend.set_options(method='matrix_product_state')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Allows returning a configured backend using `AerProvider.get_backend` by calling `set_options` on the backend object before returning.

### Details and comments

PR #1006 should be merged first to prevent the backend options from persisting past the lifetime of the returned object.

