### PR TITLE
Add default save instruction labels

### DIFF
--- a/qiskit/providers/aer/library/__init__.py
+++ b/qiskit/providers/aer/library/__init__.py
@@ -67,6 +67,16 @@ QuantumCircuit Methods
 
 .. note ::
 
+    **Save Instruction Labels**
+
+    Each save instruction has a default label for accessing from the
+    circuit result data, however duplicate labels in results will result
+    in an exception being raised. If you use more than 1 instance of a
+    specific save instruction you must set a custom label for the
+    additional instructions.
+
+.. note ::
+
     **Pershot Data with Measurement Sampling Optimization**
 
     When saving pershot data by using the ``pershot=True`` kwarg

--- a/qiskit/providers/aer/library/save_amplitudes.py
+++ b/qiskit/providers/aer/library/save_amplitudes.py
@@ -21,17 +21,17 @@ from .save_data import SaveSingleData, SaveAverageData, default_qubits
 class SaveAmplitudes(SaveSingleData):
     """Save complex statevector amplitudes."""
     def __init__(self,
-                 key,
                  num_qubits,
                  params,
+                 label="amplitudes",
                  pershot=False,
                  conditional=False):
         """Instruction to save complex statevector amplitudes.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the snapshot type.
             params (list): list of entries to vale.
+            label (str): the key for retrieving saved data from results.
             pershot (bool): if True save a list of amplitudes vectors for each
                             shot of the simulation rather than the a single
                             amplitude vector [Default: False].
@@ -42,10 +42,10 @@ class SaveAmplitudes(SaveSingleData):
         Raises:
             ExtensionError: if params is invalid for the specified number of qubits.
         """
+        if label is None:
+            label = "amplitudes"
         params = _format_amplitude_params(params, num_qubits)
