### PR TITLE
use single shot to find available methods

### DIFF
--- a/qiskit/providers/aer/backends/backend_utils.py
+++ b/qiskit/providers/aer/backends/backend_utils.py
@@ -61,6 +61,7 @@ def available_methods(controller, methods):
     for method in methods:
         qobj = assemble(dummy_circ,
                         optimization_level=0,
+                        shots=1,
                         method=method)
         result = cpp_execute(controller, qobj)
         if result.get('success', False):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

use `shots=1` to get available methods of qasm simulator

### Details and comments

`available_methods` in [`backend_utils`](https://github.com/Qiskit/qiskit-aer/blob/c36dc29c842276d0706f164b56725734a974645e/qiskit/providers/aer/backends/backend_utils.py) uses the default number of shots. It should be `1` from performance perspective.