### PR TITLE
Fix condtional instructions using `c_if` not working for reg of size>=64 on BasicAer backend

### DIFF
--- a/releasenotes/notes/fix-c-if-large-register-79d6649395e57ff5.yaml
+++ b/releasenotes/notes/fix-c-if-large-register-79d6649395e57ff5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes a bug that resulted in `c_if` not working when the
+    width of the conditional register was greater than 64. See
+    `#1077 <https://github.com/Qiskit/qiskit-aer/issues/1077>`.

--- a/src/framework/creg.hpp
+++ b/src/framework/creg.hpp
@@ -178,13 +178,20 @@ void ClassicalRegister::apply_bfunc(const Operations::Op &op) {
   } else {
     // We need to use big ints so we implement the bit-mask via the binary string
     // representation rather than using a big integer class
-    std::string mask_bin = Utils::hex2bin(mask); // has 0b prefix while creg_register_ doesn't
-    size_t length = std::min(mask_bin.size() - 2, creg_register_.size()); // -2 to remove 0b
+    std::string mask_bin = Utils::hex2bin(mask, false);
+    size_t length = std::min(mask_bin.size(), creg_register_.size());
     std::string masked_val = std::string(length, '0');
     for (size_t rev_pos = 0; rev_pos < length; rev_pos++) {
       masked_val[length - 1 - rev_pos] = (mask_bin[mask_bin.size() - 1 - rev_pos] 
                                           & creg_register_[creg_register_.size() - 1 - rev_pos]);
     }
+    // remove leading 0's
+    size_t end_i = masked_val.find('1');
+    if (end_i == std::string::npos)
+        masked_val = "0";
+    else
+        masked_val.erase(0, end_i);
+
     masked_val = Utils::bin2hex(masked_val); // convert to hex string
     // Using string comparison to compare to target value
     compared = masked_val.compare(target_val);

--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -1018,7 +1018,7 @@ std::string hex2bin(std::string str, bool prefix) {
 
   // We go via long integer conversion, so we process 64-bit chunks at
   // a time
-  const size_t block = 8;
+  const size_t block = 16;
   const size_t len = str.size();
   const size_t chunks = len / block;
   const size_t remain = len % block;
@@ -1027,7 +1027,9 @@ std::string hex2bin(std::string str, bool prefix) {
   std::string bin = (prefix) ? "0b" : "";
 
   // Start with remain
-  bin += int2string(std::stoull(str.substr(0, remain), nullptr, 16), 2);
+  if (remain != 0)
+      bin += int2string(std::stoull(str.substr(0, remain), nullptr, 16), 2);
+
   for (size_t j=0; j < chunks; ++j) {
     std::string part = int2string(std::stoull(str.substr(remain + j * block, block), nullptr, 16), 2, 64);
     bin += part;

--- a/test/terra/backends/qasm_simulator/qasm_conditional.py
+++ b/test/terra/backends/qasm_simulator/qasm_conditional.py
@@ -51,6 +51,36 @@ class QasmConditionalGateTests:
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
+    def test_conditional_gates_64bit(self):
+        """Test conditional gate operations on 64-bit conditional register."""
+        shots = 100
+        # [value of conditional register, list of condtional values]
+        cases = ref_conditionals.conditional_cases_64bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(64, cases,
+                final_measure=True, conditional_type='gate')
+        # not using hex counts because number of leading zeros in results
+        # doesn't seem consistent
+        targets = ref_conditionals.condtional_counts_nbit(64, cases, shots,
+                hex_counts=False)
+
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **self.BACKEND_OPTS).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, hex_counts=False, delta=0)
+
+    def test_conditional_gates_132bit(self):
+        """Test conditional gate operations on 132-bit conditional register."""
+        shots = 100
+        cases = ref_conditionals.conditional_cases_132bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(132, cases, final_measure=True,
+                conditional_type='gate')
+        targets = ref_conditionals.condtional_counts_nbit(132, cases, shots,
+                hex_counts=False)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **self.BACKEND_OPTS).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, hex_counts=False, delta=0)
+
 
 class QasmConditionalUnitaryTests:
     """QasmSimulator conditional tests."""
@@ -84,6 +114,33 @@ class QasmConditionalUnitaryTests:
             qobj, **self.BACKEND_OPTS).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0)
+
+    def test_conditional_unitary_64bit(self):
+        """Test conditional unitary operations on 64-bit conditional register."""
+        shots = 100
+        cases = ref_conditionals.conditional_cases_64bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(64, cases,
+                final_measure=True, conditional_type='unitary')
+        targets = ref_conditionals.condtional_counts_nbit(64, cases, shots,
+                hex_counts=False)
+
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **self.BACKEND_OPTS).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, hex_counts=False, delta=0)
+
+    def test_conditional_unitary_132bit(self):
+        """Test conditional unitary operations on 132-bit conditional register."""
+        shots = 100
+        cases = ref_conditionals.conditional_cases_132bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(132, cases, final_measure=True,
+                conditional_type='unitary')
+        targets = ref_conditionals.condtional_counts_nbit(132, cases, shots,
+                hex_counts=False)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **self.BACKEND_OPTS).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, hex_counts=False, delta=0)
 
 
 class QasmConditionalKrausTests:
