### PR TITLE
Add ``SaveStatevector`` and ``SaveDensityMatrix`` instructions

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -295,11 +295,11 @@ class QasmSimulator(AerBackend):
             'initialize', 'delay', 'pauli', 'mcx_gray',
             # Custom instructions
             'kraus', 'roerror', 'snapshot', 'save_expval', 'save_expval_var',
-            'save_statevector'
+            'save_density_matrix', 'save_statevector'
         ]),
         'custom_instructions': sorted([
             'roerror', 'kraus', 'snapshot', 'save_expval', 'save_expval_var',
-            'save_statevector']),
+            'save_density_matrix', 'save_statevector']),
         'gates': []
     }
 
@@ -475,7 +475,8 @@ class QasmSimulator(AerBackend):
             config.n_qubits = config.n_qubits // 2
             config.description = 'A C++ QasmQobj density matrix simulator with noise'
             config.custom_instructions = sorted([
-                'roerror', 'snapshot', 'kraus', 'superop', 'save_expval', 'save_expval_var'])
+                'roerror', 'snapshot', 'kraus', 'superop', 'save_expval', 'save_expval_var',
+                'save_density_matrix'])
             config.basis_gates = sorted([
                 'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
                 'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
@@ -488,7 +489,7 @@ class QasmSimulator(AerBackend):
             config.description = 'A C++ QasmQobj matrix product state simulator with noise'
             config.custom_instructions = sorted([
                 'roerror', 'snapshot', 'kraus', 'save_expval', 'save_expval_var',
-                'save_statevector'])
+                'save_density_matrix', 'save_statevector'])
             config.basis_gates = sorted([
                 'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
                 'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay',

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -294,10 +294,12 @@ class QasmSimulator(AerBackend):
             'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
             'initialize', 'delay', 'pauli', 'mcx_gray',
             # Custom instructions
-            'kraus', 'roerror', 'snapshot', 'save_expval', 'save_expval_var'
+            'kraus', 'roerror', 'snapshot', 'save_expval', 'save_expval_var',
+            'save_statevector'
         ]),
         'custom_instructions': sorted([
-            'roerror', 'kraus', 'snapshot', 'save_expval', 'save_expval_var']),
+            'roerror', 'kraus', 'snapshot', 'save_expval', 'save_expval_var',
+            'save_statevector']),
         'gates': []
     }
 
@@ -485,7 +487,8 @@ class QasmSimulator(AerBackend):
         elif method == 'matrix_product_state':
             config.description = 'A C++ QasmQobj matrix product state simulator with noise'
             config.custom_instructions = sorted([
-                'roerror', 'snapshot', 'kraus', 'save_expval', 'save_expval_var'])
+                'roerror', 'snapshot', 'kraus', 'save_expval', 'save_expval_var',
+                'save_statevector'])
             config.basis_gates = sorted([
                 'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
                 'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay',
@@ -508,7 +511,7 @@ class QasmSimulator(AerBackend):
         elif method == 'extended_stabilizer':
             config.n_qubits = 63  # TODO: estimate from memory
             config.description = 'A C++ QasmQobj ranked stabilizer simulator with noise'
-            config.custom_instructions = sorted(['roerror', 'snapshot'])
+            config.custom_instructions = sorted(['roerror', 'snapshot', 'save_statevector'])
             config.basis_gates = sorted([
                 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'swap',
                 'u0', 'u1', 'p', 'ccx', 'ccz', 'delay'

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -128,7 +128,7 @@ class StatevectorSimulator(AerBackend):
             'mcp', 'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz',
             'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
             'initialize', 'kraus', 'roerror', 'delay', 'pauli',
-            'save_expval', 'save_statevector'
+            'save_expval', 'save_density_matrix', 'save_statevector'
         ],
         'gates': []
     }

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -128,7 +128,7 @@ class StatevectorSimulator(AerBackend):
             'mcp', 'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz',
             'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
             'initialize', 'kraus', 'roerror', 'delay', 'pauli',
-            'save_expval',
+            'save_expval', 'save_statevector'
         ],
         'gates': []
     }

--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -35,6 +35,7 @@ Instruction Classes
 
     SaveExpectationValue
     SaveExpectationValueVariance
+    SaveStatevector
 
 Then can also be used using custom QuantumCircuit methods
 
@@ -46,6 +47,7 @@ QuantumCircuit Methods
 
     save_expectation_value
     save_expectation_value_variance
+    save_statevector
 
 .. note ::
 
@@ -67,8 +69,10 @@ QuantumCircuit Methods
     state.
 """
 
-__all__ = ['SaveExpectationValue', 'SaveExpectationValueVariance']
+__all__ = ['SaveExpectationValue', 'SaveExpectationValueVariance',
+           'SaveStatevector']
 
 from .save_expectation_value import (
     SaveExpectationValue, save_expectation_value,
     SaveExpectationValueVariance, save_expectation_value_variance)
+from .save_statevector import SaveStatevector, save_statevector

--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -36,6 +36,7 @@ Instruction Classes
     SaveExpectationValue
     SaveExpectationValueVariance
     SaveStatevector
+    SaveStatevectorDict
 
 Then can also be used using custom QuantumCircuit methods
 
@@ -48,6 +49,7 @@ QuantumCircuit Methods
     save_expectation_value
     save_expectation_value_variance
     save_statevector
+    save_statevector_dict
 
 .. note ::
 
@@ -70,9 +72,10 @@ QuantumCircuit Methods
 """
 
 __all__ = ['SaveExpectationValue', 'SaveExpectationValueVariance',
-           'SaveStatevector']
+           'SaveStatevector', 'SaveStatevectorDict']
 
 from .save_expectation_value import (
     SaveExpectationValue, save_expectation_value,
     SaveExpectationValueVariance, save_expectation_value_variance)
 from .save_statevector import SaveStatevector, save_statevector
+from .save_statevector import SaveStatevectorDict, save_statevector_dict

--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -35,6 +35,7 @@ Instruction Classes
 
     SaveExpectationValue
     SaveExpectationValueVariance
+    SaveDensityMatrix
     SaveStatevector
     SaveStatevectorDict
 
@@ -48,6 +49,7 @@ QuantumCircuit Methods
 
     save_expectation_value
     save_expectation_value_variance
+    save_density_matrix
     save_statevector
     save_statevector_dict
 
@@ -72,10 +74,11 @@ QuantumCircuit Methods
 """
 
 __all__ = ['SaveExpectationValue', 'SaveExpectationValueVariance',
-           'SaveStatevector', 'SaveStatevectorDict']
+           'SaveStatevector', 'SaveStatevectorDict', 'SaveDensityMatrix']
 
 from .save_expectation_value import (
     SaveExpectationValue, save_expectation_value,
     SaveExpectationValueVariance, save_expectation_value_variance)
 from .save_statevector import SaveStatevector, save_statevector
 from .save_statevector import SaveStatevectorDict, save_statevector_dict
+from .save_density_matrix import SaveDensityMatrix, save_density_matrix

--- a/qiskit/providers/aer/library/save_data.py
+++ b/qiskit/providers/aer/library/save_data.py
@@ -84,9 +84,9 @@ class SaveAverageData(SaveData):
                  name,
                  key,
                  num_qubits,
+                 unnormalized=False,
                  pershot=False,
                  conditional=False,
-                 unnormalized=False,
                  params=None):
         """Create new save data instruction.
 
@@ -94,15 +94,15 @@ class SaveAverageData(SaveData):
             name (str): the name of hte save instruction.
             key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the snapshot type.
+            unnormalized (bool): If True return save the unnormalized accumulated
+                                 or conditional accumulated data over all shot.
+                                 [Default: False].
             pershot (bool): if True save a list of data for each shot of the
                             simulation rather than the average over  all shots
                             [Default: False].
             conditional (bool): if True save the average or pershot data
                                 conditional on the current classical register
                                 values [Default: False].
-            unnormalized (bool): If True return save the unnormalized accumulated
-                                 or conditional accumulated data over all shot.
-                                 [Default: False].
             params (list or None): Optional, the parameters for instruction
                                    [Default: None].
         """

--- a/qiskit/providers/aer/library/save_data.py
+++ b/qiskit/providers/aer/library/save_data.py
@@ -28,7 +28,8 @@ class SaveData(Directive):
     """Pragma Instruction to save simulator data."""
 
     _allowed_subtypes = set([
-        'single', 'list', 'c_list', 'average', 'c_average', 'accum', 'c_accum'
+        'single', 'c_single', 'list', 'c_list',
+        'average', 'c_average', 'accum', 'c_accum'
     ])
 
     def __init__(self, name, key, num_qubits, subtype='single', params=None):
@@ -134,15 +135,15 @@ class SaveSingleData(SaveData):
             num_qubits (int): the number of qubits for the snapshot type.
             pershot (bool): if True save a list of data for each shot of the
                             simulation [Default: False].
-            conditional (bool): if True save pershot data conditional on the
+            conditional (bool): if True save data conditional on the
                                 current classical register values
                                 [Default: False].
             params (list or None): Optional, the parameters for instruction
                                    [Default: None].
         """
-        subtype = 'single'
-        if pershot:
-            subtype = 'c_list' if conditional else 'list'
+        subtype = 'list' if pershot else 'single'
+        if conditional:
+            subtype = 'c_' + subtype
         super().__init__(name, key, num_qubits, subtype=subtype, params=params)
 
 

