### PR TITLE
Update setup-build action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         if: runner.os == 'Linux'
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
         if: runner.os == 'Windows'
       - name: Compile Standalone Windows
         run: |
@@ -219,7 +219,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version}}-
         if: runner.os == 'Windows'
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
         if: runner.os == 'Windows'
       - name: Install Deps
         run: python -m pip install -U -r requirements-dev.txt wheel git+https://github.com/Qiskit/qiskit-terra


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the version of the setup-msbuild action we use in
the windows ci jobs. This action is used to setup the compilers in the
windows environment, but the version we were using was relying on a
previously deprecated and now removed feature in github actions and has
now stopped working. By updating the version we should unblock CI.

### Details and comments