### PR TITLE
[WIP] Fix gpu wheel build 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,68 +1,67 @@
 name: Build
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches: [ master ]
 jobs:
-  wheel-build:
-    name: Build qiskit-aer wheels
-    strategy:
-      matrix:
-        os: ["macOS-latest", "ubuntu-latest"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.7'
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==1.5.5
-      - name: Build wheels
-        env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
-          CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11"
-          CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
-          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
-          CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"
-          CIBW_TEST_REQUIRES: "git+https://github.com/Qiskit/qiskit-terra.git"
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-      - name: Publish Wheels
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
-        run : |
-          pip install -U twine
-          twine upload wheelhouse/*
-  sdist:
-    name: Publish qiskit-aer sdist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.8'
-      - name: Install Deps
-        run: pip install -U twine wheel
-      - name: Build Artifacts
-        run: |
-          python setup.py sdist
-        shell: bash
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./dist/qiskit*
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
-        run: twine upload dist/qiskit*
+#  wheel-build:
+#    name: Build qiskit-aer wheels
+#    strategy:
+#      matrix:
+#        os: ["macOS-latest", "ubuntu-latest"]
+#    runs-on: ${{ matrix.os }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions/setup-python@v2
+#        name: Install Python
+#        with:
+#          python-version: '3.7'
+#      - name: Install cibuildwheel
+#        run: |
+#          python -m pip install cibuildwheel==1.5.5
+#      - name: Build wheels
+#        env:
+#          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
+#          CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11"
+#          CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
+#          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
+#          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
+#          CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"
+#          CIBW_TEST_REQUIRES: "git+https://github.com/Qiskit/qiskit-terra.git"
+#        run: |
+#          python -m cibuildwheel --output-dir wheelhouse
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          path: ./wheelhouse/*.whl
+#      - name: Publish Wheels
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: qiskit
+#        run : |
+#          pip install -U twine
+#          twine upload wheelhouse/*
+#  sdist:
+#    name: Publish qiskit-aer sdist
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions/setup-python@v2
+#        name: Install Python
+#        with:
+#          python-version: '3.8'
+#      - name: Install Deps
+#        run: pip install -U twine wheel
+#      - name: Build Artifacts
+#        run: |
+#          python setup.py sdist
+#        shell: bash
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          path: ./dist/qiskit*
+#      - name: Publish to PyPi
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: qiskit
+#        run: twine upload dist/qiskit*
   gpu-build:
     name: Build qiskit-aer-gpu wheels
     runs-on: ubuntu-latest
@@ -90,10 +89,10 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Publish Wheels
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
-        run : |
-          pip install -U twine
-          twine upload wheelhouse/*
+#      - name: Publish Wheels
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: qiskit
+#        run : |
+#          pip install -U twine
+#          twine upload wheelhouse/*

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -391,7 +391,7 @@ size_t Controller::get_system_memory_mb() {
 #endif
 #ifdef AER_THRUST_CUDA
   int iDev,nDev,j;
-  cudaGetDeviceCount(&nDev);
+  if(cudaGetDeviceCount(&nDev) != cudaSuccess) nDev = 0;
   for(iDev=0;iDev<nDev;iDev++){
     size_t freeMem,totalMem;
     cudaSetDevice(iDev);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There is a bug in the code that makes the verify_wheel.py script
run forever when we build the gpu wheel. The problem is the check
of memory available on CUDA devices when there are no CUDA devices
available, as is the case for our GPU wheel build action.


### Details and comments


