### PR TITLE
Increase CI test timeouts

### DIFF
--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -83,7 +83,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     needs: [sdist, lint]
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/tests_mac.yml
+++ b/.github/workflows/tests_mac.yml
@@ -77,7 +77,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     needs: [sdist, lint]
-    timeout-minutes: 25
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -40,7 +40,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     needs: ["lint"]
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Increases timeout of unit tests, adds more time for slower MacOS tests.

### Details and comments

* Increase linux and windows timeout from 25min to 30 min
* Increase macos timeout from 25 min to 40 min