--- a/qiskit/providers/aer/library/save_density_matrix.py
+++ b/qiskit/providers/aer/library/save_density_matrix.py
@@ -40,7 +40,7 @@ class SaveDensityMatrix(SaveAverageData):
                                 conditional on the current classical register
                                 values [Default: False].
         """
-        super().__init__("save_densmat",
+        super().__init__("save_density_matrix",
                          key,
                          num_qubits,
                          pershot=pershot,

--- a/qiskit/providers/aer/library/save_density_matrix.py
+++ b/qiskit/providers/aer/library/save_density_matrix.py
@@ -58,8 +58,9 @@ def save_density_matrix(self,
 
     Args:
         key (str): the key for retrieving saved data from results.
-        qubits (list or None): the qubits to apply snapshot to. If None all
-                               qubits will be snapshot [Default: None].
+        qubits (list or None): the qubits to save reduced density matrix on.
+                               If None the full density matrix of qubits will
+                               be saved [Default: None].
         unnormalized (bool): If True return save the unnormalized accumulated
                              or conditional accumulated density matrix over
                              all shots [Default: False].

--- a/qiskit/providers/aer/library/save_density_matrix.py
+++ b/qiskit/providers/aer/library/save_density_matrix.py
@@ -1,0 +1,85 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Simulator instruction to save a density matrix.
+"""
+
+from qiskit.circuit import QuantumCircuit
+from .save_data import SaveAverageData, default_qubits
+
+
+class SaveDensityMatrix(SaveAverageData):
+    """Save a reduced density matrix."""
+    def __init__(self,
+                 key,
+                 num_qubits,
+                 unnormalized=False,
+                 pershot=False,
+                 conditional=False):
+        """Create new instruction to save the simulator reduced density matrix.
+
+        Args:
+            key (str): the key for retrieving saved data from results.
+            num_qubits (int): the number of qubits for the save instruction.
+            unnormalized (bool): If True return save the unnormalized accumulated
+                                 or conditional accumulated density matrix over
+                                 all shots [Default: False].
+            pershot (bool): if True save a list of density matrices for each shot
+                            of the  simulation rather than the average over
+                            all shots [Default: False].
+            conditional (bool): if True save the average or pershot data
+                                conditional on the current classical register
+                                values [Default: False].
+        """
+        super().__init__("save_densmat",
+                         key,
+                         num_qubits,
+                         pershot=pershot,
+                         unnormalized=unnormalized,
+                         conditional=conditional)
+
+
+def save_density_matrix(self,
+                        key,
+                        qubits=None,
+                        conditional=False,
+                        pershot=False,
+                        unnormalized=False):
+    """Save the current simulator quantum state as a density matrix.
+
+    Args:
+        key (str): the key for retrieving saved data from results.
+        qubits (list or None): the qubits to apply snapshot to. If None all
+                               qubits will be snapshot [Default: None].
+        unnormalized (bool): If True return save the unnormalized accumulated
+                             or conditional accumulated density matrix over
+                             all shots [Default: False].
+        pershot (bool): if True save a list of density matrices for each shot
+                        of the  simulation rather than the average over
+                        all shots [Default: False].
+        conditional (bool): if True save the average or pershot data
+                            conditional on the current classical register
+                            values [Default: False].
+
+    Returns:
+        QuantumCircuit: with attached instruction.
+    """
+    qubits = default_qubits(self, qubits=qubits)
+    instr = SaveDensityMatrix(key,
+                              len(qubits),
+                              unnormalized=unnormalized,
+                              pershot=pershot,
+                              conditional=conditional)
+    return self.append(instr, qubits)
+
+
+QuantumCircuit.save_density_matrix = save_density_matrix

--- a/qiskit/providers/aer/library/save_density_matrix.py
+++ b/qiskit/providers/aer/library/save_density_matrix.py
@@ -43,17 +43,17 @@ class SaveDensityMatrix(SaveAverageData):
         super().__init__("save_density_matrix",
                          key,
                          num_qubits,
-                         pershot=pershot,
                          unnormalized=unnormalized,
+                         pershot=pershot,
                          conditional=conditional)
 
 
 def save_density_matrix(self,
                         key,
                         qubits=None,
-                        conditional=False,
+                        unnormalized=False,
                         pershot=False,
-                        unnormalized=False):
+                        conditional=False):
     """Save the current simulator quantum state as a density matrix.
 
     Args:

--- a/qiskit/providers/aer/library/save_expectation_value.py
+++ b/qiskit/providers/aer/library/save_expectation_value.py
@@ -78,8 +78,8 @@ class SaveExpectationValueVariance(SaveAverageData):
                  key,
                  operator,
                  unnormalized=False,
-                 conditional=False,
-                 pershot=False):
+                 pershot=False,
+                 conditional=False):
         r"""Instruction to save the expectation value and variance of a Hermitian operator.
 
         The expectation value of a Hermitian operator :math:`H` for a
@@ -118,8 +118,8 @@ class SaveExpectationValueVariance(SaveAverageData):
         super().__init__('save_expval_var',
                          key,
                          operator.num_qubits,
-                         pershot=pershot,
                          unnormalized=unnormalized,
+                         pershot=pershot,
                          conditional=conditional,
                          params=params)
 

--- a/qiskit/providers/aer/library/save_expectation_value.py
+++ b/qiskit/providers/aer/library/save_expectation_value.py
@@ -26,8 +26,8 @@ class SaveExpectationValue(SaveAverageData):
                  key,
                  operator,
                  unnormalized=False,
-                 conditional=False,
-                 pershot=False):
+                 pershot=False,
+                 conditional=False):
         r"""Instruction to save the expectation value of a Hermitian operator.
 
         The expectation value of a Hermitian operator :math:`H` for a simulator
@@ -66,9 +66,9 @@ class SaveExpectationValue(SaveAverageData):
         super().__init__('save_expval',
                          key,
                          operator.num_qubits,
-                         conditional=conditional,
-                         pershot=pershot,
                          unnormalized=unnormalized,
+                         pershot=pershot,
+                         conditional=conditional,
                          params=params)
 
 
@@ -118,9 +118,9 @@ class SaveExpectationValueVariance(SaveAverageData):
         super().__init__('save_expval_var',
                          key,
                          operator.num_qubits,
-                         conditional=conditional,
                          pershot=pershot,
                          unnormalized=unnormalized,
+                         conditional=conditional,
                          params=params)
 
 
@@ -162,8 +162,8 @@ def save_expectation_value(self,
                            operator,
                            qubits,
                            unnormalized=False,
-                           conditional=False,
-                           pershot=False):
+                           pershot=False,
+                           conditional=False):
     r"""Save the expectation value of a Hermitian operator.
 
     Args:
@@ -193,8 +193,8 @@ def save_expectation_value(self,
     instr = SaveExpectationValue(key,
                                  operator,
                                  unnormalized=unnormalized,
-                                 conditional=conditional,
-                                 pershot=pershot)
+                                 pershot=pershot,
+                                 conditional=conditional)
     return self.append(instr, qubits)
 
 
@@ -203,8 +203,8 @@ def save_expectation_value_variance(self,
                                     operator,
                                     qubits,
                                     unnormalized=False,
-                                    conditional=False,
-                                    pershot=False):
+                                    pershot=False,
+                                    conditional=False):
     r"""Save the expectation value of a Hermitian operator.
 
     Args:
@@ -233,8 +233,8 @@ def save_expectation_value_variance(self,
     instr = SaveExpectationValueVariance(key,
                                          operator,
                                          unnormalized=unnormalized,
-                                         conditional=conditional,
-                                         pershot=pershot)
+                                         pershot=pershot,
+                                         conditional=conditional)
     return self.append(instr, qubits)
 
 

--- a/qiskit/providers/aer/library/save_statevector.py
+++ b/qiskit/providers/aer/library/save_statevector.py
@@ -1,0 +1,93 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Simulator instruction to save statevector.
+"""
+
+from qiskit.circuit import QuantumCircuit
+from .save_data import SaveSingleData, default_qubits
+
+
+class SaveStatevector(SaveSingleData):
+    """Save statevector"""
+    def __init__(self, key, num_qubits, pershot=False, conditional=False):
+        """Create new instruction to save the simualtor statevector.
+
+        Args:
+            key (str): the key for retrieving saved data from results.
+            num_qubits (int): the number of qubits of the
+            pershot (bool): if True save a list of statevectors for each
+                            shot of the simulation rather than a single
+                            statevector [Default: False].
+            conditional (bool): if True save data conditional on the current
+                                classical register values [Default: False].
+
+        .. note::
+
+            This save instruction must always be performed on the full width of
+            qubits in a circuit, otherwise an exception will be raised during
+            simulation.
+
+        .. note ::
+
+            In cetain cases the list returned by ``pershot=True`` may only
+            contain a single value, rather than the number of shots. This
+            happens when running an ideal simulation on a circuit that
+            supports measurement sampling because it has measurements at
+            the end. In this case only a single shot is simulated and
+            measurement samples for all shots are calculated from the final
+            state.
+        """
+        super().__init__('save_statevector',
+                         key,
+                         num_qubits,
+                         pershot=pershot,
+                         conditional=conditional)
+
+
+def save_statevector(self, key, pershot=False, conditional=False):
+    """Save the current simulator quantum state as a statevector.
+
+    Args:
+        key (str): the key for retrieving saved data from results.
+        pershot (bool): if True save a list of statevectors for each
+                        shot of the simulation [Default: False].
+        conditional (bool): if True save pershot data conditional on the
+                            current classical register values
+                            [Default: False].
+
+    Returns:
+        QuantumCircuit: with attached instruction.
+
+    .. note:
+
+        This instruction is always defined across all qubits in a circuit.
+
+    .. note ::
+
+        In cetain cases the list returned by ``pershot=True`` may only
+        contain a single value, rather than the number of shots. This
+        happens when running an ideal simulation on a circuit that
+        supports measurement sampling because it has measurements at
+        the end. In this case only a single shot is simulated and
+        measurement samples for all shots are calculated from the final
+        state.
+    """
+    qubits = default_qubits(self)
+    instr = SaveStatevector(key,
+                            len(qubits),
+                            pershot=pershot,
+                            conditional=conditional)
+    return self.append(instr, qubits)
+
+
+QuantumCircuit.save_statevector = save_statevector

--- a/qiskit/providers/aer/library/save_statevector.py
+++ b/qiskit/providers/aer/library/save_statevector.py
@@ -36,18 +36,35 @@ class SaveStatevector(SaveSingleData):
             This save instruction must always be performed on the full width of
             qubits in a circuit, otherwise an exception will be raised during
             simulation.
