### PR TITLE
Allow v2 provider backends

### DIFF
--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -18,7 +18,7 @@ import logging
 from warnings import warn
 
 from qiskit.circuit import Instruction
-from qiskit.providers import BaseBackend
+from qiskit.providers import BaseBackend, Backend
 from qiskit.providers.models import BackendProperties
 
 from ..backends.aerbackend import AerJSONEncoder
@@ -269,7 +269,7 @@ class NoiseModel:
         Raises:
             NoiseError: If the input backend is not valid.
         """
-        if isinstance(backend, BaseBackend):
+        if isinstance(backend, (BaseBackend, Backend)):
             properties = backend.properties()
             if not properties:
                 raise NoiseError('Qiskit backend {} does not have a '

--- a/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
@@ -17,7 +17,7 @@
 
 from warnings import warn
 from collections import OrderedDict
-from qiskit.providers import BaseBackend
+from qiskit.providers import BaseBackend, Backend
 from ...aererror import AerError
 from .hamiltonian_model import HamiltonianModel
 
@@ -94,7 +94,7 @@ class PulseSystemModel():
             AerError: If channel or u_channel_lo are invalid.
         """
 
-        if not isinstance(backend, BaseBackend):
+        if not isinstance(backend, (BaseBackend, Backend)):
             raise AerError("{} is not a Qiskit backend".format(backend))
 
         # get relevant information from backend

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup_requirements = common_requirements + [
 if not _DISABLE_CONAN:
     setup_requirements.append('conan>=1.22.2')
 
-requirements = common_requirements + ['qiskit-terra>=0.12.0']
+requirements = common_requirements + ['qiskit-terra>=0.16.0']
 
 if not hasattr(setuptools,
                'find_namespace_packages') or not inspect.ismethod(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Qiskit/qiskit-terra#5086 introduced v2 provider with new classes `Backend`, `Job`, and `Provider`. `ibmq-provider` is switching to v2 provider interface, and this PR ensures that `Backend` will be accepted in addition to `BaseBackend`. 


### Details and comments