@@ -119,6 +176,33 @@ class QasmConditionalKrausTests:
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0)
 
+    def test_conditional_kraus_64bit(self):
+        """Test conditional kraus operations on 64-bit conditional register."""
+        shots = 100
+        cases = ref_conditionals.conditional_cases_64bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(64, cases,
+                final_measure=True, conditional_type='kraus')
+        targets = ref_conditionals.condtional_counts_nbit(64, cases, shots,
+                hex_counts=False)
+
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **self.BACKEND_OPTS).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, hex_counts=False, delta=0)
+
+    def test_conditional_kraus_132bit(self):
+        """Test conditional kraus operations on 132-bit conditional register."""
+        shots = 100
+        cases = ref_conditionals.conditional_cases_132bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(132, cases, final_measure=True,
+                conditional_type='kraus')
+        targets = ref_conditionals.condtional_counts_nbit(132, cases, shots,
+                hex_counts=False)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **self.BACKEND_OPTS).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, hex_counts=False, delta=0)
+
 
 class QasmConditionalSuperOpTests:
     """QasmSimulator conditional tests."""
@@ -152,3 +236,30 @@ class QasmConditionalSuperOpTests:
             qobj, **self.BACKEND_OPTS).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0)
+
+    def test_conditional_superop_64bit(self):
+        """Test conditional superop operations on 64-bit conditional register."""
+        shots = 100
+        cases = ref_conditionals.conditional_cases_64bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(64, cases,
+                final_measure=True, conditional_type='superop')
+        targets = ref_conditionals.condtional_counts_nbit(64, cases, shots,
+                hex_counts=False)
+
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **self.BACKEND_OPTS).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, hex_counts=False, delta=0)
+
+    def test_conditional_superop_132bit(self):
+        """Test conditional superop operations on 132-bit conditional register."""
+        shots = 100
+        cases = ref_conditionals.conditional_cases_132bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(132, cases, final_measure=True,
+                conditional_type='superop')
+        targets = ref_conditionals.condtional_counts_nbit(132, cases, shots,
+                hex_counts=False)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **self.BACKEND_OPTS).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, hex_counts=False, delta=0)

--- a/test/terra/backends/statevector_simulator/statevector_basics.py
+++ b/test/terra/backends/statevector_simulator/statevector_basics.py
@@ -162,6 +162,54 @@ class StatevectorSimulatorTests:
         self.assertSuccess(result)
         self.compare_statevector(result, circuits, targets)
 
+    def test_conditional_gate_64bit(self):
+        """Test conditional gates on 64-bit conditional register."""
+        cases = ref_conditionals.conditional_cases_64bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(64, cases,
+            final_measure=False, conditional_type='gate')
+        targets = ref_conditionals.conditional_statevector_nbit(cases)
+        job = execute(circuits, self.SIMULATOR, shots=1, **self.BACKEND_OPTS)
+        result = job.result()
+        self.assertSuccess(result)
+
+        self.compare_statevector(result, circuits, targets)
+
+    def test_conditional_unitary_64bit(self):
+        """Test conditional unitary on 64-bit conditional register."""
+        cases = ref_conditionals.conditional_cases_64bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(64, cases,
+            final_measure=False, conditional_type='unitary')
+        targets = ref_conditionals.conditional_statevector_nbit(cases)
+        job = execute(circuits, self.SIMULATOR, shots=1, **self.BACKEND_OPTS)
+        result = job.result()
+        self.assertSuccess(result)
+
+        self.compare_statevector(result, circuits, targets)
+
+    def test_conditional_gate_132bit(self):
+        """Test conditional gates on 132-bit conditional register."""
+        cases = ref_conditionals.conditional_cases_132bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(132, cases,
+            final_measure=False, conditional_type='gate')
+        targets = ref_conditionals.conditional_statevector_nbit(cases)
+        job = execute(circuits, self.SIMULATOR, shots=1, **self.BACKEND_OPTS)
+        result = job.result()
+        self.assertSuccess(result)
+
+        self.compare_statevector(result, circuits, targets)
+
+    def test_conditional_unitary_132bit(self):
+        """Test conditional unitary on 132-bit conditional register."""
+        cases = ref_conditionals.conditional_cases_132bit()
+        circuits = ref_conditionals.conditional_circuits_nbit(132, cases,
+            final_measure=False, conditional_type='unitary')
+        targets = ref_conditionals.conditional_statevector_nbit(cases)
+        job = execute(circuits, self.SIMULATOR, shots=1, **self.BACKEND_OPTS)
+        result = job.result()
+        self.assertSuccess(result)
+
+        self.compare_statevector(result, circuits, targets)
+
     # ---------------------------------------------------------------------
     # Test h-gate
     # ---------------------------------------------------------------------