-
-        .. note ::
-
-            In cetain cases the list returned by ``pershot=True`` may only
-            contain a single value, rather than the number of shots. This
-            happens when running an ideal simulation on a circuit that
-            supports measurement sampling because it has measurements at
-            the end. In this case only a single shot is simulated and
-            measurement samples for all shots are calculated from the final
-            state.
         """
         super().__init__('save_statevector',
+                         key,
+                         num_qubits,
+                         pershot=pershot,
+                         conditional=conditional)
+
+
+class SaveStatevectorDict(SaveSingleData):
+    """Save statevector as ket-form dictionary."""
+    def __init__(self, key, num_qubits, pershot=False, conditional=False):
+        """Create new instruction to save the simualtor statevector as a dict.
+
+        Args:
+            key (str): the key for retrieving saved data from results.
+            num_qubits (int): the number of qubits of the
+            pershot (bool): if True save a list of statevectors for each
+                            shot of the simulation rather than a single
+                            statevector [Default: False].
+            conditional (bool): if True save data conditional on the current
+                                classical register values [Default: False].
+
+        .. note::
+
+            This save instruction must always be performed on the full width of
+            qubits in a circuit, otherwise an exception will be raised during
+            simulation.
+        """
+        super().__init__('save_statevector_dict',
                          key,
                          num_qubits,
                          pershot=pershot,
@@ -71,16 +88,6 @@ def save_statevector(self, key, pershot=False, conditional=False):
     .. note:
 
         This instruction is always defined across all qubits in a circuit.
-
-    .. note ::
-
-        In cetain cases the list returned by ``pershot=True`` may only
-        contain a single value, rather than the number of shots. This
-        happens when running an ideal simulation on a circuit that
-        supports measurement sampling because it has measurements at
-        the end. In this case only a single shot is simulated and
-        measurement samples for all shots are calculated from the final
-        state.
     """
     qubits = default_qubits(self)
     instr = SaveStatevector(key,
@@ -90,4 +97,31 @@ def save_statevector(self, key, pershot=False, conditional=False):
     return self.append(instr, qubits)
 
 
+def save_statevector_dict(self, key, pershot=False, conditional=False):
+    """Save the current simulator quantum state as a statevector as a dict.
+
+    Args:
+        key (str): the key for retrieving saved data from results.
+        pershot (bool): if True save a list of statevectors for each
+                        shot of the simulation [Default: False].
+        conditional (bool): if True save pershot data conditional on the
+                            current classical register values
+                            [Default: False].
+
+    Returns:
+        QuantumCircuit: with attached instruction.
+
+    .. note:
+
+        This instruction is always defined across all qubits in a circuit.
+    """
+    qubits = default_qubits(self)
+    instr = SaveStatevectorDict(key,
+                                len(qubits),
+                                pershot=pershot,
+                                conditional=conditional)
+    return self.append(instr, qubits)
+
+
 QuantumCircuit.save_statevector = save_statevector
+QuantumCircuit.save_statevector_dict = save_statevector_dict

--- a/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
+++ b/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
@@ -19,3 +19,15 @@ features:
     This instruction can also be appended to a quantum circuit by using the
     :class:`~qiskit.providers.aer.library.save_expectation_value_variance``
     circuit method which is added to ``QuantumCircuit`` when importing Aer.
+  - |
+    Adds a :class:`qiskit.providers.aer.library.SaveStatevector` quantum circuit
+    instruction for saving the current statevector of the
+    :class:`~qiskit.providers.aer.StatevectorSimulator` or
+    :class:`~qiskit.providers.aer.QasmSimulator` with a supported simulation
+    method (``"statevector"``, ``"statevector_gpu"``,
+    ``"matrix_product_state"``, ``"extended_stabilizer"``). Note that this
+    instruction always acts on the full width of the circuit being executed.
+    
+    This instruction can also be appended to a quantum circuit by using the
+    :class:`~qiskit.providers.aer.library.save_statevector`` circuit method
+    which is added to ``QuantumCircuit`` when importing Aer.

--- a/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
+++ b/releasenotes/notes/save-data-instructions-24b127612c9f6502.yaml
@@ -31,3 +31,15 @@ features:
     This instruction can also be appended to a quantum circuit by using the
     :class:`~qiskit.providers.aer.library.save_statevector`` circuit method
     which is added to ``QuantumCircuit`` when importing Aer.
+  - |
+    Adds a :class:`qiskit.providers.aer.library.SaveDensityMatrix` quantum circuit
+    instruction for saving the reduced density matrix on the specified qubits
+    for the current simulator state of the
+    :class:`~qiskit.providers.aer.StatevectorSimulator` or
+    :class:`~qiskit.providers.aer.QasmSimulator` with a supported simulation
+    method (``"density_matrix"``, ``"density_matrix_gpu"``, ``"statevector"``,
+    ``"statevector_gpu"``, ``"matrix_product_state"``). 
+    
+    This instruction can also be appended to a quantum circuit by using the
+    :class:`~qiskit.providers.aer.library.save_density_matrix`` circuit method
+    which is added to ``QuantumCircuit`` when importing Aer.

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -41,7 +41,7 @@ enum class OpType {
   // Noise instructions
   kraus, superop, roerror, noise_switch,
   // Save instructions
-  save_expval, save_expval_var, save_statevec
+  save_expval, save_expval_var, save_statevec, save_statevec_ket
 };
 
 enum class DataSubType {
@@ -76,6 +76,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     stream << "save_expval_var";
   case OpType::save_statevec:
     stream << "save_statevector";
+    break;
+  case OpType::save_statevec_ket:
+    stream << "save_statevector_dict";
     break;
   case OpType::snapshot:
     stream << "snapshot";
@@ -483,6 +486,8 @@ Op json_to_op(const json_t &js) {
     return json_to_op_save_expval(js, true);
   if (name == "save_statevector")
     return json_to_op_save_default(js);
+  if (name == "save_statevector_dict")
+    return json_to_op_save_default(js);
   // Snapshot
   if (name == "snapshot")
     return json_to_op_snapshot(js);
@@ -876,7 +881,8 @@ Op json_to_op_save_default(const json_t &js) {
 
   // Handle default types type
   static const std::unordered_map<std::string, OpType> default_names({
-    {"save_statevector", OpType::save_statevec}
+    {"save_statevector", OpType::save_statevec},
+    {"save_statevector_dict", OpType::save_statevec_ket}
   });
   // NOTE: these will be added later
   auto type_it = default_names.find(op.name);

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -881,6 +881,7 @@ Op json_to_op_save_default(const json_t &js) {
   // Get subtype
   static const std::unordered_map<std::string, DataSubType> subtypes {
     {"single", DataSubType::single},
+    {"c_single", DataSubType::c_single},
     {"average", DataSubType::average},
     {"c_average", DataSubType::c_average},
     {"list", DataSubType::list},

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -41,7 +41,8 @@ enum class OpType {
   // Noise instructions
   kraus, superop, roerror, noise_switch,
   // Save instructions
-  save_expval, save_expval_var, save_statevec, save_statevec_ket
+  save_expval, save_expval_var, save_statevec, save_statevec_ket,
+  save_densmat
 };
 
 enum class DataSubType {
@@ -49,7 +50,9 @@ enum class DataSubType {
 };
 
 static const std::unordered_set<OpType> SAVE_TYPES = {
-  OpType::save_expval, OpType::save_expval_var
+  OpType::save_expval, OpType::save_expval_var,
+  OpType::save_statevec, OpType::save_statevec_ket,
+  OpType::save_densmat
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
@@ -79,6 +82,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     break;
   case OpType::save_statevec_ket:
     stream << "save_statevector_dict";
+    break;
+  case OpType::save_densmat:
+    stream << "save_density_matrix";
     break;
   case OpType::snapshot:
     stream << "snapshot";
@@ -427,7 +433,7 @@ Op json_to_op_initialize(const json_t &js);
 Op json_to_op_pauli(const json_t &js);
 
 // Save data
-Op json_to_op_save_default(const json_t &js);
+Op json_to_op_save_default(const json_t &js, OpType op_type);
 Op json_to_op_save_expval(const json_t &js, bool variance);
 
 // Snapshots
@@ -485,9 +491,11 @@ Op json_to_op(const json_t &js) {
   if (name == "save_expval_var")
     return json_to_op_save_expval(js, true);
   if (name == "save_statevector")
-    return json_to_op_save_default(js);
+    return json_to_op_save_default(js, OpType::save_statevec);
   if (name == "save_statevector_dict")
-    return json_to_op_save_default(js);
+    return json_to_op_save_default(js, OpType::save_statevec_ket);
+  if (name == "save_density_matrix")
+    return json_to_op_save_default(js, OpType::save_densmat);
   // Snapshot
   if (name == "snapshot")
     return json_to_op_snapshot(js);
@@ -875,20 +883,10 @@ Op json_to_op_noise_switch(const json_t &js) {
 // Implementation: Save data deserialization
 //------------------------------------------------------------------------------
 
-Op json_to_op_save_default(const json_t &js) {
+Op json_to_op_save_default(const json_t &js, OpType op_type) {
   Op op;
+  op.type = op_type;
   JSON::get_value(op.name, "name", js);
-
-  // Handle default types type
-  static const std::unordered_map<std::string, OpType> default_names({
-    {"save_statevector", OpType::save_statevec},
-    {"save_statevector_dict", OpType::save_statevec_ket}
-  });
-  // NOTE: these will be added later
-  auto type_it = default_names.find(op.name);
-  if (type_it != default_names.end()) {
-    op.type = type_it->second;
-  }
 
   // Get subtype
   static const std::unordered_map<std::string, DataSubType> subtypes {
@@ -920,11 +918,10 @@ Op json_to_op_save_default(const json_t &js) {
 }
 
 Op json_to_op_save_expval(const json_t &js, bool variance) {
-
   // Initialized default save instruction params
-  Op op = json_to_op_save_default(js);
-  op.type = (variance) ? OpType::save_expval_var
-                       : OpType::save_expval;
+  auto op_type = (variance) ? OpType::save_expval_var
+                            : OpType::save_expval;
+  Op op = json_to_op_save_default(js, op_type);
 
   // Parse Pauli operator components
   const auto threshold = 1e-12; // drop small components

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -41,7 +41,7 @@ enum class OpType {
   // Noise instructions
   kraus, superop, roerror, noise_switch,
   // Save instructions
-  save_expval, save_expval_var
+  save_expval, save_expval_var, save_statevec
 };
 
 enum class DataSubType {
@@ -74,6 +74,8 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     break;
   case OpType::save_expval_var:
     stream << "save_expval_var";
+  case OpType::save_statevec:
+    stream << "save_statevector";
     break;
   case OpType::snapshot:
     stream << "snapshot";
@@ -479,6 +481,8 @@ Op json_to_op(const json_t &js) {
     return json_to_op_save_expval(js, false);
   if (name == "save_expval_var")
     return json_to_op_save_expval(js, true);
+  if (name == "save_statevector")
+    return json_to_op_save_default(js);
   // Snapshot
   if (name == "snapshot")
     return json_to_op_snapshot(js);
@@ -871,7 +875,9 @@ Op json_to_op_save_default(const json_t &js) {
   JSON::get_value(op.name, "name", js);
 
   // Handle default types type
-  static const std::unordered_map<std::string, OpType> default_names;
+  static const std::unordered_map<std::string, OpType> default_names({
+    {"save_statevector", OpType::save_statevec}
+  });
   // NOTE: these will be added later
   auto type_it = default_names.find(op.name);
   if (type_it != default_names.end()) {

--- a/src/framework/results/data/data.hpp
+++ b/src/framework/results/data/data.hpp
@@ -28,6 +28,7 @@
 #include "framework/results/data/mixins/data_rvector.hpp"
 #include "framework/results/data/mixins/data_cmatrix.hpp"
 #include "framework/results/data/mixins/data_cvector.hpp"
+#include "framework/results/data/mixins/data_cdict.hpp"
 
 namespace AER {
 
@@ -39,7 +40,8 @@ struct Data : public DataCreg,
               public DataRValue,
               public DataRVector,
               public DataCVector,
-              public DataCMatrix {
+              public DataCMatrix,
+              public DataCDict {
 
   //----------------------------------------------------------------
   // Measurement data
@@ -132,6 +134,7 @@ Data &Data::combine(Data &&other) {
   DataRVector::combine(std::move(other));
   DataCVector::combine(std::move(other));
   DataCMatrix::combine(std::move(other));
+  DataCDict::combine(std::move(other));
   DataCreg::combine(std::move(other));
   return *this;
 }
@@ -142,6 +145,7 @@ json_t Data::to_json() {
   DataRVector::add_to_json(result);
   DataCVector::add_to_json(result);
   DataCMatrix::add_to_json(result);
+  DataCDict::add_to_json(result);
   DataCreg::add_to_json(result);
   return result;
 }

--- a/src/framework/results/data/mixins/data_cdict.hpp
+++ b/src/framework/results/data/mixins/data_cdict.hpp
@@ -1,0 +1,66 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2021.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_results_data_cdict_hpp_
+#define _aer_framework_results_data_cdict_hpp_
+
+#include <complex>
+#include <map>
+
+#include "framework/results/data/subtypes/data_map.hpp"
+#include "framework/results/data/subtypes/list_data.hpp"
+#include "framework/results/data/subtypes/single_data.hpp"
+#include "framework/types.hpp"
+
+namespace AER {
+
+//============================================================================
+// Result container for Qiskit-Aer
+//============================================================================
+
+struct DataCDict : public DataMap<SingleData, std::map<std::string, complex_t>, 1>,
+                   public DataMap<SingleData, std::map<std::string, complex_t>, 2>,
+                   public DataMap<ListData, std::map<std::string, complex_t>, 1>,
+                   public DataMap<ListData, std::map<std::string, complex_t>, 2> {
+
+  // Serialize engine data to JSON
+  void add_to_json(json_t &result);
+
+  // Combine stored data
+  DataCDict &combine(DataCDict &&other);
+};
+
+//------------------------------------------------------------------------------
+// Implementation
+//------------------------------------------------------------------------------
+
+DataCDict &DataCDict::combine(DataCDict &&other) {
+  DataMap<SingleData, std::map<std::string, complex_t>, 1>::combine(std::move(other));
+  DataMap<SingleData, std::map<std::string, complex_t>, 2>::combine(std::move(other));
+  DataMap<ListData, std::map<std::string, complex_t>, 1>::combine(std::move(other));
+  DataMap<ListData, std::map<std::string, complex_t>, 2>::combine(std::move(other));
+  return *this;
+}
+
+void DataCDict::add_to_json(json_t &result) {
+  DataMap<SingleData, std::map<std::string, complex_t>, 1>::add_to_json(result);
+  DataMap<SingleData, std::map<std::string, complex_t>, 2>::add_to_json(result);
+  DataMap<ListData, std::map<std::string, complex_t>, 1>::add_to_json(result);
+  DataMap<ListData, std::map<std::string, complex_t>, 2>::add_to_json(result);
+}
+
+//------------------------------------------------------------------------------
+} // end namespace AER
+//------------------------------------------------------------------------------
+#endif

--- a/src/framework/results/data/mixins/data_cmatrix.hpp
+++ b/src/framework/results/data/mixins/data_cmatrix.hpp
@@ -31,6 +31,8 @@ namespace AER {
 struct DataCMatrix :
     public DataMap<SingleData, matrix<complex_t>, 1>,
     public DataMap<SingleData, matrix<complexf_t>, 1>,
+    public DataMap<SingleData, matrix<complex_t>, 2>,
+    public DataMap<SingleData, matrix<complexf_t>, 2>,
     public DataMap<ListData, matrix<complex_t>, 1>,
     public DataMap<ListData, matrix<complexf_t>, 1>,
     public DataMap<ListData, matrix<complex_t>, 2>,
@@ -58,6 +60,8 @@ struct DataCMatrix :
 DataCMatrix &DataCMatrix::combine(DataCMatrix &&other) {
   DataMap<SingleData, matrix<complex_t>, 1>::combine(std::move(other));
   DataMap<SingleData, matrix<complexf_t>, 1>::combine(std::move(other));
+  DataMap<SingleData, matrix<complex_t>, 2>::combine(std::move(other));
+  DataMap<SingleData, matrix<complexf_t>, 2>::combine(std::move(other));
   DataMap<ListData, matrix<complex_t>, 1>::combine(std::move(other));
   DataMap<ListData, matrix<complexf_t>, 1>::combine(std::move(other));
   DataMap<ListData, matrix<complex_t>, 2>::combine(std::move(other));
@@ -77,6 +81,8 @@ void DataCMatrix::add_to_json(json_t &result) {
 
   DataMap<SingleData, matrix<complex_t>, 1>::add_to_json(result);
   DataMap<SingleData, matrix<complexf_t>, 1>::add_to_json(result);
+  DataMap<SingleData, matrix<complex_t>, 2>::add_to_json(result);
+  DataMap<SingleData, matrix<complexf_t>, 2>::add_to_json(result);
   DataMap<ListData, matrix<complex_t>, 1>::add_to_json(result);
   DataMap<ListData, matrix<complexf_t>, 1>::add_to_json(result);
   DataMap<ListData, matrix<complex_t>, 2>::add_to_json(result);

--- a/src/framework/results/data/mixins/data_cvector.hpp
+++ b/src/framework/results/data/mixins/data_cvector.hpp
@@ -28,6 +28,8 @@ namespace AER {
 
 struct DataCVector : public DataMap<SingleData, Vector<complex_t>, 1>,
                      public DataMap<SingleData, Vector<complexf_t>, 1>,
+                     public DataMap<SingleData, Vector<complex_t>, 2>,
+                     public DataMap<SingleData, Vector<complexf_t>, 2>,
                      public DataMap<ListData, Vector<complex_t>, 1>,
                      public DataMap<ListData, Vector<complexf_t>, 1>,
                      public DataMap<ListData, Vector<complex_t>, 2>,
@@ -47,6 +49,8 @@ struct DataCVector : public DataMap<SingleData, Vector<complex_t>, 1>,
 DataCVector &DataCVector::combine(DataCVector &&other) {
   DataMap<SingleData, Vector<complex_t>, 1>::combine(std::move(other));
   DataMap<SingleData, Vector<complexf_t>, 1>::combine(std::move(other));
+  DataMap<SingleData, Vector<complex_t>, 2>::combine(std::move(other));
+  DataMap<SingleData, Vector<complexf_t>, 2>::combine(std::move(other));
   DataMap<ListData, Vector<complex_t>, 1>::combine(std::move(other));
   DataMap<ListData, Vector<complexf_t>, 1>::combine(std::move(other));
   DataMap<ListData, Vector<complex_t>, 2>::combine(std::move(other));
@@ -57,6 +61,8 @@ DataCVector &DataCVector::combine(DataCVector &&other) {
 void DataCVector::add_to_json(json_t &result) {
   DataMap<SingleData, Vector<complex_t>, 1>::add_to_json(result);
   DataMap<SingleData, Vector<complexf_t>, 1>::add_to_json(result);
+  DataMap<SingleData, Vector<complex_t>, 2>::add_to_json(result);
+  DataMap<SingleData, Vector<complexf_t>, 2>::add_to_json(result);
   DataMap<ListData, Vector<complex_t>, 1>::add_to_json(result);
   DataMap<ListData, Vector<complexf_t>, 1>::add_to_json(result);
   DataMap<ListData, Vector<complex_t>, 2>::add_to_json(result);

--- a/src/framework/results/data/mixins/pybind_data_cdict.hpp
+++ b/src/framework/results/data/mixins/pybind_data_cdict.hpp
@@ -1,0 +1,53 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2021.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_framework_result_data_pybind_data_cdict_hpp_
+#define _aer_framework_result_data_pybind_data_cdict_hpp_
+
+#include "framework/results/data/mixins/data_cdict.hpp"
+#include "framework/results/data/subtypes/pybind_data_map.hpp"
+
+//------------------------------------------------------------------------------
+// Aer C++ -> Python Conversion
+//------------------------------------------------------------------------------
+
+namespace AerToPy {
+
+// Move an DataCDict container object to a new Python dict
+py::object to_python(AER::DataCDict &&data);
+
+// Move an DataCDict container object to an existing new Python dict
+void add_to_python(py::dict &pydata, AER::DataCDict &&data);
+
+} //end namespace AerToPy
+
+
+//============================================================================
+// Implementations
+//============================================================================
+
+py::object AerToPy::to_python(AER::DataCDict &&data) {
+  py::dict pydata;
+  AerToPy::add_to_python(pydata, std::move(data));
+  return std::move(pydata);
+}
+
+void AerToPy::add_to_python(py::dict &pydata, AER::DataCDict &&data) {
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, std::map<std::string, AER::complex_t>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, std::map<std::string, AER::complex_t>, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, std::map<std::string, AER::complex_t>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, std::map<std::string, AER::complex_t>, 2>&&>(data));
+}
+
+#endif

--- a/src/framework/results/data/mixins/pybind_data_cmatrix.hpp
+++ b/src/framework/results/data/mixins/pybind_data_cmatrix.hpp
@@ -46,6 +46,8 @@ py::object AerToPy::to_python(AER::DataCMatrix &&data) {
 void AerToPy::add_to_python(py::dict &pydata, AER::DataCMatrix &&data) {
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, matrix<AER::complex_t>, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, matrix<AER::complexf_t>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, matrix<AER::complex_t>, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, matrix<AER::complexf_t>, 2>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, matrix<AER::complex_t>, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, matrix<AER::complexf_t>, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, matrix<AER::complex_t>, 2>&&>(data));

--- a/src/framework/results/data/mixins/pybind_data_cvector.hpp
+++ b/src/framework/results/data/mixins/pybind_data_cvector.hpp
@@ -46,6 +46,8 @@ py::object AerToPy::to_python(AER::DataCVector &&data) {
 void AerToPy::add_to_python(py::dict &pydata, AER::DataCVector &&data) {
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, AER::Vector<AER::complex_t>, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, AER::Vector<AER::complexf_t>, 1>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, AER::Vector<AER::complex_t>, 2>&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::SingleData, AER::Vector<AER::complexf_t>, 2>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, AER::Vector<AER::complex_t>, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, AER::Vector<AER::complexf_t>, 1>&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataMap<AER::ListData, AER::Vector<AER::complex_t>, 2>&&>(data));

--- a/src/framework/results/data/pybind_data.hpp
+++ b/src/framework/results/data/pybind_data.hpp
@@ -21,6 +21,7 @@
 #include "framework/results/data/mixins/pybind_data_rvector.hpp"
 #include "framework/results/data/mixins/pybind_data_cmatrix.hpp"
 #include "framework/results/data/mixins/pybind_data_cvector.hpp"
+#include "framework/results/data/mixins/pybind_data_cdict.hpp"
 
 namespace AerToPy {
 
@@ -41,6 +42,7 @@ py::object AerToPy::to_python(AER::Data &&data) {
   AerToPy::add_to_python(pydata, static_cast<AER::DataRVector&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataCVector&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataCMatrix&&>(data));
+  AerToPy::add_to_python(pydata, static_cast<AER::DataCDict&&>(data));
   AerToPy::add_to_python(pydata, static_cast<AER::DataCreg&&>(data));
   return std::move(pydata);
 }

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -46,7 +46,7 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::roerror, Operations::OpType::matrix,
      Operations::OpType::diagonal_matrix, Operations::OpType::kraus,
      Operations::OpType::superop, Operations::OpType::save_expval,
-     Operations::OpType::save_expval_var},
+     Operations::OpType::save_expval_var, Operations::OpType::save_densmat},
     // Gates
     {"U",    "CX",  "u1", "u2",  "u3", "u",   "cx",   "cy",  "cz",
      "swap", "id",  "x",  "y",   "z",  "h",   "s",    "sdg", "t",
@@ -184,9 +184,23 @@ protected:
   // Save data instructions
   //-----------------------------------------------------------------------
 
+  // Save the current density matrix or reduced density matrix
+  void apply_save_density_matrix(const Operations::Op &op,
+                                 ExperimentResult &result,
+                                 bool last_op = false);
+
   // Helper function for computing expectation value
   virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) override;
+
+  // Return the reduced density matrix for the simulator
+  cmatrix_t reduced_density_matrix(const reg_t &qubits, bool last_op = false);
+  cmatrix_t reduced_density_matrix_helper(const reg_t &qubits,
+                                          const reg_t &qubits_sorted);
+  cmatrix_t reduced_density_matrix_cpu(const reg_t &qubits,
+                                       const reg_t &qubits_sorted);
+  cmatrix_t reduced_density_matrix_thrust(const reg_t &qubits,
+                                          const reg_t &qubits_sorted);
 
   //-----------------------------------------------------------------------
   // Measurement Helpers
@@ -238,14 +252,6 @@ protected:
   // Snapshot the expectation value of a matrix operator
   void snapshot_matrix_expval(const Operations::Op &op, ExperimentResult &result,
                               bool variance);
-
-  // Return the reduced density matrix for the simulator
-  cmatrix_t reduced_density_matrix(const reg_t &qubits,
-                                   const reg_t &qubits_sorted);
-  cmatrix_t reduced_density_matrix_cpu(const reg_t &qubits,
-                                       const reg_t &qubits_sorted);
-  cmatrix_t reduced_density_matrix_thrust(const reg_t &qubits,
-                                          const reg_t &qubits_sorted);
 
   //-----------------------------------------------------------------------
   // Single-qubit gate helpers
@@ -470,6 +476,9 @@ void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
         case Operations::OpType::save_expval_var:
           BaseState::apply_save_expval(op, result);
           break;
+        case Operations::OpType::save_densmat:
+          apply_save_density_matrix(op, result, final_ops && ops.size() == i + 1);
+          break;
         default:
           throw std::invalid_argument("DensityMatrix::State::invalid instruction \'" +
                                       op.name + "\'.");
@@ -486,6 +495,139 @@ template <class statevec_t>
 double State<statevec_t>::expval_pauli(const reg_t &qubits,
                                        const std::string& pauli) {
   return BaseState::qreg_.expval_pauli(qubits, pauli);
+}
+
+template <class densmat_t>
+void State<densmat_t>::apply_save_density_matrix(const Operations::Op &op,
+                                                 ExperimentResult &result,
+                                                 bool last_op) {
+  BaseState::save_data_average(result, op.string_params[0],
+                               reduced_density_matrix(op.qubits, last_op),
+                               op.save_type);
+}
+
+template <class densmat_t>
+cmatrix_t State<densmat_t>::reduced_density_matrix(const reg_t& qubits, bool last_op) {
+  cmatrix_t reduced_state;
+
+  // Check if tracing over all qubits
+  if (qubits.empty()) {
+    reduced_state = cmatrix_t(1, 1);
+    reduced_state[0] = BaseState::qreg_.trace();
+  } else {
+
+    auto qubits_sorted = qubits;
+    std::sort(qubits_sorted.begin(), qubits_sorted.end());
+
+    if ((qubits.size() == BaseState::qreg_.num_qubits()) && (qubits == qubits_sorted)) {
+      if (last_op) {
+        reduced_state = BaseState::qreg_.move_to_matrix();
+      } else {
+        reduced_state = BaseState::qreg_.copy_to_matrix();
+      }
+    } else {
+      reduced_state = reduced_density_matrix_helper(qubits, qubits_sorted);
+    }
+  }
+  return reduced_state;
+}
+
+template <class statevec_t>
+cmatrix_t
+State<statevec_t>::reduced_density_matrix_helper(const reg_t &qubits,
+                                          const reg_t &qubits_sorted) {
+  return reduced_density_matrix_cpu(qubits, qubits_sorted);
+}
+
+#ifdef AER_THRUST_SUPPORTED
+// Thrust specialization must copy memory from device to host
+template <>
+cmatrix_t State<QV::DensityMatrixThrust<float>>::reduced_density_matrix_helper(
+    const reg_t &qubits, const reg_t &qubits_sorted) {
+
+  return reduced_density_matrix_thrust(qubits, qubits_sorted);
+}
+
+template <>
+cmatrix_t State<QV::DensityMatrixThrust<double>>::reduced_density_matrix_helper(
+    const reg_t &qubits, const reg_t &qubits_sorted) {
+
+  return reduced_density_matrix_thrust(qubits, qubits_sorted);
+}
+#endif
+
+template <class densmat_t>
+cmatrix_t
+State<densmat_t>::reduced_density_matrix_cpu(const reg_t &qubits,
+                                             const reg_t &qubits_sorted) {
+
+  // Get superoperator qubits
+  const reg_t squbits = BaseState::qreg_.superop_qubits(qubits);
+  const reg_t squbits_sorted = BaseState::qreg_.superop_qubits(qubits_sorted);
+
+  // Get dimensions
+  const size_t N = qubits.size();
+  const size_t DIM = 1ULL << N;
+  const int_t VDIM = 1ULL << (2 * N);
+  const size_t END = 1ULL << (BaseState::qreg_.num_qubits() - N);
+  const size_t SHIFT = END + 1;
+
+  // TODO: If we are not going to apply any additional instructions after
+  //       this function we could move the memory when constructing rather
+  //       than copying
+  const auto &vmat = BaseState::qreg_.data();
+  cmatrix_t reduced_state(DIM, DIM, false);
+  {
+    // Fill matrix with first iteration
+    const auto inds = QV::indexes(squbits, squbits_sorted, 0);
+    for (int_t i = 0; i < VDIM; ++i) {
+      reduced_state[i] = complex_t(vmat[inds[i]]);
+    }
+  }
+  // Accumulate with remaning blocks
+  for (size_t k = 1; k < END; k++) {
+    const auto inds = QV::indexes(squbits, squbits_sorted, k * SHIFT);
+    for (int_t i = 0; i < VDIM; ++i) {
+      reduced_state[i] += complex_t(vmat[inds[i]]);
+    }
+  }
+  return reduced_state;
+}
+
+template <class densmat_t>
+cmatrix_t
+State<densmat_t>::reduced_density_matrix_thrust(const reg_t &qubits,
+                                                const reg_t &qubits_sorted) {
+
+  // Get superoperator qubits
+  const reg_t squbits = BaseState::qreg_.superop_qubits(qubits);
+  const reg_t squbits_sorted = BaseState::qreg_.superop_qubits(qubits_sorted);
+
+  // Get dimensions
+  const size_t N = qubits.size();
+  const size_t DIM = 1ULL << N;
+  const int_t VDIM = 1ULL << (2 * N);
+  const size_t END = 1ULL << (BaseState::qreg_.num_qubits() - N);
+  const size_t SHIFT = END + 1;
+
+  // Copy vector to host memory
+  auto vmat = BaseState::qreg_.vector();
+  cmatrix_t reduced_state(DIM, DIM, false);
+  {
+    // Fill matrix with first iteration
+    const auto inds = QV::indexes(squbits, squbits_sorted, 0);
+    for (int_t i = 0; i < VDIM; ++i) {
+      reduced_state[i] = std::move(vmat[inds[i]]);
+    }
+  }
+  // Accumulate with remaning blocks
+  for (size_t k = 1; k < END; k++) {
+    const auto inds = QV::indexes(squbits, squbits_sorted, k * SHIFT);
+    for (int_t i = 0; i < VDIM; ++i) {
+      reduced_state[i] += complex_t(std::move(vmat[inds[i]]));
+    }
+  }
+  return reduced_state;
 }
 
 //=========================================================================
@@ -585,129 +727,10 @@ template <class densmat_t>
 void State<densmat_t>::snapshot_density_matrix(const Operations::Op &op,
                                                ExperimentResult &result,
                                                bool last_op) {
-  cmatrix_t reduced_state;
-
-  // Check if tracing over all qubits
-  if (op.qubits.empty()) {
-    reduced_state = cmatrix_t(1, 1);
-    reduced_state[0] = BaseState::qreg_.trace();
-  } else {
-
-    auto qubits_sorted = op.qubits;
-    std::sort(qubits_sorted.begin(), qubits_sorted.end());
-
-    if ((op.qubits.size() == BaseState::qreg_.num_qubits()) && (op.qubits == qubits_sorted)) {
-      if (last_op) {
-        reduced_state = BaseState::qreg_.move_to_matrix();
-      } else {
-        reduced_state = BaseState::qreg_.copy_to_matrix();
-      }
-    } else {
-      reduced_state = reduced_density_matrix(op.qubits, qubits_sorted);
-    }
-  }
-
   result.legacy_data.add_average_snapshot("density_matrix", op.string_params[0],
-                            BaseState::creg_.memory_hex(),
-                            std::move(reduced_state), false);
-}
-
-template <class statevec_t>
-cmatrix_t
-State<statevec_t>::reduced_density_matrix(const reg_t &qubits,
-                                          const reg_t &qubits_sorted) {
-  return reduced_density_matrix_cpu(qubits, qubits_sorted);
-}
-
-#ifdef AER_THRUST_SUPPORTED
-// Thrust specialization must copy memory from device to host
-template <>
-cmatrix_t State<QV::DensityMatrixThrust<float>>::reduced_density_matrix(
-    const reg_t &qubits, const reg_t &qubits_sorted) {
-
-  return reduced_density_matrix_thrust(qubits, qubits_sorted);
-}
-
-template <>
-cmatrix_t State<QV::DensityMatrixThrust<double>>::reduced_density_matrix(
-    const reg_t &qubits, const reg_t &qubits_sorted) {
-
-  return reduced_density_matrix_thrust(qubits, qubits_sorted);
-}
-#endif
-
-template <class densmat_t>
-cmatrix_t
-State<densmat_t>::reduced_density_matrix_cpu(const reg_t &qubits,
-                                             const reg_t &qubits_sorted) {
-
-  // Get superoperator qubits
-  const reg_t squbits = BaseState::qreg_.superop_qubits(qubits);
-  const reg_t squbits_sorted = BaseState::qreg_.superop_qubits(qubits_sorted);
-
-  // Get dimensions
-  const size_t N = qubits.size();
-  const size_t DIM = 1ULL << N;
-  const int_t VDIM = 1ULL << (2 * N);
-  const size_t END = 1ULL << (BaseState::qreg_.num_qubits() - N);
-  const size_t SHIFT = END + 1;
-
-  // TODO: If we are not going to apply any additional instructions after
-  //       this function we could move the memory when constructing rather
-  //       than copying
-  const auto &vmat = BaseState::qreg_.data();
-  cmatrix_t reduced_state(DIM, DIM, false);
-  {
-    // Fill matrix with first iteration
-    const auto inds = QV::indexes(squbits, squbits_sorted, 0);
-    for (int_t i = 0; i < VDIM; ++i) {
-      reduced_state[i] = complex_t(vmat[inds[i]]);
-    }
-  }
-  // Accumulate with remaning blocks
-  for (size_t k = 1; k < END; k++) {
-    const auto inds = QV::indexes(squbits, squbits_sorted, k * SHIFT);
-    for (int_t i = 0; i < VDIM; ++i) {
-      reduced_state[i] += complex_t(vmat[inds[i]]);
-    }
-  }
-  return reduced_state;
-}
-
-template <class densmat_t>
-cmatrix_t
-State<densmat_t>::reduced_density_matrix_thrust(const reg_t &qubits,
-                                                const reg_t &qubits_sorted) {
-
-  // Get superoperator qubits
-  const reg_t squbits = BaseState::qreg_.superop_qubits(qubits);
-  const reg_t squbits_sorted = BaseState::qreg_.superop_qubits(qubits_sorted);
-
-  // Get dimensions
-  const size_t N = qubits.size();
-  const size_t DIM = 1ULL << N;
-  const int_t VDIM = 1ULL << (2 * N);
-  const size_t END = 1ULL << (BaseState::qreg_.num_qubits() - N);
-  const size_t SHIFT = END + 1;
-
-  // Copy vector to host memory
-  auto vmat = BaseState::qreg_.vector();
-  cmatrix_t reduced_state(DIM, DIM, false);
-  {
-    // Fill matrix with first iteration
-    const auto inds = QV::indexes(squbits, squbits_sorted, 0);
-    for (int_t i = 0; i < VDIM; ++i) {
-      reduced_state[i] = std::move(vmat[inds[i]]);
-    }
-  }
-  // Accumulate with remaning blocks
-  for (size_t k = 1; k < END; k++) {
-    const auto inds = QV::indexes(squbits, squbits_sorted, k * SHIFT);
-    for (int_t i = 0; i < VDIM; ++i) {
-      reduced_state[i] += complex_t(std::move(vmat[inds[i]]));
-    }
-  }
-  return reduced_state;
+                                          BaseState::creg_.memory_hex(),
+                                          reduced_density_matrix(op.qubits, last_op),
+                                          false);
 }
 
 //=========================================================================

--- a/src/simulators/extended_stabilizer/ch_runner.hpp
+++ b/src/simulators/extended_stabilizer/ch_runner.hpp
@@ -142,7 +142,7 @@ public:
   std::vector<uint_t> stabilizer_sampler(uint_t n_shots, AER::RngEngine &rng);
   //Utilities for the state-vector snapshot.
   complex_t amplitude(uint_t x_measure);
-  void state_vector(std::vector<complex_t> &svector, uint_t default_samples, uint_t repetitions, AER::RngEngine &rng);
+  AER::Vector<complex_t> statevector(uint_t default_samples, uint_t repetitions, AER::RngEngine &rng);
 
 };
 
@@ -719,7 +719,7 @@ complex_t Runner::amplitude(uint_t x_measure)
   return {real_part, imag_part};
 }
 
-void Runner::state_vector(std::vector<complex_t> &svector, uint_t default_samples, uint_t repetitions, AER::RngEngine &rng)
+AER::Vector<complex_t> Runner::statevector(uint_t default_samples, uint_t repetitions, AER::RngEngine &rng)
 {
   uint_t ceil = 1ULL << n_qubits_;
   uint_t n_samples = std::llrint(0.5 * std::pow(n_qubits_, 2));
@@ -727,11 +727,9 @@ void Runner::state_vector(std::vector<complex_t> &svector, uint_t default_sample
   {
     n_samples = default_samples;
   }
-  if (!svector.empty())
-  {
-    svector.clear();
-  }
-  svector.reserve(ceil);
+
+  AER::Vector<complex_t> svector(ceil, false);
+
   // double norm = 1;
   double norm = 1;
   if(num_states_ > 1)
@@ -740,8 +738,9 @@ void Runner::state_vector(std::vector<complex_t> &svector, uint_t default_sample
   }
   for(uint_t i=0; i<ceil; i++)
   {
-    svector.push_back(amplitude(i)/std::sqrt(norm));
+    svector[i] = amplitude(i)/std::sqrt(norm);
   }
+  return svector;
 }
 
 //=========================================================================

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -36,7 +36,7 @@ const Operations::OpSet StateOpSet(
   {Operations::OpType::gate, Operations::OpType::measure,
     Operations::OpType::reset, Operations::OpType::barrier,
     Operations::OpType::roerror, Operations::OpType::bfunc,
-    Operations::OpType::snapshot},
+    Operations::OpType::snapshot, Operations::OpType::save_statevec},
   // Gates
   {"CX", "u0", "u1", "p", "cx", "cz", "swap", "id", "x", "y", "z", "h",
     "s", "sdg", "t", "tdg", "ccx", "ccz", "delay"},
@@ -141,6 +141,11 @@ protected:
   //-----------------------------------------------------------------------
   // Save data instructions
   //-----------------------------------------------------------------------
+
+  // Compute and save the statevector for the current simulator state
+  void apply_save_statevector(const Operations::Op &op,
+                              ExperimentResult &result,
+                              RngEngine &rng);
 
   // Helper function for computing expectation value
   virtual double expval_pauli(const reg_t &qubits,
@@ -341,8 +346,10 @@ bool State::check_measurement_opt(const std::vector<Operations::Op> &ops) const
     {
       return false;
     }
-    if (op.type == Operations::OpType::measure || op.type == Operations::OpType::bfunc ||
-        op.type == Operations::OpType::snapshot)
+    if (op.type == Operations::OpType::measure ||
+        op.type == Operations::OpType::bfunc ||
+        op.type == Operations::OpType::snapshot ||
+        op.type == Operations::OpType::save_statevec)
     {
       return false;
     }
@@ -409,6 +416,9 @@ void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &
             case Operations::OpType::snapshot:
               apply_snapshot(op, result, rng);
               break;
+            case Operations::OpType::save_statevec:
+              apply_save_statevector(op, result, rng);
+              break;
             default:
               throw std::invalid_argument("CH::State::apply_ops does not support operations of the type \'" + 
                                           op.name + "\'.");
@@ -418,7 +428,6 @@ void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &
       }
     }
   }
-  
 }
 
 std::vector<reg_t> State::sample_measure(const reg_t& qubits,
@@ -537,6 +546,9 @@ void State::apply_stabilizer_circuit(const std::vector<Operations::Op> &ops,
         break;
       case Operations::OpType::snapshot:
         apply_snapshot(op, result, rng);
+        break;
+      case Operations::OpType::save_statevec:
+        apply_save_statevector(op, result, rng);
         break;
       default:
         throw std::invalid_argument("CH::State::apply_stabilizer_circuit does not support operations of the type \'" + 
@@ -716,6 +728,20 @@ void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank)
   }
 }
 
+void State::apply_save_statevector(const Operations::Op &op,
+                                   ExperimentResult &result,
+                                   RngEngine& rng) {
+  if (op.qubits.size() != BaseState::qreg_.get_n_qubits()) {
+    throw std::invalid_argument(
+        "Save statevector was not applied to all qubits."
+        " Only the full statevector can be saved.");
+  }
+  BaseState::save_data_pershot(
+    result, op.string_params[0],
+    BaseState::qreg_.statevector(norm_estimation_samples_, 3, rng),
+    op.save_type);
+}
+
 void State::apply_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng)
 {
   auto it = snapshotset_.find(op.name);
@@ -747,14 +773,8 @@ void State::apply_snapshot(const Operations::Op &op, ExperimentResult &result, R
 
 void State::statevector_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng)
 {
-  cvector_t statevector;
-  BaseState::qreg_.state_vector(statevector,  norm_estimation_samples_, 3, rng);
-  double sum = 0.;
-  for(uint_t i=0; i<statevector.size(); i++)
-  {
-    sum += std::pow(std::abs(statevector[i]), 2);
-  }
-  result.legacy_data.add_pershot_snapshot("statevector", op.string_params[0], statevector);
+  result.legacy_data.add_pershot_snapshot("statevector", op.string_params[0],
+     BaseState::qreg_.statevector(norm_estimation_samples_, 3, rng));
 }
 
 void State::probabilities_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng)

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -50,7 +50,7 @@ const Operations::OpSet StateOpSet(
    Operations::OpType::bfunc, Operations::OpType::roerror,
    Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
    Operations::OpType::kraus, Operations::OpType::save_expval,
-   Operations::OpType::save_expval_var},
+   Operations::OpType::save_expval_var, Operations::OpType::save_statevec},
   // Gates
   {"id", "x",  "y", "z", "s",  "sdg", "h",  "t",   "tdg",  "p", "u1",
    "u2", "u3", "u", "U", "CX", "cx",  "cy", "cz", "cp", "cu1", "swap", "ccx",
@@ -211,6 +211,10 @@ protected:
   //-----------------------------------------------------------------------
   // Save data instructions
   //-----------------------------------------------------------------------
+
+  // Compute and save the statevector for the current simulator state
+  void apply_save_statevector(const Operations::Op &op,
+                              ExperimentResult &result);
 
   // Helper function for computing expectation value
   virtual double expval_pauli(const reg_t &qubits,
@@ -516,6 +520,9 @@ void State::apply_ops(const std::vector<Operations::Op> &ops,
         case Operations::OpType::save_expval_var:
           BaseState::apply_save_expval(op, result);
           break;
+        case Operations::OpType::save_statevec:
+          apply_save_statevector(op, result);
+          break;
         default:
           throw std::invalid_argument("MatrixProductState::State::invalid instruction \'" +
                                       op.name + "\'.");
@@ -531,6 +538,17 @@ void State::apply_ops(const std::vector<Operations::Op> &ops,
 double State::expval_pauli(const reg_t &qubits,
                            const std::string& pauli) {
   return BaseState::qreg_.expectation_value_pauli(qubits, pauli).real();
+}
+
+void State::apply_save_statevector(const Operations::Op &op,
+                                   ExperimentResult &result) {
+  if (op.qubits.size() != BaseState::qreg_.num_qubits()) {
+    throw std::invalid_argument(
+        "Save statevector was not applied to all qubits."
+        " Only the full statevector can be saved.");
+  }
+  BaseState::save_data_pershot(result, op.string_params[0],
+                               qreg_.full_statevector(), op.save_type);
 }
 
 //=========================================================================
@@ -611,9 +629,8 @@ void State::snapshot_matrix_expval(const Operations::Op &op,
 void State::snapshot_state(const Operations::Op &op,
 			   ExperimentResult &result,
 			   std::string name) {
-  cvector_t statevector;
-  qreg_.full_state_vector(statevector);
-  result.legacy_data.add_pershot_snapshot("statevector", op.string_params[0], statevector);
+  result.legacy_data.add_pershot_snapshot(
+    "statevector", op.string_params[0], qreg_.full_statevector());
 }
 
 void State::snapshot_amplitudes(const Operations::Op &op,

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -188,7 +188,7 @@ public:
   //----------------------------------------------------------------
   virtual std::ostream&  print(std::ostream& out) const;
 
-  void full_state_vector(cvector_t &state_vector);
+  Vector<complex_t> full_statevector();
 
   cvector_t get_amplitude_vector(const reg_t &base_values);
   complex_t get_single_amplitude(const std::string &base_value);
@@ -360,7 +360,8 @@ private:
   // This function computes the state vector for all the consecutive qubits 
   // between first_index and last_index
   MPS_Tensor state_vec_as_MPS(uint_t first_index, uint_t last_index) const;
-  void full_state_vector_internal(cvector_t &state_vector, const reg_t &qubits) ;
+
+  Vector<complex_t> full_state_vector_internal(const reg_t &qubits) ;
 
   void get_probabilities_vector_internal(rvector_t& probvector, const reg_t &qubits) const;
 

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -219,7 +219,7 @@ public:
                          DataSubType type = DataSubType::average) const;
   
   // Save data type which is pershot and does not support accumulator or average
-  // This supports DataSubTypes: single, list, c_list
+  // This supports DataSubTypes: single, c_single, list, c_list
   template <class T>
   void save_data_pershot(ExperimentResult &result,
                          const std::string &key, const T& datum,
@@ -448,7 +448,7 @@ void State<state_t>::save_data_pershot(ExperimentResult &result,
       result.data.add_single(std::move(datum), key);
       break;
     case DataSubType::c_single:
-      result.data.add_single(datum, key, creg_.memory_hex());
+      result.data.add_single(std::move(datum), key, creg_.memory_hex());
       break;
     case DataSubType::list:
       result.data.add_list(std::move(datum), key);

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -47,7 +47,9 @@ const Operations::OpSet StateOpSet(
      Operations::OpType::matrix, Operations::OpType::diagonal_matrix,
      Operations::OpType::multiplexer, Operations::OpType::kraus,
      Operations::OpType::sim_op, Operations::OpType::save_expval,
-     Operations::OpType::save_expval_var, Operations::OpType::save_statevec},
+     Operations::OpType::save_expval_var, Operations::OpType::save_statevec
+     // Operations::OpType::save_statevec_ket  // TODO
+     },
     // Gates
     {"u1",     "u2",      "u3",  "u",    "U",    "CX",   "cx",   "cz",
      "cy",     "cp",      "cu1", "cu2",  "cu3",  "swap", "id",   "p",
@@ -222,6 +224,10 @@ protected:
   void apply_save_statevector(const Operations::Op &op,
                               ExperimentResult &result,
                               bool last_op);
+
+  // Save the current state of the statevector simulator as a ket-form map.
+  void apply_save_statevector_ket(const Operations::Op &op,
+                                  ExperimentResult &result);
 
   // Helper function for computing expectation value
   virtual double expval_pauli(const reg_t &qubits,
@@ -564,6 +570,9 @@ void State<statevec_t>::apply_ops(const std::vector<Operations::Op> &ops,
         case Operations::OpType::save_statevec:
           apply_save_statevector(op, result, final_ops && ops.size() == i + 1);
           break;
+        // case Operations::OpType::save_statevec_ket:
+        //   apply_save_statevector_ket(op, result);
+        //   break;
         default:
           throw std::invalid_argument(
               "QubitVector::State::invalid instruction \'" + op.name + "\'.");
@@ -588,7 +597,7 @@ void State<statevec_t>::apply_save_statevector(const Operations::Op &op,
                                                bool last_op) {
   if (op.qubits.size() != BaseState::qreg_.num_qubits()) {
     throw std::invalid_argument(
-        "Save statevector was not applied to all qubits."
+        op.name + " was not applied to all qubits."
         " Only the full statevector can be saved.");
   }
   if (last_op) {
@@ -600,6 +609,21 @@ void State<statevec_t>::apply_save_statevector(const Operations::Op &op,
                                  BaseState::qreg_.copy_to_vector(),
                                  op.save_type);
   }
+}
+
+template <class statevec_t>
+void State<statevec_t>::apply_save_statevector_ket(const Operations::Op &op,
+                                                   ExperimentResult &result) {
+  if (op.qubits.size() != BaseState::qreg_.num_qubits()) {
+    throw std::invalid_argument(
+        op.name + " was not applied to all qubits."
+        " Only the full statevector can be saved.");
+  }
+  // TODO: compute state ket
+  std::map<std::string, complex_t> state_ket;
+
+  BaseState::save_data_pershot(result, op.string_params[0],
+                               std::move(state_ket), op.save_type);
 }
 
 //=========================================================================

--- a/test/terra/backends/qasm_simulator/qasm_save.py
+++ b/test/terra/backends/qasm_simulator/qasm_save.py
@@ -15,8 +15,9 @@ QasmSimulator Integration Tests for Save instructions
 
 from .qasm_save_expval import QasmSaveExpectationValueTests
 from .qasm_save_statevector import QasmSaveStatevectorTests
-
+from .qasm_save_density_matrix import QasmSaveDensityMatrixTests
 
 class QasmSaveDataTests(QasmSaveExpectationValueTests,
-                        QasmSaveStatevectorTests):
+                        QasmSaveStatevectorTests,
+                        QasmSaveDensityMatrixTests):
     """QasmSimulator SaveData instruction tests."""

--- a/test/terra/backends/qasm_simulator/qasm_save.py
+++ b/test/terra/backends/qasm_simulator/qasm_save.py
@@ -14,7 +14,9 @@ QasmSimulator Integration Tests for Save instructions
 """
 
 from .qasm_save_expval import QasmSaveExpectationValueTests
+from .qasm_save_statevector import QasmSaveStatevectorTests
 
 
-class QasmSaveDataTests(QasmSaveExpectationValueTests):
+class QasmSaveDataTests(QasmSaveExpectationValueTests,
+                        QasmSaveStatevectorTests):
     """QasmSimulator SaveData instruction tests."""

--- a/test/terra/backends/qasm_simulator/qasm_save_density_matrix.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_density_matrix.py
@@ -1,0 +1,180 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+QasmSimulator Integration Tests for SaveDensityMatrix instruction
+"""
+
+import numpy as np
+import qiskit.quantum_info as qi
+from qiskit import QuantumCircuit, assemble
+from qiskit.providers.aer import QasmSimulator
+
+
+class QasmSaveDensityMatrixTests:
+    """QasmSimulator SaveDensityMatrix instruction tests."""
+
+    SIMULATOR = QasmSimulator()
+    BACKEND_OPTS = {}
+
+    def test_save_density_matrix(self):
+        """Test save density matrix for instruction"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust',
+            'matrix_product_state'
+        ]
+
+        # Stabilizer test circuit
+        circ = QuantumCircuit(3)
+        circ.h(0)
+        circ.sdg(0)
+        circ.cx(0, 1)
+        circ.cx(0, 2)
+
+        # Target statevector
+        target = qi.DensityMatrix(circ)
+
+        # Add save to circuit
+        save_key = 'state'
+        circ.save_density_matrix(save_key)
+
+        # Run
+        opts = self.BACKEND_OPTS.copy()
+        qobj = assemble(circ, self.SIMULATOR)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            data = result.data(0)
+            self.assertIn(save_key, data)
+            value = qi.DensityMatrix(result.data(0)[save_key])
+            self.assertAlmostEqual(value, target)
+
+    def test_save_density_matrix_conditional(self):
+        """Test conditional save density matrix instruction"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust',
+            'matrix_product_state'
+        ]
+
+        # Stabilizer test circuit
+        save_key = 'state'
+        circ = QuantumCircuit(2)
+        circ.h(0)
+        circ.sdg(0)
+        circ.cx(0, 1)
+        circ.measure_all()
+        circ.save_density_matrix(save_key, conditional=True)
+
+        # Target statevector
+        target = {'0x0': qi.DensityMatrix(np.diag([1, 0, 0, 0])),
+                  '0x3': qi.DensityMatrix(np.diag([0, 0, 0, 1]))}
+
+        # Run
+        opts = self.BACKEND_OPTS.copy()
+        qobj = assemble(circ, self.SIMULATOR, shots=10)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            data = result.data(0)
+            self.assertIn(save_key, data)
+            for key, state in data[save_key].items():
+                self.assertIn(key, target)
+                self.assertAlmostEqual(qi.DensityMatrix(state), target[key])
+
+    def test_save_density_matrix_pershot(self):
+        """Test pershot save density matrix instruction"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust',
+            'matrix_product_state'
+        ]
+
+        # Stabilizer test circuit
+        circ = QuantumCircuit(1)
+        circ.x(0)
+        circ.reset(0)
+        circ.h(0)
+        circ.sdg(0)
+
+        # Target statevector
+        target = qi.DensityMatrix(circ)
+
+        # Add save
+        save_key = 'state'
+        circ.save_density_matrix(save_key, pershot=True)
+
+        # Run
+        shots = 10
+        opts = self.BACKEND_OPTS.copy()
+        qobj = assemble(circ, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            data = result.data(0)
+            self.assertIn(save_key, data)
+            value = result.data(0)[save_key]
+            for state in value:
+                self.assertAlmostEqual(qi.DensityMatrix(state), target)
+
+    def test_save_density_matrix_pershot_conditional(self):
+        """Test pershot conditional save density matrix instruction"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust',
+            'matrix_product_state'
+        ]
+
+        # Stabilizer test circuit
+        circ = QuantumCircuit(1)
+        circ.x(0)
+        circ.reset(0)
+        circ.h(0)
+        circ.sdg(0)
+
+        # Target statevector
+        target = qi.DensityMatrix(circ)
+
+        # Add save
+        save_key = 'state'
+        circ.save_density_matrix(save_key, pershot=True, conditional=True)
+        circ.measure_all()
+
+        # Run
+        shots = 10
+        opts = self.BACKEND_OPTS.copy()
+        qobj = assemble(circ, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            data = result.data(0)
+            self.assertIn(save_key, data)
+            value = result.data(0)[save_key]
+            self.assertIn('0x0', value)
+            for state in value['0x0']:
+                self.assertAlmostEqual(qi.DensityMatrix(state), target)

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """
-QasmSimulator Integration Tests for Snapshot instructions
+QasmSimulator Integration Tests for SaveExpval instruction
 """
 
 from ddt import ddt, data

--- a/test/terra/backends/qasm_simulator/qasm_save_statevector.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_statevector.py
@@ -1,0 +1,177 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+QasmSimulator Integration Tests for SaveStatevector instruction
+"""
+
+import qiskit.quantum_info as qi
+from qiskit import QuantumCircuit, assemble
+from qiskit.providers.aer import QasmSimulator
+
+
+class QasmSaveStatevectorTests:
+    """QasmSimulator SaveStatevector instruction tests."""
+
+    SIMULATOR = QasmSimulator()
+    BACKEND_OPTS = {}
+
+    def test_save_statevector(self):
+        """Test save statevector for instruction"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'matrix_product_state', 'extended_stabilizer'
+        ]
+
+        # Stabilizer test circuit
+        circ = QuantumCircuit(3)
+        circ.h(0)
+        circ.sdg(0)
+        circ.cx(0, 1)
+        circ.cx(0, 2)
+
+        # Target statevector
+        target = qi.Statevector(circ)
+
+        # Add save to circuit
+        save_key = 'sv'
+        circ.save_statevector(save_key)
+
+        # Run
+        opts = self.BACKEND_OPTS.copy()
+        qobj = assemble(circ, self.SIMULATOR)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            data = result.data(0)
+            self.assertIn(save_key, data)
+            value = qi.Statevector(result.data(0)[save_key])
+            self.assertAlmostEqual(value, target)
+
+    def test_save_statevector_conditional(self):
+        """Test conditional save statevector instruction"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'matrix_product_state', 'extended_stabilizer'
+        ]
+
+        # Stabilizer test circuit
+        save_key = 'sv'
+        circ = QuantumCircuit(2)
+        circ.h(0)
+        circ.sdg(0)
+        circ.cx(0, 1)
+        circ.measure_all()
+        circ.save_statevector(save_key, conditional=True)
+
+        # Target statevector
+        target = {'0x0': qi.Statevector([1, 0, 0, 0]),
+                  '0x3': qi.Statevector([0, 0, 0, -1j])}
+
+        # Run
+        opts = self.BACKEND_OPTS.copy()
+        qobj = assemble(circ, self.SIMULATOR, shots=10)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            data = result.data(0)
+            self.assertIn(save_key, data)
+            for key, vec in data[save_key].items():
+                self.assertIn(key, target)
+                self.assertAlmostEqual(qi.Statevector(vec), target[key])
+
+    def test_save_statevector_pershot(self):
+        """Test pershot save statevector instruction"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'matrix_product_state', 'extended_stabilizer'
+        ]
+
+        # Stabilizer test circuit
+        circ = QuantumCircuit(1)
+        circ.x(0)
+        circ.reset(0)
+        circ.h(0)
+        circ.sdg(0)
+
+        # Target statevector
+        target = qi.Statevector(circ)
+
+        # Add save
+        save_key = 'sv'
+        circ.save_statevector(save_key, pershot=True)
+
+        # Run
+        shots = 10
+        opts = self.BACKEND_OPTS.copy()
+        qobj = assemble(circ, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            data = result.data(0)
+            self.assertIn(save_key, data)
+            value = result.data(0)[save_key]
+            self.assertEqual(len(value), shots)
+            for vec in value:
+                self.assertAlmostEqual(qi.Statevector(vec), target)
+
+    def test_save_statevector_pershot_conditional(self):
+        """Test pershot conditional save statevector instruction"""
+
+        SUPPORTED_METHODS = [
+            'automatic', 'statevector', 'statevector_gpu', 'statevector_thrust',
+            'matrix_product_state', 'extended_stabilizer'
+        ]
+
+        # Stabilizer test circuit
+        circ = QuantumCircuit(1)
+        circ.x(0)
+        circ.reset(0)
+        circ.h(0)
+        circ.sdg(0)
+
+        # Target statevector
+        target = qi.Statevector(circ)
+
+        # Add save
+        save_key = 'sv'
+        circ.save_statevector(save_key, pershot=True, conditional=True)
+        circ.measure_all()
+
+        # Run
+        shots = 10
+        opts = self.BACKEND_OPTS.copy()
+        qobj = assemble(circ, self.SIMULATOR, shots=shots)
+        result = self.SIMULATOR.run(qobj, **opts).result()
+        method = opts.get('method', 'automatic')
+        if method not in SUPPORTED_METHODS:
+            self.assertFalse(result.success)
+        else:
+            self.assertTrue(result.success)
+            data = result.data(0)
+            self.assertIn(save_key, data)
+            value = result.data(0)[save_key]
+            self.assertIn('0x0', value)
+            self.assertEqual(len(value['0x0']), shots)
+            for vec in value['0x0']:
+                self.assertAlmostEqual(qi.Statevector(vec), target)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds support for new `SaveStatevector` and `SaveDensityMatrix` instructions as outlined in #1062. These function can be used with the circuit method `save_statevector` (`save_density_matrix`) which are automatically monkey patched when importing the Aer provider.

~Depends on #1101~

### Details and comments

By default this instruction saves a single statevector (unlike snapshot_statevector which saves a list by default). For a multi-shot simulation this will be the statevector of the last shot. It also supports 

* saving as a list of statevectors for each simulated shot (`pershot=True`)
* saving a single or list of statevectors conditional on any classical register values from preceding measurements (`conditional=True`)

#### Basic example

```python
import qiskit
from qiskit.providers.aer import QasmSimulator

# Initial state circuit
qc = qiskit.QuantumCircuit(2)
qc.h(0)
qc.cx(0, 1)

# Save final statevector
qc.save_statevector('statevector')

# Run
sim = QasmSimulator()
result = qiskit.execute(qc, sim).result()

print(result.data(0))
```
```python
{'statevector': array([0.70710678+0.j, 0.+0.j, 0.+0.j, 0.70710678+0.j])}
```


