### PR TITLE
Fix conan dependency problem with urllib3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install deps
-        run: pip install conan
+        run: pip install urllib3<1.26 conan
       - name: Install openblas
         run: |
           set -e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install deps
-        run: pip install urllib3<1.26 conan
+        run: pip install "urllib3<1.26" conan
       - name: Install openblas
         run: |
           set -e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "conan>=1.22.2", "scikit-build", "cmake!=3.17.1,!=3.17.0", "ninja", "pybind11>2.4", "Cython>0.27.1"]
+requires = ["setuptools", "wheel", "urllib3<1.26", "conan>=1.22.2", "scikit-build", "cmake!=3.17.1,!=3.17.0", "ninja", "pybind11>2.4", "Cython>0.27.1"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,6 @@ sphinx-automodapi
 jupyter-sphinx;python_version<'3.8'
 reno>=3.1.0
 ddt>=1.2.0,!=1.4.0
+
+# Problem with Conan and urllib3==1.26
+urllib3<1.26

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ if not _DISABLE_CONAN:
     try:
         from conans import client
     except ImportError:
+        # Problem with Conan and urllib3 1.26
+        subprocess.call([sys.executable, '-m', 'pip', 'install', 'urllib3<1.26'])
+
         subprocess.call([sys.executable, '-m', 'pip', 'install', 'conan'])
         from conans import client
 
@@ -60,6 +63,7 @@ setup_requirements = common_requirements + [
     'cmake!=3.17,!=3.17.0',
 ]
 if not _DISABLE_CONAN:
+    setup_requirements.append('urllib3<1.26')
     setup_requirements.append('conan>=1.22.2')
 
 requirements = common_requirements + ['qiskit-terra>=0.12.0']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`urllib3` 1.26.0 has been released, causing a dependency when installing conan (coming form `requests` lib).
Here I add `urllib3` add as a dependency and constraint it to <1.26 to avoid this problem.

### Details and comments

The issue has been already reported to `Conan` team by some users: https://github.com/conan-io/conan/issues/8041.
Here https://github.com/conan-io/conan/pull/8042 they mention that `requests` lib version 2.25 (to be released ~~today~~ tomorrow: https://github.com/psf/requests/issues/5654) will be compatible with this `urllib3` 1.26. In the meantime we can use this ugly fix. 

