### PR TITLE
Add new save expectation value instructions

### DIFF
--- a/docs/apidocs/aer.rst
+++ b/docs/apidocs/aer.rst
@@ -8,7 +8,8 @@ Qiskit Aer API Reference
     :maxdepth: 1
 
     aer_provider
-    aer_extensions
+    aer_library
     aer_noise
     aer_pulse
     aer_utils
+    aer_extensions

--- a/docs/apidocs/aer_library.rst
+++ b/docs/apidocs/aer_library.rst
@@ -1,0 +1,6 @@
+.. _aer-library:
+
+.. automodule:: qiskit.providers.aer.library
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/qiskit/providers/aer/__init__.py
+++ b/qiskit/providers/aer/__init__.py
@@ -65,6 +65,7 @@ from .aerprovider import AerProvider
 from .aerjob import AerJob
 from .aererror import AerError
 from .backends import *
+from . import library
 from . import pulse
 from . import noise
 from . import utils

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -294,9 +294,9 @@ class QasmSimulator(AerBackend):
             'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
             'initialize', 'delay', 'pauli', 'mcx_gray',
             # Custom instructions
-            'kraus', 'roerror', 'snapshot'
+            'kraus', 'roerror', 'snapshot', 'save_expval'
         ]),
-        'custom_instructions': sorted(['roerror', 'kraus', 'snapshot']),
+        'custom_instructions': sorted(['roerror', 'kraus', 'snapshot', 'save_expval']),
         'gates': []
     }
 
@@ -471,7 +471,8 @@ class QasmSimulator(AerBackend):
         ]:
             config.n_qubits = config.n_qubits // 2
             config.description = 'A C++ QasmQobj density matrix simulator with noise'
