### PR TITLE
Fix numpy ABI incompatibility when building with numpy 1.20

### DIFF
--- a/src/open_pulse/test_python_to_cpp.cpp
+++ b/src/open_pulse/test_python_to_cpp.cpp
@@ -37,7 +37,7 @@ bool cpp_test_py_dict_string_list_of_list_of_doubles_to_cpp_map_string_vec_of_ve
     return map == expected;
 }
 
-bool cpp_test_np_array_of_doubles(PyArrayObject * val){
+bool cpp_test_np_array_of_doubles(py::array val){
     // val = np.array([0., 1., 2., 3.])
     auto vec = get_value<NpArray<double>>(val);
     if(vec[0] != 0. || vec[1] != 1. || vec[2] != 2. || vec[3] != 3.)
@@ -46,7 +46,7 @@ bool cpp_test_np_array_of_doubles(PyArrayObject * val){
     return true;
 }
 
-bool cpp_test_np_2D_array_of_doubles(PyArrayObject * val){
+bool cpp_test_np_2D_array_of_doubles(py::array val){
     // val = np.array([[0., 1., 2., 3.],[10.,20.,30.,40]])
     auto vec = get_value<NpArray<double>>(val);
     if(vec(0, 0) != 0. || vec(0, 1) != 1. || vec(0, 2) != 2. || vec(0, 3) != 3. ||

--- a/src/open_pulse/test_python_to_cpp.hpp
+++ b/src/open_pulse/test_python_to_cpp.hpp
@@ -17,7 +17,6 @@
 
 #include "misc/warnings.hpp"
 DISABLE_WARNING_PUSH
-#include <numpy/arrayobject.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 DISABLE_WARNING_POP
@@ -31,8 +30,8 @@ bool cpp_test_py_list_to_cpp_vec(PyObject * val);
 bool cpp_test_py_list_of_lists_to_cpp_vector_of_vectors(PyObject * val);
 bool cpp_test_py_dict_string_numeric_to_cpp_map_string_numeric(PyObject * val);
 bool cpp_test_py_dict_string_list_of_list_of_doubles_to_cpp_map_string_vec_of_vecs_of_doubles(PyObject * val);
-bool cpp_test_np_array_of_doubles(PyArrayObject * val);
-bool cpp_test_np_2D_array_of_doubles(PyArrayObject * val);
+bool cpp_test_np_array_of_doubles(py::array val);
+bool cpp_test_np_2D_array_of_doubles(py::array val);
 bool cpp_test_evaluate_hamiltonians(PyObject * val);
 bool cpp_test_py_ordered_map(PyObject * val);
 
@@ -48,9 +47,9 @@ PYBIND11_MODULE(test_python_to_cpp, m) {
     m.def("test_py_dict_string_list_of_list_of_doubles_to_cpp_map_string_vec_of_vecs_of_doubles",
         [](py::dict dict) { return cpp_test_py_dict_string_list_of_list_of_doubles_to_cpp_map_string_vec_of_vecs_of_doubles(dict.ptr()); } , "");
     m.def("test_np_array_of_doubles",
-            [](py::array_t<double> array_doubles) { return cpp_test_np_array_of_doubles(reinterpret_cast<PyArrayObject *>(array_doubles.ptr())); } , "");
+            [](py::array_t<double> array_doubles) { return cpp_test_np_array_of_doubles(array_doubles); } , "");
     m.def("test_np_2D_array_of_doubles",
-            [](py::array_t<double> array_doubles) { return cpp_test_np_2D_array_of_doubles(reinterpret_cast<PyArrayObject *>(array_doubles.ptr())); } , "");
+            [](py::array_t<double> array_doubles) { return cpp_test_np_2D_array_of_doubles(array_doubles); } , "");
     m.def("test_evaluate_hamiltonians", [](py::list list) { return cpp_test_evaluate_hamiltonians(list.ptr()); } , "");
     m.def("test_py_ordered_map", [](py::dict dict) { return cpp_test_py_ordered_map(dict.ptr()); } , "");
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Removed some direct calls to the `numpy C API` by using `Pybind11` instead.
`Pybind11` relies on python buffer protocol and does not depend on
`numpy` headers.

### Details and comments

This only fix the problem for master, where all `cython` code has been removed, so it won't solve 0.7.4 issue #1120.   

