### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm && yum install -y openblas-devel"
           CIBW_BEFORE_BUILD: "pip install -U virtualenv pybind11"
-          CIBW_SKIP: "cp27-* cp34-* cp35-* cp39-* pp*"
+          CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2020-12-03-912b0de"
           CIBW_MANYLINUX_I686_IMAGE: "quay.io/pypa/manylinux2010_i686:2020-12-03-912b0de"
           CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==1.7.0
+        run: python -m pip install -U cibuildwheel==1.7.1
       - name: Build Wheels
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm && yum install -y openblas-devel"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.7'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.5.5
+          python -m pip install cibuildwheel==1.7.1
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm && yum install -y openblas-devel"
@@ -74,7 +74,7 @@ jobs:
           python-version: '3.7'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.5.5
+          python -m pip install cibuildwheel==1.7.1
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 && yum install -y https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm"

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -42,7 +42,7 @@ jobs:
     needs: ["lint"]
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         platform: [
           { os: "ubuntu-latest", python-architecture: "x64" },
         ]
@@ -86,7 +86,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: ["ubuntu-latest"]
     env:
       AER_THRUST_BACKEND: OMP

--- a/.github/workflows/tests_mac.yml
+++ b/.github/workflows/tests_mac.yml
@@ -42,7 +42,7 @@ jobs:
     needs: ["lint"]
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         platform: [
           { os: "macOS-latest",   python-architecture: "x64"},
         ]
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: ["macOS-latest"]
     env:
       AER_THRUST_BACKEND: OMP

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: ["windows-latest"]
     env:
       AER_THRUST_BACKEND: OMP

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,6 +140,8 @@ stages:
               python.version: '3.7'
             Python38:
               python.version: '3.8'
+            Python38:
+              python.version: '3.9'
         variables:
           PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
         steps:
@@ -229,6 +231,8 @@ stages:
               python.version: '3.7'
             Python38:
               python.version: '3.8'
+            Python38:
+              python.version: '3.9'
         variables:
           PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,7 @@ stages:
               python.version: '3.7'
             Python38:
               python.version: '3.8'
-            Python38:
+            Python39:
               python.version: '3.9'
         variables:
           PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
@@ -231,7 +231,7 @@ stages:
               python.version: '3.7'
             Python38:
               python.version: '3.8'
-            Python38:
+            Python39:
               python.version: '3.9'
         variables:
           PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip

--- a/releasenotes/notes/add-python3.9-83b3b4e5c3d59571.yaml
+++ b/releasenotes/notes/add-python3.9-83b3b4e5c3d59571.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Python 3.9 support has been added in this release. You can now run Qiskit
+    Aer using Python 3.9 without building from source.
+deprecations:
+  - |
+    Python 3.6 support has been deprecated and will be removed in a future
+    release. When support is removed you will need to upgrade the Python
+    version you're using to Python 3.7 or above.

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
     ],
     python_requires=">=3.6",

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -86,14 +86,6 @@ class QiskitAerTestCase(QiskitTestCase):
         """
         return os.path.normpath(os.path.join(path.value, filename))
 
-    def assertNoLogs(self, logger=None, level=None):
-        """
-        Context manager to test that no message is sent to the specified
-        logger and level (the opposite of TestCase.assertLogs()).
-        """
-        # pylint: disable=invalid-name
-        return _AssertNoLogsContext(self, logger, level)
-
     def assertSuccess(self, result):
         """Assert that simulation executed without errors"""
         success = getattr(result, 'success', False)
@@ -327,32 +319,6 @@ class QiskitAerTestCase(QiskitTestCase):
 
         msg = self._formatMessage(msg, standard_msg)
         raise self.failureException(msg)
-
-
-class _AssertNoLogsContext(unittest.case._AssertLogsContext):
-    """A context manager used to implement TestCase.assertNoLogs()."""
-
-    # pylint: disable=inconsistent-return-statements
-    def __exit__(self, exc_type, exc_value, tb):
-        """
-        This is a modified version of TestCase._AssertLogsContext.__exit__(...)
-        """
-        self.logger.handlers = self.old_handlers
-        self.logger.propagate = self.old_propagate
-        self.logger.setLevel(self.old_level)
-        if exc_type is not None:
-            # let unexpected exceptions pass through
-            return False
-
-        if self.watcher.records:
-            msg = 'logs of level {} or higher triggered on {}:\n'.format(
-                logging.getLevelName(self.level), self.logger.name)
-            for record in self.watcher.records:
-                msg += 'logger %s %s:%i: %s\n' % (record.name, record.pathname,
-                                                  record.lineno,
-                                                  record.getMessage())
-
-            self._raiseFailure(msg)
 
 
 def _is_ci_fork_pull_request():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py36, py37, py38, lint
+envlist = py36, py37, py38, py39, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds official python 3.9 support to qiskit-aer. This
includes CI, release notes, and package metadata.

### Details and comments

Fixes #1067

Upstream dependencies that need Python 3.9 support:

~- [ ] osqp~ (sidestepped by skipping cvxpy tests for py39)