### PR TITLE
Bump manylinux2010 docker image for wheel jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U virtualenv pybind11"
           CIBW_SKIP: "cp27-* cp34-* cp35-* cp39-* pp*"
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
-          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
+          CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"
+          CIBW_MANYLINUX_I686_IMAGE: "quay.io/pypa/manylinux2010_i686:2020-12-03-912b0de"
           CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"
           CIBW_TEST_REQUIRES: "git+https://github.com/Qiskit/qiskit-terra.git"
         run: cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         run: python -m pip install -U cibuildwheel==1.7.0
       - name: Build Wheels
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
+          CIBW_BEFORE_ALL_LINUX: "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U virtualenv pybind11"
           CIBW_SKIP: "cp27-* cp34-* cp35-* cp39-* pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         run: python -m pip install -U cibuildwheel==1.7.0
       - name: Build Wheels
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && yum install -y openblas-devel"
+          CIBW_BEFORE_ALL_LINUX: "yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm && yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U virtualenv pybind11"
           CIBW_SKIP: "cp27-* cp34-* cp35-* cp39-* pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11"
           CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
-          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
+          CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"
+          CIBW_MANYLINUX_I686_IMAGE: "quay.io/pypa/manylinux2010_i686:2020-12-03-912b0de"
           CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"
           CIBW_TEST_REQUIRES: "git+https://github.com/Qiskit/qiskit-terra.git"
         run: |
@@ -80,8 +80,8 @@ jobs:
           CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1"
           CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11 && yum install -y openblas-devel"
           CIBW_SKIP: "cp27-* cp34-* cp35-* *-manylinux_i686 pp*"
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
-          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
+          CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"
+          CIBW_MANYLINUX_I686_IMAGE: "quay.io/pypa/manylinux2010_i686:2020-12-03-912b0de"
           CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu AER_THRUST_BACKEND=CUDA CUDACXX=/usr/local/cuda/bin/nvcc
           CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"
           CIBW_TEST_REQUIRES: "git+https://github.com/Qiskit/qiskit-terra.git"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           python -m pip install cibuildwheel==1.5.5
       - name: Build wheels
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && yum install -y openblas-devel"
+          CIBW_BEFORE_ALL_LINUX: "yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm && yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11"
           CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"
@@ -77,7 +77,7 @@ jobs:
           python -m pip install cibuildwheel==1.5.5
       - name: Build wheels
         env:
-          CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+          CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 && yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"
           CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11 && yum install -y openblas-devel"
           CIBW_SKIP: "cp27-* cp34-* cp35-* *-manylinux_i686 pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           python -m pip install cibuildwheel==1.5.5
       - name: Build wheels
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
+          CIBW_BEFORE_ALL_LINUX: "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11"
           CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"
@@ -77,7 +77,7 @@ jobs:
           python -m pip install cibuildwheel==1.5.5
       - name: Build wheels
         env:
-          CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1"
+          CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
           CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11 && yum install -y openblas-devel"
           CIBW_SKIP: "cp27-* cp34-* cp35-* *-manylinux_i686 pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The default version of the manylinux2010 docker images used by
cibuildwheel are trying to use a nonexistent yum repository now that
centos 6 is eol. The latest version of the docker image has been
updated. This commit manually sets the docker image to the latest
version to unblock CI. This PR can be reverted when cibuildwheel
releases a new version that bumps their default manylinux2010 version
(see joerick/cibuildwheel#472 for more details on that).

### Details and comments


