### PR TITLE
Fix bug with nested omp being applied incorrectly

### DIFF
--- a/releasenotes/notes/fix-omp-nested-9d120cd1a08725ab.yaml
+++ b/releasenotes/notes/fix-omp-nested-9d120cd1a08725ab.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a bug with nested OpenMP flag was being set to true when it
+    shouldn't be.

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -543,18 +543,10 @@ Result Controller::execute(std::vector<Circuit> &circuits,
 
 #ifdef _OPENMP
     if (parallel_shots_ > 1 || parallel_experiments_ > 1) {
-      #ifdef _WIN32
-        omp_set_nested(1);
-      #else:
-        omp_set_max_active_levels(2);
-      #endif
+      omp_set_nested(1);
       result.metadata["omp_nested"] = true;
     } else {
-      #ifdef _WIN32
-        omp_set_nested(0);
-      #else
-        omp_set_max_active_levels(1);
-      #endif
+      omp_set_nested(0);
       result.metadata["omp_nested"] = false;
     }
 #endif

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -542,8 +542,21 @@ Result Controller::execute(std::vector<Circuit> &circuits,
     result.metadata["max_memory_mb"] = max_memory_mb_;
 
 #ifdef _OPENMP
-    if (parallel_shots_ > 1 || parallel_state_update_ > 1)
-      omp_set_nested(1);
+    if (parallel_shots_ > 1 || parallel_experiments_ > 1) {
+      #ifdef _WIN32
+        omp_set_nested(1);
+      #else:
+        omp_set_max_active_levels(2);
+      #endif
+      result.metadata["omp_nested"] = true;
+    } else {
+      #ifdef _WIN32
+        omp_set_nested(0);
+      #else
+        omp_set_max_active_levels(1);
+      #endif
+      result.metadata["omp_nested"] = false;
+    }
 #endif
     // then- and else-blocks have intentionally duplication.
     // Nested omp has significant overheads even though a guard condition exists.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes bug with nested OpenMP flag getting set to True when it shouldn't have

### Details and comments

* The condition was checking parallel shots or parallel state update, when it should have been parallel shots or parallel experiments.
* Explicitly disable nested openmp when the above condition isn't satisfied