### PR TITLE
Add arm64 release wheel jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ jobs:
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python {project}/tools/verify_wheels.py"
+      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+---
+notifications:
+  email: false
+
+cache:
+  pip: true
+
+os: linux
+dist: bionic
+language: python
+python: 3.7
+jobs:
+  include:
+    - name: Build aarch64 wheels
+      arch: arm64-graviton2
+      services:
+        - docker
+      install:
+        - echo ""
+      env:
+        - CIBW_BEFORE_ALL_LINUX="yum install -y openblas-devel"
+        - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
+        - TWINE_USERNAME=qiskit
+        - CIBW_TEST_COMMAND="python {project}/tools/verify_wheels.py"
+        - CIBW_TEST_REQUIRES="git+https://github.com/Qiskit/qiskit-terra.git"
+      if: tag IS present
+      script:
+        - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python: 3.7
 jobs:
   include:
     - name: Build aarch64 wheels
-      arch: arm64-graviton2
+      arch: arm64
       services:
         - docker
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ jobs:
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python {project}/tools/verify_wheels.py"
         - CIBW_TEST_REQUIRES="git+https://github.com/Qiskit/qiskit-terra.git"
-      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       install:
         - echo ""
       env:
-        - CIBW_BEFORE_ALL_LINUX="yum-config-manager --enable epel-testing && yum install -y openblas-devel"
+        - CIBW_BEFORE_ALL_LINUX="yum install -y https://dl.fedoraproject.org/pub/epel/7/aarch64/Packages/e/epel-release-7-12.noarch.rpm && yum install -y openblas-devel"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python {project}/tools/verify_wheels.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       install:
         - echo ""
       env:
-        - CIBW_BEFORE_ALL_LINUX="yum install -y openblas-devel"
+        - CIBW_BEFORE_ALL_LINUX="yum-config-manager --enable epel-testing && yum install -y openblas-devel"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python {project}/tools/verify_wheels.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python {project}/tools/verify_wheels.py"
-        - CIBW_TEST_REQUIRES="git+https://github.com/Qiskit/qiskit-terra.git"
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new CI job to publish precompiled binary wheels for
linux on aarch64 (arm64). Since the latest numpy and scipy releases now
publish wheels for aarch64 we can run CI jobs to do the same since we
won't be spending all our CI time budget compiling upstream dependencies
from source anymore (terra 0.17.0 will be publishing wheels aarch64
wheels too). This enables users running on linux aarch64 systems
to install qiskit without having to compile everything from source
anymore. To build these wheels this commit uses travis, which is the
only CI system that offers non-x86 nodes.

### Details and comments