-        super().__init__("save_amplitudes",
-                         key,
-                         num_qubits,
+        super().__init__("save_amplitudes", num_qubits, label,
                          pershot=pershot,
                          conditional=conditional,
                          params=params)
@@ -54,18 +54,18 @@ class SaveAmplitudes(SaveSingleData):
 class SaveAmplitudesSquared(SaveAverageData):
     """Save squared statevector amplitudes (probabilities)."""
     def __init__(self,
-                 key,
                  num_qubits,
                  params,
+                 label="amplitudes_squared",
                  unnormalized=False,
                  pershot=False,
                  conditional=False):
         """Instruction to save squared statevector amplitudes (probabilities).
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the snapshot type.
             params (list): list of entries to vale.
+            label (str): the key for retrieving saved data from results.
             unnormalized (bool): If True return save the unnormalized accumulated
                                  probabilities over all shots [Default: False].
             pershot (bool): if True save a list of probability vectors for each
@@ -80,20 +80,20 @@ class SaveAmplitudesSquared(SaveAverageData):
         """
         params = _format_amplitude_params(params, num_qubits)
         super().__init__("save_amplitudes_sq",
-                         key,
                          num_qubits,
+                         label,
                          unnormalized=unnormalized,
                          pershot=pershot,
                          conditional=conditional,
                          params=params)
 
 
-def save_amplitudes(self, key, params, pershot=False, conditional=False):
+def save_amplitudes(self, params, label="amplitudes", pershot=False, conditional=False):
     """Save complex statevector amplitudes.
 
     Args:
-        key (str): the key for retrieving saved data from results.
         params (List[int] or List[str]): the basis states to return amplitudes for.
+        label (str): the key for retrieving saved data from results.
         pershot (bool): if True save a list of amplitudes vectors for each
                         shot of the simulation rather than the a single
                         amplitude vector [Default: False].
@@ -108,20 +108,20 @@ def save_amplitudes(self, key, params, pershot=False, conditional=False):
         ExtensionError: if params is invalid for the specified number of qubits.
     """
     qubits = default_qubits(self)
-    instr = SaveAmplitudes(key, len(qubits), params,
+    instr = SaveAmplitudes(len(qubits), params, label=label,
                            pershot=pershot, conditional=conditional)
     return self.append(instr, qubits)
 
 
-def save_amplitudes_squared(self, key, params,
+def save_amplitudes_squared(self, params, label="amplitudes_squared",
                             unnormalized=False,
                             pershot=False,
                             conditional=False):
     """Save squared statevector amplitudes (probabilities).
 
     Args:
-        key (str): the key for retrieving saved data from results.
         params (List[int] or List[str]): the basis states to return amplitudes for.
+        label (str): the key for retrieving saved data from results.
         unnormalized (bool): If True return save the unnormalized accumulated
                              probabilities over all shots [Default: False].
         pershot (bool): if True save a list of probability vectors for each
@@ -138,7 +138,7 @@ def save_amplitudes_squared(self, key, params,
         ExtensionError: if params is invalid for the specified number of qubits.
     """
     qubits = default_qubits(self)
-    instr = SaveAmplitudesSquared(key, len(qubits), params,
+    instr = SaveAmplitudesSquared(len(qubits), params, label=label,
                                   unnormalized=unnormalized,
                                   pershot=pershot,
                                   conditional=conditional)

--- a/qiskit/providers/aer/library/save_amplitudes.py
+++ b/qiskit/providers/aer/library/save_amplitudes.py
@@ -42,8 +42,6 @@ class SaveAmplitudes(SaveSingleData):
         Raises:
             ExtensionError: if params is invalid for the specified number of qubits.
         """
-        if label is None:
-            label = "amplitudes"
         params = _format_amplitude_params(params, num_qubits)
         super().__init__("save_amplitudes", num_qubits, label,
                          pershot=pershot,

--- a/qiskit/providers/aer/library/save_data.py
+++ b/qiskit/providers/aer/library/save_data.py
@@ -29,13 +29,13 @@ class SaveData(Instruction):
         'average', 'c_average', 'accum', 'c_accum'
     ])
 
-    def __init__(self, name, key, num_qubits, subtype='single', params=None):
+    def __init__(self, name, num_qubits, label, subtype='single', params=None):
         """Create new save data instruction.
 
         Args:
             name (str): the name of hte save instruction.
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the snapshot type.
+            label (str): the key for retrieving saved data from results.
             subtype (str): the data subtype for the instruction [Default: 'single'].
             params (list or None): Optional, the parameters for instruction
                                    [Default: None].
@@ -54,10 +54,11 @@ class SaveData(Instruction):
             raise ExtensionError(
                 "Invalid data subtype for SaveData instruction.")
 
-        if not isinstance(key, str):
-            raise ExtensionError("Invalid key for save data instruction, key must be a string.")
+        if not isinstance(label, str):
+            raise ExtensionError(
+                f"Invalid label for save data instruction, {label} must be a string.")
 
-        self._key = key
+        self._label = label
         self._subtype = subtype
         super().__init__(name, num_qubits, 0, params)
 
@@ -67,7 +68,7 @@ class SaveData(Instruction):
         # Use same fields as Snapshot instruction
         # so we dont need to modify QasmQobjInstruction
         instr.snapshot_type = self._subtype
-        instr.label = self._key
+        instr.label = self._label
         return instr
 
     def inverse(self):
@@ -79,8 +80,8 @@ class SaveAverageData(SaveData):
     """Save averageble data"""
     def __init__(self,
                  name,
-                 key,
                  num_qubits,
+                 label,
                  unnormalized=False,
                  pershot=False,
                  conditional=False,
@@ -89,8 +90,8 @@ class SaveAverageData(SaveData):
 
         Args:
             name (str): the name of hte save instruction.
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the snapshot type.
+            label (str): the key for retrieving saved data from results.
             unnormalized (bool): If True return save the unnormalized accumulated
                                  or conditional accumulated data over all shot.
                                  [Default: False].
@@ -111,7 +112,7 @@ class SaveAverageData(SaveData):
             subtype = 'average'
         if conditional:
             subtype = 'c_' + subtype
-        super().__init__(name, key, num_qubits, subtype=subtype, params=params)
+        super().__init__(name, num_qubits, label, subtype=subtype, params=params)
 
 
 class SaveSingleData(SaveData):
@@ -119,8 +120,8 @@ class SaveSingleData(SaveData):
 
     def __init__(self,
                  name,
-                 key,
                  num_qubits,
+                 label,
                  pershot=False,
                  conditional=False,
                  params=None):
@@ -128,8 +129,8 @@ class SaveSingleData(SaveData):
 
         Args:
             name (str): the name of the save instruction.
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the snapshot type.
+            label (str): the key for retrieving saved data from results.
             pershot (bool): if True save a list of data for each shot of the
                             simulation [Default: False].
             conditional (bool): if True save data conditional on the
@@ -141,7 +142,7 @@ class SaveSingleData(SaveData):
         subtype = 'list' if pershot else 'single'
         if conditional:
             subtype = 'c_' + subtype
-        super().__init__(name, key, num_qubits, subtype=subtype, params=params)
+        super().__init__(name, num_qubits, label, subtype=subtype, params=params)
 
 
 def default_qubits(circuit, qubits=None):

--- a/qiskit/providers/aer/library/save_density_matrix.py
+++ b/qiskit/providers/aer/library/save_density_matrix.py
@@ -20,16 +20,16 @@ from .save_data import SaveAverageData, default_qubits
 class SaveDensityMatrix(SaveAverageData):
     """Save a reduced density matrix."""
     def __init__(self,
-                 key,
                  num_qubits,
+                 label="density_matrix",
                  unnormalized=False,
                  pershot=False,
                  conditional=False):
         """Create new instruction to save the simulator reduced density matrix.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the save instruction.
+            label (str): the key for retrieving saved data from results.
             unnormalized (bool): If True return save the unnormalized accumulated
                                  or conditional accumulated density matrix over
                                  all shots [Default: False].
@@ -40,27 +40,25 @@ class SaveDensityMatrix(SaveAverageData):
                                 conditional on the current classical register
                                 values [Default: False].
         """
-        super().__init__("save_density_matrix",
-                         key,
-                         num_qubits,
+        super().__init__("save_density_matrix", num_qubits, label,
                          unnormalized=unnormalized,
                          pershot=pershot,
                          conditional=conditional)
 
 
 def save_density_matrix(self,
-                        key,
                         qubits=None,
+                        label="density_matrix",
                         unnormalized=False,
                         pershot=False,
                         conditional=False):
     """Save the current simulator quantum state as a density matrix.
 
     Args:
-        key (str): the key for retrieving saved data from results.
         qubits (list or None): the qubits to save reduced density matrix on.
                                If None the full density matrix of qubits will
                                be saved [Default: None].
+        label (str): the key for retrieving saved data from results.
         unnormalized (bool): If True return save the unnormalized accumulated
                              or conditional accumulated density matrix over
                              all shots [Default: False].
@@ -75,8 +73,8 @@ def save_density_matrix(self,
         QuantumCircuit: with attached instruction.
     """
     qubits = default_qubits(self, qubits=qubits)
-    instr = SaveDensityMatrix(key,
-                              len(qubits),
+    instr = SaveDensityMatrix(len(qubits),
+                              label=label,
                               unnormalized=unnormalized,
                               pershot=pershot,
                               conditional=conditional)

--- a/qiskit/providers/aer/library/save_expectation_value.py
+++ b/qiskit/providers/aer/library/save_expectation_value.py
@@ -23,8 +23,8 @@ from .save_data import SaveAverageData
 class SaveExpectationValue(SaveAverageData):
     """Save expectation value of an operator."""
     def __init__(self,
-                 key,
                  operator,
+                 label="expectation_value",
                  unnormalized=False,
                  pershot=False,
                  conditional=False):
@@ -35,8 +35,8 @@ class SaveExpectationValue(SaveAverageData):
         :math:`\langle H\rangle = \mbox{Tr}[H.\rho]`.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             operator (Pauli or SparsePauliOp or Operator): a Hermitian operator.
+            label (str): the key for retrieving saved data from results.
             unnormalized (bool): If True return save the unnormalized accumulated
                                  or conditional accumulated expectation value
                                  over all shot [Default: False].
@@ -50,7 +50,7 @@ class SaveExpectationValue(SaveAverageData):
         Raises:
             ExtensionError: if the input operator is invalid or not Hermitian.
 
-        .. note:
+        .. note::
 
             This instruction can be directly appended to a circuit using the
             :func:`save_expectation_value` circuit method.
@@ -63,9 +63,7 @@ class SaveExpectationValue(SaveAverageData):
         if not allclose(operator.coeffs.imag, 0):
             raise ExtensionError("Input operator is not Hermitian.")
         params = _expval_params(operator, variance=False)
-        super().__init__('save_expval',
-                         key,
-                         operator.num_qubits,
+        super().__init__('save_expval', operator.num_qubits, label,
                          unnormalized=unnormalized,
                          pershot=pershot,
                          conditional=conditional,
@@ -75,8 +73,8 @@ class SaveExpectationValue(SaveAverageData):
 class SaveExpectationValueVariance(SaveAverageData):
     """Save expectation value and variance of an operator."""
     def __init__(self,
-                 key,
                  operator,
+                 label="expectation_value_variance",
                  unnormalized=False,
                  pershot=False,
                  conditional=False):
@@ -88,8 +86,8 @@ class SaveExpectationValueVariance(SaveAverageData):
         :math:`\sigma^2 = \langle H^2 \rangle - \langle H \rangle>^2`.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             operator (Pauli or SparsePauliOp or Operator): a Hermitian operator.
+            label (str): the key for retrieving saved data from results.
             unnormalized (bool): If True return save the unnormalized accumulated
                                  or conditional accumulated expectation value
                                  over all shot [Default: False].
@@ -103,7 +101,8 @@ class SaveExpectationValueVariance(SaveAverageData):
         Raises:
             ExtensionError: if the input operator is invalid or not Hermitian.
 
-        .. note:
+        .. note::
+
             This instruction can be directly appended to a circuit using
             the :func:`save_expectation_value` circuit method.
         """
@@ -115,9 +114,7 @@ class SaveExpectationValueVariance(SaveAverageData):
         if not allclose(operator.coeffs.imag, 0):
             raise ExtensionError("Input operator is not Hermitian.")
         params = _expval_params(operator, variance=True)
-        super().__init__('save_expval_var',
-                         key,
-                         operator.num_qubits,
+        super().__init__('save_expval_var', operator.num_qubits, label,
                          unnormalized=unnormalized,
                          pershot=pershot,
                          conditional=conditional,
@@ -158,18 +155,18 @@ def _expval_params(operator, variance=False):
 
 
 def save_expectation_value(self,
-                           key,
                            operator,
                            qubits,
+                           label="expectation_value",
                            unnormalized=False,
                            pershot=False,
                            conditional=False):
     r"""Save the expectation value of a Hermitian operator.
 
     Args:
-        key (str): the key for retrieving saved data from results.
         operator (Pauli or SparsePauliOp or Operator): a Hermitian operator.
         qubits (list): circuit qubits to apply instruction.
+        label (str): the key for retrieving saved data from results.
         unnormalized (bool): If True return save the unnormalized accumulated
                              or conditional accumulated expectation value
                              over all shot [Default: False].
@@ -186,12 +183,13 @@ def save_expectation_value(self,
     Raises:
         ExtensionError: if the input operator is invalid or not Hermitian.
 
-    .. note:
+    .. note::
+
         This method appends a :class:`SaveExpectationValue` instruction to
         the quantum circuit.
     """
-    instr = SaveExpectationValue(key,
-                                 operator,
+    instr = SaveExpectationValue(operator,
+                                 label=label,
                                  unnormalized=unnormalized,
                                  pershot=pershot,
                                  conditional=conditional)
@@ -199,18 +197,18 @@ def save_expectation_value(self,
 
 
 def save_expectation_value_variance(self,
-                                    key,
                                     operator,
                                     qubits,
+                                    label="expectation_value_variance",
                                     unnormalized=False,
                                     pershot=False,
                                     conditional=False):
     r"""Save the expectation value of a Hermitian operator.
 
     Args:
-        key (str): the key for retrieving saved data from results.
         operator (Pauli or SparsePauliOp or Operator): a Hermitian operator.
         qubits (list): circuit qubits to apply instruction.
+        label (str): the key for retrieving saved data from results.
         unnormalized (bool): If True return save the unnormalized accumulated
                              or conditional accumulated expectation value
                              and variance over all shot [Default: False].
@@ -226,12 +224,13 @@ def save_expectation_value_variance(self,
     Raises:
         ExtensionError: if the input operator is invalid or not Hermitian.
 
-    .. note:
+    .. note::
+
         This method appends a :class:`SaveExpectationValueVariance`
         instruction to the quantum circuit.
     """
-    instr = SaveExpectationValueVariance(key,
-                                         operator,
+    instr = SaveExpectationValueVariance(operator,
+                                         label=label,
                                          unnormalized=unnormalized,
                                          pershot=pershot,
                                          conditional=conditional)

--- a/qiskit/providers/aer/library/save_probabilities.py
+++ b/qiskit/providers/aer/library/save_probabilities.py
@@ -20,16 +20,16 @@ from .save_data import SaveAverageData, default_qubits
 class SaveProbabilities(SaveAverageData):
     """Save measurement outcome probabilities vector."""
     def __init__(self,
-                 key,
                  num_qubits,
+                 label="probabilities",
                  unnormalized=False,
                  pershot=False,
                  conditional=False):
         """Instruction to save measurement probabilities vector.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the snapshot type.
+            label (str): the key for retrieving saved data from results.
             unnormalized (bool): If True return save the unnormalized accumulated
                                  probabilities over all shots [Default: False].
             pershot (bool): if True save a list of probabilities for each shot
@@ -39,9 +39,7 @@ class SaveProbabilities(SaveAverageData):
                                 on the current classical register values
                                 [Default: False].
         """
-        super().__init__("save_probabilities",
-                         key,
-                         num_qubits,
+        super().__init__("save_probabilities", num_qubits, label,
                          conditional=conditional,
                          pershot=pershot,
                          unnormalized=unnormalized)
@@ -50,16 +48,16 @@ class SaveProbabilities(SaveAverageData):
 class SaveProbabilitiesDict(SaveAverageData):
     """Save measurement outcome probabilities dict."""
     def __init__(self,
-                 key,
                  num_qubits,
+                 label="probabilities_dict",
                  unnormalized=False,
                  pershot=False,
                  conditional=False):
         """Instruction to save measurement probabilities dict.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits for the snapshot type.
+            label (str): the key for retrieving saved data from results.
             unnormalized (bool): If True return save the unnormalized accumulated
                                  probabilities over all shots [Default: False].
             pershot (bool): if True save a list of probabilities for each shot
@@ -69,26 +67,24 @@ class SaveProbabilitiesDict(SaveAverageData):
                                 on the current classical register values
                                 [Default: False].
         """
-        super().__init__("save_probabilities_dict",
-                         key,
-                         num_qubits,
+        super().__init__("save_probabilities_dict", num_qubits, label,
                          unnormalized=unnormalized,
                          pershot=pershot,
                          conditional=conditional)
 
 
 def save_probabilities(self,
-                       key,
                        qubits=None,
+                       label="probabilities",
                        unnormalized=False,
                        pershot=False,
                        conditional=False):
     """Save measurement outcome probabilities vector.
 
     Args:
-        key (str): the key for retrieving saved data from results.
         qubits (list or None): the qubits to apply snapshot to. If None all
                                qubits will be snapshot [Default: None].
+        label (str): the key for retrieving saved data from results.
         unnormalized (bool): If True return save the unnormalized accumulated
                              probabilities over all shots [Default: False].
         pershot (bool): if True save a list of probabilities for each shot
@@ -102,8 +98,8 @@ def save_probabilities(self,
         QuantumCircuit: with attached instruction.
     """
     qubits = default_qubits(self, qubits=qubits)
-    instr = SaveProbabilities(key,
-                              len(qubits),
+    instr = SaveProbabilities(len(qubits),
+                              label=label,
                               unnormalized=unnormalized,
                               pershot=pershot,
                               conditional=conditional)
@@ -111,17 +107,17 @@ def save_probabilities(self,
 
 
 def save_probabilities_dict(self,
-                            key,
                             qubits=None,
+                            label="probabilities",
                             unnormalized=False,
                             pershot=False,
                             conditional=False):
     """Save measurement outcome probabilities vector.
 
     Args:
-        key (str): the key for retrieving saved data from results.
         qubits (list or None): the qubits to apply snapshot to. If None all
                                qubits will be snapshot [Default: None].
+        label (str): the key for retrieving saved data from results.
         unnormalized (bool): If True return save the unnormalized accumulated
                              probabilities over all shots [Default: False].
         pershot (bool): if True save a list of probabilities for each shot
@@ -135,8 +131,8 @@ def save_probabilities_dict(self,
         QuantumCircuit: with attached instruction.
     """
     qubits = default_qubits(self, qubits=qubits)
-    instr = SaveProbabilitiesDict(key,
-                                  len(qubits),
+    instr = SaveProbabilitiesDict(len(qubits),
+                                  label=label,
                                   unnormalized=unnormalized,
                                   pershot=pershot,
                                   conditional=conditional)

--- a/qiskit/providers/aer/library/save_stabilizer.py
+++ b/qiskit/providers/aer/library/save_stabilizer.py
@@ -19,12 +19,13 @@ from .save_data import SaveSingleData, default_qubits
 
 class SaveStabilizer(SaveSingleData):
     """Save Stabilizer instruction"""
-    def __init__(self, key, num_qubits, pershot=False, conditional=False):
+    def __init__(self, num_qubits, label="stabilizer",
+                 pershot=False, conditional=False):
         """Create new instruction to save the stabilizer simulator state.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits of the
+            label (str): the key for retrieving saved data from results.
             pershot (bool): if True save a list of Cliffords for each
                             shot of the simulation rather than a single
                             statevector [Default: False].
@@ -37,18 +38,16 @@ class SaveStabilizer(SaveSingleData):
             qubits in a circuit, otherwise an exception will be raised during
             simulation.
         """
-        super().__init__('save_stabilizer',
-                         key,
-                         num_qubits,
+        super().__init__('save_stabilizer', num_qubits, label,
                          pershot=pershot,
                          conditional=conditional)
 
 
-def save_stabilizer(self, key, pershot=False, conditional=False):
+def save_stabilizer(self, label="stabilizer", pershot=False, conditional=False):
     """Save the current stabilizer simulator quantum state as a Clifford.
 
     Args:
-        key (str): the key for retrieving saved data from results.
+        label (str): the key for retrieving saved data from results.
         pershot (bool): if True save a list of Cliffords for each
                         shot of the simulation [Default: False].
         conditional (bool): if True save pershot data conditional on the
@@ -58,13 +57,13 @@ def save_stabilizer(self, key, pershot=False, conditional=False):
     Returns:
         QuantumCircuit: with attached instruction.
 
-    .. note:
+    .. note::
 
         This instruction is always defined across all qubits in a circuit.
     """
     qubits = default_qubits(self)
-    instr = SaveStabilizer(key,
-                           len(qubits),
+    instr = SaveStabilizer(len(qubits),
+                           label=label,
                            pershot=pershot,
                            conditional=conditional)
     return self.append(instr, qubits)

--- a/qiskit/providers/aer/library/save_statevector.py
+++ b/qiskit/providers/aer/library/save_statevector.py
@@ -77,7 +77,6 @@ def save_statevector(self, label="statevector", pershot=False, conditional=False
     """Save the current simulator quantum state as a statevector.
 
     Args:
-        key (str): the key for retrieving saved data from results.
         pershot (bool): if True save a list of statevectors for each
                         shot of the simulation [Default: False].
         label (str): the key for retrieving saved data from results.

--- a/qiskit/providers/aer/library/save_statevector.py
+++ b/qiskit/providers/aer/library/save_statevector.py
@@ -19,12 +19,15 @@ from .save_data import SaveSingleData, default_qubits
 
 class SaveStatevector(SaveSingleData):
     """Save statevector"""
-    def __init__(self, key, num_qubits, pershot=False, conditional=False):
+    def __init__(self, num_qubits,
+                 label="statevector",
+                 pershot=False,
+                 conditional=False):
         """Create new instruction to save the simualtor statevector.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits of the
+            label (str): the key for retrieving saved data from results.
             pershot (bool): if True save a list of statevectors for each
                             shot of the simulation rather than a single
                             statevector [Default: False].
@@ -37,21 +40,22 @@ class SaveStatevector(SaveSingleData):
             qubits in a circuit, otherwise an exception will be raised during
             simulation.
         """
-        super().__init__('save_statevector',
-                         key,
-                         num_qubits,
+        super().__init__('save_statevector', num_qubits, label,
                          pershot=pershot,
                          conditional=conditional)
 
 
 class SaveStatevectorDict(SaveSingleData):
     """Save statevector as ket-form dictionary."""
-    def __init__(self, key, num_qubits, pershot=False, conditional=False):
+    def __init__(self, num_qubits,
+                 label="statevector_dict",
+                 pershot=False,
+                 conditional=False):
         """Create new instruction to save the simualtor statevector as a dict.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits of the
+            label (str): the key for retrieving saved data from results.
             pershot (bool): if True save a list of statevectors for each
                             shot of the simulation rather than a single
                             statevector [Default: False].
@@ -64,20 +68,19 @@ class SaveStatevectorDict(SaveSingleData):
             qubits in a circuit, otherwise an exception will be raised during
             simulation.
         """
-        super().__init__('save_statevector_dict',
-                         key,
-                         num_qubits,
+        super().__init__('save_statevector_dict', num_qubits, label,
                          pershot=pershot,
                          conditional=conditional)
 
 
-def save_statevector(self, key, pershot=False, conditional=False):
+def save_statevector(self, label="statevector", pershot=False, conditional=False):
     """Save the current simulator quantum state as a statevector.
 
     Args:
         key (str): the key for retrieving saved data from results.
         pershot (bool): if True save a list of statevectors for each
                         shot of the simulation [Default: False].
+        label (str): the key for retrieving saved data from results.
         conditional (bool): if True save pershot data conditional on the
                             current classical register values
                             [Default: False].
@@ -85,23 +88,23 @@ def save_statevector(self, key, pershot=False, conditional=False):
     Returns:
         QuantumCircuit: with attached instruction.
 
-    .. note:
+    .. note::
 
         This instruction is always defined across all qubits in a circuit.
     """
     qubits = default_qubits(self)
-    instr = SaveStatevector(key,
-                            len(qubits),
+    instr = SaveStatevector(len(qubits),
+                            label=label,
                             pershot=pershot,
                             conditional=conditional)
     return self.append(instr, qubits)
 
 
-def save_statevector_dict(self, key, pershot=False, conditional=False):
+def save_statevector_dict(self, label="statevector", pershot=False, conditional=False):
     """Save the current simulator quantum state as a statevector as a dict.
 
     Args:
-        key (str): the key for retrieving saved data from results.
+        label (str): the key for retrieving saved data from results.
         pershot (bool): if True save a list of statevectors for each
                         shot of the simulation [Default: False].
         conditional (bool): if True save pershot data conditional on the
@@ -111,13 +114,13 @@ def save_statevector_dict(self, key, pershot=False, conditional=False):
     Returns:
         QuantumCircuit: with attached instruction.
 
-    .. note:
+    .. note::
 
         This instruction is always defined across all qubits in a circuit.
     """
     qubits = default_qubits(self)
-    instr = SaveStatevectorDict(key,
-                                len(qubits),
+    instr = SaveStatevectorDict(len(qubits),
+                                label=label,
                                 pershot=pershot,
                                 conditional=conditional)
     return self.append(instr, qubits)

--- a/qiskit/providers/aer/library/save_unitary.py
+++ b/qiskit/providers/aer/library/save_unitary.py
@@ -19,7 +19,7 @@ from .save_data import SaveSingleData, default_qubits
 
 class SaveUnitary(SaveSingleData):
     """Save Unitary"""
-    def __init__(self, key, num_qubits, pershot=False):
+    def __init__(self, num_qubits, label="unitary", pershot=False):
         """Create new instruction to save the unitary simulator state.
 
         Args:
@@ -35,30 +35,28 @@ class SaveUnitary(SaveSingleData):
             qubits in a circuit, otherwise an exception will be raised during
             simulation.
         """
-        super().__init__('save_unitary',
-                         key,
-                         num_qubits,
+        super().__init__('save_unitary', num_qubits, label,
                          pershot=pershot)
 
 
-def save_unitary(self, key, pershot=False):
+def save_unitary(self, label="unitary", pershot=False):
     """Save the current state of the unitary simulator.
 
     Args:
-        key (str): the key for retrieving saved data from results.
+        label (str): the key for retrieving saved data from results.
         pershot (bool): if True save a list of unitaries for each
                         shot of the simulation [Default: False].
 
     Returns:
         QuantumCircuit: with attached instruction.
 
-    .. note:
+    .. note::
 
         This instruction is always defined across all qubits in a circuit.
     """
     qubits = default_qubits(self)
-    instr = SaveUnitary(key,
-                        len(qubits),
+    instr = SaveUnitary(len(qubits),
+                        label=label,
                         pershot=pershot)
     return self.append(instr, qubits)
 

--- a/qiskit/providers/aer/library/save_unitary.py
+++ b/qiskit/providers/aer/library/save_unitary.py
@@ -23,8 +23,8 @@ class SaveUnitary(SaveSingleData):
         """Create new instruction to save the unitary simulator state.
 
         Args:
-            key (str): the key for retrieving saved data from results.
             num_qubits (int): the number of qubits of the
+            label (str): the key for retrieving saved data from results.
             pershot (bool): if True save a list of unitaries for each
                             shot of the simulation rather than a single
                             statevector [Default: False].

--- a/test/terra/backends/qasm_simulator/qasm_save_amplitudes.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_amplitudes.py
@@ -50,8 +50,8 @@ class QasmSaveAmplitudesTests:
         target = qi.Statevector(circ).data[params]
 
         # Add save to circuit
-        save_key = 'amps'
-        circ.save_amplitudes(save_key, params)
+        label = 'amps'
+        circ.save_amplitudes(params, label=label)
 
         # Run
         opts = self.BACKEND_OPTS.copy()
@@ -63,8 +63,8 @@ class QasmSaveAmplitudesTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = result.data(0)[save_key]
+            self.assertIn(label, data)
+            value = result.data(0)[label]
             self.assertTrue(np.allclose(value, target))
 
     @data([0, 1, 2, 3, 4, 5, 6, 7],
@@ -73,7 +73,7 @@ class QasmSaveAmplitudesTests:
           [0],
           [5, 2],
           [7, 0])
-    def test_save_amplitudes_squared_clifford(self, params):
+    def test_save_amplitudes_squared_nonclifford(self, params):
         """Test save_amplitudes_squared instruction"""
 
         SUPPORTED_METHODS = [
@@ -89,8 +89,8 @@ class QasmSaveAmplitudesTests:
         target = np.abs(qi.Statevector(circ).data[params]) ** 2
 
         # Add save to circuit
-        save_key = 'amps'
-        circ.save_amplitudes_squared(save_key, params)
+        label = 'amps'
+        circ.save_amplitudes_squared(params, label=label)
 
         # Run
         opts = self.BACKEND_OPTS.copy()
@@ -102,8 +102,8 @@ class QasmSaveAmplitudesTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = result.data(0)[save_key]
+            self.assertIn(label, data)
+            value = result.data(0)[label]
             self.assertTrue(np.allclose(value, target))
 
     @data([0, 1, 2, 3, 4, 5, 6, 7],
@@ -132,8 +132,8 @@ class QasmSaveAmplitudesTests:
         target = np.abs(qi.Statevector(circ).data[params]) ** 2
 
         # Add save to circuit
-        save_key = 'amps'
-        circ.save_amplitudes_squared(save_key, params)
+        label = 'amps'
+        circ.save_amplitudes_squared(params, label=label)
 
         # Run
         opts = self.BACKEND_OPTS.copy()
@@ -145,6 +145,6 @@ class QasmSaveAmplitudesTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = result.data(0)[save_key]
+            self.assertIn(label, data)
+            value = result.data(0)[label]
             self.assertTrue(np.allclose(value, target))

--- a/test/terra/backends/qasm_simulator/qasm_save_density_matrix.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_density_matrix.py
@@ -45,8 +45,8 @@ class QasmSaveDensityMatrixTests:
         target = qi.DensityMatrix(circ)
 
         # Add save to circuit
-        save_key = 'state'
-        circ.save_density_matrix(save_key)
+        label = 'state'
+        circ.save_density_matrix(label=label)
 
         # Run
         opts = self.BACKEND_OPTS.copy()
@@ -58,8 +58,8 @@ class QasmSaveDensityMatrixTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = qi.DensityMatrix(result.data(0)[save_key])
+            self.assertIn(label, data)
+            value = qi.DensityMatrix(result.data(0)[label])
             self.assertAlmostEqual(value, target)
 
     def test_save_density_matrix_conditional(self):
@@ -72,13 +72,13 @@ class QasmSaveDensityMatrixTests:
         ]
 
         # Stabilizer test circuit
-        save_key = 'state'
+        label = 'state'
         circ = QuantumCircuit(2)
         circ.h(0)
         circ.sdg(0)
         circ.cx(0, 1)
         circ.measure_all()
-        circ.save_density_matrix(save_key, conditional=True)
+        circ.save_density_matrix(label=label, conditional=True)
 
         # Target statevector
         target = {'0x0': qi.DensityMatrix(np.diag([1, 0, 0, 0])),
@@ -94,8 +94,8 @@ class QasmSaveDensityMatrixTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            for key, state in data[save_key].items():
+            self.assertIn(label, data)
+            for key, state in data[label].items():
                 self.assertIn(key, target)
                 self.assertAlmostEqual(qi.DensityMatrix(state), target[key])
 
@@ -119,8 +119,8 @@ class QasmSaveDensityMatrixTests:
         target = qi.DensityMatrix(circ)
 
         # Add save
-        save_key = 'state'
-        circ.save_density_matrix(save_key, pershot=True)
+        label = 'state'
+        circ.save_density_matrix(label=label, pershot=True)
 
         # Run
         shots = 10
@@ -133,8 +133,8 @@ class QasmSaveDensityMatrixTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = result.data(0)[save_key]
+            self.assertIn(label, data)
+            value = result.data(0)[label]
             for state in value:
                 self.assertAlmostEqual(qi.DensityMatrix(state), target)
 
@@ -158,8 +158,8 @@ class QasmSaveDensityMatrixTests:
         target = qi.DensityMatrix(circ)
 
         # Add save
-        save_key = 'state'
-        circ.save_density_matrix(save_key, pershot=True, conditional=True)
+        label = 'state'
+        circ.save_density_matrix(label=label, pershot=True, conditional=True)
         circ.measure_all()
 
         # Run
@@ -173,8 +173,8 @@ class QasmSaveDensityMatrixTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = result.data(0)[save_key]
+            self.assertIn(label, data)
+            value = result.data(0)[label]
             self.assertIn('0x0', value)
             for state in value['0x0']:
                 self.assertAlmostEqual(qi.DensityMatrix(state), target)

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -52,7 +52,7 @@ class QasmSaveExpectationValueTests:
         method = opts.get('method', 'automatic')
         circ = transpile(state_circ, basis_gates=[
             'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'cx', 'cz', 'swap'])
-        circ.save_expectation_value('expval', oper, [0, 1])
+        circ.save_expectation_value(oper, [0, 1], label='expval')
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         if method not in SUPPORTED_METHODS:
@@ -87,7 +87,7 @@ class QasmSaveExpectationValueTests:
         method = opts.get('method', 'automatic')
         circ = transpile(state_circ, basis_gates=[
             'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'cx', 'cz', 'swap'])
-        circ.save_expectation_value_variance('expval', oper, [0, 1])
+        circ.save_expectation_value_variance(oper, [0, 1], label='expval')
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         if method not in SUPPORTED_METHODS:
@@ -119,7 +119,7 @@ class QasmSaveExpectationValueTests:
         method = opts.get('method', 'automatic')
         circ = transpile(state_circ, basis_gates=[
             'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'cx', 'cz', 'swap'])
-        circ.save_expectation_value('expval', oper, qubits)
+        circ.save_expectation_value(oper, qubits, label='expval')
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         if method not in SUPPORTED_METHODS:
@@ -153,7 +153,7 @@ class QasmSaveExpectationValueTests:
         method = opts.get('method', 'automatic')
         circ = transpile(state_circ, basis_gates=[
             'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'cx', 'cz', 'swap'])
-        circ.save_expectation_value_variance('expval', oper, qubits)
+        circ.save_expectation_value_variance(oper, qubits, label='expval')
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         if method not in SUPPORTED_METHODS:
@@ -185,7 +185,7 @@ class QasmSaveExpectationValueTests:
         opts = self.BACKEND_OPTS.copy()
         method = opts.get('method', 'automatic')
         circ = transpile(state_circ, basis_gates=['u1', 'u2', 'u3', 'cx', 'swap'])
-        circ.save_expectation_value('expval', oper, [0, 1])
+        circ.save_expectation_value(oper, [0, 1], label='expval')
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         if method not in SUPPORTED_METHODS:
@@ -219,7 +219,7 @@ class QasmSaveExpectationValueTests:
         opts = self.BACKEND_OPTS.copy()
         method = opts.get('method', 'automatic')
         circ = transpile(state_circ, basis_gates=['u1', 'u2', 'u3', 'cx', 'swap'])
-        circ.save_expectation_value_variance('expval', oper, [0, 1])
+        circ.save_expectation_value_variance(oper, [0, 1], label='expval')
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         if method not in SUPPORTED_METHODS:
@@ -250,7 +250,7 @@ class QasmSaveExpectationValueTests:
         opts = self.BACKEND_OPTS.copy()
         method = opts.get('method', 'automatic')
         circ = transpile(state_circ, basis_gates=['u1', 'u2', 'u3', 'cx', 'swap'])
-        circ.save_expectation_value('expval', oper, qubits)
+        circ.save_expectation_value(oper, qubits, label='expval')
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         if method not in SUPPORTED_METHODS:
@@ -283,7 +283,7 @@ class QasmSaveExpectationValueTests:
         opts = self.BACKEND_OPTS.copy()
         method = opts.get('method', 'automatic')
         circ = transpile(state_circ, basis_gates=['u1', 'u2', 'u3', 'cx', 'swap'])
-        circ.save_expectation_value_variance('expval', oper, qubits)
+        circ.save_expectation_value_variance(oper, qubits, label='expval')
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         if method not in SUPPORTED_METHODS:

--- a/test/terra/backends/qasm_simulator/qasm_save_probabilities.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_probabilities.py
@@ -49,10 +49,10 @@ class QasmSaveProbabilitiesTests:
         target = state.probabilities(qubits)
 
         # Snapshot circuit
-        key = 'probs'
+        label = 'probs'
         opts = self.BACKEND_OPTS.copy()
         circ = transpile(circ, self.SIMULATOR)
-        circ.save_probabilities(key, qubits)
+        circ.save_probabilities(qubits, label)
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         method = opts.get('method', 'automatic')
@@ -60,7 +60,7 @@ class QasmSaveProbabilitiesTests:
             self.assertFalse(result.success)
         else:
             self.assertTrue(result.success)
-            value = result.data(0)[key]
+            value = result.data(0)[label]
             self.assertTrue(np.allclose(value, target))
 
     @data([0, 1], [1, 0], [0], [1])
@@ -83,10 +83,10 @@ class QasmSaveProbabilitiesTests:
         target = state.probabilities_dict(qubits)
 
         # Snapshot circuit
-        key = 'probs'
+        label = 'probs'
         opts = self.BACKEND_OPTS.copy()
         circ = transpile(circ, self.SIMULATOR)
-        circ.save_probabilities_dict(key, qubits)
+        circ.save_probabilities_dict(qubits, label)
         qobj = assemble(circ)
         result = self.SIMULATOR.run(qobj, **opts).result()
         method = opts.get('method', 'automatic')
@@ -94,5 +94,5 @@ class QasmSaveProbabilitiesTests:
             self.assertFalse(result.success)
         else:
             self.assertTrue(result.success)
-            value = Counts(result.data(0)[key], memory_slots=len(qubits))
+            value = Counts(result.data(0)[label], memory_slots=len(qubits))
             self.assertDictAlmostEqual(value, target)

--- a/test/terra/backends/qasm_simulator/qasm_save_stabilizer.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_stabilizer.py
@@ -40,8 +40,8 @@ class QasmSaveStabilizerTests:
         target = qi.Clifford(circ)
 
         # Add save to circuit
-        save_key = 'state'
-        circ.save_stabilizer(save_key)
+        label = 'state'
+        circ.save_stabilizer(label)
 
         # Run
         opts = self.BACKEND_OPTS.copy()
@@ -53,6 +53,6 @@ class QasmSaveStabilizerTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = qi.Clifford.from_dict(result.data(0)[save_key])
+            self.assertIn(label, data)
+            value = qi.Clifford.from_dict(result.data(0)[label])
             self.assertEqual(value, target)

--- a/test/terra/backends/qasm_simulator/qasm_save_statevector.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_statevector.py
@@ -43,8 +43,8 @@ class QasmSaveStatevectorTests:
         target = qi.Statevector(circ)
 
         # Add save to circuit
-        save_key = 'sv'
-        circ.save_statevector(save_key)
+        label = 'sv'
+        circ.save_statevector(label)
 
         # Run
         opts = self.BACKEND_OPTS.copy()
@@ -56,8 +56,8 @@ class QasmSaveStatevectorTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = qi.Statevector(result.data(0)[save_key])
+            self.assertIn(label, data)
+            value = qi.Statevector(result.data(0)[label])
             self.assertAlmostEqual(value, target)
 
     def test_save_statevector_conditional(self):
@@ -69,13 +69,13 @@ class QasmSaveStatevectorTests:
         ]
 
         # Stabilizer test circuit
-        save_key = 'sv'
+        label = 'sv'
         circ = QuantumCircuit(2)
         circ.h(0)
         circ.sdg(0)
         circ.cx(0, 1)
         circ.measure_all()
-        circ.save_statevector(save_key, conditional=True)
+        circ.save_statevector(label, conditional=True)
 
         # Target statevector
         target = {'0x0': qi.Statevector([1, 0, 0, 0]),
@@ -91,8 +91,8 @@ class QasmSaveStatevectorTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            for key, vec in data[save_key].items():
+            self.assertIn(label, data)
+            for key, vec in data[label].items():
                 self.assertIn(key, target)
                 self.assertAlmostEqual(qi.Statevector(vec), target[key])
 
@@ -115,8 +115,8 @@ class QasmSaveStatevectorTests:
         target = qi.Statevector(circ)
 
         # Add save
-        save_key = 'sv'
-        circ.save_statevector(save_key, pershot=True)
+        label = 'sv'
+        circ.save_statevector(label, pershot=True)
 
         # Run
         shots = 10
@@ -129,8 +129,8 @@ class QasmSaveStatevectorTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = result.data(0)[save_key]
+            self.assertIn(label, data)
+            value = result.data(0)[label]
             self.assertEqual(len(value), shots)
             for vec in value:
                 self.assertAlmostEqual(qi.Statevector(vec), target)
@@ -154,8 +154,8 @@ class QasmSaveStatevectorTests:
         target = qi.Statevector(circ)
 
         # Add save
-        save_key = 'sv'
-        circ.save_statevector(save_key, pershot=True, conditional=True)
+        label = 'sv'
+        circ.save_statevector(label, pershot=True, conditional=True)
         circ.measure_all()
 
         # Run
@@ -169,8 +169,8 @@ class QasmSaveStatevectorTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = result.data(0)[save_key]
+            self.assertIn(label, data)
+            value = result.data(0)[label]
             self.assertIn('0x0', value)
             self.assertEqual(len(value['0x0']), shots)
             for vec in value['0x0']:

--- a/test/terra/backends/unitary_simulator/unitary_save.py
+++ b/test/terra/backends/unitary_simulator/unitary_save.py
@@ -39,8 +39,8 @@ class UnitarySaveUnitaryTests:
         target = qi.Operator(circ)
 
         # Add save to circuit
-        save_key = 'state'
-        circ.save_unitary(save_key)
+        label = 'state'
+        circ.save_unitary(label)
 
         # Run
         opts = self.BACKEND_OPTS.copy()
@@ -52,6 +52,6 @@ class UnitarySaveUnitaryTests:
         else:
             self.assertTrue(result.success)
             data = result.data(0)
-            self.assertIn(save_key, data)
-            value = qi.Operator(result.data(0)[save_key])
+            self.assertIn(label, data)
+            value = qi.Operator(result.data(0)[label])
             self.assertEqual(value, target)

--- a/test/terra/extensions/test_save_amplitudes.py
+++ b/test/terra/extensions/test_save_amplitudes.py
@@ -23,42 +23,42 @@ class TestSaveAmplitudes(QiskitAerTestCase):
 
     def test_invalid_key_raises(self):
         """Test save instruction key is str"""
-        self.assertRaises(ExtensionError, lambda: SaveAmplitudes(1, 1, [0]))
+        self.assertRaises(ExtensionError, lambda: SaveAmplitudes(1, [0], 1))
 
     def test_invalid_state_raises(self):
         """Test non-Hermitian op raises exception."""
-        self.assertRaises(ExtensionError, lambda: SaveAmplitudes('key', 2, [4]))
+        self.assertRaises(ExtensionError, lambda: SaveAmplitudes(2, [4], 'key'))
 
     def test_default_kwarg(self):
         """Test default kwargs"""
         key = 'test_key'
-        instr = SaveAmplitudes(key, 2, [0])
+        instr = SaveAmplitudes(2, [0], key)
         self.assertEqual(instr.name, 'save_amplitudes')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'single')
 
     def test_cond_kwarg(self):
         """Test conditional kwarg"""
         key = 'test_key'
-        instr = SaveAmplitudes(key, 2, [0], conditional=True)
+        instr = SaveAmplitudes(2, [0], key, conditional=True)
         self.assertEqual(instr.name, 'save_amplitudes')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'c_single')
 
     def test_pershot_kwarg(self):
         """Test pershot kwarg"""
         key = 'test_key'
-        instr = SaveAmplitudes(key, 2, [0], pershot=True)
+        instr = SaveAmplitudes(2, [0], key, pershot=True)
         self.assertEqual(instr.name, 'save_amplitudes')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'list')
 
     def test_pershot_cond_kwarg(self):
         """Test pershot, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveAmplitudes(key, 2, [0], conditional=True, pershot=True)
+        instr = SaveAmplitudes(2, [0], key, conditional=True, pershot=True)
         self.assertEqual(instr.name, 'save_amplitudes')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'c_list')
 
 

--- a/test/terra/extensions/test_save_expval.py
+++ b/test/terra/extensions/test_save_expval.py
@@ -25,59 +25,59 @@ class TestSaveExpectationValue(QiskitAerTestCase):
 
     def test_invalid_key_raises(self):
         """Test save instruction key is str"""
-        self.assertRaises(ExtensionError, lambda: SaveExpectationValue(1, Pauli('Z')))
+        self.assertRaises(ExtensionError, lambda: SaveExpectationValue(Pauli('Z'), 1))
 
     def test_nonhermitian_raises(self):
         """Test non-Hermitian op raises exception."""
         op = [[0, 1j], [1j, 0]]
-        self.assertRaises(ExtensionError, lambda: SaveExpectationValue('expval', op))
+        self.assertRaises(ExtensionError, lambda: SaveExpectationValue(op, 'expval'))
 
     def test_default_kwarg(self):
         """Test default kwargs"""
         key = 'test_key'
-        instr = SaveExpectationValue(key, Pauli('X'))
+        instr = SaveExpectationValue(Pauli('X'), key)
         self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'average')
 
     def test_cond_kwarg(self):
         """Test conditional kwarg"""
         key = 'test_key'
-        instr = SaveExpectationValue(key, Pauli('X'), conditional=True)
+        instr = SaveExpectationValue(Pauli('X'), key, conditional=True)
         self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'c_average')
 
     def test_unnorm_kwarg(self):
         """Test unnormalized kwarg"""
         key = 'test_key'
-        instr = SaveExpectationValue(key, Pauli('X'), unnormalized=True)
+        instr = SaveExpectationValue(Pauli('X'), key, unnormalized=True)
         self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'accum')
 
     def test_unnorm_cond_kwarg(self):
         """Test unnormalized, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpectationValue(key, Pauli('X'), conditional=True, unnormalized=True)
+        instr = SaveExpectationValue(Pauli('X'), key, conditional=True, unnormalized=True)
         self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'c_accum')
 
     def test_pershot_kwarg(self):
         """Test pershot kwarg"""
         key = 'test_key'
-        instr = SaveExpectationValue(key, Pauli('X'), pershot=True)
+        instr = SaveExpectationValue(Pauli('X'), key, pershot=True)
         self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'list')
 
     def test_pershot_cond_kwarg(self):
         """Test pershot, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpectationValue(key, Pauli('X'), conditional=True, pershot=True)
+        instr = SaveExpectationValue(Pauli('X'), key, conditional=True, pershot=True)
         self.assertEqual(instr.name, 'save_expval')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'c_list')
 
 
@@ -86,59 +86,59 @@ class TestSaveExpectationValueVariance(QiskitAerTestCase):
 
     def test_invalid_key_raises(self):
         """Test save instruction key is str"""
-        self.assertRaises(ExtensionError, lambda: SaveExpectationValueVariance(1, Pauli('Z')))
+        self.assertRaises(ExtensionError, lambda: SaveExpectationValueVariance(Pauli('Z'), 1))
 
     def test_nonhermitian_raises(self):
         """Test non-Hermitian op raises exception."""
         op = [[0, 1j], [1j, 0]]
-        self.assertRaises(ExtensionError, lambda: SaveExpectationValueVariance('expval', op))
+        self.assertRaises(ExtensionError, lambda: SaveExpectationValueVariance(op, 'expval'))
 
     def test_default_kwarg(self):
         """Test default kwargs"""
         key = 'test_key'
-        instr = SaveExpectationValueVariance(key, Pauli('X'))
+        instr = SaveExpectationValueVariance(Pauli('X'), key)
         self.assertEqual(instr.name, 'save_expval_var')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'average')
 
     def test_cond_kwarg(self):
         """Test conditional kwarg"""
         key = 'test_key'
-        instr = SaveExpectationValueVariance(key, Pauli('X'), conditional=True)
+        instr = SaveExpectationValueVariance(Pauli('X'), key, conditional=True)
         self.assertEqual(instr.name, 'save_expval_var')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'c_average')
 
     def test_unnorm_kwarg(self):
         """Test unnormalized kwarg"""
         key = 'test_key'
-        instr = SaveExpectationValueVariance(key, Pauli('X'), unnormalized=True)
+        instr = SaveExpectationValueVariance(Pauli('X'), key, unnormalized=True)
         self.assertEqual(instr.name, 'save_expval_var')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'accum')
 
     def test_unnorm_cond_kwarg(self):
         """Test unnormalized, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpectationValueVariance(key, Pauli('X'), conditional=True, unnormalized=True)
+        instr = SaveExpectationValueVariance(Pauli('X'), key, conditional=True, unnormalized=True)
         self.assertEqual(instr.name, 'save_expval_var')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'c_accum')
 
     def test_pershot_kwarg(self):
         """Test pershot kwarg"""
         key = 'test_key'
-        instr = SaveExpectationValueVariance(key, Pauli('X'), pershot=True)
+        instr = SaveExpectationValueVariance(Pauli('X'), key, pershot=True)
         self.assertEqual(instr.name, 'save_expval_var')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'list')
 
     def test_pershot_cond_kwarg(self):
         """Test pershot, conditonal kwargs"""
         key = 'test_key'
-        instr = SaveExpectationValueVariance(key, Pauli('X'), conditional=True, pershot=True)
+        instr = SaveExpectationValueVariance(Pauli('X'), key, conditional=True, pershot=True)
         self.assertEqual(instr.name, 'save_expval_var')
-        self.assertEqual(instr._key, key)
+        self.assertEqual(instr._label, key)
         self.assertEqual(instr._subtype, 'c_list')
 
 


### PR DESCRIPTION
Changes order of save instruction args to make the first positional arg `key` into a kwarg `label` with a default string value specific to each save instruction type.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR changes the format of the recently added save instructions to make the positional `key` arg a `label` kwarg. It also gives a default label value to each instruction so that they can be used without specifying a label.

### Details and comments

This allows use such as `circ.save_statevector()`, which will return result `{"statevector": state_vec}` and `circ.save_statevector(label='psi')` which will return result as `{"psi": state_vec}`.

Note that duplicate labels in a circuit raise an exception on execution, so if two of the same save instruction are used in a circuit non-default labels must be specified in the additional instructions. A note on this was added to the API docs.

