### PR TITLE
change default max_memory_mb from half to full system memory

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -142,7 +142,7 @@ class QasmSimulator(AerBackend):
       to store a state vector. If a state vector needs more, an error
       is thrown. In general, a state vector of n-qubits uses 2^n complex
       values (16 Bytes). If set to 0, the maximum will be automatically
-      set to half the system memory size (Default: 0).
+      set to the system memory size (Default: 0).
 
     * ``optimize_ideal_threshold`` (int): Sets the qubit threshold for
       applying circuit optimization passes on ideal circuits.

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -81,7 +81,7 @@ class StatevectorSimulator(AerBackend):
       to store a state vector. If a state vector needs more, an error
       is thrown. In general, a state vector of n-qubits uses 2^n complex
       values (16 Bytes). If set to 0, the maximum will be automatically
-      set to half the system memory size (Default: 0).
+      set to the system memory size (Default: 0).
 
     * ``statevector_parallel_threshold`` (int): Sets the threshold that
       "n_qubits" must be greater than to enable OpenMP

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -87,7 +87,7 @@ class UnitarySimulator(AerBackend):
       to store a state vector. If a state vector needs more, an error
       is thrown. In general, a state vector of n-qubits uses 2^n complex
       values (16 Bytes). If set to 0, the maximum will be automatically
-      set to half the system memory size (Default: 0).
+      set to the system memory size (Default: 0).
 
     * ``"statevector_parallel_threshold"`` (int): Sets the threshold that
       2 * "n_qubits" must be greater than to enable OpenMP

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -372,8 +372,8 @@ void Controller::clear_parallelization() {
   num_gpus_ = 0;
 
   explicit_parallelization_ = false;
-  max_memory_mb_ = get_system_memory_mb() / 2;
-  max_gpu_memory_mb_ = get_gpu_memory_mb() / 2;
+  max_memory_mb_ = get_system_memory_mb();
+  max_gpu_memory_mb_ = get_gpu_memory_mb();
 }
 
 void Controller::set_parallelization_experiments(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Allow Aer to use all the system memory.

### Details and comments

This PR fixes #1114.

Currently, Aer uses the half of system memory (`sysconf(_SC_PAGE_SIZE) * sysconf(_SC_PHYS_PAGES) / 2`),  but `BasicAer` allows to use the all (`psutil.virtual_memory()`).

This PR changes the default value of `max_memory_mb` to all the system memory.