### PR TITLE
Add missing sdist release job (#998)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,6 +40,29 @@ jobs:
         run : |
           pip install -U twine
           twine upload wheelhouse/*
+  sdist:
+    name: Publish qiskit-aer sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+      - name: Install Deps
+        run: pip install -U twine wheel
+      - name: Build Artifacts
+        run: |
+          python setup.py sdist
+        shell: bash
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/qiskit*
+      - name: Publish to PyPi
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: qiskit
+        run: twine upload dist/qiskit*
   gpu-build:
     name: Build qiskit-aer-gpu wheels
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the recent aer 0.7.0 release we noticed that in the migration of CI
jobs to github actions in #881 the job to create and publish and sdist
at release time was lost. This commit corrects this and adds a new job
to create and publish to pypi the qiskit-aer sdist at release time.

### Details and comments

Backported from #998 
(cherry picked from commit cb5f41400f07328b9d4328b39bae3e2d8006f1d7)