### PR TITLE
Remove deprecated usage of omp_set_nested

### DIFF
--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -549,11 +549,19 @@ Result Controller::execute(std::vector<Circuit> &circuits,
     if (parallel_experiments_ > 1 && parallel_experiments_ < max_parallel_threads_) {
       // Nested parallel experiments
       parallel_nested_ = true;
+      #ifdef _WIN32
       omp_set_nested(1);
+      #else
+      omp_set_max_active_levels(3);
+      #endif
       result.metadata["omp_nested"] = parallel_nested_;
     } else {
       parallel_nested_ = false;
+      #ifdef _WIN32
       omp_set_nested(0);
+      #else
+      omp_set_max_active_levels(1);
+      #endif
     }
 #endif
     // then- and else-blocks have intentionally duplication.
@@ -661,10 +669,18 @@ void Controller::execute_circuit(Circuit &circ,
     if (!parallel_nested_) {
       if (parallel_shots_ > 1 && parallel_state_update_ > 1) {
         // Nested parallel shots + state update
+        #ifdef _WIN32
         omp_set_nested(1);
+        #else
+        omp_set_max_active_levels(2);
+        #endif
         result.metadata["omp_nested"] = true;
       } else {
+        #ifdef _WIN32
         omp_set_nested(0);
+        #else
+        omp_set_max_active_levels(1);
+        #endif
       }
     }
     #endif

--- a/src/misc/clang_omp_symbols.hpp
+++ b/src/misc/clang_omp_symbols.hpp
@@ -218,6 +218,11 @@ extern "C" {
     void __KAI_KMPC_CONVENTION omp_set_nested(int foo){
         _hook_omp_set_nested(foo);
     }
+    using omp_set_max_active_levels_t = void(*)(int);
+    omp_set_max_active_levels_t _hook_omp_set_max_active_levels;
+    void __KAI_KMPC_CONVENTION omp_set_max_active_levels(int foo){
+        _hook_omp_set_max_active_levels(foo);
+    }
     using omp_get_num_procs_t = int(*)(void);
     omp_get_num_procs_t _hook_omp_get_num_procs;
     int __KAI_KMPC_CONVENTION omp_get_num_procs(void) {
@@ -325,6 +330,7 @@ void populate_hooks(void * handle){
     _hook_omp_get_num_threads = reinterpret_cast<decltype(&omp_get_num_threads)>(dlsym(handle, "omp_get_num_threads"));
     _hook_omp_get_thread_num = reinterpret_cast<decltype(&omp_get_thread_num)>(dlsym(handle, "omp_get_thread_num"));
     _hook_omp_set_nested = reinterpret_cast<decltype(&omp_set_nested)>(dlsym(handle, "omp_set_nested"));
+    _hook_omp_set_max_active_levels = reinterpret_cast<decltype(&omp_set_max_active_levels)>(dlsym(handle, "omp_set_max_active_levels"));
     _hook_omp_get_num_procs = reinterpret_cast<decltype(&omp_get_num_procs)>(dlsym(handle, "omp_get_num_procs"));
 }
 

--- a/src/misc/gcc_omp_symbols.hpp
+++ b/src/misc/gcc_omp_symbols.hpp
@@ -71,6 +71,11 @@ extern "C" {
     void __KAI_KMPC_CONVENTION omp_set_nested(int foo){
         _hook_omp_set_nested(foo);
     }
+    using omp_set_max_active_levels_t = void(*)(int);
+    omp_set_max_active_levels_t _hook_omp_set_max_active_levels;
+    void __KAI_KMPC_CONVENTION omp_set_max_active_levels(int foo){
+        _hook_omp_set_max_active_levels(foo);
+    }
     using omp_get_num_threads_t = int(*)(void);
     omp_get_num_threads_t _hook_omp_get_num_threads;
     int __KAI_KMPC_CONVENTION omp_get_num_threads(void) {
@@ -101,6 +106,7 @@ namespace Hacks {
         _hook_omp_get_num_threads = reinterpret_cast<decltype(&omp_get_num_threads)>(dlsym(handle, "omp_get_num_threads"));
         _hook_omp_get_max_threads = reinterpret_cast<decltype(&omp_get_max_threads)>(dlsym(handle, "omp_get_max_threads"));
         _hook_omp_set_nested = reinterpret_cast<decltype(&omp_set_nested)>(dlsym(handle, "omp_set_nested"));
+        _hook_omp_set_max_active_levels = reinterpret_cast<decltype(&omp_set_max_active_levels)>(dlsym(handle, "omp_set_max_active_levels"));
         _hook_omp_get_thread_num = reinterpret_cast<decltype(&omp_get_thread_num)>(dlsym(handle, "omp_get_thread_num"));
         _hook_omp_get_num_procs = reinterpret_cast<decltype(&omp_get_num_procs)>(dlsym(handle, "omp_get_num_procs"));
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

On mac and linux use `omp_set_max_active_levels` instead of `omp_set_nested`

### Details and comments

OpenMP has deprecated `omp_set_nested` for `omp_set_max_active_levels` which was introduced in OMP 3.0. This means it isn't available on Windows (OMP 2.0) so we still need to use the old function call there.