--- a/test/terra/reference/ref_conditionals.py
+++ b/test/terra/reference/ref_conditionals.py
@@ -339,6 +339,8 @@ def conditional_circuits_2bit(final_measure=True, conditional_type='gate'):
     return circuits
 
 
+
+
 def conditional_counts_2bit(shots, hex_counts=True):
     """2-bit conditional circuits reference counts."""
     targets = []
@@ -448,4 +450,105 @@ def conditional_statevector_2bit():
     targets.append(state_0)
     # Conditional on 11 (cr = 11)
     targets.append(state_1)
+    return targets
+
+
+# ==========================================================================
+# Conditionals on large (>= 64) registers
+# ==========================================================================
+
+def conditional_cases_64bit():
+    """Test cases for conditional on 64-bit registers."""
+    # [value of conditional register, list of condtional values]
+    return [
+                (0,       [0, 1, 2**63]),
+                (1,       [1, 2**63]),
+                (2**32,   [2**32, 0, 2**31]),
+                (2**32-1, [2**32-1, 0, 0xffffffff00000000]),
+                (2**64-1, [2**64-1, 0]),
+                (2337843, [2337843, 0]),
+            ]
+
+
+def conditional_cases_132bit():
+    """Test cases for conditional on 132-bit registers."""
+    # [value of conditional register, list of condtional values]
+    return [
+                (0,     [0, 1]),
+                (1,     [1, 0, 2**131]),
+                (2**131, [2**131, 1]),
+                (2**132-1, [2**132-1, 0, 1]),
+        ]
+
+
+def conditional_circuits_nbit(n, cases, final_measure=True,
+        conditional_type='gate'):
+    """Conditional gates on n bit classical register.
+    Args:
+        n(int):       width of conditional register
+        cases(list):  list of tuples `(register_value, condtional_values)`
+                      where register_value is the value of n-bit conditional
+                      register, and conditional_values is a list of conditional
+                      values for each test case.
+                      Eg. [(0, [0, 1])] would return a list of two circuits,
+                      the conditional register will store a value of 0 when
+                      the condtional instruction conditioned is applied for both,
+                      but conditioned value is 0 and 1 for the first and second
+                      repectively.
+    """
+    circuits = []
+    qr   = QuantumRegister(1)
+    cond = ClassicalRegister(n, 'cond')
+    if final_measure:
+        cr = ClassicalRegister(1, 'meas')
+        regs = (qr, cr, cond)
+    else:
+        regs = (qr, cond)
+
+    for reg_val, cond_vals in cases:
+        # bit string for value in conditional register
+        bin_reg_val = bin(reg_val)[2:]
+        str_n = len(bin_reg_val)
+
+        for cond_val in cond_vals:
+            circuit = QuantumCircuit(*regs)
+
+            # encode reg_val into conditional register
+            circuit.x(qr)
+            for i, c in enumerate(bin_reg_val):
+                if c == '1':
+                    circuit.measure(qr[0], cond[str_n-i-1])
+            circuit.x(qr)
+
+            # apply x to qr[0] if cond register has value cond_val
+            add_conditional_x(circuit, qr[0], cond, cond_val, conditional_type)
+            if final_measure:
+                circuit.measure(qr, cr)
+            circuits.append(circuit)
+    return circuits
+
+
+def condtional_counts_nbit(n, cases, shots, hex_counts=True):
+    """n-bit condtional circuits reference counts."""
+    targets = []
+    for reg_val, cond_vals in cases:
+        for cond_val in cond_vals:
+            cr = 1 if reg_val == cond_val else 0
+            if hex_counts:
+                key = '{:#x}'.format(reg_val * 2 + cr)
+            else:
+                key = '{} {}'.format(bin(reg_val)[2:].zfill(n), str(cr))
+            targets.append({key: shots})
+    return targets
+
+
+def conditional_statevector_nbit(cases):
+    """n-bit conditional circuits reference statevector."""
+    targets = []
+    for reg_val, cond_vals in cases:
+        for cond_val in cond_vals:
+            if reg_val == cond_val:
+                targets.append(np.array([0, 1]))
+            else:
+                targets.append(np.array([1, 0]))
     return targets


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added fix for bug where executing conditional instruction with `c_if` on the `BasicAer` backend  either resulted in a crash or incorrect result for registers larger than or equal to 64-bits. 

Fixes #1077 

### Details and comments

The `hex2bin` routine in `util.hpp` used 8 hex-character instead for 16 for the block size to process in 64-bit chunks. Also added check to avoid invoking `std::stoull` with empty string, which was causing the crashes.

In the implementation of `ClassicalRegister::apply_bfunc,` truncated the leading zeros before comparing the masked register value with the target value for the conditional.
