### PR TITLE
Fix noise model basis_gates when constructing from device

### DIFF
--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -278,7 +278,7 @@ class NoiseModel:
         elif isinstance(backend, BackendProperties):
             properties = backend
             basis_gates = set()
-            for prop in backend.properties().gates:
+            for prop in properties.gates:
                 basis_gates.add(prop.gate)
             basis_gates = list(basis_gates)
         else:

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -278,8 +278,8 @@ class NoiseModel:
         elif isinstance(backend, BackendProperties):
             properties = backend
             basis_gates = set()
-            for g in backend.properties().gates:
-                basis_gates.add(g.gate)
+            for prop in backend.properties().gates:
+                basis_gates.add(prop.gate)
             basis_gates = list(basis_gates)
         else:
             raise NoiseError('{} is not a Qiskit backend or'

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -93,12 +93,12 @@ class NoiseModel:
 
     # Checks for standard 1-3 qubit instructions
     _1qubit_instructions = set([
-        "x90", "u1", "u2", "u3", "U", "id", "x", "y", "z", "h", "s", "sdg",
-        "t", "tdg", "r", "rx", "ry", "rz", "p"
-    ])
-    _2qubit_instructions = set(["cx", "cy", "cz", "swap", "rxx", "ryy", "rzz",
-                                "rzx", "cu1", "cu2", "cu3", "cp"])
-    _3qubit_instructions = set(["ccx", "cswap"])
+        'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
+        'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg'])
+    _2qubit_instructions = set([
+        'swap', 'cx', 'cy', 'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx',
+        'ryy', 'rzz', 'rzx'])
+    _3qubit_instructions = set(['ccx', 'cswap'])
 
     def __init__(self, basis_gates=None):
         """Initialize an empty noise model.
@@ -271,15 +271,20 @@ class NoiseModel:
         """
         if isinstance(backend, (BaseBackend, Backend)):
             properties = backend.properties()
+            basis_gates = backend.configuration().basis_gates
             if not properties:
                 raise NoiseError('Qiskit backend {} does not have a '
                                  'BackendProperties'.format(backend))
         elif isinstance(backend, BackendProperties):
             properties = backend
+            basis_gates = set()
+            for g in backend.properties().gates:
+                basis_gates.add(g.gate)
+            basis_gates = list(basis_gates)
         else:
             raise NoiseError('{} is not a Qiskit backend or'
                              ' BackendProperties'.format(backend))
-        noise_model = NoiseModel()
+        noise_model = NoiseModel(basis_gates=basis_gates)
 
         # Add single-qubit readout errors
         if readout_error:

--- a/releasenotes/notes/fix-noise-basis-gates-ecdfa43394ff78e3.yaml
+++ b/releasenotes/notes/fix-noise-basis-gates-ecdfa43394ff78e3.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixes bug in
+    :meth:`~qiskit.providers.aer.noise.NoiseModel.from_backend` and
+    :meth:`~qiskit.providers.aer.QasmSimulator.from_backend` where
+    :attr:`~qiskit.providers.aer.noise.NoiseModel.basis_gates` was set
+    incorrectly for IBMQ devices with basis gate set
+   ``['id', 'rz', 'sx', 'x', 'cx']``. Now the noise model will always
+   have the same basis gates as the backend basis gates regardless of
+   whether those instructions have errors in the noise model or not.

--- a/releasenotes/notes/fix-noise-basis-gates-ecdfa43394ff78e3.yaml
+++ b/releasenotes/notes/fix-noise-basis-gates-ecdfa43394ff78e3.yaml
@@ -6,6 +6,6 @@ fixes:
     :meth:`~qiskit.providers.aer.QasmSimulator.from_backend` where
     :attr:`~qiskit.providers.aer.noise.NoiseModel.basis_gates` was set
     incorrectly for IBMQ devices with basis gate set
-   ``['id', 'rz', 'sx', 'x', 'cx']``. Now the noise model will always
-   have the same basis gates as the backend basis gates regardless of
-   whether those instructions have errors in the noise model or not.
+    ``['id', 'rz', 'sx', 'x', 'cx']``. Now the noise model will always
+    have the same basis gates as the backend basis gates regardless of
+    whether those instructions have errors in the noise model or not.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1107 

### Details and comments

Fixes bug in `NoiseModel.from_backend` and `QasmSimulator.from_backend` where `basis_gates` was set incorrectly for IBMQ devices with basis gate set ``['id', 'rz', 'sx', 'x', 'cx']``. Now the noise model will always have the same basis gates as the backend basis gates regardless of whether those instructions have errors in the noise model or not.
