### PR TITLE
Pass CMAKE_GENERATOR_PLATFORM thorugh scikit_build in win32 builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import os
 import setuptools
 import subprocess
 import sys
+import platform
 
 
 PACKAGE_NAME = os.getenv('QISKIT_AER_PACKAGE_NAME', 'qiskit-aer')
@@ -80,6 +81,12 @@ README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
 with open(README_PATH) as readme_file:
     README = readme_file.read()
 
+
+cmake_args = ["-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9"]
+is_win_32_bit = (platform.system() == 'Windows' and platform.architecture()[0] == "32bit")
+if is_win_32_bit:
+    cmake_args.append("-DCMAKE_GENERATOR_PLATFORM=Win32")
+
 setup(
     name=PACKAGE_NAME,
     version=VERSION,
@@ -112,7 +119,7 @@ setup(
     install_requires=requirements,
     setup_requires=setup_requirements,
     include_package_data=True,
-    cmake_args=["-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9"],
+    cmake_args=cmake_args,
     keywords="qiskit aer simulator quantum addon backend",
     zip_safe=False
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

It seems that when forcing scikit-build to use Visual Studio 2019 through
`CMAKE_GENERATOR` env var, it is always assuming it is building for 64 bits,
even if you are working with `Python` 32 bits. More over, it doesn't honor the
`CMAKE_GENERATOR_PLATFORM` env variable, so no option to use the proper 32 bits
compiler. In this commit we check if we are in a `Win` 32 bit `Python` environment
and pass `CMAKE_GENERATOR_PLATFORM=Win32` directly to `CMake`.

### Details and comments


