### PR TITLE
Restrict cvxpy testing to python 3.7 and 3.8

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           set -e
           cd qiskit-tutorials
-          rm -rf tutorials/chemistry tutorials/circuits tutorials/circuits_advanced tutorials/finance tutorials/optimization tutorials/algorithms tutorials/operators
+          rm -rf tutorials/chemistry tutorials/circuits tutorials/circuits_advanced tutorials/finance tutorials/optimization tutorials/algorithms tutorials/operators tutorials/noise
           sphinx-build -b html . _build/html
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           set -e
           cd qiskit-tutorials
-          rm -rf tutorials/chemistry tutorials/circuits tutorials/circuits_advanced tutorials/finance tutorials/optimization tutorials/noise
+          rm -rf tutorials/chemistry tutorials/circuits tutorials/circuits_advanced tutorials/finance tutorials/optimization tutorials/algorithms tutorials/operators
           sphinx-build -b html . _build/html
       - uses: actions/upload-artifact@v2
         with:

--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -340,7 +340,9 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds, pulse_to_int, dt, q
                 structs['channels'][chan_name][1].extend([inst['t0'] * dt,
                                                           inst['phase'],
                                                           cond])
-
+            # Delay instruction
+            elif inst['name'] == 'delay':
+                pass  # nothing to be done in this case
             # A standard pulse
             else:
                 start = inst['t0'] * dt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ cmake!=3.17.1,!=3.17.0
 conan>=1.22.2
 scikit-build
 asv
-cvxpy>=1.0.0
+cvxpy>=1.0.0;python_version>'3.6' and python_version<='3.8'
 pylint
 pycodestyle
 Sphinx>=1.8.3

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -66,7 +66,7 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
                 for idx, entry in enumerate(sim_dict[key]):
                     for entry_key in entry:
                         if entry_key == 'samples':
-                            self.assertTrue(all(entry[entry_key] == backend_dict[key][idx][entry_key]))
+                            self.assertTrue(np.array_equal(entry[entry_key], backend_dict[key][idx][entry_key]))
                         else:
                             self.assertTrue(entry[entry_key] == backend_dict[key][idx][entry_key])
             else:

--- a/test/terra/noise/test_noise_transformation.py
+++ b/test/terra/noise/test_noise_transformation.py
@@ -13,6 +13,7 @@
 NoiseTransformer class tests
 """
 
+import unittest
 from ..common import QiskitAerTestCase
 
 import numpy
@@ -26,7 +27,13 @@ from qiskit.providers.aer.noise.errors.standard_errors import reset_error
 from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
 from qiskit.providers.aer.noise.errors.quantum_error import QuantumError
 
+try:
+    import cvxpy
+    HAS_CVXPY = True
+except ImportError:
+    HAS_CVXPY = False
 
+@unittest.skipUnless(HAS_CVXPY, 'cvxpy is required to run these tests')
 class TestNoiseTransformer(QiskitAerTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The cvxpy packaging (more specifically scs) is causing issues in CI for
us because since it is incorrectly trying to install numpy from a
pre-release package which does not support python 3.6. The nature of
this issue is difficult to pin because it's not using pip to install
numpy. Since cvxpy is only used in a single place, noise
transformations, instead of trying to workaround these scs packaging
issues this commit just restricts the test requirements on cvxpy to only
match pytho 3.7 or 3.8. If cvxpy is not installed the noise
transformation tests will now skip instead of fail.

### Details and comments

Co-authored-by: Daniel Puzzuoli <dan.puzzuoli@gmail.com>
