### PR TITLE
Add Windows Python 3.9 release wheel builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
         - bash: |
             set -x
             set -e
-            for version in 3.6 3.7 3.8 ; do
+            for version in 3.6 3.7 3.8 3.9 ; do
                 conda create --yes --quiet --name qiskit-aer-$version python=$version
             done
           displayName: Create Anaconda environments
@@ -41,7 +41,7 @@ stages:
             set -x
             set -e
             mkdir wheelhouse
-            for version in 3.6 3.7 3.8 ; do
+            for version in 3.6 3.7 3.8 3.9 ; do
                 source activate qiskit-aer-$version
                 conda update --yes -n base conda
                 conda config --add channels conda-forge
@@ -87,7 +87,7 @@ stages:
         - bash: |
             set -x
             set -e
-            for version in 3.6 3.7 3.8 ; do
+            for version in 3.6 3.7 3.8 3.9 ; do
                 conda create --yes --quiet --name qiskit-aer-$version python=$version
             done
           displayName: Create Anaconda environments
@@ -97,7 +97,7 @@ stages:
             set -x
             set -e
             mkdir wheelhouse
-            for version in 3.6 3.7 3.8 ; do
+            for version in 3.6 3.7 3.8 3.9 ; do
                 source activate qiskit-aer-$version
                 conda install --yes --quiet --name qiskit-aer-$version python=$version numpy cmake pip setuptools pybind11 scipy
                 python -m pip install -U setuptools wheel


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In 0.7.3 we backported the Python 3.9 support PR to include builds for
running Aer on Python 3.9 in that release. However, as was discovered
during that release process the wheels for windows (both 64bit and
32bit) on 3.9 were missing. We never added 3.9 to the version list for
the wheels to build. This commit fixes that oversight so that we ensure
that we're building Python 3.9 wheels on windows too.

### Details and comments


