### PR TITLE
Refactor where avx2 needed headers are included

### DIFF
--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -17,14 +17,6 @@
 #include <iostream>
 #include <string>
 
-#ifdef _MSC_VER
-#include <intrin.h>
-#elif defined(__GNUC__)
-#ifndef __PPC64__
-#include <cpuid.h>
-#endif
-#endif
-
 #include "version.hpp"
 // Simulator
 #include "controllers/qasm_controller.hpp"

--- a/qiskit/providers/aer/backends/wrappers/bindings.cc
+++ b/qiskit/providers/aer/backends/wrappers/bindings.cc
@@ -1,10 +1,4 @@
 #include <iostream>
-#include "misc/common_macros.hpp"
-#if defined(_MSC_VER)
-#include <intrin.h>
-#elif defined(GNUC_AVX2)
-#include <cpuid.h>
-#endif
 
 #include "misc/warnings.hpp"
 DISABLE_WARNING_PUSH

--- a/src/framework/avx2_detect.hpp
+++ b/src/framework/avx2_detect.hpp
@@ -18,7 +18,14 @@
 #include <array>
 #include <vector>
 #include <bitset>
+
 #include "misc/common_macros.hpp"
+#if defined(_MSC_VER)
+    #include <intrin.h>
+#elif defined(GNUC_AVX2)
+    #include <cpuid.h>
+#endif
+
 
 namespace {
 inline void ccpuid(int cpu_info[4], int function_id){


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Move avx2 needed headers inclusion from qasm_simulator.cpp and bindings.cc to avx2_detect.hpp, where are actually used.

### Details and comments


