### PR TITLE
Add _directive attr to Save instruction

### DIFF
--- a/qiskit/providers/aer/extensions/snapshot.py
+++ b/qiskit/providers/aer/extensions/snapshot.py
@@ -25,6 +25,8 @@ from qiskit.extensions.exceptions import ExtensionError
 class Snapshot(Instruction):
     """Simulator snapshot instruction."""
 
+    _directive = True
+
     def __init__(self,
                  label,
                  snapshot_type='statevector',

--- a/qiskit/providers/aer/library/save_data.py
+++ b/qiskit/providers/aer/library/save_data.py
@@ -16,17 +16,14 @@ Simulator instruction to save custom internal data to results.
 import copy
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister
-# TEMP For compatiblity until Terra PR #5701 is merged
-try:
-    from qiskit.circuit import Directive
-except ImportError:
-    from qiskit.circuit import Instruction as Directive
+from qiskit.circuit import Instruction
 from qiskit.extensions.exceptions import ExtensionError
 
 
-class SaveData(Directive):
+class SaveData(Instruction):
     """Pragma Instruction to save simulator data."""
 
+    _directive = True
     _allowed_subtypes = set([
         'single', 'c_single', 'list', 'c_list',
         'average', 'c_average', 'accum', 'c_accum'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add `_directive` attribute to save instructions to make compatible with Terra transpiler/unroller/drawer.

### Details and comments

On-hold until Terra PR https://github.com/Qiskit/qiskit-terra/pull/5701 is merged.