-            config.custom_instructions = sorted(['roerror', 'snapshot', 'kraus', 'superop'])
+            config.custom_instructions = sorted([
+                'roerror', 'snapshot', 'kraus', 'superop', 'save_expval'])
             config.basis_gates = sorted([
                 'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
                 'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
@@ -482,6 +483,7 @@ class QasmSimulator(AerBackend):
         # Matrix product state method
         elif method == 'matrix_product_state':
             config.description = 'A C++ QasmQobj matrix product state simulator with noise'
+            config.custom_instructions = sorted(['roerror', 'snapshot', 'kraus', 'save_expval'])
             config.basis_gates = sorted([
                 'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
                 'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay',
@@ -493,7 +495,7 @@ class QasmSimulator(AerBackend):
         elif method == 'stabilizer':
             config.n_qubits = 5000  # TODO: estimate from memory
             config.description = 'A C++ QasmQobj Clifford stabilizer simulator with noise'
-            config.custom_instructions = sorted(['roerror', 'snapshot'])
+            config.custom_instructions = sorted(['roerror', 'snapshot', 'save_expval'])
             config.basis_gates = sorted([
                 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'cx', 'cy', 'cz',
                 'swap', 'delay',

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -294,9 +294,10 @@ class QasmSimulator(AerBackend):
             'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
             'initialize', 'delay', 'pauli', 'mcx_gray',
             # Custom instructions
-            'kraus', 'roerror', 'snapshot', 'save_expval'
+            'kraus', 'roerror', 'snapshot', 'save_expval', 'save_expval_var'
         ]),
-        'custom_instructions': sorted(['roerror', 'kraus', 'snapshot', 'save_expval']),
+        'custom_instructions': sorted([
+            'roerror', 'kraus', 'snapshot', 'save_expval', 'save_expval_var']),
         'gates': []
     }
 
@@ -472,7 +473,7 @@ class QasmSimulator(AerBackend):
             config.n_qubits = config.n_qubits // 2
             config.description = 'A C++ QasmQobj density matrix simulator with noise'
             config.custom_instructions = sorted([
-                'roerror', 'snapshot', 'kraus', 'superop', 'save_expval'])
+                'roerror', 'snapshot', 'kraus', 'superop', 'save_expval', 'save_expval_var'])
             config.basis_gates = sorted([
                 'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
                 'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
@@ -483,7 +484,8 @@ class QasmSimulator(AerBackend):
         # Matrix product state method
         elif method == 'matrix_product_state':
             config.description = 'A C++ QasmQobj matrix product state simulator with noise'
-            config.custom_instructions = sorted(['roerror', 'snapshot', 'kraus', 'save_expval'])
+            config.custom_instructions = sorted([
+                'roerror', 'snapshot', 'kraus', 'save_expval', 'save_expval_var'])
             config.basis_gates = sorted([
                 'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
                 'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay',
@@ -495,7 +497,8 @@ class QasmSimulator(AerBackend):
         elif method == 'stabilizer':
             config.n_qubits = 5000  # TODO: estimate from memory
             config.description = 'A C++ QasmQobj Clifford stabilizer simulator with noise'
-            config.custom_instructions = sorted(['roerror', 'snapshot', 'save_expval'])
+            config.custom_instructions = sorted([
+                'roerror', 'snapshot', 'save_expval', 'save_expval_var'])
             config.basis_gates = sorted([
                 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'cx', 'cy', 'cz',
                 'swap', 'delay',

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -127,7 +127,8 @@ class StatevectorSimulator(AerBackend):
             'rzz', 'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx',
             'mcp', 'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz',
             'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
-            'initialize', 'kraus', 'roerror', 'delay', 'pauli'
+            'initialize', 'kraus', 'roerror', 'delay', 'pauli',
+            'save_expval',
         ],
         'gates': []
     }

--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -1,0 +1,51 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+=========================================================
+Instruction Library (:mod:`qiskit.providers.aer.library`)
+=========================================================
+
+.. currentmodule:: qiskit.providers.aer.library
+
+This library contains custom qiskit :class:`~qiskit.QuantumCircuit`
+:class:`~qiskit.circuit.Instruction` subclasses that can be used
+with the Aer circuit simulator backends.
+
+Saving Simulator Data
+=====================
+
+The following classes can be used to directly save data from the
+simulator to the returned result object.
+
+Instruction Classes
+-------------------
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    SaveExpval
+
+Then can also be used using custom QuantumCircuit methods
+
+QuantumCircuit Methods
+----------------------
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    save_expval
+"""
+
+__all__ = ['SaveExpval']
+
+from .save_expval import SaveExpval, save_expval

--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -33,8 +33,8 @@ Instruction Classes
 .. autosummary::
     :toctree: ../stubs/
 
-    SaveExpval
-    SaveExpvalVar
+    SaveExpectationValue
+    SaveExpectationValueVariance
 
 Then can also be used using custom QuantumCircuit methods
 
@@ -67,7 +67,7 @@ QuantumCircuit Methods
     state.
 """
 
-__all__ = ['SaveExpval', 'SaveExpvalVar']
+__all__ = ['SaveExpectationValue', 'SaveExpectationValueVariance']
 
-from .save_expval import SaveExpval, save_expval
-from .save_expval import SaveExpvalVar, save_expval_var
+from .save_expval import SaveExpectationValue, save_expval
+from .save_expval import SaveExpectationValueVariance, save_expval_var

--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -46,6 +46,25 @@ QuantumCircuit Methods
 
     save_expval
     save_expval_var
+
+.. note ::
+
+    **Pershot Data with Measurement Sampling Optimization**
+
+    When saving pershot data by using the ``pershot=True`` kwarg
+    in the above instructions, the resulting list may only contain
+    a single value rather than the number of shots. This
+    happens when a run circuit supports measurement sampling because
+    it is either
+
+    1. An ideal simulation with all measurements at the end.
+
+    2. A noisy simulation using the density matrix method with all
+    measurements at the end.
+
+    In both these cases only a single shot is actually simulated and
+    measurement samples for all shots are calculated from the final
+    state.
 """
 
 __all__ = ['SaveExpval', 'SaveExpvalVar']

--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -44,8 +44,8 @@ QuantumCircuit Methods
 .. autosummary::
     :toctree: ../stubs/
 
-    save_expval
-    save_expval_var
+    save_expectation_value
+    save_expectation_value_variance
 
 .. note ::
 
@@ -69,5 +69,6 @@ QuantumCircuit Methods
 
 __all__ = ['SaveExpectationValue', 'SaveExpectationValueVariance']
 
-from .save_expval import SaveExpectationValue, save_expval
-from .save_expval import SaveExpectationValueVariance, save_expval_var
+from .save_expectation_value import (
+    SaveExpectationValue, save_expectation_value,
+    SaveExpectationValueVariance, save_expectation_value_variance)

--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -34,6 +34,7 @@ Instruction Classes
     :toctree: ../stubs/
 
     SaveExpval
+    SaveExpvalVar
 
 Then can also be used using custom QuantumCircuit methods
 
@@ -44,8 +45,10 @@ QuantumCircuit Methods
     :toctree: ../stubs/
 
     save_expval
+    save_expval_var
 """
 
-__all__ = ['SaveExpval']
+__all__ = ['SaveExpval', 'SaveExpvalVar']
 
 from .save_expval import SaveExpval, save_expval
+from .save_expval import SaveExpvalVar, save_expval_var

--- a/qiskit/providers/aer/library/save_data.py
+++ b/qiskit/providers/aer/library/save_data.py
@@ -51,6 +51,9 @@ class SaveData(Instruction):
             raise ExtensionError(
                 "Invalid data subtype for SaveData instruction.")
 
+        if not isinstance(key, str):
+            raise ExtensionError("Invalid key for save data instruction, key must be a string.")
+
         self._key = key
         self._subtype = subtype
         super().__init__(name, num_qubits, 0, params)

--- a/qiskit/providers/aer/library/save_data.py
+++ b/qiskit/providers/aer/library/save_data.py
@@ -1,0 +1,176 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Simulator instruction to save custom internal data to results.
+"""
+
+import copy
+
+from qiskit.circuit import Instruction, QuantumCircuit, QuantumRegister
+from qiskit.extensions.exceptions import ExtensionError
+
+
+class SaveData(Instruction):
+    """Pragma Instruction to save simulator data."""
+
+    _allowed_subtypes = set([
+        'single', 'list', 'c_list', 'average', 'c_average', 'accum', 'c_accum'
+    ])
+
+    def __init__(self, name, key, num_qubits, subtype='single', params=None):
+        """Create new save data instruction.
+
+        Args:
+            name (str): the name of hte save instruction.
+            key (str): the key for retrieving saved data from results.
+            num_qubits (int): the number of qubits for the snapshot type.
+            subtype (str): the data subtype for the instruction [Default: 'single'].
+            params (list or None): Optional, the parameters for instruction
+                                   [Default: None].
+
+        Raises:
+            ExtensionError: if the subtype string is invalid.
+
+        Additional Information:
+            The supported subtypes are 'single', 'list', 'c_list', 'average',
+            'c_average', 'accum', 'c_accum'.
+        """
+        if params is None:
+            params = {}
+
+        if subtype not in self._allowed_subtypes:
+            raise ExtensionError(
+                "Invalid data subtype for SaveData instruction.")
+
+        self._key = key
+        self._subtype = subtype
+        super().__init__(name, num_qubits, 0, params)
+
+    def assemble(self):
+        """Return the QasmQobjInstruction for the intructions."""
+        instr = super().assemble()
+        # Use same fields as Snapshot instruction
+        # so we dont need to modify QasmQobjInstruction
+        instr.snapshot_type = self._subtype
+        instr.label = self._key
+        return instr
+
+    def inverse(self):
+        """Special case. Return self."""
+        return copy.copy(self)
+
+
+class SaveAverageData(SaveData):
+    """Save averageble data"""
+    def __init__(self,
+                 name,
+                 key,
+                 num_qubits,
+                 pershot=False,
+                 conditional=False,
+                 unnormalized=False,
+                 params=None):
+        """Create new save data instruction.
+
+        Args:
+            name (str): the name of hte save instruction.
+            key (str): the key for retrieving saved data from results.
+            num_qubits (int): the number of qubits for the snapshot type.
+            pershot (bool): if True save a list of data for each shot of the
+                            simulation rather than the average over  all shots
+                            [Default: False].
+            conditional (bool): if True save the average or pershot data
+                                conditional on the current classical register
+                                values [Default: False].
+            unnormalized (bool): If True return save the unnormalized accumulated
+                                 or conditional accumulated data over all shot.
+                                 [Default: False].
+            params (list or None): Optional, the parameters for instruction
+                                   [Default: None].
+        """
+        if pershot:
+            subtype = 'list'
+        elif unnormalized:
+            subtype = 'accum'
+        else:
+            subtype = 'average'
+        if conditional:
+            subtype = 'c_' + subtype
+        super().__init__(name, key, num_qubits, subtype=subtype, params=params)
+
+
+class SaveSingleData(SaveData):
+    """Save non-averagable single data type."""
+
+    def __init__(self,
+                 name,
+                 key,
+                 num_qubits,
+                 pershot=False,
+                 conditional=False,
+                 params=None):
+        """Create new save data instruction.
+
+        Args:
+            name (str): the name of the save instruction.
+            key (str): the key for retrieving saved data from results.
+            num_qubits (int): the number of qubits for the snapshot type.
+            pershot (bool): if True save a list of data for each shot of the
+                            simulation [Default: False].
+            conditional (bool): if True save pershot data conditional on the
+                                current classical register values
+                                [Default: False].
+            params (list or None): Optional, the parameters for instruction
+                                   [Default: None].
+        """
+        subtype = 'single'
+        if pershot:
+            subtype = 'c_list' if conditional else 'list'
+        super().__init__(name, key, num_qubits, subtype=subtype, params=params)
+
+
+def default_qubits(circuit, qubits=None):
+    """Helper method to return list of qubits.
+
+    Args:
+        circuit (QuantumCircuit): a quantum circuit.
+        qubits (list or QuantumRegister): Optional, qubits argument,
+            If None the returned list will be all qubits in the circuit.
+            [Default: None]
+
+    Raises:
+            ExtensionError: if default qubits fails.
+
+    Returns:
+        list: qubits list.
+    """
+    # Convert label to string for backwards compatibility
+    # If no qubits are specified we add all qubits so it acts as a barrier
+    # This is needed for full register snapshots like statevector
+    if isinstance(qubits, QuantumRegister):
+        qubits = qubits[:]
+    if not qubits:
+        tuples = []
+        if isinstance(circuit, QuantumCircuit):
+            for register in circuit.qregs:
+                tuples.append(register)
+        if not tuples:
+            raise ExtensionError('no qubits for snapshot')
+        qubits = []
+        for tuple_element in tuples:
+            if isinstance(tuple_element, QuantumRegister):
+                for j in range(tuple_element.size):
+                    qubits.append(tuple_element[j])
+            else:
+                qubits.append(tuple_element)
+
+    return qubits

--- a/qiskit/providers/aer/library/save_data.py
+++ b/qiskit/providers/aer/library/save_data.py
@@ -15,11 +15,16 @@ Simulator instruction to save custom internal data to results.
 
 import copy
 
-from qiskit.circuit import Instruction, QuantumCircuit, QuantumRegister
+from qiskit.circuit import QuantumCircuit, QuantumRegister
+# TEMP For compatiblity until Terra PR #5701 is merged
+try:
+    from qiskit.circuit import Directive
+except ImportError:
+    from qiskit.circuit import Instruction as Directive
 from qiskit.extensions.exceptions import ExtensionError
 
 
-class SaveData(Instruction):
+class SaveData(Directive):
     """Pragma Instruction to save simulator data."""
 
     _allowed_subtypes = set([

--- a/qiskit/providers/aer/library/save_expectation_value.py
+++ b/qiskit/providers/aer/library/save_expectation_value.py
@@ -60,8 +60,6 @@ class SaveExpectationValue(SaveAverageData):
             operator = SparsePauliOp(operator)
         elif not isinstance(operator, SparsePauliOp):
             operator = SparsePauliOp.from_operator(Operator(operator))
-        if not isinstance(operator, SparsePauliOp):
-            raise ExtensionError("Invalid input operator")
         if not allclose(operator.coeffs.imag, 0):
             raise ExtensionError("Input operator is not Hermitian.")
         params = _expval_params(operator, variance=False)
@@ -114,8 +112,6 @@ class SaveExpectationValueVariance(SaveAverageData):
             operator = SparsePauliOp(operator)
         elif not isinstance(operator, SparsePauliOp):
             operator = SparsePauliOp.from_operator(Operator(operator))
-        if not isinstance(operator, SparsePauliOp):
-            raise ExtensionError("Invalid input operator")
         if not allclose(operator.coeffs.imag, 0):
             raise ExtensionError("Input operator is not Hermitian.")
         params = _expval_params(operator, variance=True)

--- a/qiskit/providers/aer/library/save_expectation_value.py
+++ b/qiskit/providers/aer/library/save_expectation_value.py
@@ -53,7 +53,7 @@ class SaveExpectationValue(SaveAverageData):
         .. note:
 
             This instruction can be directly appended to a circuit using the
-            :func:`save_expval` circuit method.
+            :func:`save_expectation_value` circuit method.
         """
         # Convert O to SparsePauliOp representation
         if isinstance(operator, Pauli):
@@ -107,7 +107,7 @@ class SaveExpectationValueVariance(SaveAverageData):
 
         .. note:
             This instruction can be directly appended to a circuit using
-            the :func:`save_expval_var` circuit method.
+            the :func:`save_expectation_value` circuit method.
         """
         # Convert O to SparsePauliOp representation
         if isinstance(operator, Pauli):
@@ -161,13 +161,13 @@ def _expval_params(operator, variance=False):
     return list(params.items())
 
 
-def save_expval(self,
-                key,
-                operator,
-                qubits,
-                unnormalized=False,
-                conditional=False,
-                pershot=False):
+def save_expectation_value(self,
+                           key,
+                           operator,
+                           qubits,
+                           unnormalized=False,
+                           conditional=False,
+                           pershot=False):
     r"""Save the expectation value of a Hermitian operator.
 
     Args:
@@ -202,13 +202,13 @@ def save_expval(self,
     return self.append(instr, qubits)
 
 
-def save_expval_var(self,
-                    key,
-                    operator,
-                    qubits,
-                    unnormalized=False,
-                    conditional=False,
-                    pershot=False):
+def save_expectation_value_variance(self,
+                                    key,
+                                    operator,
+                                    qubits,
+                                    unnormalized=False,
+                                    conditional=False,
+                                    pershot=False):
     r"""Save the expectation value of a Hermitian operator.
 
     Args:
@@ -242,5 +242,5 @@ def save_expval_var(self,
     return self.append(instr, qubits)
 
 
-QuantumCircuit.save_expval = save_expval
-QuantumCircuit.save_expval_var = save_expval_var
+QuantumCircuit.save_expectation_value = save_expectation_value
+QuantumCircuit.save_expectation_value_variance = save_expectation_value_variance

--- a/qiskit/providers/aer/library/save_expval.py
+++ b/qiskit/providers/aer/library/save_expval.py
@@ -1,0 +1,189 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Simulator instruction to save exact operator expectation value.
+"""
+
+from numpy import allclose
+from qiskit.quantum_info import Pauli, SparsePauliOp, Operator
+from qiskit.circuit import QuantumCircuit
+from qiskit.extensions.exceptions import ExtensionError
+from .save_data import SaveAverageData
+
+
+class SaveExpval(SaveAverageData):
+    """Save expectation value of an operator."""
+    def __init__(self,
+                 key,
+                 operator,
+                 variance=False,
+                 unnormalized=False,
+                 conditional=False,
+                 pershot=False):
+        r"""Create new a instruction to save the expectation value of a Hermitian operator.
+
+        Args:
+            key (str): the key for retrieving saved data from results.
+            operator (Pauli or SparsePauliOp or Operator): a Hermitian operator.
+            variance (bool): if True save both the expectation value
+                             :math:`\langle O \rangle>`, and the variance
+                             :math:`\sigma^2 = \langle O \rangle^2 - \langle O \rangle>^2`
+                             [Default: False].
+            unnormalized (bool): If True return save the unnormalized accumulated
+                                 or conditional accumulated expectation value
+                                 over all shot [Default: False].
+            pershot (bool): if True save a list of expectation values for each shot
+                            of the simulation rather than the average over
+                            all shots [Default: False].
+            conditional (bool): if True save the average or pershot data
+                                conditional on the current classical register
+                                values [Default: False].
+
+        Raises:
+            ExtensionError: if the input operator is invalid or not Hermitian.
+
+        .. note ::
+
+            In cetain cases the list returned by ``pershot=True`` may only
+            contain a single value, rather than the number of shots. This
+            happens when a run circuit supports measurement sampling because
+            it is either
+
+            1. An ideal simulation with all measurements at the end.
+
+            2. A noisy simulation using the density matrix method with all
+            measurements at the end.
+
+            In both these cases only a single shot is actually simulated and
+            measurement samples for all shots are calculated from the final
+            state.
+        """
+        # Convert O to SparsePauliOp representation
+        if isinstance(operator, Pauli):
+            operator = SparsePauliOp(operator)
+        elif not isinstance(operator, SparsePauliOp):
+            operator = SparsePauliOp.from_operator(Operator(operator))
+        if not isinstance(operator, SparsePauliOp):
+            raise ExtensionError("Invalid input operator")
+        if not allclose(operator.coeffs.imag, 0):
+            raise ExtensionError("Input operator is not Hermitian.")
+        params = _expval_params(operator, variance=variance)
+        self._variance = variance
+        super().__init__('save_expval',
+                         key,
+                         operator.num_qubits,
+                         conditional=conditional,
+                         pershot=pershot,
+                         unnormalized=unnormalized,
+                         params=params)
+
+    def assemble(self):
+        """Return the QasmQobjInstruction for the intructions."""
+        instr = super().assemble()
+        if self._variance:
+            instr.name += '_var'
+        return instr
+
+
+def _expval_params(operator, variance=False):
+
+    # Convert O to SparsePauliOp representation
+    if isinstance(operator, Pauli):
+        operator = SparsePauliOp(operator)
+    elif not isinstance(operator, SparsePauliOp):
+        operator = SparsePauliOp.from_operator(Operator(operator))
+    if not isinstance(operator, SparsePauliOp):
+        raise ExtensionError("Invalid input operator")
+
+    params = {}
+
+    # Add Pauli basis components of O
+    for pauli, coeff in operator.label_iter():
+        if pauli in params:
+            coeff1 = params[pauli][0]
+            params[pauli] = (coeff1 + coeff.real, 0)
+        else:
+            params[pauli] = (coeff.real, 0)
+
+    # Add Pauli basis components of O^2
+    if variance:
+        for pauli, coeff in operator.dot(operator).label_iter():
+            if pauli in params:
+                coeff1, coeff2 = params[pauli]
+                params[pauli] = (coeff1, coeff2 + coeff.real)
+            else:
+                params[pauli] = (0, coeff.real)
+
+    # Convert to list
+    return list(params.items())
+
+
+def save_expval(self,
+                key,
+                operator,
+                qubits,
+                variance=False,
+                unnormalized=False,
+                conditional=False,
+                pershot=False):
+    r"""Save the expectation value of a Hermitian operator.
+
+    Args:
+        key (str): the key for retrieving saved data from results.
+        operator (Pauli or SparsePauliOp or Operator): a Hermitian operator.
+        qubits (list): circuit qubits to apply instruction.
+        variance (bool): if True save both the expectation value
+                         :math:`\langle O \rangle>`, and the variance
+                         :math:`\sigma^2 = \langle O \rangle^2 - \langle O \rangle>^2`
+                         [Default: False].
+        unnormalized (bool): If True return save the unnormalized accumulated
+                             or conditional accumulated expectation value
+                             over all shot [Default: False].
+        pershot (bool): if True save a list of expectation values for each shot
+                        of the simulation rather than the average over
+                        all shots [Default: False].
+        conditional (bool): if True save the average or pershot data
+                            conditional on the current classical register
+                            values [Default: False].
+
+    Returns:
+        QuantumCircuit: with attached instruction.
+
+    Raises:
+        ExtensionError: if the input operator is invalid or not Hermitian.
+
+    .. note ::
+
+        In cetain cases the list returned by ``pershot=True`` may only
+        contain a single value, rather than the number of shots. This
+        happens when a run circuit supports measurement sampling because
+        it is either
+
+        1. An ideal simulation with all measurements at the end.
+
+        2. A noisy simulation using the density matrix method with all
+           measurements at the end.
+
+        In both these cases only a single shot is actually simulated and
+        measurement samples for all shots are calculated from the final
+        state.
+    """
+    instr = SaveExpval(key,
+                       operator,
+                       variance=variance,
+                       unnormalized=unnormalized,
+                       conditional=conditional,
+                       pershot=pershot)
+    return self.append(instr, qubits)
+
+
+QuantumCircuit.save_expval = save_expval

--- a/qiskit/providers/aer/library/save_expval.py
+++ b/qiskit/providers/aer/library/save_expval.py
@@ -20,7 +20,7 @@ from qiskit.extensions.exceptions import ExtensionError
 from .save_data import SaveAverageData
 
 
-class SaveExpval(SaveAverageData):
+class SaveExpectationValue(SaveAverageData):
     """Save expectation value of an operator."""
     def __init__(self,
                  key,
@@ -49,6 +49,11 @@ class SaveExpval(SaveAverageData):
 
         Raises:
             ExtensionError: if the input operator is invalid or not Hermitian.
+
+        .. note:
+
+            This instruction can be directly appended to a circuit using the
+            :func:`save_expval` circuit method.
         """
         # Convert O to SparsePauliOp representation
         if isinstance(operator, Pauli):
@@ -69,8 +74,8 @@ class SaveExpval(SaveAverageData):
                          params=params)
 
 
-class SaveExpvalVar(SaveAverageData):
-    """Save expectation value of an operator."""
+class SaveExpectationValueVariance(SaveAverageData):
+    """Save expectation value and variance of an operator."""
     def __init__(self,
                  key,
                  operator,
@@ -99,6 +104,10 @@ class SaveExpvalVar(SaveAverageData):
 
         Raises:
             ExtensionError: if the input operator is invalid or not Hermitian.
+
+        .. note:
+            This instruction can be directly appended to a circuit using
+            the :func:`save_expval_var` circuit method.
         """
         # Convert O to SparsePauliOp representation
         if isinstance(operator, Pauli):
@@ -168,8 +177,8 @@ def save_expval(self,
         unnormalized (bool): If True return save the unnormalized accumulated
                              or conditional accumulated expectation value
                              over all shot [Default: False].
-        pershot (bool): if True save a list of expectation values for each shot
-                        of the simulation rather than the average over
+        pershot (bool): if True save a list of expectation values for each
+                        shot of the simulation rather than the average over
                         all shots [Default: False].
         conditional (bool): if True save the average or pershot data
                             conditional on the current classical register
@@ -180,12 +189,16 @@ def save_expval(self,
 
     Raises:
         ExtensionError: if the input operator is invalid or not Hermitian.
+
+    .. note:
+        This method appends a :class:`SaveExpectationValue` instruction to
+        the quantum circuit.
     """
-    instr = SaveExpval(key,
-                       operator,
-                       unnormalized=unnormalized,
-                       conditional=conditional,
-                       pershot=pershot)
+    instr = SaveExpectationValue(key,
+                                 operator,
+                                 unnormalized=unnormalized,
+                                 conditional=conditional,
+                                 pershot=pershot)
     return self.append(instr, qubits)
 
 
@@ -205,9 +218,9 @@ def save_expval_var(self,
         unnormalized (bool): If True return save the unnormalized accumulated
                              or conditional accumulated expectation value
                              and variance over all shot [Default: False].
-        pershot (bool): if True save a list of expectation values and variances
-                        for each shot of the simulation rather than the
-                        average over all shots [Default: False].
+        pershot (bool): if True save a list of expectation values and
+                        variances for each shot of the simulation rather than
+                        the average over all shots [Default: False].
         conditional (bool): if True save the data conditional on the current
                             classical register values [Default: False].
 
@@ -216,12 +229,16 @@ def save_expval_var(self,
 
     Raises:
         ExtensionError: if the input operator is invalid or not Hermitian.
+
+    .. note:
+        This method appends a :class:`SaveExpectationValueVariance`
+        instruction to the quantum circuit.
     """
-    instr = SaveExpvalVar(key,
-                          operator,
-                          unnormalized=unnormalized,
-                          conditional=conditional,
-                          pershot=pershot)
+    instr = SaveExpectationValueVariance(key,
+                                         operator,
+                                         unnormalized=unnormalized,
+                                         conditional=conditional,
+                                         pershot=pershot)
     return self.append(instr, qubits)
 
 

--- a/qiskit/providers/aer/library/save_expval.py
+++ b/qiskit/providers/aer/library/save_expval.py
@@ -49,22 +49,6 @@ class SaveExpval(SaveAverageData):
 
         Raises:
             ExtensionError: if the input operator is invalid or not Hermitian.
-
-        .. note ::
-
-            In cetain cases the list returned by ``pershot=True`` may only
-            contain a single value, rather than the number of shots. This
-            happens when a run circuit supports measurement sampling because
-            it is either
-
-            1. An ideal simulation with all measurements at the end.
-
-            2. A noisy simulation using the density matrix method with all
-            measurements at the end.
-
-            In both these cases only a single shot is actually simulated and
-            measurement samples for all shots are calculated from the final
-            state.
         """
         # Convert O to SparsePauliOp representation
         if isinstance(operator, Pauli):
@@ -115,22 +99,6 @@ class SaveExpvalVar(SaveAverageData):
 
         Raises:
             ExtensionError: if the input operator is invalid or not Hermitian.
-
-        .. note ::
-
-            In cetain cases the list returned by ``pershot=True`` may only
-            contain a single value, rather than the number of shots. This
-            happens when a run circuit supports measurement sampling because
-            it is either
-
-            1. An ideal simulation with all measurements at the end.
-
-            2. A noisy simulation using the density matrix method with all
-            measurements at the end.
-
-            In both these cases only a single shot is actually simulated and
-            measurement samples for all shots are calculated from the final
-            state.
         """
         # Convert O to SparsePauliOp representation
         if isinstance(operator, Pauli):
@@ -212,22 +180,6 @@ def save_expval(self,
 
     Raises:
         ExtensionError: if the input operator is invalid or not Hermitian.
-
-    .. note ::
-
-        In cetain cases the list returned by ``pershot=True`` may only
-        contain a single value, rather than the number of shots. This
-        happens when a run circuit supports measurement sampling because
-        it is either
-
-        1. An ideal simulation with all measurements at the end.
-
-        2. A noisy simulation using the density matrix method with all
-           measurements at the end.
-
-        In both these cases only a single shot is actually simulated and
-        measurement samples for all shots are calculated from the final
-        state.
     """
     instr = SaveExpval(key,
                        operator,
@@ -264,22 +216,6 @@ def save_expval_var(self,
 
     Raises:
         ExtensionError: if the input operator is invalid or not Hermitian.
-
-    .. note ::
-
-        In cetain cases the list returned by ``pershot=True`` may only
-        contain a single value, rather than the number of shots. This
-        happens when a run circuit supports measurement sampling because
-        it is either
-
-        1. An ideal simulation with all measurements at the end.
-
-        2. A noisy simulation using the density matrix method with all
-           measurements at the end.
-
-        In both these cases only a single shot is actually simulated and
-        measurement samples for all shots are calculated from the final
-        state.
     """
     instr = SaveExpvalVar(key,
                           operator,

--- a/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
+++ b/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
@@ -7,8 +7,8 @@ features:
     for the simulator state :math:`\rho`.
     
     This instruction can also be appended to a quantum circuit by using the
-    :class:`~qiskit.providers.aer.library.save_expval`` circuit method which
-    is added to ``QuantumCircuit`` when importing Aer.
+    :class:`~qiskit.providers.aer.library.save_.save_expectation_value``
+    circuit method which is added to ``QuantumCircuit`` when importing Aer.
   - |
     Adds a :class:`qiskit.providers.aer.library.SaveExpectationValueVariance`
     quantum circuit instruction for saving the expectation value
@@ -17,5 +17,5 @@ features:
     Hermitian operator :math:`H` for the simulator state :math:`\rho`.
     
     This instruction can also be appended to a quantum circuit by using the
-    :class:`~qiskit.providers.aer.library.save_expval_var`` circuit method which
-    is added to ``QuantumCircuit`` when importing Aer.
+    :class:`~qiskit.providers.aer.library..save_expectation_value_variance``
+    circuit method which is added to ``QuantumCircuit`` when importing Aer.

--- a/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
+++ b/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
@@ -7,7 +7,7 @@ features:
     for the simulator state :math:`\rho`.
     
     This instruction can also be appended to a quantum circuit by using the
-    :class:`~qiskit.providers.aer.library.save_.save_expectation_value``
+    :class:`~qiskit.providers.aer.library.save_expectation_value``
     circuit method which is added to ``QuantumCircuit`` when importing Aer.
   - |
     Adds a :class:`qiskit.providers.aer.library.SaveExpectationValueVariance`
@@ -17,5 +17,5 @@ features:
     Hermitian operator :math:`H` for the simulator state :math:`\rho`.
     
     This instruction can also be appended to a quantum circuit by using the
-    :class:`~qiskit.providers.aer.library..save_expectation_value_variance``
+    :class:`~qiskit.providers.aer.library.save_expectation_value_variance``
     circuit method which is added to ``QuantumCircuit`` when importing Aer.

--- a/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
+++ b/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
@@ -9,7 +9,6 @@ features:
     This instruction can also be appended to a quantum circuit by using the
     :class:`~qiskit.providers.aer.library.save_expval`` circuit method which
     is added to ``QuantumCircuit`` when importing Aer.
-
   - |
     Adds a :class:`qiskit.providers.aer.library.SaveExpvalVar` quantum circuit
     instruction for saving the expectation value

--- a/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
+++ b/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
@@ -1,8 +1,8 @@
 ---
 features:
   - |
-    Adds a :class:`qiskit.providers.aer.library.SaveExpval` quantum circuit
-    instruction for saving the expectation value
+    Adds a :class:`qiskit.providers.aer.library.SaveExpectationValue`
+    quantum circuit instruction for saving the expectation value
     :math:`\langle H\rangle = Tr[H\rho]` of a Hermitian operator :math:`H`
     for the simulator state :math:`\rho`.
     
@@ -10,8 +10,8 @@ features:
     :class:`~qiskit.providers.aer.library.save_expval`` circuit method which
     is added to ``QuantumCircuit`` when importing Aer.
   - |
-    Adds a :class:`qiskit.providers.aer.library.SaveExpvalVar` quantum circuit
-    instruction for saving the expectation value
+    Adds a :class:`qiskit.providers.aer.library.SaveExpectationValueVariance`
+    quantum circuit instruction for saving the expectation value
     :math:`\langle H\rangle = Tr[H\rho]`, and variance
     :math:`Var(H) = \langle H^2\rangle - \langle H\rangle^2`, of a
     Hermitian operator :math:`H` for the simulator state :math:`\rho`.

--- a/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
+++ b/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
@@ -1,0 +1,22 @@
+---
+features:
+  - |
+    Adds a :class:`qiskit.providers.aer.library.SaveExpval` quantum circuit
+    instruction for saving the expectation value
+    :math:`\langle H\rangle = Tr[H\rho]` of a Hermitian operator :math:`H`
+    for the simulator state :math:`\rho`.
+    
+    This instruction can also be appended to a quantum circuit by using the
+    :class:`~qiskit.providers.aer.library.save_expval`` circuit method which
+    is added to ``QuantumCircuit`` when importing Aer.
+
+  - |
+    Adds a :class:`qiskit.providers.aer.library.SaveExpvalVar` quantum circuit
+    instruction for saving the expectation value
+    :math:`\langle H\rangle = Tr[H\rho]`, and variance
+    :math:`Var(H) = \langle H^2\rangle - \langle H\rangle^2`, of a
+    Hermitian operator :math:`H` for the simulator state :math:`\rho`.
+    
+    This instruction can also be appended to a quantum circuit by using the
+    :class:`~qiskit.providers.aer.library.save_expval_var`` circuit method which
+    is added to ``QuantumCircuit`` when importing Aer.

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -91,10 +91,11 @@ public:
   inline void set_random_seed() {seed = std::random_device()();}
 
 private:
-  Operations::OpSet opset_;      // Set of operation types contained in circuit
-  std::set<uint_t> qubitset_;    // Set of qubits used in the circuit
-  std::set<uint_t> memoryset_;   // Set of memory bits used in the circuit
-  std::set<uint_t> registerset_; // Set of register bits used in the circuit
+  Operations::OpSet opset_;       // Set of operation types contained in circuit
+  std::set<uint_t> qubitset_;     // Set of qubits used in the circuit
+  std::set<uint_t> memoryset_;    // Set of memory bits used in the circuit
+  std::set<uint_t> registerset_;  // Set of register bits used in the circuit
+  std::set<std::string> saveset_; // Set of key names for save data instructions
 };
 
 // Json conversion function
@@ -112,6 +113,7 @@ void Circuit::set_params() {
   qubitset_.clear();
   memoryset_.clear();
   registerset_.clear();
+  saveset_.clear();
   can_sample = true;
   first_measure_pos = 0;
 
@@ -126,6 +128,15 @@ void Circuit::set_params() {
     qubitset_.insert(op.qubits.begin(), op.qubits.end());
     memoryset_.insert(op.memory.begin(), op.memory.end());
     registerset_.insert(op.registers.begin(), op.registers.end());
+
+    // Check for duplicate save keys
+    if (Operations::SAVE_TYPES.find(op.type) != Operations::SAVE_TYPES.end()) {
+      auto pair = saveset_.insert(op.string_params[0]);
+      if (!pair.second) {
+        throw std::invalid_argument("Duplicate key \"" + op.string_params[0] +
+                                    "\" in save instruction.");
+      }
+    }
 
     // Compute measure sampling check
     if (can_sample) {

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -41,15 +41,15 @@ enum class OpType {
   // Noise instructions
   kraus, superop, roerror, noise_switch,
   // Save instructions
-  save_expval
+  save_expval, save_expval_var
 };
 
 enum class DataSubType {
-  single, list, c_list, accum, c_accum, average, c_average
+  single, c_single, list, c_list, accum, c_accum, average, c_average
 };
 
 const std::unordered_set<OpType> SAVE_TYPES = {
-  OpType::save_expval
+  OpType::save_expval, OpType::save_expval_var
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
@@ -71,6 +71,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     break;
   case OpType::save_expval:
     stream << "save_expval";
+    break;
+  case OpType::save_expval_var:
+    stream << "save_expval_var";
     break;
   case OpType::snapshot:
     stream << "snapshot";
@@ -147,7 +150,6 @@ struct Op {
 
   // Expvals
   std::vector<std::tuple<std::string, double, double>> expval_params;
-  bool expval_variance = false;
 
   // Legacy Snapshots
   DataSubType save_type = DataSubType::single;
@@ -421,7 +423,7 @@ Op json_to_op_pauli(const json_t &js);
 
 // Save data
 Op json_to_op_save_default(const json_t &js);
-Op json_to_op_save_expval(const json_t &js, bool variance = false);
+Op json_to_op_save_expval(const json_t &js, bool variance);
 
 // Snapshots
 Op json_to_op_snapshot(const json_t &js);
@@ -908,8 +910,8 @@ Op json_to_op_save_expval(const json_t &js, bool variance) {
 
   // Initialized default save instruction params
   Op op = json_to_op_save_default(js);
-  op.type = OpType::save_expval;
-  op.expval_variance = variance;
+  op.type = (variance) ? OpType::save_expval_var
+                       : OpType::save_expval;
 
   // Parse Pauli operator components
   const auto threshold = 1e-12; // drop small components

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -48,7 +48,7 @@ enum class DataSubType {
   single, c_single, list, c_list, accum, c_accum, average, c_average
 };
 
-const std::unordered_set<OpType> SAVE_TYPES = {
+static const std::unordered_set<OpType> SAVE_TYPES = {
   OpType::save_expval, OpType::save_expval_var
 };
 
@@ -871,7 +871,7 @@ Op json_to_op_save_default(const json_t &js) {
   JSON::get_value(op.name, "name", js);
 
   // Handle default types type
-  const std::unordered_map<std::string, OpType> default_names;
+  static const std::unordered_map<std::string, OpType> default_names;
   // NOTE: these will be added later
   auto type_it = default_names.find(op.name);
   if (type_it != default_names.end()) {
@@ -879,7 +879,7 @@ Op json_to_op_save_default(const json_t &js) {
   }
 
   // Get subtype
-  const std::unordered_map<std::string, DataSubType> subtypes {
+  static const std::unordered_map<std::string, DataSubType> subtypes {
     {"single", DataSubType::single},
     {"average", DataSubType::average},
     {"c_average", DataSubType::c_average},

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -37,8 +37,19 @@ enum class RegComparison {Equal, NotEqual, Less, LessEqual, Greater, GreaterEqua
 // Enum class for operation types
 enum class OpType {
   gate, measure, reset, bfunc, barrier, snapshot,
-  matrix, diagonal_matrix, multiplexer, kraus, superop, roerror,
-  noise_switch, initialize, sim_op, nop
+  matrix, diagonal_matrix, multiplexer, initialize, sim_op, nop,
+  // Noise instructions
+  kraus, superop, roerror, noise_switch,
+  // Save instructions
+  save_expval
+};
+
+enum class DataSubType {
+  single, list, c_list, accum, c_accum, average, c_average
+};
+
+const std::unordered_set<OpType> SAVE_TYPES = {
+  OpType::save_expval
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
@@ -57,6 +68,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     break;
   case OpType::barrier:
     stream << "barrier";
+    break;
+  case OpType::save_expval:
+    stream << "save_expval";
     break;
   case OpType::snapshot:
     stream << "snapshot";
@@ -131,7 +145,12 @@ struct Op {
   // Readout error
   std::vector<rvector_t> probs;
 
-  // Snapshots
+  // Expvals
+  std::vector<std::tuple<std::string, double, double>> expval_params;
+  bool expval_variance = false;
+
+  // Legacy Snapshots
+  DataSubType save_type = DataSubType::single;
   using pauli_component_t = std::pair<complex_t, std::string>; // Pair (coeff, label_string)
   using matrix_component_t = std::pair<complex_t, std::vector<std::pair<reg_t, cmatrix_t>>>; // vector of Pair(qubits, matrix), combined with coefficient
   std::vector<pauli_component_t> params_expval_pauli;
@@ -400,6 +419,10 @@ Op json_to_op_bfunc(const json_t &js);
 Op json_to_op_initialize(const json_t &js);
 Op json_to_op_pauli(const json_t &js);
 
+// Save data
+Op json_to_op_save_default(const json_t &js);
+Op json_to_op_save_expval(const json_t &js, bool variance = false);
+
 // Snapshots
 Op json_to_op_snapshot(const json_t &js);
 Op json_to_op_snapshot_default(const json_t &js);
@@ -449,6 +472,11 @@ Op json_to_op(const json_t &js) {
     return json_to_op_diagonal(js);
   if (name == "superop")
     return json_to_op_superop(js);
+  // Save
+  if (name == "save_expval")
+    return json_to_op_save_expval(js, false);
+  if (name == "save_expval_var")
+    return json_to_op_save_expval(js, true);
   // Snapshot
   if (name == "snapshot")
     return json_to_op_snapshot(js);
@@ -833,6 +861,88 @@ Op json_to_op_noise_switch(const json_t &js) {
 }
 
 //------------------------------------------------------------------------------
+// Implementation: Save data deserialization
+//------------------------------------------------------------------------------
+
+Op json_to_op_save_default(const json_t &js) {
+  Op op;
+  JSON::get_value(op.name, "name", js);
+
+  // Handle default types type
+  const std::unordered_map<std::string, OpType> default_names;
+  // NOTE: these will be added later
+  auto type_it = default_names.find(op.name);
+  if (type_it != default_names.end()) {
+    op.type = type_it->second;
+  }
+
+  // Get subtype
+  const std::unordered_map<std::string, DataSubType> subtypes {
+    {"single", DataSubType::single},
+    {"average", DataSubType::average},
+    {"c_average", DataSubType::c_average},
+    {"list", DataSubType::list},
+    {"c_list", DataSubType::c_list},
+    {"accum", DataSubType::accum},
+    {"c_accum", DataSubType::c_accum},
+  };
+  std::string subtype;
+  JSON::get_value(subtype, "snapshot_type", js);
+  auto subtype_it = subtypes.find(subtype);
+  if (subtype_it == subtypes.end()) {
+    throw std::runtime_error("Invalid data subtype \"" + subtype +
+                             "\" in save data instruction.");
+  }
+  op.save_type = subtype_it->second;
+ 
+  // Get data key
+  op.string_params.emplace_back("");
+  JSON::get_value(op.string_params[0], "label", js);
+
+  // Add optional qubits field
+  JSON::get_value(op.qubits, "qubits", js);
+  return op;
+}
+
+Op json_to_op_save_expval(const json_t &js, bool variance) {
+
+  // Initialized default save instruction params
+  Op op = json_to_op_save_default(js);
+  op.type = OpType::save_expval;
+  op.expval_variance = variance;
+
+  // Parse Pauli operator components
+  const auto threshold = 1e-12; // drop small components
+  // Get components
+  if (JSON::check_key("params", js) && js["params"].is_array()) {
+    for (const auto &comp : js["params"]) {
+      // Get complex coefficient
+      std::vector<double> coeffs = comp[1];
+      if (std::abs(coeffs[0]) > threshold || std::abs(coeffs[1]) > threshold) {
+        std::string pauli = comp[0];
+        if (pauli.size() != op.qubits.size()) {
+          throw std::invalid_argument(std::string("Invalid expectation value save instruction ") +
+                                      "(Pauli label does not match qubit number.).");
+        }
+        op.expval_params.emplace_back(pauli, coeffs[0], coeffs[1]);
+      }
+    }
+  } else {
+    throw std::invalid_argument("Invalid save expectation value \"params\".");
+  }
+
+  // Check edge case of all coefficients being empty
+  // In this case the operator had all coefficients zero, or sufficiently close
+  // to zero that they were all truncated.
+  if (op.expval_params.empty()) {
+    std::string pauli(op.qubits.size(), 'I');
+    op.expval_params.emplace_back(pauli, 0., 0.);
+  }
+
+  return op;
+}
+
+//------------------------------------------------------------------------------
 // Implementation: Snapshot deserialization
 //------------------------------------------------------------------------------
 
@@ -890,21 +1000,15 @@ Op json_to_op_snapshot_amplitudes(const json_t &js) {
 
 
 Op json_to_op_snapshot_pauli(const json_t &js) {
-  // Load default snapshot parameters
   Op op = json_to_op_snapshot_default(js);
 
-  // Check qubits are valid
-  check_empty_qubits(op);
-  check_duplicate_qubits(op);
-
-  // Parse Pauli operator components
   const auto threshold = 1e-15; // drop small components
   // Get components
   if (JSON::check_key("params", js) && js["params"].is_array()) {
     for (const auto &comp : js["params"]) {
       // Check component is length-2 array
       if (!comp.is_array() || comp.size() != 2)
-        throw std::invalid_argument("Invalid Pauli expval snapshot (param component " + 
+        throw std::invalid_argument("Invalid Pauli expval params (param component " + 
                                     comp.dump() + " invalid).");
       // Get complex coefficient
       complex_t coeff = comp[0];
@@ -925,7 +1029,7 @@ Op json_to_op_snapshot_pauli(const json_t &js) {
       } // end if > threshold
     } // end component loop
   } else {
-    throw std::invalid_argument("Invalid Pauli snapshot \"params\".");
+    throw std::invalid_argument("Invalid Pauli expectation value value snapshot \"params\".");
   }
   // Check edge case of all coefficients being empty
   // In this case the operator had all coefficients zero, or sufficiently close
@@ -936,6 +1040,7 @@ Op json_to_op_snapshot_pauli(const json_t &js) {
     complex_t coeff(0);
     op.params_expval_pauli.emplace_back(coeff, pauli);
   }
+
   return op;
 }
 

--- a/src/framework/results/data/data.hpp
+++ b/src/framework/results/data/data.hpp
@@ -24,6 +24,8 @@
 
 // Data Containers
 #include "framework/results/data/mixins/data_creg.hpp"
+#include "framework/results/data/mixins/data_rvalue.hpp"
+#include "framework/results/data/mixins/data_rvector.hpp"
 #include "framework/results/data/mixins/data_cmatrix.hpp"
 #include "framework/results/data/mixins/data_cvector.hpp"
 
@@ -33,7 +35,9 @@ namespace AER {
 // Result container for Qiskit-Aer
 //============================================================================
 
-struct Data : public DataCReg,
+struct Data : public DataCreg,
+              public DataRValue,
+              public DataRVector,
               public DataCVector,
               public DataCMatrix {
 
@@ -124,17 +128,21 @@ struct Data : public DataCReg,
 //------------------------------------------------------------------------------
 
 Data &Data::combine(Data &&other) {
+  DataRValue::combine(std::move(other));
+  DataRVector::combine(std::move(other));
   DataCVector::combine(std::move(other));
   DataCMatrix::combine(std::move(other));
-  DataCReg::combine(std::move(other));
+  DataCreg::combine(std::move(other));
   return *this;
 }
 
 json_t Data::to_json() {
   json_t result;
+  DataRValue::add_to_json(result);
+  DataRVector::add_to_json(result);
   DataCVector::add_to_json(result);
   DataCMatrix::add_to_json(result);
-  DataCReg::add_to_json(result);
+  DataCreg::add_to_json(result);
   return result;
 }
 

--- a/src/framework/results/data/mixins/data_cmatrix.hpp
+++ b/src/framework/results/data/mixins/data_cmatrix.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/mixins/data_creg.hpp
+++ b/src/framework/results/data/mixins/data_creg.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/mixins/data_creg.hpp
+++ b/src/framework/results/data/mixins/data_creg.hpp
@@ -26,27 +26,27 @@ namespace AER {
 // Result container for Qiskit-Aer
 //============================================================================
 
-struct DataCReg : public DataMap<AccumData, uint_t, 2>,     // Counts
+struct DataCreg : public DataMap<AccumData, uint_t, 2>,     // Counts
                   public DataMap<ListData, std::string, 1>  // Memory
 {
   // Serialize engine data to JSON
   void add_to_json(json_t &result);
 
   // Combine stored data
-  DataCReg &combine(DataCReg &&other);
+  DataCreg &combine(DataCreg &&other);
 };
 
 //------------------------------------------------------------------------------
 // Implementation
 //------------------------------------------------------------------------------
 
-DataCReg &DataCReg::combine(DataCReg &&other) {
+DataCreg &DataCreg::combine(DataCreg &&other) {
   DataMap<ListData, std::string, 1>::combine(std::move(other));
   DataMap<AccumData, uint_t, 2>::combine(std::move(other));
   return *this;
 }
 
-void DataCReg::add_to_json(json_t &result) {
+void DataCreg::add_to_json(json_t &result) {
   DataMap<ListData, std::string, 1>::add_to_json(result);
   DataMap<AccumData, uint_t, 2>::add_to_json(result);
 }

--- a/src/framework/results/data/mixins/data_cvector.hpp
+++ b/src/framework/results/data/mixins/data_cvector.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/mixins/data_rvalue.hpp
+++ b/src/framework/results/data/mixins/data_rvalue.hpp
@@ -1,0 +1,75 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2021.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_results_data_rvalue_hpp_
+#define _aer_framework_results_data_rvalue_hpp_
+
+#include "framework/results/data/subtypes/data_map.hpp"
+#include "framework/results/data/subtypes/accum_data.hpp"
+#include "framework/results/data/subtypes/average_data.hpp"
+#include "framework/results/data/subtypes/list_data.hpp"
+#include "framework/results/data/subtypes/single_data.hpp"
+#include "framework/types.hpp"
+
+namespace AER {
+
+//============================================================================
+// Result container for Qiskit-Aer
+//============================================================================
+
+struct DataRValue :
+    public DataMap<SingleData, double, 1>,
+    public DataMap<ListData, double, 1>,
+    public DataMap<ListData, double, 2>,
+    public DataMap<AccumData, double, 1>,
+    public DataMap<AccumData, double, 2>,
+    public DataMap<AverageData, double, 1>,
+    public DataMap<AverageData, double, 2> {
+
+  // Serialize engine data to JSON
+  void add_to_json(json_t &result);
+
+  // Combine stored data
+  DataRValue &combine(DataRValue &&other);
+};
+
+//------------------------------------------------------------------------------
+// Implementation
+//------------------------------------------------------------------------------
+
+DataRValue &DataRValue::combine(DataRValue &&other) {
+  DataMap<SingleData, double, 1>::combine(std::move(other));
+  DataMap<ListData, double, 1>::combine(std::move(other));
+  DataMap<ListData, double, 2>::combine(std::move(other));
+  DataMap<AccumData, double, 1>::combine(std::move(other));
+  DataMap<AccumData, double, 2>::combine(std::move(other));
+  DataMap<AverageData, double, 1>::combine(std::move(other));
+  DataMap<AverageData, double, 2>::combine(std::move(other));
+  return *this;
+}
+
+void DataRValue::add_to_json(json_t &result) {
+  DataMap<SingleData, double, 1>::add_to_json(result);
+  DataMap<ListData, double, 1>::add_to_json(result);
+  DataMap<ListData, double, 2>::add_to_json(result);
+  DataMap<AccumData, double, 1>::add_to_json(result);
+  DataMap<AccumData, double, 2>::add_to_json(result);
+  DataMap<AverageData, double, 1>::add_to_json(result);
+  DataMap<AverageData, double, 2>::add_to_json(result);
+}
+
+//------------------------------------------------------------------------------
+} // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/results/data/mixins/data_rvalue.hpp
+++ b/src/framework/results/data/mixins/data_rvalue.hpp
@@ -29,7 +29,6 @@ namespace AER {
 //============================================================================
 
 struct DataRValue :
-    public DataMap<SingleData, double, 1>,
     public DataMap<ListData, double, 1>,
     public DataMap<ListData, double, 2>,
     public DataMap<AccumData, double, 1>,
@@ -49,7 +48,6 @@ struct DataRValue :
 //------------------------------------------------------------------------------
 
 DataRValue &DataRValue::combine(DataRValue &&other) {
-  DataMap<SingleData, double, 1>::combine(std::move(other));
   DataMap<ListData, double, 1>::combine(std::move(other));
   DataMap<ListData, double, 2>::combine(std::move(other));
   DataMap<AccumData, double, 1>::combine(std::move(other));
@@ -60,7 +58,6 @@ DataRValue &DataRValue::combine(DataRValue &&other) {
 }
 
 void DataRValue::add_to_json(json_t &result) {
-  DataMap<SingleData, double, 1>::add_to_json(result);
   DataMap<ListData, double, 1>::add_to_json(result);
   DataMap<ListData, double, 2>::add_to_json(result);
   DataMap<AccumData, double, 1>::add_to_json(result);

--- a/src/framework/results/data/mixins/data_rvector.hpp
+++ b/src/framework/results/data/mixins/data_rvector.hpp
@@ -1,0 +1,74 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2021.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_results_data_rvector_hpp_
+#define _aer_framework_results_data_rvector_hpp_
+
+#include "framework/results/data/subtypes/data_map.hpp"
+#include "framework/results/data/subtypes/list_data.hpp"
+#include "framework/results/data/subtypes/single_data.hpp"
+#include "framework/results/data/subtypes/accum_data.hpp"
+#include "framework/results/data/subtypes/average_data.hpp"
+#include "framework/types.hpp"
+
+namespace AER {
+
+//============================================================================
+// Result container for Qiskit-Aer
+//============================================================================
+
+struct DataRVector : public DataMap<SingleData, Vector<double>, 1>,
+                     public DataMap<ListData, Vector<double>, 1>,
+                     public DataMap<ListData, Vector<double>, 2>,
+                     public DataMap<AccumData, Vector<double>, 1>,
+                     public DataMap<AccumData, Vector<double>, 2>,
+                     public DataMap<AverageData, Vector<double>, 1>,
+                     public DataMap<AverageData, Vector<double>, 2> {
+
+  // Serialize engine data to JSON
+  void add_to_json(json_t &result);
+
+  // Combine stored data
+  DataRVector &combine(DataRVector &&other);
+};
+
+//------------------------------------------------------------------------------
+// Implementation
+//------------------------------------------------------------------------------
+
+DataRVector &DataRVector::combine(DataRVector &&other) {
+  DataMap<SingleData, Vector<double>, 1>::combine(std::move(other));
+  DataMap<ListData, Vector<double>, 1>::combine(std::move(other));
+  DataMap<ListData, Vector<double>, 2>::combine(std::move(other));
+  DataMap<AccumData, Vector<double>, 1>::combine(std::move(other));
+  DataMap<AccumData, Vector<double>, 2>::combine(std::move(other));
+  DataMap<AverageData, Vector<double>, 1>::combine(std::move(other));
+  DataMap<AverageData, Vector<double>, 2>::combine(std::move(other));
+  return *this;
+}
+
+void DataRVector::add_to_json(json_t &result) {
+  DataMap<SingleData, Vector<double>, 1>::add_to_json(result);
+  DataMap<ListData, Vector<double>, 1>::add_to_json(result);
+  DataMap<ListData, Vector<double>, 2>::add_to_json(result);
+  DataMap<AccumData, Vector<double>, 1>::add_to_json(result);
+  DataMap<AccumData, Vector<double>, 2>::add_to_json(result);
+  DataMap<AverageData, Vector<double>, 1>::add_to_json(result);
+  DataMap<AverageData, Vector<double>, 2>::add_to_json(result);
+}
+
+//------------------------------------------------------------------------------
+} // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/results/data/mixins/data_rvector.hpp
+++ b/src/framework/results/data/mixins/data_rvector.hpp
@@ -28,13 +28,13 @@ namespace AER {
 // Result container for Qiskit-Aer
 //============================================================================
 
-struct DataRVector : public DataMap<SingleData, Vector<double>, 1>,
-                     public DataMap<ListData, Vector<double>, 1>,
-                     public DataMap<ListData, Vector<double>, 2>,
-                     public DataMap<AccumData, Vector<double>, 1>,
-                     public DataMap<AccumData, Vector<double>, 2>,
-                     public DataMap<AverageData, Vector<double>, 1>,
-                     public DataMap<AverageData, Vector<double>, 2> {
+struct DataRVector : public DataMap<SingleData, std::vector<double>, 1>,
+                     public DataMap<ListData, std::vector<double>, 1>,
+                     public DataMap<ListData, std::vector<double>, 2>,
+                     public DataMap<AccumData, std::vector<double>, 1>,
+                     public DataMap<AccumData, std::vector<double>, 2>,
+                     public DataMap<AverageData, std::vector<double>, 1>,
+                     public DataMap<AverageData, std::vector<double>, 2> {
 
   // Serialize engine data to JSON
   void add_to_json(json_t &result);
@@ -48,24 +48,24 @@ struct DataRVector : public DataMap<SingleData, Vector<double>, 1>,
 //------------------------------------------------------------------------------
 
 DataRVector &DataRVector::combine(DataRVector &&other) {
-  DataMap<SingleData, Vector<double>, 1>::combine(std::move(other));
-  DataMap<ListData, Vector<double>, 1>::combine(std::move(other));
-  DataMap<ListData, Vector<double>, 2>::combine(std::move(other));
-  DataMap<AccumData, Vector<double>, 1>::combine(std::move(other));
-  DataMap<AccumData, Vector<double>, 2>::combine(std::move(other));
-  DataMap<AverageData, Vector<double>, 1>::combine(std::move(other));
-  DataMap<AverageData, Vector<double>, 2>::combine(std::move(other));
+  DataMap<SingleData, std::vector<double>, 1>::combine(std::move(other));
+  DataMap<ListData, std::vector<double>, 1>::combine(std::move(other));
+  DataMap<ListData, std::vector<double>, 2>::combine(std::move(other));
+  DataMap<AccumData, std::vector<double>, 1>::combine(std::move(other));
+  DataMap<AccumData, std::vector<double>, 2>::combine(std::move(other));
+  DataMap<AverageData, std::vector<double>, 1>::combine(std::move(other));
+  DataMap<AverageData, std::vector<double>, 2>::combine(std::move(other));
   return *this;
 }
 
 void DataRVector::add_to_json(json_t &result) {
-  DataMap<SingleData, Vector<double>, 1>::add_to_json(result);
-  DataMap<ListData, Vector<double>, 1>::add_to_json(result);
-  DataMap<ListData, Vector<double>, 2>::add_to_json(result);
-  DataMap<AccumData, Vector<double>, 1>::add_to_json(result);
-  DataMap<AccumData, Vector<double>, 2>::add_to_json(result);
-  DataMap<AverageData, Vector<double>, 1>::add_to_json(result);
-  DataMap<AverageData, Vector<double>, 2>::add_to_json(result);
+  DataMap<SingleData, std::vector<double>, 1>::add_to_json(result);
+  DataMap<ListData, std::vector<double>, 1>::add_to_json(result);
+  DataMap<ListData, std::vector<double>, 2>::add_to_json(result);
+  DataMap<AccumData, std::vector<double>, 1>::add_to_json(result);
+  DataMap<AccumData, std::vector<double>, 2>::add_to_json(result);
+  DataMap<AverageData, std::vector<double>, 1>::add_to_json(result);
+  DataMap<AverageData, std::vector<double>, 2>::add_to_json(result);
 }
 
 //------------------------------------------------------------------------------

--- a/src/framework/results/data/mixins/data_rvector.hpp
+++ b/src/framework/results/data/mixins/data_rvector.hpp
@@ -28,8 +28,7 @@ namespace AER {
 // Result container for Qiskit-Aer
 //============================================================================
 
-struct DataRVector : public DataMap<SingleData, std::vector<double>, 1>,
-                     public DataMap<ListData, std::vector<double>, 1>,
+struct DataRVector : public DataMap<ListData, std::vector<double>, 1>,
                      public DataMap<ListData, std::vector<double>, 2>,
                      public DataMap<AccumData, std::vector<double>, 1>,
                      public DataMap<AccumData, std::vector<double>, 2>,
@@ -48,7 +47,6 @@ struct DataRVector : public DataMap<SingleData, std::vector<double>, 1>,
 //------------------------------------------------------------------------------
 
 DataRVector &DataRVector::combine(DataRVector &&other) {
-  DataMap<SingleData, std::vector<double>, 1>::combine(std::move(other));
   DataMap<ListData, std::vector<double>, 1>::combine(std::move(other));
   DataMap<ListData, std::vector<double>, 2>::combine(std::move(other));
   DataMap<AccumData, std::vector<double>, 1>::combine(std::move(other));
@@ -59,7 +57,6 @@ DataRVector &DataRVector::combine(DataRVector &&other) {
 }
 
 void DataRVector::add_to_json(json_t &result) {
-  DataMap<SingleData, std::vector<double>, 1>::add_to_json(result);
   DataMap<ListData, std::vector<double>, 1>::add_to_json(result);
   DataMap<ListData, std::vector<double>, 2>::add_to_json(result);
   DataMap<AccumData, std::vector<double>, 1>::add_to_json(result);

--- a/src/framework/results/data/mixins/pybind_data_cmatrix.hpp
+++ b/src/framework/results/data/mixins/pybind_data_cmatrix.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/mixins/pybind_data_creg.hpp
+++ b/src/framework/results/data/mixins/pybind_data_creg.hpp
@@ -24,11 +24,11 @@
 
 namespace AerToPy {
 
-// Move an DataCReg container object to a new Python dict
-py::object to_python(AER::DataCReg &&data);
+// Move an DataCreg container object to a new Python dict
+py::object to_python(AER::DataCreg &&data);
 
-// Move an DataCReg container object to an existing new Python dict
-void add_to_python(py::dict &pydata, AER::DataCReg &&data);
+// Move an DataCreg container object to an existing new Python dict
+void add_to_python(py::dict &pydata, AER::DataCreg &&data);
 
 } //end namespace AerToPy
 
@@ -37,13 +37,13 @@ void add_to_python(py::dict &pydata, AER::DataCReg &&data);
 // Implementations
 //============================================================================
 
-py::object AerToPy::to_python(AER::DataCReg &&data) {
+py::object AerToPy::to_python(AER::DataCreg &&data) {
   py::dict pydata;
   AerToPy::add_to_python(pydata, std::move(data));
   return std::move(pydata);
 }
 
-void AerToPy::add_to_python(py::dict &pydata, AER::DataCReg &&data) {
+void AerToPy::add_to_python(py::dict &pydata, AER::DataCreg &&data) {
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, std::string, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, AER::uint_t, 2>&&>(data));
 }

--- a/src/framework/results/data/mixins/pybind_data_creg.hpp
+++ b/src/framework/results/data/mixins/pybind_data_creg.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/mixins/pybind_data_cvector.hpp
+++ b/src/framework/results/data/mixins/pybind_data_cvector.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/mixins/pybind_data_rvalue.hpp
+++ b/src/framework/results/data/mixins/pybind_data_rvalue.hpp
@@ -1,0 +1,56 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2021.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_result_data_pybind_data_rvalue_hpp_
+#define _aer_framework_result_data_pybind_data_rvalue_hpp_
+
+#include "framework/results/data/mixins/data_rvalue.hpp"
+#include "framework/results/data/subtypes/pybind_data_map.hpp"
+
+//------------------------------------------------------------------------------
+// Aer C++ -> Python Conversion
+//------------------------------------------------------------------------------
+
+namespace AerToPy {
+
+// Move an DataRValue container object to a new Python dict
+py::object to_python(AER::DataRValue &&data);
+
+// Move an DataRValue container object to an existing new Python dict
+void add_to_python(py::dict &pydata, AER::DataRValue &&data);
+
+} //end namespace AerToPy
+
+
+//============================================================================
+// Implementations
+//============================================================================
+
+py::object AerToPy::to_python(AER::DataRValue &&data) {
+  py::dict pydata;
+  AerToPy::add_to_python(pydata, std::move(data));
+  return std::move(pydata);
+}
+
+void AerToPy::add_to_python(py::dict &pydata, AER::DataRValue &&data) {
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, double, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, double, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, double, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, double, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, double, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AverageData, double, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AverageData, double, 2>&&>(data));
+}
+
+#endif

--- a/src/framework/results/data/mixins/pybind_data_rvalue.hpp
+++ b/src/framework/results/data/mixins/pybind_data_rvalue.hpp
@@ -44,7 +44,6 @@ py::object AerToPy::to_python(AER::DataRValue &&data) {
 }
 
 void AerToPy::add_to_python(py::dict &pydata, AER::DataRValue &&data) {
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, double, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, double, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, double, 2>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, double, 1>&&>(data));

--- a/src/framework/results/data/mixins/pybind_data_rvector.hpp
+++ b/src/framework/results/data/mixins/pybind_data_rvector.hpp
@@ -1,0 +1,56 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2021.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_result_data_pybind_data_rvector_hpp_
+#define _aer_framework_result_data_pybind_data_rvector_hpp_
+
+#include "framework/results/data/mixins/data_rvector.hpp"
+#include "framework/results/data/subtypes/pybind_data_map.hpp"
+
+//------------------------------------------------------------------------------
+// Aer C++ -> Python Conversion
+//------------------------------------------------------------------------------
+
+namespace AerToPy {
+
+// Move an DataRVector container object to a new Python dict
+py::object to_python(AER::DataRVector &&data);
+
+// Move an DataRVector container object to an existing new Python dict
+void add_to_python(py::dict &pydata, AER::DataRVector &&data);
+
+} //end namespace AerToPy
+
+
+//============================================================================
+// Implementations
+//============================================================================
+
+py::object AerToPy::to_python(AER::DataRVector &&data) {
+  py::dict pydata;
+  AerToPy::add_to_python(pydata, std::move(data));
+  return std::move(pydata);
+}
+
+void AerToPy::add_to_python(py::dict &pydata, AER::DataRVector &&data) {
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, AER::Vector<double>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, AER::Vector<double>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, AER::Vector<double>, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, AER::Vector<double>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, AER::Vector<double>, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AverageData, AER::Vector<double>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AverageData, AER::Vector<double>, 2>&&>(data));
+}
+
+#endif

--- a/src/framework/results/data/mixins/pybind_data_rvector.hpp
+++ b/src/framework/results/data/mixins/pybind_data_rvector.hpp
@@ -44,13 +44,13 @@ py::object AerToPy::to_python(AER::DataRVector &&data) {
 }
 
 void AerToPy::add_to_python(py::dict &pydata, AER::DataRVector &&data) {
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, AER::Vector<double>, 1>&&>(data));
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, AER::Vector<double>, 1>&&>(data));
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, AER::Vector<double>, 2>&&>(data));
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, AER::Vector<double>, 1>&&>(data));
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, AER::Vector<double>, 2>&&>(data));
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AverageData, AER::Vector<double>, 1>&&>(data));
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AverageData, AER::Vector<double>, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, std::vector<double>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, std::vector<double>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, std::vector<double>, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, std::vector<double>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, std::vector<double>, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AverageData, std::vector<double>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AverageData, std::vector<double>, 2>&&>(data));
 }
 
 #endif

--- a/src/framework/results/data/mixins/pybind_data_rvector.hpp
+++ b/src/framework/results/data/mixins/pybind_data_rvector.hpp
@@ -44,7 +44,6 @@ py::object AerToPy::to_python(AER::DataRVector &&data) {
 }
 
 void AerToPy::add_to_python(py::dict &pydata, AER::DataRVector &&data) {
-  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, std::vector<double>, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, std::vector<double>, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, std::vector<double>, 2>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::AccumData, std::vector<double>, 1>&&>(data));

--- a/src/framework/results/data/pybind_data.hpp
+++ b/src/framework/results/data/pybind_data.hpp
@@ -17,6 +17,8 @@
 
 #include "framework/results/data/data.hpp"
 #include "framework/results/data/mixins/pybind_data_creg.hpp"
+#include "framework/results/data/mixins/pybind_data_rvalue.hpp"
+#include "framework/results/data/mixins/pybind_data_rvector.hpp"
 #include "framework/results/data/mixins/pybind_data_cmatrix.hpp"
 #include "framework/results/data/mixins/pybind_data_cvector.hpp"
 
@@ -35,9 +37,11 @@ template <> py::object to_python(AER::Data &&data);
 template <>
 py::object AerToPy::to_python(AER::Data &&data) {
   py::dict pydata;
+  AerToPy::add_to_python(pydata, static_cast<AER::DataRValue&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataRVector&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataCVector&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataCMatrix&&>(data));
-  AerToPy::add_to_python(pydata, static_cast<AER::DataCReg&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataCreg&&>(data));
   return std::move(pydata);
 }
 

--- a/src/framework/results/data/subtypes/accum_data.hpp
+++ b/src/framework/results/data/subtypes/accum_data.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/subtypes/average_data.hpp
+++ b/src/framework/results/data/subtypes/average_data.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/subtypes/data_map.hpp
+++ b/src/framework/results/data/subtypes/data_map.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/subtypes/list_data.hpp
+++ b/src/framework/results/data/subtypes/list_data.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/subtypes/pybind_data_map.hpp
+++ b/src/framework/results/data/subtypes/pybind_data_map.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/subtypes/pybind_subtypes.hpp
+++ b/src/framework/results/data/subtypes/pybind_subtypes.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/framework/results/data/subtypes/single_data.hpp
+++ b/src/framework/results/data/subtypes/single_data.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2020.
+ * (C) Copyright IBM 2021.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -185,7 +185,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -483,7 +483,7 @@ void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
 //=========================================================================
 
 template <class statevec_t>
-double State<statevec_t>::pauli_expval(const reg_t &qubits,
+double State<statevec_t>::expval_pauli(const reg_t &qubits,
                                        const std::string& pauli) {
   return BaseState::qreg_.expval_pauli(qubits, pauli);
 }
@@ -572,7 +572,7 @@ void State<densmat_t>::snapshot_pauli_expval(const Operations::Op &op,
   for (const auto &param : op.params_expval_pauli) {
     const auto &coeff = param.first;
     const auto &pauli = param.second;
-    expval += coeff * pauli_expval(op.qubits, pauli);
+    expval += coeff * expval_pauli(op.qubits, pauli);
   }
 
   // Add to snapshot

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -45,7 +45,8 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::barrier, Operations::OpType::bfunc,
      Operations::OpType::roerror, Operations::OpType::matrix,
      Operations::OpType::diagonal_matrix, Operations::OpType::kraus,
-     Operations::OpType::superop, Operations::OpType::save_expval},
+     Operations::OpType::superop, Operations::OpType::save_expval,
+     Operations::OpType::save_expval_var},
     // Gates
     {"U",    "CX",  "u1", "u2",  "u3", "u",   "cx",   "cy",  "cz",
      "swap", "id",  "x",  "y",   "z",  "h",   "s",    "sdg", "t",
@@ -466,6 +467,7 @@ void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
           apply_kraus(op.qubits, op.mats);
           break;
         case Operations::OpType::save_expval:
+        case Operations::OpType::save_expval_var:
           BaseState::apply_save_expval(op, result);
           break;
         default:

--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -586,23 +586,110 @@ void State<densmat_t>::apply_chunk_swap(const reg_t &qubits)
 
 template <class statevec_t>
 double State<statevec_t>::expval_pauli(const reg_t &qubits,
-                                       const std::string& pauli) {
-
-  // Accumulate expval across chunks
+                                       const std::string& pauli) 
+{
+  reg_t qubits_in_chunk;
+  reg_t qubits_out_chunk;
+  std::string pauli_in_chunk;
+  std::string pauli_out_chunk;
+  int_t i,n;
   double expval(0.);
-  int_t i;
-  #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
-    for(i=0;i<BaseState::num_local_chunks_;i++){
-      uint_t irow,icol;
-      irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_)/2);
-      icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)/2));
-      if(irow == icol){   //only diagonal chunks are calculated
-        expval += BaseState::qregs_[i].expval_pauli(qubits, pauli);
+
+  //get inner/outer chunk pauli string
+  n = pauli.size();
+  for(i=0;i<n;i++){
+    if(qubits[i] < BaseState::chunk_bits_/2){
+      qubits_in_chunk.push_back(qubits[i]);
+      pauli_in_chunk.push_back(pauli[n-i-1]);
+    }
+    else{
+      qubits_out_chunk.push_back(qubits[i]);
+      pauli_out_chunk.push_back(pauli[n-i-1]);
+    }
+  }
+
+  if(qubits_out_chunk.size() > 0){  //there are bits out of chunk
+    std::complex<double> coeff = 1.0;
+
+    std::reverse(pauli_out_chunk.begin(),pauli_out_chunk.end());
+    std::reverse(pauli_in_chunk.begin(),pauli_in_chunk.end());
+
+    uint_t x_mask, z_mask, num_y, x_max;
+    std::tie(x_mask, z_mask, num_y, x_max) = AER::QV::pauli_masks_and_phase(qubits_out_chunk, pauli_out_chunk);
+
+    AER::QV::add_y_phase(num_y,coeff);
+
+    if(x_mask != 0){    //pairing state is out of chunk
+      bool on_same_process = true;
+#ifdef AER_MPI
+      int proc_bits = 0;
+      uint_t procs = distributed_procs_;
+      while(procs > 1){
+        if((procs & 1) != 0){
+          proc_bits = -1;
+          break;
+        }
+        proc_bits++;
+        procs >>= 1;
+      }
+      if(x_mask & (~((1ull << (BaseState::num_qubits_/2 - proc_bits)) - 1)) != 0){    //data exchange between processes is required
+        on_same_process = false;
+      }
+#endif
+
+      x_mask >>= (BaseState::chunk_bits_/2);
+      z_mask >>= (BaseState::chunk_bits_/2);
+      x_max -= (BaseState::chunk_bits_/2);
+
+      const uint_t mask_u = ~((1ull << (x_max + 1)) - 1);
+      const uint_t mask_l = (1ull << x_max) - 1;
+
+#pragma omp parallel for if(BaseState::chunk_omp_parallel_ && on_same_process) private(i) reduction(+:expval)
+      for(i=0;i<BaseState::num_global_chunks_/2;i++){
+        uint_t iChunk = ((i << 1) & mask_u) | (i & mask_l);
+        uint_t pair_chunk = iChunk ^ x_mask;
+        uint_t iProc = BaseState::get_process_by_chunk(pair_chunk);
+
+        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+          uint_t z_count,z_count_pair;
+          z_count = AER::Utils::popcount(iChunk & z_mask);
+          z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
+
+          if(iProc == BaseState::distributed_rank_){  //pair is on the same process
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+          }
+          else{
+            BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+            //refer receive buffer to calculate expectation value
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+          }
+        }
+        else if(iProc == BaseState::distributed_rank_){  //pair is on this process
+          BaseState::send_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+        }
       }
     }
-  #ifdef AER_MPI
-    BaseState::reduce_sum(expval);
-  #endif
+    else{ //no exchange between chunks
+      z_mask >>= (BaseState::chunk_bits_/2);
+#pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
+      for(i=0;i<BaseState::num_local_chunks_;i++){
+        double sign = 1.0;
+        if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
+          sign = -1.0;
+        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk,coeff);
+      }
+    }
+  }
+  else{ //all bits are inside chunk
+#pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
+    for(i=0;i<BaseState::num_local_chunks_;i++){
+      expval += BaseState::qregs_[i].expval_pauli(qubits, pauli);
+    }
+  }
+
+#ifdef AER_MPI
+  BaseState::reduce_sum(expval);
+#endif
   return expval;
 }
 

--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -165,7 +165,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -585,7 +585,7 @@ void State<densmat_t>::apply_chunk_swap(const reg_t &qubits)
 //=========================================================================
 
 template <class statevec_t>
-double State<statevec_t>::pauli_expval(const reg_t &qubits,
+double State<statevec_t>::expval_pauli(const reg_t &qubits,
                                        const std::string& pauli) {
 
   // Accumulate expval across chunks
@@ -691,7 +691,7 @@ void State<densmat_t>::snapshot_pauli_expval(const Operations::Op &op,
   for (const auto &param : op.params_expval_pauli) {
     const auto& coeff = param.first;
     const auto& pauli = param.second;
-    expval += coeff * pauli_expval(op.qubits, pauli);
+    expval += coeff * expval_pauli(op.qubits, pauli);
   }
 
   // Add to snapshot

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -134,9 +134,17 @@ protected:
   void statevector_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
   // //Compute probabilities from a stabilizer rank decomposition
   void probabilities_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
-
+  
   const static stringmap_t<Gates> gateset_;
   const static stringmap_t<Snapshots> snapshotset_;
+
+  //-----------------------------------------------------------------------
+  // Save data instructions
+  //-----------------------------------------------------------------------
+
+  // Helper function for computing expectation value
+  virtual double pauli_expval(const reg_t &qubits,
+                              const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
   //Parameters and methods specific to the Stabilizer Rank Decomposition
@@ -823,6 +831,12 @@ void State::probabilities_snapshot(const Operations::Op &op, ExperimentResult &r
 //-------------------------------------------------------------------------
 // Implementation: Utility
 //-------------------------------------------------------------------------
+
+double State::pauli_expval(const reg_t &qubits, const std::string& pauli) {
+  // TODO: Add support
+  throw std::runtime_error(
+    "Extended stabilizer method does not support Pauli expectation values.");
+}
 
 inline void to_json(json_t &js, cvector_t vec)
 {

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -143,7 +143,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -832,7 +832,7 @@ void State::probabilities_snapshot(const Operations::Op &op, ExperimentResult &r
 // Implementation: Utility
 //-------------------------------------------------------------------------
 
-double State::pauli_expval(const reg_t &qubits, const std::string& pauli) {
+double State::expval_pauli(const reg_t &qubits, const std::string& pauli) {
   // TODO: Add support
   throw std::runtime_error(
     "Extended stabilizer method does not support Pauli expectation values.");

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -49,7 +49,8 @@ const Operations::OpSet StateOpSet(
    Operations::OpType::snapshot, Operations::OpType::barrier,
    Operations::OpType::bfunc, Operations::OpType::roerror,
    Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
-   Operations::OpType::kraus, Operations::OpType::save_expval},
+   Operations::OpType::kraus, Operations::OpType::save_expval,
+   Operations::OpType::save_expval_var},
   // Gates
   {"id", "x",  "y", "z", "s",  "sdg", "h",  "t",   "tdg",  "p", "u1",
    "u2", "u3", "u", "U", "CX", "cx",  "cy", "cz", "cp", "cu1", "swap", "ccx",
@@ -512,6 +513,7 @@ void State::apply_ops(const std::vector<Operations::Op> &ops,
           apply_kraus(op.qubits, op.mats, rng);
           break;
         case Operations::OpType::save_expval:
+        case Operations::OpType::save_expval_var:
           BaseState::apply_save_expval(op, result);
           break;
         default:

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -49,7 +49,7 @@ const Operations::OpSet StateOpSet(
    Operations::OpType::snapshot, Operations::OpType::barrier,
    Operations::OpType::bfunc, Operations::OpType::roerror,
    Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
-   Operations::OpType::kraus},
+   Operations::OpType::kraus, Operations::OpType::save_expval},
   // Gates
   {"id", "x",  "y", "z", "s",  "sdg", "h",  "t",   "tdg",  "p", "u1",
    "u2", "u3", "u", "U", "CX", "cx",  "cy", "cz", "cp", "cu1", "swap", "ccx",
@@ -206,6 +206,14 @@ protected:
   void apply_kraus(const reg_t &qubits,
                    const std::vector<cmatrix_t> &kmats,
                    RngEngine &rng);
+
+  //-----------------------------------------------------------------------
+  // Save data instructions
+  //-----------------------------------------------------------------------
+
+  // Helper function for computing expectation value
+  virtual double pauli_expval(const reg_t &qubits,
+                              const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
   // Measurement Helpers
@@ -503,12 +511,24 @@ void State::apply_ops(const std::vector<Operations::Op> &ops,
         case Operations::OpType::kraus:
           apply_kraus(op.qubits, op.mats, rng);
           break;
+        case Operations::OpType::save_expval:
+          BaseState::apply_save_expval(op, result);
+          break;
         default:
           throw std::invalid_argument("MatrixProductState::State::invalid instruction \'" +
                                       op.name + "\'.");
       }
     }
   }
+}
+
+//=========================================================================
+// Implementation: Save data
+//=========================================================================
+
+double State::pauli_expval(const reg_t &qubits,
+                           const std::string& pauli) {
+  return BaseState::qreg_.expectation_value_pauli(qubits, pauli).real();
 }
 
 //=========================================================================
@@ -528,8 +548,7 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
   for (const auto &param : op.params_expval_pauli) {
     complex_t coeff = param.first;
     std::string pauli_matrices = param.second;
-    complex_t pauli_expval = qreg_.expectation_value_pauli(op.qubits, pauli_matrices);
-    expval += coeff * pauli_expval;
+    expval += coeff * pauli_expval(op.qubits, pauli_matrices);
   }
 
   // add to snapshot

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -213,7 +213,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -528,7 +528,7 @@ void State::apply_ops(const std::vector<Operations::Op> &ops,
 // Implementation: Save data
 //=========================================================================
 
-double State::pauli_expval(const reg_t &qubits,
+double State::expval_pauli(const reg_t &qubits,
                            const std::string& pauli) {
   return BaseState::qreg_.expectation_value_pauli(qubits, pauli).real();
 }
@@ -550,7 +550,7 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
   for (const auto &param : op.params_expval_pauli) {
     complex_t coeff = param.first;
     std::string pauli_matrices = param.second;
-    expval += coeff * pauli_expval(op.qubits, pauli_matrices);
+    expval += coeff * expval_pauli(op.qubits, pauli_matrices);
   }
 
   // add to snapshot

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -33,8 +33,8 @@ const Operations::OpSet StateOpSet(
   {Operations::OpType::gate, Operations::OpType::measure,
     Operations::OpType::reset, Operations::OpType::snapshot,
     Operations::OpType::barrier, Operations::OpType::bfunc,
-    Operations::OpType::roerror,
-    Operations::OpType::save_expval},
+    Operations::OpType::roerror, Operations::OpType::save_expval,
+    Operations::OpType::save_expval_var},
   // Gates
   {"CX", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s", "sdg",
    "sx", "delay"},
@@ -312,6 +312,7 @@ void State::apply_ops(const std::vector<Operations::Op> &ops,
           apply_snapshot(op, result);
           break;
         case Operations::OpType::save_expval:
+        case Operations::OpType::save_expval_var:
           apply_save_expval(op, result);
           break;
         default:

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -139,7 +139,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -449,7 +449,7 @@ std::vector<reg_t> State::sample_measure(const reg_t &qubits,
 // Implementation: Save data
 //=========================================================================
 
-double State::pauli_expval(const reg_t &qubits,
+double State::expval_pauli(const reg_t &qubits,
                            const std::string& pauli) {
   // Compute expval components
   auto state_cpy = BaseState::qreg_;
@@ -624,7 +624,7 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
   for (const auto &param : op.params_expval_pauli) {
     const auto &coeff = param.first;
     const auto &pauli = param.second;
-    expval += coeff * pauli_expval(op.qubits, pauli);
+    expval += coeff * expval_pauli(op.qubits, pauli);
   }
 
   // add to snapshot

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -360,9 +360,6 @@ void State<state_t>::save_data_average(ExperimentResult &result,
                                        const T& datum,
                                        DataSubType type) const {
   switch (type) {
-    case DataSubType::single:
-      result.data.add_single(datum, key);
-      break;
     case DataSubType::list:
       result.data.add_list(datum, key);
       break;
@@ -393,9 +390,6 @@ void State<state_t>::save_data_average(ExperimentResult &result,
                                        T&& datum,
                                        DataSubType type) const {
   switch (type) {
-    case DataSubType::single:
-      result.data.add_single(std::move(datum), key);
-      break;
     case DataSubType::list:
       result.data.add_list(std::move(datum), key);
       break;

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -23,11 +23,6 @@
 
 namespace AER {
 
-// Result data subtypes
-enum class DataSubType {
-  single, list, c_list, accum, c_accum, average, c_average
-};
-
 namespace Base {
 
 //=========================================================================
@@ -39,6 +34,7 @@ class State {
 
 public:
   using ignore_argument = void;
+  using DataSubType = Operations::DataSubType;
 
   //-----------------------------------------------------------------------
   // Constructors
@@ -132,9 +128,13 @@ public:
                                     const = 0;
 
   //memory allocation (previously called before inisitalize_qreg)
-  virtual void allocate(uint_t num_qubits)
-  {
-  }
+  virtual void allocate(uint_t num_qubits) {}
+
+  // Return the expectation value of a N-qubit Pauli operator
+  // If the simulator does not support Pauli expectation value this should
+  // raise an exception.
+  virtual double pauli_expval(const reg_t &qubits,
+                              const std::string& pauli) = 0;
 
   //-----------------------------------------------------------------------
   // Optional: Load config settings
@@ -229,6 +229,13 @@ public:
   void save_data_pershot(ExperimentResult &result,
                          const std::string &key, T&& datum,
                          DataSubType type = DataSubType::list) const;
+
+  //-----------------------------------------------------------------------
+  // Common instructions
+  //-----------------------------------------------------------------------
+  
+  // Apply a save expectation value instruction
+  void apply_save_expval(const Operations::Op &op, ExperimentResult &result);
 
   //-----------------------------------------------------------------------
   // Standard snapshots
@@ -496,6 +503,38 @@ void State<state_t>::snapshot_creg_register(const Operations::Op &op,
   result.legacy_data.add_pershot_snapshot(name,
                                op.string_params[0],
                                creg_.register_hex());
+}
+
+
+template <class state_t>
+void State<state_t>::apply_save_expval(const Operations::Op &op,
+                                       ExperimentResult &result){
+  // Check empty edge case
+  if (op.expval_params.empty()) {
+    throw std::invalid_argument(
+        "Invalid save expval instruction (Pauli components are empty).");
+  }
+
+  // Accumulate expval components
+  double expval(0.);
+  double sq_expval(0.);
+
+  for (const auto &param : op.expval_params) {
+    // param is tuple (pauli, coeff, sq_coeff)
+    const auto val = pauli_expval(op.qubits, std::get<0>(param));
+    expval += std::get<1>(param) * val;
+    if (op.expval_variance) {
+      sq_expval += std::get<2>(param) * val;
+    }
+  }
+  if (op.expval_variance) {
+    Vector<double> expval_var(2);
+    expval_var[0] = expval;  // mean
+    expval_var[1] = sq_expval - expval * expval;  // variance
+    save_data_average(result, op.string_params[0], expval_var, op.save_type);
+  } else {
+    save_data_average(result, op.string_params[0], expval, op.save_type);
+  }
 }
 
 

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -133,7 +133,7 @@ public:
   // Return the expectation value of a N-qubit Pauli operator
   // If the simulator does not support Pauli expectation value this should
   // raise an exception.
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) = 0;
 
   //-----------------------------------------------------------------------
@@ -522,7 +522,7 @@ void State<state_t>::apply_save_expval(const Operations::Op &op,
 
   for (const auto &param : op.expval_params) {
     // param is tuple (pauli, coeff, sq_coeff)
-    const auto val = pauli_expval(op.qubits, std::get<0>(param));
+    const auto val = expval_pauli(op.qubits, std::get<0>(param));
     expval += std::get<1>(param) * val;
     if (variance) {
       sq_expval += std::get<2>(param) * val;

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -528,7 +528,7 @@ void State<state_t>::apply_save_expval(const Operations::Op &op,
     }
   }
   if (op.expval_variance) {
-    Vector<double> expval_var(2);
+    std::vector<double> expval_var(2);
     expval_var[0] = expval;  // mean
     expval_var[1] = sq_expval - expval * expval;  // variance
     save_data_average(result, op.string_params[0], expval_var, op.save_type);

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -136,7 +136,7 @@ public:
   // Return the expectation value of a N-qubit Pauli operator
   // If the simulator does not support Pauli expectation value this should
   // raise an exception.
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) = 0;
 
   //-----------------------------------------------------------------------
@@ -779,7 +779,7 @@ void StateChunk<state_t>::apply_save_expval(const Operations::Op &op,
 
   for (const auto &param : op.expval_params) {
     // param is tuple (pauli, coeff, sq_coeff)
-    const auto val = pauli_expval(op.qubits, std::get<0>(param));
+    const auto val = expval_pauli(op.qubits, std::get<0>(param));
     expval += std::get<1>(param) * val;
     if (variance) {
       sq_expval += std::get<2>(param) * val;

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -307,7 +307,6 @@ public:
   // The Pauli is input as a length N string of I,X,Y,Z characters.
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const complex_t &coeff = 1) const;
-  
   //for multi-chunk inter chunk expectation
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const QubitVector<data_t>& pair_chunk, 

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -307,9 +307,12 @@ public:
   // The Pauli is input as a length N string of I,X,Y,Z characters.
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const complex_t &coeff = 1) const;
+  
   //for multi-chunk inter chunk expectation
-  double expval_pauli(const reg_t &qubits, const std::string &pauli,const QubitVector<data_t>& pair_chunk, 
-                      const uint_t z_count,const uint_t z_count_pair,
+  double expval_pauli(const reg_t &qubits, const std::string &pauli,
+                      const QubitVector<data_t>& pair_chunk, 
+                      const uint_t z_count,
+                      const uint_t z_count_pair,
                       const complex_t &coeff = 1) const;
 
   //-----------------------------------------------------------------------

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -46,7 +46,8 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::bfunc, Operations::OpType::roerror,
      Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
      Operations::OpType::multiplexer, Operations::OpType::kraus,
-     Operations::OpType::sim_op, Operations::OpType::save_expval},
+     Operations::OpType::sim_op, Operations::OpType::save_expval,
+     Operations::OpType::save_expval_var},
     // Gates
     {"u1",     "u2",      "u3",  "u",    "U",    "CX",   "cx",   "cz",
      "cy",     "cp",      "cu1", "cu2",  "cu3",  "swap", "id",   "p",
@@ -549,6 +550,7 @@ void State<statevec_t>::apply_ops(const std::vector<Operations::Op> &ops,
             BaseState::qreg_.leave_register_blocking();
           }
         case Operations::OpType::save_expval:
+        case Operations::OpType::save_expval_var:
           BaseState::apply_save_expval(op, result);
           break;
         default:

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -216,7 +216,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
   //-----------------------------------------------------------------------
   // Measurement Helpers
@@ -566,7 +566,7 @@ void State<statevec_t>::apply_ops(const std::vector<Operations::Op> &ops,
 //=========================================================================
 
 template <class statevec_t>
-double State<statevec_t>::pauli_expval(const reg_t &qubits,
+double State<statevec_t>::expval_pauli(const reg_t &qubits,
                                        const std::string& pauli) {
   return BaseState::qreg_.expval_pauli(qubits, pauli);
 }
@@ -669,7 +669,7 @@ void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
   for (const auto &param : op.params_expval_pauli) {
     const auto &coeff = param.first;
     const auto &pauli = param.second;
-    expval += coeff * pauli_expval(op.qubits, pauli);
+    expval += coeff * expval_pauli(op.qubits, pauli);
   }
 
   // Add to snapshot

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -544,19 +544,111 @@ void State<statevec_t>::apply_op(const int_t iChunk,const Operations::Op &op,
 //=========================================================================
 
 template <class statevec_t>
-double State<statevec_t>::expval_pauli(const reg_t &qubits,
-                                       const std::string& pauli) {
-
-  // Accumulate expval across chunks
+double State<statevec_t>::pauli_expval(const reg_t &qubits,
+                                       const std::string& pauli) 
+{
+  reg_t qubits_in_chunk;
+  reg_t qubits_out_chunk;
+  std::string pauli_in_chunk;
+  std::string pauli_out_chunk;
+  int_t i,n;
   double expval(0.);
-  int_t i;
+
+  //get inner/outer chunk pauli string
+  n = pauli.size();
+  for(i=0;i<n;i++){
+    if(qubits[i] < BaseState::chunk_bits_){
+      qubits_in_chunk.push_back(qubits[i]);
+      pauli_in_chunk.push_back(pauli[n-i-1]);
+    }
+    else{
+      qubits_out_chunk.push_back(qubits[i]);
+      pauli_out_chunk.push_back(pauli[n-i-1]);
+    }
+  }
+
+  if(qubits_out_chunk.size() > 0){  //there are bits out of chunk
+    std::complex<double> coeff = 1.0;
+
+    std::reverse(pauli_out_chunk.begin(),pauli_out_chunk.end());
+    std::reverse(pauli_in_chunk.begin(),pauli_in_chunk.end());
+
+    uint_t x_mask, z_mask, num_y, x_max;
+    std::tie(x_mask, z_mask, num_y, x_max) = AER::QV::pauli_masks_and_phase(qubits_out_chunk, pauli_out_chunk);
+
+    AER::QV::add_y_phase(num_y,coeff);
+
+    if(x_mask != 0){    //pairing state is out of chunk
+      bool on_same_process = true;
+#ifdef AER_MPI
+      int proc_bits = 0;
+      uint_t procs = distributed_procs_;
+      while(procs > 1){
+        if((procs & 1) != 0){
+          proc_bits = -1;
+          break;
+        }
+        proc_bits++;
+        procs >>= 1;
+      }
+      if(x_mask & (~((1ull << (BaseState::num_qubits_ - proc_bits)) - 1)) != 0){    //data exchange between processes is required
+        on_same_process = false;
+      }
+#endif
+
+      x_mask >>= BaseState::chunk_bits_;
+      z_mask >>= BaseState::chunk_bits_;
+      x_max -= BaseState::chunk_bits_;
+
+      const uint_t mask_u = ~((1ull << (x_max + 1)) - 1);
+      const uint_t mask_l = (1ull << x_max) - 1;
+
+#pragma omp parallel for if(BaseState::chunk_omp_parallel_ && on_same_process) private(i) reduction(+:expval)
+      for(i=0;i<BaseState::num_global_chunks_/2;i++){
+        uint_t iChunk = ((i << 1) & mask_u) | (i & mask_l);
+        uint_t pair_chunk = iChunk ^ x_mask;
+        uint_t iProc = BaseState::get_process_by_chunk(pair_chunk);
+
+        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+          uint_t z_count,z_count_pair;
+          z_count = AER::Utils::popcount(iChunk & z_mask);
+          z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
+
+          if(iProc == BaseState::distributed_rank_){  //pair is on the same process
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+          }
+          else{
+            BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+            //refer receive buffer to calculate expectation value
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+          }
+        }
+        else if(iProc == BaseState::distributed_rank_){  //pair is on this process
+          BaseState::send_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+        }
+      }
+    }
+    else{ //no exchange between chunks
+      z_mask >>= BaseState::chunk_bits_;
+#pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
+      for(i=0;i<BaseState::num_local_chunks_;i++){
+        double sign = 1.0;
+        if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
+          sign = -1.0;
+        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk,coeff);
+      }
+    }
+  }
+  else{ //all bits are inside chunk
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
     for(i=0;i<BaseState::num_local_chunks_;i++){
       expval += BaseState::qregs_[i].expval_pauli(qubits, pauli);
     }
-  #ifdef AER_MPI
-    BaseState::reduce_sum(expval);
-  #endif
+  }
+
+#ifdef AER_MPI
+  BaseState::reduce_sum(expval);
+#endif
   return expval;
 }
 

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -545,7 +545,8 @@ void State<statevec_t>::apply_op(const int_t iChunk,const Operations::Op &op,
 
 template <class statevec_t>
 double State<statevec_t>::expval_pauli(const reg_t &qubits,
-                                       const std::string& pauli) {
+                                       const std::string& pauli) 
+{
   reg_t qubits_in_chunk;
   reg_t qubits_out_chunk;
   std::string pauli_in_chunk;
@@ -1408,12 +1409,13 @@ void State<statevec_t>::apply_initialize(const reg_t &qubits,
 //=========================================================================
 
 template <class statevec_t>
-void State<statevec_t>::apply_multiplexer(const int_t iChunk, const reg_t &control_qubits, const reg_t &target_qubits, const std::vector<cmatrix_t> &mmat) {
-	// (1) Pack vector of matrices into single (stacked) matrix ... note: matrix dims: rows = DIM[qubit.size()] columns = DIM[|target bits|]
-	cmatrix_t multiplexer_matrix = Utils::stacked_matrix(mmat);
+void State<statevec_t>::apply_multiplexer(const int_t iChunk, const reg_t &control_qubits, const reg_t &target_qubits, const std::vector<cmatrix_t> &mmat) 
+{
+  // (1) Pack vector of matrices into single (stacked) matrix ... note: matrix dims: rows = DIM[qubit.size()] columns = DIM[|target bits|]
+  cmatrix_t multiplexer_matrix = Utils::stacked_matrix(mmat);
 
-	// (2) Treat as single, large(r), chained/batched matrix operator
-	apply_multiplexer(iChunk,control_qubits, target_qubits, multiplexer_matrix);
+  // (2) Treat as single, large(r), chained/batched matrix operator
+  apply_multiplexer(iChunk,control_qubits, target_qubits, multiplexer_matrix);
 }
 
 

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -183,7 +183,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -544,7 +544,7 @@ void State<statevec_t>::apply_op(const int_t iChunk,const Operations::Op &op,
 //=========================================================================
 
 template <class statevec_t>
-double State<statevec_t>::pauli_expval(const reg_t &qubits,
+double State<statevec_t>::expval_pauli(const reg_t &qubits,
                                        const std::string& pauli) {
 
   // Accumulate expval across chunks
@@ -662,7 +662,7 @@ void State<statevec_t>::snapshot_pauli_expval(const Operations::Op &op,
   for (const auto &param : op.params_expval_pauli) {
     const auto& coeff = param.first;
     const auto& pauli = param.second;
-    expval += coeff * pauli_expval(op.qubits, pauli);
+    expval += coeff * expval_pauli(op.qubits, pauli);
   }
 
   // Add to snapshot

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -544,9 +544,8 @@ void State<statevec_t>::apply_op(const int_t iChunk,const Operations::Op &op,
 //=========================================================================
 
 template <class statevec_t>
-double State<statevec_t>::pauli_expval(const reg_t &qubits,
-                                       const std::string& pauli) 
-{
+double State<statevec_t>::expval_pauli(const reg_t &qubits,
+                                       const std::string& pauli) {
   reg_t qubits_in_chunk;
   reg_t qubits_out_chunk;
   std::string pauli_in_chunk;

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -149,6 +149,14 @@ protected:
                      const double lambda);
 
   //-----------------------------------------------------------------------
+  // Save data instructions
+  //-----------------------------------------------------------------------
+
+  // Helper function for computing expectation value
+  virtual double pauli_expval(const reg_t &qubits,
+                              const std::string& pauli) override;
+    
+  //-----------------------------------------------------------------------
   // Config Settings
   //-----------------------------------------------------------------------
 
@@ -479,6 +487,12 @@ void State<data_t>::apply_snapshot(const Operations::Op &op,
         "QubitSuperoperator::State::invalid snapshot instruction \'" + op.name +
         "\'.");
   }
+}
+
+template <class data_t>
+double  State<data_t>::pauli_expval(const reg_t &qubits,
+                                    const std::string& pauli) {
+  throw std::runtime_error("SuperOp simulator does not support Pauli expectation values.");
 }
 
 //------------------------------------------------------------------------------

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -153,7 +153,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
     
   //-----------------------------------------------------------------------
@@ -490,7 +490,7 @@ void State<data_t>::apply_snapshot(const Operations::Op &op,
 }
 
 template <class data_t>
-double  State<data_t>::pauli_expval(const reg_t &qubits,
+double  State<data_t>::expval_pauli(const reg_t &qubits,
                                     const std::string& pauli) {
   throw std::runtime_error("SuperOp simulator does not support Pauli expectation values.");
 }

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -158,6 +158,14 @@ protected:
                        const double phi, const double lambda);
 
   //-----------------------------------------------------------------------
+  // Save data instructions
+  //-----------------------------------------------------------------------
+
+  // Helper function for computing expectation value
+  virtual double pauli_expval(const reg_t &qubits,
+                              const std::string& pauli) override;
+
+  //-----------------------------------------------------------------------
   // Config Settings
   //-----------------------------------------------------------------------
 
@@ -508,6 +516,13 @@ void State<unitary_matrix_t>::apply_global_phase() {
       {0}, {BaseState::global_phase_, BaseState::global_phase_}
     );
   }
+}
+
+
+template <class unitary_matrix_t>
+double  State<unitary_matrix_t>::pauli_expval(const reg_t &qubits,
+                                              const std::string& pauli) {
+  throw std::runtime_error("Unitary simulator does not support Pauli expectation values.");
 }
 
 //------------------------------------------------------------------------------

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -162,7 +162,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -520,7 +520,7 @@ void State<unitary_matrix_t>::apply_global_phase() {
 
 
 template <class unitary_matrix_t>
-double  State<unitary_matrix_t>::pauli_expval(const reg_t &qubits,
+double  State<unitary_matrix_t>::expval_pauli(const reg_t &qubits,
                                               const std::string& pauli) {
   throw std::runtime_error("Unitary simulator does not support Pauli expectation values.");
 }

--- a/src/simulators/unitary/unitary_state_chunk.hpp
+++ b/src/simulators/unitary/unitary_state_chunk.hpp
@@ -32,6 +32,28 @@
 namespace AER {
 namespace QubitUnitaryChunk {
 
+// OpSet of supported instructions
+const Operations::OpSet StateOpSet(
+    // Op types
+    {Operations::OpType::gate, Operations::OpType::barrier,
+     Operations::OpType::matrix, Operations::OpType::diagonal_matrix},
+    // Gates
+    {"u1",     "u2",      "u3",  "u",    "U",    "CX",   "cx",   "cz",
+     "cy",     "cp",      "cu1", "cu2",  "cu3",  "swap", "id",   "p",
+     "x",      "y",       "z",   "h",    "s",    "sdg",  "t",    "tdg",
+     "r",      "rx",      "ry",  "rz",   "rxx",  "ryy",  "rzz",  "rzx",
+     "ccx",    "cswap",   "mcx", "mcy",  "mcz",  "mcu1", "mcu2", "mcu3",
+     "mcswap", "mcphase", "mcr", "mcrx", "mcry", "mcry", "sx",   "csx",
+     "mcsx",   "delay", "pauli"},
+    // Snapshots
+    {});
+
+// Allowed gates enum class
+enum class Gates {
+  id, h, s, sdg, t, tdg, rxx, ryy, rzz, rzx,
+  mcx, mcy, mcz, mcr, mcrx, mcry, mcrz, mcp, mcu2, mcu3, mcswap, mcsx, pauli,
+};
+
 //=========================================================================
 // QubitUnitary State subclass
 //=========================================================================
@@ -41,7 +63,7 @@ class State : public Base::StateChunk<unitary_matrix_t> {
 public:
   using BaseState = Base::StateChunk<unitary_matrix_t>;
 
-  State() : BaseState(QubitUnitary::StateOpSet) {}
+  State() : BaseState(StateOpSet) {}
   virtual ~State() = default;
 
   //-----------------------------------------------------------------------
@@ -122,6 +144,14 @@ protected:
   // NOTE: if N=1 this is just a regular u3 gate.
   void apply_gate_mcu3(const uint_t iChunk,const reg_t &qubits, const double theta,
                        const double phi, const double lambda);
+
+  //-----------------------------------------------------------------------
+  // Save data instructions
+  //-----------------------------------------------------------------------
+
+  // Helper function for computing expectation value
+  virtual double pauli_expval(const reg_t &qubits,
+                              const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
   // Config Settings
@@ -517,7 +547,11 @@ void State<unitary_matrix_t>::apply_global_phase() {
   }
 }
 
-
+template <class unitary_matrix_t>
+double  State<unitary_matrix_t>::pauli_expval(const reg_t &qubits,
+                                              const std::string& pauli) {
+  throw std::runtime_error("Unitary simulator does not support Pauli expectation values.");
+}
 
 //------------------------------------------------------------------------------
 } // namespace QubitUnitary

--- a/src/simulators/unitary/unitary_state_chunk.hpp
+++ b/src/simulators/unitary/unitary_state_chunk.hpp
@@ -150,7 +150,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Helper function for computing expectation value
-  virtual double pauli_expval(const reg_t &qubits,
+  virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -548,7 +548,7 @@ void State<unitary_matrix_t>::apply_global_phase() {
 }
 
 template <class unitary_matrix_t>
-double  State<unitary_matrix_t>::pauli_expval(const reg_t &qubits,
+double  State<unitary_matrix_t>::expval_pauli(const reg_t &qubits,
                                               const std::string& pauli) {
   throw std::runtime_error("Unitary simulator does not support Pauli expectation values.");
 }

--- a/test/terra/backends/qasm_simulator/qasm_save.py
+++ b/test/terra/backends/qasm_simulator/qasm_save.py
@@ -13,8 +13,10 @@
 QasmSimulator Integration Tests for Save instructions
 """
 
-from .qasm_save_expval import QasmSaveExpvalTests
+from .qasm_save_expval import QasmSaveExpectationValueTests
+from .qasm_save_expval import QasmSaveExpectationValueVarianceTests
 
 
-class QasmSaveDataTests(QasmSaveExpvalTests):
+class QasmSaveDataTests(QasmSaveExpectationValueTests,
+                        QasmSaveExpectationValueVarianceTests):
     """QasmSimulator SaveData instruction tests."""

--- a/test/terra/backends/qasm_simulator/qasm_save.py
+++ b/test/terra/backends/qasm_simulator/qasm_save.py
@@ -14,9 +14,7 @@ QasmSimulator Integration Tests for Save instructions
 """
 
 from .qasm_save_expval import QasmSaveExpectationValueTests
-from .qasm_save_expval import QasmSaveExpectationValueVarianceTests
 
 
-class QasmSaveDataTests(QasmSaveExpectationValueTests,
-                        QasmSaveExpectationValueVarianceTests):
+class QasmSaveDataTests(QasmSaveExpectationValueTests):
     """QasmSimulator SaveData instruction tests."""

--- a/test/terra/backends/qasm_simulator/qasm_save.py
+++ b/test/terra/backends/qasm_simulator/qasm_save.py
@@ -1,0 +1,20 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+QasmSimulator Integration Tests for Save instructions
+"""
+
+from .qasm_save_expval import QasmSaveExpvalTests
+
+
+class QasmSaveDataTests(QasmSaveExpvalTests):
+    """QasmSimulator SaveData instruction tests."""

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -47,11 +47,12 @@ class QasmSaveExpvalTests:
         target = qi.Statevector(state).expectation_value(oper).real.round(10)
 
         # Snapshot circuit
+        opts = self.BACKEND_OPTS.copy()
         circ = transpile(state, self.SIMULATOR)
         circ.save_expval('expval', oper, [0, 1])
-        qobj = assemble(circ, **self.BACKEND_OPTS)
-        result = self.SIMULATOR.run(qobj).result()
-        method = self.BACKEND_OPTS.get('method', 'automatic')
+        qobj = assemble(circ)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
         if method not in SUPPORTED_METHODS:
             self.assertFalse(result.success)
         else:
@@ -76,11 +77,12 @@ class QasmSaveExpvalTests:
         target = qi.Statevector(state).expectation_value(oper, qubits).real
 
         # Snapshot circuit
+        opts = self.BACKEND_OPTS.copy()
         circ = transpile(state, self.SIMULATOR)
         circ.save_expval('expval', oper, qubits)
-        qobj = assemble(circ, **self.BACKEND_OPTS)
-        result = self.SIMULATOR.run(qobj).result()
-        method = self.BACKEND_OPTS.get('method', 'automatic')
+        qobj = assemble(circ)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
         if method not in SUPPORTED_METHODS:
             self.assertFalse(result.success)
         else:
@@ -106,11 +108,12 @@ class QasmSaveExpvalTests:
         target = qi.Statevector(state).expectation_value(oper).real
 
         # Snapshot circuit
+        opts = self.BACKEND_OPTS.copy()
         circ = transpile(state, self.SIMULATOR)
         circ.save_expval('expval', oper, [0, 1])
-        qobj = assemble(circ, **self.BACKEND_OPTS)
-        result = self.SIMULATOR.run(qobj).result()
-        method = self.BACKEND_OPTS.get('method', 'automatic')
+        qobj = assemble(circ)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
         if method not in SUPPORTED_METHODS:
             self.assertFalse(result.success)
         else:
@@ -135,11 +138,12 @@ class QasmSaveExpvalTests:
         target = qi.Statevector(state).expectation_value(oper, qubits).real
 
         # Snapshot circuit
+        opts = self.BACKEND_OPTS.copy()
         circ = transpile(state, self.SIMULATOR)
         circ.save_expval('expval', oper, qubits)
-        qobj = assemble(circ, **self.BACKEND_OPTS)
-        result = self.SIMULATOR.run(qobj).result()
-        method = self.BACKEND_OPTS.get('method', 'automatic')
+        qobj = assemble(circ)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
         if method not in SUPPORTED_METHODS:
             self.assertFalse(result.success)
         else:

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -1,0 +1,148 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+QasmSimulator Integration Tests for Snapshot instructions
+"""
+
+from ddt import ddt, data
+
+import qiskit.quantum_info as qi
+from qiskit.circuit.library import QuantumVolume
+from qiskit.compiler import transpile, assemble
+
+from qiskit.providers.aer import QasmSimulator
+
+
+@ddt
+class QasmSaveExpvalTests:
+    """QasmSimulator SaveExpval instruction tests."""
+
+    SIMULATOR = QasmSimulator()
+    BACKEND_OPTS = {}
+
+    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
+          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    def test_save_expval_stabilizer_pauli(self, pauli):
+        """Test Pauli expval for stabilizer circuit"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust',
+            'matrix_product_state', 'stabilizer'
+        ]
+        SEED = 5832
+
+        # Stabilizer test circuit
+        state = qi.random_clifford(2, seed=SEED).to_circuit()
+        oper = qi.Pauli(pauli)
+        target = qi.Statevector(state).expectation_value(oper).real.round(10)
+
+        # Snapshot circuit
+        circ = transpile(state, self.SIMULATOR)
+        circ.save_expval('expval', oper, [0, 1])
+        qobj = assemble(circ, **self.BACKEND_OPTS)
+        result = self.SIMULATOR.run(qobj).result()
+        method = self.BACKEND_OPTS.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            value = result.data(0)['expval']
+            self.assertAlmostEqual(value, target)
+
+    @data([0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1])
+    def test_save_expval_stabilizer_hermitian(self, qubits):
+        """Test expval for stabilizer circuit and Hermitian operator"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust',
+            'matrix_product_state', 'stabilizer'
+        ]
+        SEED = 7123
+
+        # Stabilizer test circuit
+        state = qi.random_clifford(3, seed=SEED).to_circuit()
+        oper = qi.random_hermitian(4, traceless=True, seed=SEED)
+        target = qi.Statevector(state).expectation_value(oper, qubits).real
+
+        # Snapshot circuit
+        circ = transpile(state, self.SIMULATOR)
+        circ.save_expval('expval', oper, qubits)
+        qobj = assemble(circ, **self.BACKEND_OPTS)
+        result = self.SIMULATOR.run(qobj).result()
+        method = self.BACKEND_OPTS.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            value = result.data(0)['expval']
+            self.assertAlmostEqual(value, target)
+
+    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
+          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    def test_save_expval_nonstabilizer_pauli(self, pauli):
+        """Test Pauli expval for non-stabilizer circuit"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust',
+            'matrix_product_state'
+        ]
+        SEED = 7382
+
+        # Stabilizer test circuit
+        state = QuantumVolume(2, 1, seed=SEED)
+        oper = qi.Pauli(pauli)
+        target = qi.Statevector(state).expectation_value(oper).real
+
+        # Snapshot circuit
+        circ = transpile(state, self.SIMULATOR)
+        circ.save_expval('expval', oper, [0, 1])
+        qobj = assemble(circ, **self.BACKEND_OPTS)
+        result = self.SIMULATOR.run(qobj).result()
+        method = self.BACKEND_OPTS.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            value = result.data(0)['expval']
+            self.assertAlmostEqual(value, target)
+
+    @data([0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1])
+    def test_save_expval_nonstabilizer_hermitian(self, qubits):
+        """Test expval for non-stabilizer circuit and Hermitian operator"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust',
+            'matrix_product_state'
+        ]
+        SEED = 8124
+
+        # Stabilizer test circuit
+        state = QuantumVolume(3, 1, seed=SEED)
+        oper = qi.random_hermitian(4, traceless=True, seed=SEED)
+        target = qi.Statevector(state).expectation_value(oper, qubits).real
+
+        # Snapshot circuit
+        circ = transpile(state, self.SIMULATOR)
+        circ.save_expval('expval', oper, qubits)
+        qobj = assemble(circ, **self.BACKEND_OPTS)
+        result = self.SIMULATOR.run(qobj).result()
+        method = self.BACKEND_OPTS.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            value = result.data(0)['expval']
+            self.assertAlmostEqual(value, target)

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -49,7 +49,7 @@ class QasmSaveExpectationValueTests:
         # Snapshot circuit
         opts = self.BACKEND_OPTS.copy()
         circ = transpile(state, self.SIMULATOR)
-        circ.save_expval('expval', oper, [0, 1])
+        circ.save_expectation_value('expval', oper, [0, 1])
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         method = opts.get('method', 'automatic')
@@ -79,7 +79,7 @@ class QasmSaveExpectationValueTests:
         # Snapshot circuit
         opts = self.BACKEND_OPTS.copy()
         circ = transpile(state, self.SIMULATOR)
-        circ.save_expval('expval', oper, qubits)
+        circ.save_expectation_value('expval', oper, qubits)
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         method = opts.get('method', 'automatic')
@@ -110,7 +110,7 @@ class QasmSaveExpectationValueTests:
         # Snapshot circuit
         opts = self.BACKEND_OPTS.copy()
         circ = transpile(state, self.SIMULATOR)
-        circ.save_expval('expval', oper, [0, 1])
+        circ.save_expectation_value('expval', oper, [0, 1])
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         method = opts.get('method', 'automatic')
@@ -140,7 +140,7 @@ class QasmSaveExpectationValueTests:
         # Snapshot circuit
         opts = self.BACKEND_OPTS.copy()
         circ = transpile(state, self.SIMULATOR)
-        circ.save_expval('expval', oper, qubits)
+        circ.save_expectation_value('expval', oper, qubits)
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         method = opts.get('method', 'automatic')

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -23,8 +23,8 @@ from qiskit.providers.aer import QasmSimulator
 
 
 @ddt
-class QasmSaveExpvalTests:
-    """QasmSimulator SaveExpval instruction tests."""
+class QasmSaveExpectationValueTests:
+    """QasmSimulator SaveExpectationValue instruction tests."""
 
     SIMULATOR = QasmSimulator()
     BACKEND_OPTS = {}

--- a/test/terra/backends/test_qasm_simulator.py
+++ b/test/terra/backends/test_qasm_simulator.py
@@ -41,6 +41,8 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmReadoutNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
+# Save data tests
+from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -82,6 +84,7 @@ class TestQasmSimulator(common.QiskitAerTestCase,
                         QasmResetNoiseTests,
                         QasmKrausNoiseTests,
                         QasmBasicsTests,
+                        QasmSaveExpvalTests,
                         QasmStandardGateStatevectorTests,
                         QasmStandardGateDensityMatrixTests,
                         QasmDelayGateTests,

--- a/test/terra/backends/test_qasm_simulator.py
+++ b/test/terra/backends/test_qasm_simulator.py
@@ -42,7 +42,7 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
 # Save data tests
-from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
+from test.terra.backends.qasm_simulator.qasm_save import QasmSaveDataTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -84,7 +84,7 @@ class TestQasmSimulator(common.QiskitAerTestCase,
                         QasmResetNoiseTests,
                         QasmKrausNoiseTests,
                         QasmBasicsTests,
-                        QasmSaveExpvalTests,
+                        QasmSaveDataTests,
                         QasmStandardGateStatevectorTests,
                         QasmStandardGateDensityMatrixTests,
                         QasmDelayGateTests,

--- a/test/terra/backends/test_qasm_simulator_density_matrix.py
+++ b/test/terra/backends/test_qasm_simulator_density_matrix.py
@@ -43,7 +43,7 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
 from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
 from test.terra.backends.qasm_simulator.qasm_fusion import QasmFusionTests
 # Save data tests
-from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
+from test.terra.backends.qasm_simulator.qasm_save import QasmSaveDataTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -61,7 +61,7 @@ class DensityMatrixTests(
         QasmAlgorithmTests, QasmAlgorithmTestsWaltzBasis,
         QasmAlgorithmTestsMinimalBasis, QasmUnitaryGateTests, QasmDiagonalGateTests,
         QasmReadoutNoiseTests, QasmPauliNoiseTests, QasmResetNoiseTests,
-        QasmKrausNoiseTests, QasmSaveExpvalTests,
+        QasmKrausNoiseTests, QasmSaveDataTests,
         QasmSnapshotStatevectorTests,
         QasmSnapshotDensityMatrixTests, QasmSnapshotProbabilitiesTests,
         QasmSnapshotExpValPauliTests, QasmSnapshotExpValPauliNCTests,

--- a/test/terra/backends/test_qasm_simulator_density_matrix.py
+++ b/test/terra/backends/test_qasm_simulator_density_matrix.py
@@ -42,6 +42,8 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
 # Other tests
 from test.terra.backends.qasm_simulator.qasm_method import QasmMethodTests
 from test.terra.backends.qasm_simulator.qasm_fusion import QasmFusionTests
+# Save data tests
+from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -59,7 +61,8 @@ class DensityMatrixTests(
         QasmAlgorithmTests, QasmAlgorithmTestsWaltzBasis,
         QasmAlgorithmTestsMinimalBasis, QasmUnitaryGateTests, QasmDiagonalGateTests,
         QasmReadoutNoiseTests, QasmPauliNoiseTests, QasmResetNoiseTests,
-        QasmKrausNoiseTests, QasmSnapshotStatevectorTests,
+        QasmKrausNoiseTests, QasmSaveExpvalTests,
+        QasmSnapshotStatevectorTests,
         QasmSnapshotDensityMatrixTests, QasmSnapshotProbabilitiesTests,
         QasmSnapshotExpValPauliTests, QasmSnapshotExpValPauliNCTests,
         QasmSnapshotExpValMatrixTests, QasmSnapshotStabilizerTests,

--- a/test/terra/backends/test_qasm_simulator_matrix_product_state.py
+++ b/test/terra/backends/test_qasm_simulator_matrix_product_state.py
@@ -40,7 +40,7 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
 # Save data tests
-from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
+from test.terra.backends.qasm_simulator.qasm_save import QasmSaveDataTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -70,7 +70,7 @@ class TestQasmMatrixProductStateSimulator(
         QasmPauliNoiseTests,
         QasmResetNoiseTests,
         QasmKrausNoiseTests,
-        QasmSaveExpvalTests,
+        QasmSaveDataTests,
         QasmSnapshotStatevectorTests,
         QasmSnapshotDensityMatrixTests,
         QasmSnapshotProbabilitiesTests,

--- a/test/terra/backends/test_qasm_simulator_matrix_product_state.py
+++ b/test/terra/backends/test_qasm_simulator_matrix_product_state.py
@@ -39,6 +39,8 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmReadoutNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
+# Save data tests
+from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -68,6 +70,7 @@ class TestQasmMatrixProductStateSimulator(
         QasmPauliNoiseTests,
         QasmResetNoiseTests,
         QasmKrausNoiseTests,
+        QasmSaveExpvalTests,
         QasmSnapshotStatevectorTests,
         QasmSnapshotDensityMatrixTests,
         QasmSnapshotProbabilitiesTests,

--- a/test/terra/backends/test_qasm_simulator_stabilizer.py
+++ b/test/terra/backends/test_qasm_simulator_stabilizer.py
@@ -30,6 +30,8 @@ from test.terra.backends.qasm_simulator.qasm_algorithms import QasmAlgorithmTest
 from test.terra.backends.qasm_simulator.qasm_noise import QasmReadoutNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
+# Save data tests
+from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -51,6 +53,7 @@ class TestQasmStabilizerSimulator(common.QiskitAerTestCase,
                                   QasmReadoutNoiseTests,
                                   QasmResetNoiseTests,
                                   QasmPauliNoiseTests,
+                                  QasmSaveExpvalTests,
                                   QasmSnapshotStatevectorTests,
                                   QasmSnapshotDensityMatrixTests,
                                   QasmSnapshotProbabilitiesTests,

--- a/test/terra/backends/test_qasm_simulator_stabilizer.py
+++ b/test/terra/backends/test_qasm_simulator_stabilizer.py
@@ -31,7 +31,7 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmReadoutNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 # Save data tests
-from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
+from test.terra.backends.qasm_simulator.qasm_save import QasmSaveDataTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -53,7 +53,7 @@ class TestQasmStabilizerSimulator(common.QiskitAerTestCase,
                                   QasmReadoutNoiseTests,
                                   QasmResetNoiseTests,
                                   QasmPauliNoiseTests,
-                                  QasmSaveExpvalTests,
+                                  QasmSaveDataTests,
                                   QasmSnapshotStatevectorTests,
                                   QasmSnapshotDensityMatrixTests,
                                   QasmSnapshotProbabilitiesTests,

--- a/test/terra/backends/test_qasm_simulator_statevector.py
+++ b/test/terra/backends/test_qasm_simulator_statevector.py
@@ -40,6 +40,8 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmReadoutNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
+# Save data tests
+from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -66,6 +68,7 @@ class StatevectorTests(
         QasmReadoutNoiseTests, QasmPauliNoiseTests, QasmThreadManagementTests,
         QasmFusionTests, QasmDelayMeasureTests, QasmQubitsTruncateTests,
         QasmResetNoiseTests, QasmKrausNoiseTests, QasmBasicsTests,
+        QasmSaveExpvalTests,
         QasmSnapshotStatevectorTests, QasmSnapshotDensityMatrixTests,
         QasmSnapshotProbabilitiesTests, QasmSnapshotExpValPauliTests,
         QasmSnapshotExpValPauliNCTests, QasmSnapshotExpValMatrixTests,

--- a/test/terra/backends/test_qasm_simulator_statevector.py
+++ b/test/terra/backends/test_qasm_simulator_statevector.py
@@ -41,7 +41,7 @@ from test.terra.backends.qasm_simulator.qasm_noise import QasmPauliNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmResetNoiseTests
 from test.terra.backends.qasm_simulator.qasm_noise import QasmKrausNoiseTests
 # Save data tests
-from test.terra.backends.qasm_simulator.qasm_save_expval import QasmSaveExpvalTests
+from test.terra.backends.qasm_simulator.qasm_save import QasmSaveDataTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
@@ -68,7 +68,7 @@ class StatevectorTests(
         QasmReadoutNoiseTests, QasmPauliNoiseTests, QasmThreadManagementTests,
         QasmFusionTests, QasmDelayMeasureTests, QasmQubitsTruncateTests,
         QasmResetNoiseTests, QasmKrausNoiseTests, QasmBasicsTests,
-        QasmSaveExpvalTests,
+        QasmSaveDataTests,
         QasmSnapshotStatevectorTests, QasmSnapshotDensityMatrixTests,
         QasmSnapshotProbabilitiesTests, QasmSnapshotExpValPauliTests,
         QasmSnapshotExpValPauliNCTests, QasmSnapshotExpValMatrixTests,

--- a/test/terra/extensions/test_save_expval.py
+++ b/test/terra/extensions/test_save_expval.py
@@ -1,0 +1,147 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import unittest
+
+
+from qiskit.extensions.exceptions import ExtensionError
+from qiskit.providers.aer.library import SaveExpval
+from qiskit.quantum_info.operators import Pauli
+
+from ..common import QiskitAerTestCase
+
+
+class TestSaveExpval(QiskitAerTestCase):
+    """SaveExpval instruction tests"""
+
+    def test_invalid_key_raises(self):
+        """Test save instruction key is str"""
+        self.assertRaises(ExtensionError, lambda: SaveExpval(1, Pauli('Z')))
+
+    def test_nonhermitian_raises(self):
+        """Test non-Hermitian op raises exception."""
+        op = [[0, 1j], [1j, 0]]
+        self.assertRaises(ExtensionError, lambda: SaveExpval('expval', op))
+
+    def test_default_kwarg(self):
+        """Test default kwargs"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'))
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertFalse(instr._variance)
+        self.assertEqual(instr._subtype, 'average')
+
+    def test_cond_kwarg(self):
+        """Test conditional kwarg"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), conditional=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertFalse(instr._variance)
+        self.assertEqual(instr._subtype, 'c_average')
+
+    def test_var_kwarg(self):
+        """Test variance kwarg"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), variance=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertTrue(instr._variance)
+        self.assertEqual(instr._subtype, 'average')
+
+    def test_var_cond_kwarg(self):
+        """Test variance, conditional kwargs"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), variance=True, conditional=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertTrue(instr._variance)
+        self.assertEqual(instr._subtype, 'c_average')
+
+    def test_unnorm_kwarg(self):
+        """Test unnormalized kwarg"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), unnormalized=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertFalse(instr._variance)
+        self.assertEqual(instr._subtype, 'accum')
+
+    def test_unnorm_cond_kwarg(self):
+        """Test unnormalized, conditonal kwargs"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), conditional=True, unnormalized=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertFalse(instr._variance)
+        self.assertEqual(instr._subtype, 'c_accum')
+
+    def test_unnorm_var_kwarg(self):
+        """Test unnormalized, variance kwargs"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), variance=True, unnormalized=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertTrue(instr._variance)
+        self.assertEqual(instr._subtype, 'accum')
+
+    def test_unnorm_var_cond_kwarg(self):
+        """Test unnormalized, conditional kwargs"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), variance=True, conditional=True,
+                           unnormalized=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertTrue(instr._variance)
+        self.assertEqual(instr._subtype, 'c_accum')
+
+    def test_pershot_kwarg(self):
+        """Test pershot kwarg"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), pershot=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertFalse(instr._variance)
+        self.assertEqual(instr._subtype, 'list')
+
+    def test_pershot_cond_kwarg(self):
+        """Test pershot, conditonal kwargs"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), conditional=True, pershot=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertFalse(instr._variance)
+        self.assertEqual(instr._subtype, 'c_list')
+
+    def test_pershot_var_kwarg(self):
+        """Test pershot, variance kwargs"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), variance=True, pershot=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertTrue(instr._variance)
+        self.assertEqual(instr._subtype, 'list')
+
+    def test_pershot_var_cond_kwarg(self):
+        """Test pershot, conditional kwargs"""
+        key = 'test_key'
+        instr = SaveExpval(key, Pauli('X'), variance=True, conditional=True,
+                           pershot=True)
+        self.assertEqual(instr.name, 'save_expval')
+        self.assertEqual(instr._key, key)
+        self.assertTrue(instr._variance)
+        self.assertEqual(instr._subtype, 'c_list')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/terra/extensions/test_save_expval.py
+++ b/test/terra/extensions/test_save_expval.py
@@ -14,28 +14,28 @@ import unittest
 
 
 from qiskit.extensions.exceptions import ExtensionError
-from qiskit.providers.aer.library import SaveExpval, SaveExpvalVar
+from qiskit.providers.aer.library import SaveExpectationValue, SaveExpectationValueVariance
 from qiskit.quantum_info.operators import Pauli
 
 from ..common import QiskitAerTestCase
 
 
-class TestSaveExpval(QiskitAerTestCase):
-    """SaveExpval instruction tests"""
+class TestSaveExpectationValue(QiskitAerTestCase):
+    """SaveExpectationValue instruction tests"""
 
     def test_invalid_key_raises(self):
         """Test save instruction key is str"""
-        self.assertRaises(ExtensionError, lambda: SaveExpval(1, Pauli('Z')))
+        self.assertRaises(ExtensionError, lambda: SaveExpectationValue(1, Pauli('Z')))
 
     def test_nonhermitian_raises(self):
         """Test non-Hermitian op raises exception."""
         op = [[0, 1j], [1j, 0]]
-        self.assertRaises(ExtensionError, lambda: SaveExpval('expval', op))
+        self.assertRaises(ExtensionError, lambda: SaveExpectationValue('expval', op))
 
     def test_default_kwarg(self):
         """Test default kwargs"""
         key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'))
+        instr = SaveExpectationValue(key, Pauli('X'))
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'average')
@@ -43,7 +43,7 @@ class TestSaveExpval(QiskitAerTestCase):
     def test_cond_kwarg(self):
         """Test conditional kwarg"""
         key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), conditional=True)
+        instr = SaveExpectationValue(key, Pauli('X'), conditional=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'c_average')
@@ -51,7 +51,7 @@ class TestSaveExpval(QiskitAerTestCase):
     def test_unnorm_kwarg(self):
         """Test unnormalized kwarg"""
         key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), unnormalized=True)
+        instr = SaveExpectationValue(key, Pauli('X'), unnormalized=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'accum')
@@ -59,7 +59,7 @@ class TestSaveExpval(QiskitAerTestCase):
     def test_unnorm_cond_kwarg(self):
         """Test unnormalized, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), conditional=True, unnormalized=True)
+        instr = SaveExpectationValue(key, Pauli('X'), conditional=True, unnormalized=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'c_accum')
@@ -67,7 +67,7 @@ class TestSaveExpval(QiskitAerTestCase):
     def test_pershot_kwarg(self):
         """Test pershot kwarg"""
         key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), pershot=True)
+        instr = SaveExpectationValue(key, Pauli('X'), pershot=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'list')
@@ -75,28 +75,28 @@ class TestSaveExpval(QiskitAerTestCase):
     def test_pershot_cond_kwarg(self):
         """Test pershot, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), conditional=True, pershot=True)
+        instr = SaveExpectationValue(key, Pauli('X'), conditional=True, pershot=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'c_list')
 
 
-class TestSaveExpvalVar(QiskitAerTestCase):
-    """SaveExpval instruction tests"""
+class TestSaveExpectationValueVariance(QiskitAerTestCase):
+    """SaveExpectationValue instruction tests"""
 
     def test_invalid_key_raises(self):
         """Test save instruction key is str"""
-        self.assertRaises(ExtensionError, lambda: SaveExpvalVar(1, Pauli('Z')))
+        self.assertRaises(ExtensionError, lambda: SaveExpectationValueVariance(1, Pauli('Z')))
 
     def test_nonhermitian_raises(self):
         """Test non-Hermitian op raises exception."""
         op = [[0, 1j], [1j, 0]]
-        self.assertRaises(ExtensionError, lambda: SaveExpvalVar('expval', op))
+        self.assertRaises(ExtensionError, lambda: SaveExpectationValueVariance('expval', op))
 
     def test_default_kwarg(self):
         """Test default kwargs"""
         key = 'test_key'
-        instr = SaveExpvalVar(key, Pauli('X'))
+        instr = SaveExpectationValueVariance(key, Pauli('X'))
         self.assertEqual(instr.name, 'save_expval_var')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'average')
@@ -104,7 +104,7 @@ class TestSaveExpvalVar(QiskitAerTestCase):
     def test_cond_kwarg(self):
         """Test conditional kwarg"""
         key = 'test_key'
-        instr = SaveExpvalVar(key, Pauli('X'), conditional=True)
+        instr = SaveExpectationValueVariance(key, Pauli('X'), conditional=True)
         self.assertEqual(instr.name, 'save_expval_var')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'c_average')
@@ -112,7 +112,7 @@ class TestSaveExpvalVar(QiskitAerTestCase):
     def test_unnorm_kwarg(self):
         """Test unnormalized kwarg"""
         key = 'test_key'
-        instr = SaveExpvalVar(key, Pauli('X'), unnormalized=True)
+        instr = SaveExpectationValueVariance(key, Pauli('X'), unnormalized=True)
         self.assertEqual(instr.name, 'save_expval_var')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'accum')
@@ -120,7 +120,7 @@ class TestSaveExpvalVar(QiskitAerTestCase):
     def test_unnorm_cond_kwarg(self):
         """Test unnormalized, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpvalVar(key, Pauli('X'), conditional=True, unnormalized=True)
+        instr = SaveExpectationValueVariance(key, Pauli('X'), conditional=True, unnormalized=True)
         self.assertEqual(instr.name, 'save_expval_var')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'c_accum')
@@ -128,7 +128,7 @@ class TestSaveExpvalVar(QiskitAerTestCase):
     def test_pershot_kwarg(self):
         """Test pershot kwarg"""
         key = 'test_key'
-        instr = SaveExpvalVar(key, Pauli('X'), pershot=True)
+        instr = SaveExpectationValueVariance(key, Pauli('X'), pershot=True)
         self.assertEqual(instr.name, 'save_expval_var')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'list')
@@ -136,7 +136,7 @@ class TestSaveExpvalVar(QiskitAerTestCase):
     def test_pershot_cond_kwarg(self):
         """Test pershot, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpvalVar(key, Pauli('X'), conditional=True, pershot=True)
+        instr = SaveExpectationValueVariance(key, Pauli('X'), conditional=True, pershot=True)
         self.assertEqual(instr.name, 'save_expval_var')
         self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'c_list')

--- a/test/terra/extensions/test_save_expval.py
+++ b/test/terra/extensions/test_save_expval.py
@@ -14,7 +14,7 @@ import unittest
 
 
 from qiskit.extensions.exceptions import ExtensionError
-from qiskit.providers.aer.library import SaveExpval
+from qiskit.providers.aer.library import SaveExpval, SaveExpvalVar
 from qiskit.quantum_info.operators import Pauli
 
 from ..common import QiskitAerTestCase
@@ -38,7 +38,6 @@ class TestSaveExpval(QiskitAerTestCase):
         instr = SaveExpval(key, Pauli('X'))
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
-        self.assertFalse(instr._variance)
         self.assertEqual(instr._subtype, 'average')
 
     def test_cond_kwarg(self):
@@ -47,25 +46,6 @@ class TestSaveExpval(QiskitAerTestCase):
         instr = SaveExpval(key, Pauli('X'), conditional=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
-        self.assertFalse(instr._variance)
-        self.assertEqual(instr._subtype, 'c_average')
-
-    def test_var_kwarg(self):
-        """Test variance kwarg"""
-        key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), variance=True)
-        self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
-        self.assertTrue(instr._variance)
-        self.assertEqual(instr._subtype, 'average')
-
-    def test_var_cond_kwarg(self):
-        """Test variance, conditional kwargs"""
-        key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), variance=True, conditional=True)
-        self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
-        self.assertTrue(instr._variance)
         self.assertEqual(instr._subtype, 'c_average')
 
     def test_unnorm_kwarg(self):
@@ -74,7 +54,6 @@ class TestSaveExpval(QiskitAerTestCase):
         instr = SaveExpval(key, Pauli('X'), unnormalized=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
-        self.assertFalse(instr._variance)
         self.assertEqual(instr._subtype, 'accum')
 
     def test_unnorm_cond_kwarg(self):
@@ -83,26 +62,6 @@ class TestSaveExpval(QiskitAerTestCase):
         instr = SaveExpval(key, Pauli('X'), conditional=True, unnormalized=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
-        self.assertFalse(instr._variance)
-        self.assertEqual(instr._subtype, 'c_accum')
-
-    def test_unnorm_var_kwarg(self):
-        """Test unnormalized, variance kwargs"""
-        key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), variance=True, unnormalized=True)
-        self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
-        self.assertTrue(instr._variance)
-        self.assertEqual(instr._subtype, 'accum')
-
-    def test_unnorm_var_cond_kwarg(self):
-        """Test unnormalized, conditional kwargs"""
-        key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), variance=True, conditional=True,
-                           unnormalized=True)
-        self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
-        self.assertTrue(instr._variance)
         self.assertEqual(instr._subtype, 'c_accum')
 
     def test_pershot_kwarg(self):
@@ -111,7 +70,6 @@ class TestSaveExpval(QiskitAerTestCase):
         instr = SaveExpval(key, Pauli('X'), pershot=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
-        self.assertFalse(instr._variance)
         self.assertEqual(instr._subtype, 'list')
 
     def test_pershot_cond_kwarg(self):
@@ -120,26 +78,67 @@ class TestSaveExpval(QiskitAerTestCase):
         instr = SaveExpval(key, Pauli('X'), conditional=True, pershot=True)
         self.assertEqual(instr.name, 'save_expval')
         self.assertEqual(instr._key, key)
-        self.assertFalse(instr._variance)
         self.assertEqual(instr._subtype, 'c_list')
 
-    def test_pershot_var_kwarg(self):
-        """Test pershot, variance kwargs"""
+
+class TestSaveExpvalVar(QiskitAerTestCase):
+    """SaveExpval instruction tests"""
+
+    def test_invalid_key_raises(self):
+        """Test save instruction key is str"""
+        self.assertRaises(ExtensionError, lambda: SaveExpvalVar(1, Pauli('Z')))
+
+    def test_nonhermitian_raises(self):
+        """Test non-Hermitian op raises exception."""
+        op = [[0, 1j], [1j, 0]]
+        self.assertRaises(ExtensionError, lambda: SaveExpvalVar('expval', op))
+
+    def test_default_kwarg(self):
+        """Test default kwargs"""
         key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), variance=True, pershot=True)
-        self.assertEqual(instr.name, 'save_expval')
+        instr = SaveExpvalVar(key, Pauli('X'))
+        self.assertEqual(instr.name, 'save_expval_var')
         self.assertEqual(instr._key, key)
-        self.assertTrue(instr._variance)
+        self.assertEqual(instr._subtype, 'average')
+
+    def test_cond_kwarg(self):
+        """Test conditional kwarg"""
+        key = 'test_key'
+        instr = SaveExpvalVar(key, Pauli('X'), conditional=True)
+        self.assertEqual(instr.name, 'save_expval_var')
+        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._subtype, 'c_average')
+
+    def test_unnorm_kwarg(self):
+        """Test unnormalized kwarg"""
+        key = 'test_key'
+        instr = SaveExpvalVar(key, Pauli('X'), unnormalized=True)
+        self.assertEqual(instr.name, 'save_expval_var')
+        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._subtype, 'accum')
+
+    def test_unnorm_cond_kwarg(self):
+        """Test unnormalized, conditonal kwargs"""
+        key = 'test_key'
+        instr = SaveExpvalVar(key, Pauli('X'), conditional=True, unnormalized=True)
+        self.assertEqual(instr.name, 'save_expval_var')
+        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._subtype, 'c_accum')
+
+    def test_pershot_kwarg(self):
+        """Test pershot kwarg"""
+        key = 'test_key'
+        instr = SaveExpvalVar(key, Pauli('X'), pershot=True)
+        self.assertEqual(instr.name, 'save_expval_var')
+        self.assertEqual(instr._key, key)
         self.assertEqual(instr._subtype, 'list')
 
-    def test_pershot_var_cond_kwarg(self):
-        """Test pershot, conditional kwargs"""
+    def test_pershot_cond_kwarg(self):
+        """Test pershot, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpval(key, Pauli('X'), variance=True, conditional=True,
-                           pershot=True)
-        self.assertEqual(instr.name, 'save_expval')
+        instr = SaveExpvalVar(key, Pauli('X'), conditional=True, pershot=True)
+        self.assertEqual(instr.name, 'save_expval_var')
         self.assertEqual(instr._key, key)
-        self.assertTrue(instr._variance)
         self.assertEqual(instr._subtype, 'c_list')
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds support for new `SaveExpectationValue` and `SaveExpectationValueVariance` instructions as outlined in #1062. These function can be used with the circuit methods `save_expval`, `save_expval_var` which are automatically monkey patched when importing the Aer provider.

### Details and comments

The `SaveExpectationValuel` instruction saves expval `E[H]` of a Hermitian operator as a float, while the `SaveExpectationValueVariance` saves an array `[E[H], V[H]]` of the expval and variance `V[H] = (E[H], E[H^2] - E[H]^2)`. The operator can be input as any `BaseOperator` subclass from the quantum_info module, though it will be converted to a `SparsePauliOp` internally for the instruction.

For each of these types the result can be returned as one of the following subtypes:

* saving as a list of values for each simulated shot (`pershot=True`)
* saving without normalizing the average by number of shots (`unnormalized=True`)
* saving any of the above (average, pershot, unnormalized) conditional on any classical register values from preceding measurements (`conditional=True`)

#### Basic example

```python
import qiskit
import qiskit.quantum_info as qi
from qiskit.providers.aer import QasmSimulator

# Generate random Hermitian operator
op = qi.random_hermitian(2 ** 3, seed=10)

# Initial state circuit
qc = qiskit.QuantumCircuit(3)
qc.h(0)
qc.cx(0, 1)
qc.cx(1, 2)

# Save expectation value
qc.save_expectation_value('expval', op, [0, 1, 2])
qc.save_expectation_value_variance('expval_var', op, [0, 1, 2])

# Run
sim = QasmSimulator()
result = qiskit.execute(qc, sim).result()

print(result.data(0))
```
```python
{'expval': -1.0219294356952844, 'expval_var': array([-1.02192944,  1.44909355])}
```
