### PR TITLE
Fix out of bounds array access.

### DIFF
--- a/src/simulators/statevector/chunk/chunk.hpp
+++ b/src/simulators/statevector/chunk/chunk.hpp
@@ -155,13 +155,13 @@ public:
   {
     chunk_container_->CopyOut(dest,chunk_pos_);
   }
-  void CopyIn(thrust::complex<data_t>* src)
+  void CopyIn(thrust::complex<data_t>* src, uint_t size)
   {
-    chunk_container_->CopyIn(src,chunk_pos_);
+    chunk_container_->CopyIn(src,chunk_pos_, size);
   }
-  void CopyOut(thrust::complex<data_t>* dest)
+  void CopyOut(thrust::complex<data_t>* dest, uint_t size)
   {
-    chunk_container_->CopyOut(dest,chunk_pos_);
+    chunk_container_->CopyOut(dest,chunk_pos_, size);
   }
   void Swap(std::shared_ptr<Chunk<data_t>> src)
   {

--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -428,8 +428,8 @@ public:
 
   virtual void CopyIn(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk) = 0;
   virtual void CopyOut(std::shared_ptr<Chunk<data_t>> dest,uint_t iChunk) = 0;
-  virtual void CopyIn(thrust::complex<data_t>* src,uint_t iChunk) = 0;
-  virtual void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk) = 0;
+  virtual void CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size) = 0;
+  virtual void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size) = 0;
   virtual void Swap(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk) = 0;
 
   virtual void Zero(uint_t iChunk,uint_t count) = 0;

--- a/src/simulators/statevector/chunk/device_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/device_chunk_container.hpp
@@ -129,8 +129,8 @@ public:
 
   void CopyIn(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
   void CopyOut(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
-  void CopyIn(thrust::complex<data_t>* src,uint_t iChunk);
-  void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk);
+  void CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size);
+  void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size);
   void Swap(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
 
   void Zero(uint_t iChunk,uint_t count);
@@ -502,18 +502,21 @@ void DeviceChunkContainer<data_t>::CopyOut(std::shared_ptr<Chunk<data_t>> dest,u
 }
 
 template <typename data_t>
-void DeviceChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk)
+void DeviceChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size)
 {
-  uint_t size = 1ull << this->chunk_bits_;
+  uint_t this_size = 1ull << this->chunk_bits_;
+  if(this_size < size) throw std::runtime_error("CopyIn chunk size is less than provided size");
+  
   set_device();
-
   thrust::copy_n(src,size,data_.begin() + (iChunk << this->chunk_bits_));
 }
 
 template <typename data_t>
-void DeviceChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk)
+void DeviceChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size)
 {
-  uint_t size = 1ull << this->chunk_bits_;
+  uint_t this_size = 1ull << this->chunk_bits_;
+  if(this_size < size) throw std::runtime_error("CopyOut chunk size is less than provided size");
+  
   set_device();
   thrust::copy_n(data_.begin() + (iChunk << this->chunk_bits_),size,dest);
 }

--- a/src/simulators/statevector/chunk/host_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/host_chunk_container.hpp
@@ -103,8 +103,8 @@ public:
 
   void CopyIn(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
   void CopyOut(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
-  void CopyIn(thrust::complex<data_t>* src,uint_t iChunk);
-  void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk);
+  void CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size);
+  void CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size);
   void Swap(std::shared_ptr<Chunk<data_t>> src,uint_t iChunk);
 
   void Zero(uint_t iChunk,uint_t count);
@@ -234,17 +234,20 @@ void HostChunkContainer<data_t>::CopyOut(std::shared_ptr<Chunk<data_t>> dest,uin
 }
 
 template <typename data_t>
-void HostChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk)
+void HostChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size)
 {
-  uint_t size = 1ull << this->chunk_bits_;
-
+  uint_t this_size = 1ull << this->chunk_bits_;
+  if(this_size < size) throw std::runtime_error("CopyIn chunk size is less than provided size");
+  
   thrust::copy_n(src,size,data_.begin() + (iChunk << this->chunk_bits_));
 }
 
 template <typename data_t>
-void HostChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk)
+void HostChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size)
 {
-  uint_t size = 1ull << this->chunk_bits_;
+  uint_t this_size = 1ull << this->chunk_bits_;
+  if(this_size < size) throw std::runtime_error("CopyIn chunk size is less than provided size");
+  
   thrust::copy_n(data_.begin() + (iChunk << this->chunk_bits_),size,dest);
 }
 

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -613,7 +613,7 @@ cvector_t<data_t> QubitVectorThrust<data_t>::vector() const
 {
   cvector_t<data_t> ret(data_size_, 0.);
 
-  chunk_->CopyOut((thrust::complex<data_t>*)&ret[0]);
+  chunk_->CopyOut((thrust::complex<data_t>*)&ret[0], data_size_);
 
 #ifdef AER_DEBUG
   DebugMsg("vector");
@@ -626,7 +626,7 @@ template <typename data_t>
 AER::Vector<std::complex<data_t>> QubitVectorThrust<data_t>::copy_to_vector() const 
 {
   cvector_t<data_t> ret(data_size_, 0.);
-  chunk_->CopyOut((thrust::complex<data_t>*)&ret[0]);
+  chunk_->CopyOut((thrust::complex<data_t>*)&ret[0], data_size_);
 
 #ifdef AER_DEBUG
   DebugMsg("copy_to_vector");
@@ -641,7 +641,7 @@ AER::Vector<std::complex<data_t>> QubitVectorThrust<data_t>::move_to_vector()
   std::complex<data_t>* pRet;
   pRet = reinterpret_cast<std::complex<data_t>*>(malloc(sizeof(std::complex<data_t>) * data_size_));
 
-  chunk_->CopyOut((thrust::complex<data_t>*)pRet);
+  chunk_->CopyOut((thrust::complex<data_t>*)pRet, data_size_);
 
   const auto vec = AER::Vector<std::complex<data_t>>::move_from_buffer(data_size_, pRet);
 
@@ -1106,7 +1106,7 @@ void QubitVectorThrust<data_t>::initialize_from_vector(const cvector_t<double> &
     tmp[i] = statevec[i];
   }
 
-  chunk_->CopyIn((thrust::complex<data_t>*)&tmp[0]);
+  chunk_->CopyIn((thrust::complex<data_t>*)&tmp[0], data_size_);
 
 #ifdef AER_DEBUG
   DebugMsg("initialize_from_vector");
@@ -1127,7 +1127,7 @@ void QubitVectorThrust<data_t>::initialize_from_data(const std::complex<data_t>*
   DebugMsg("calling initialize_from_data");
 #endif
 
-  chunk_->CopyIn((thrust::complex<data_t>*)(statevec));
+  chunk_->CopyIn((thrust::complex<data_t>*)(statevec), data_size_);
 
 #ifdef AER_DEBUG
   DebugMsg("initialize_from_data");

--- a/src/simulators/unitary/unitarymatrix_thrust.hpp
+++ b/src/simulators/unitary/unitarymatrix_thrust.hpp
@@ -268,7 +268,7 @@ void UnitaryMatrixThrust<data_t>::initialize_from_matrix(const AER::cmatrix_t &m
       tmp[row + nrows * col] = mat(row, col);
     }
 
-  BaseVector::chunk_->CopyIn((thrust::complex<data_t>*)&tmp[0]);
+  BaseVector::chunk_->CopyIn((thrust::complex<data_t>*)&tmp[0], BaseVector::data_size_);
 }
 
 template <class data_t>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bug in CopyIn/CopyOut operations where out of bounds array elemets
were accessed.
`QubitvectorThrust` has a number of qubits `num_qubits`. When `move_to_vector` or
`copy_to_vector` functions are called a temporary array or vector of size
(1 << `num_qubits`) is created and passed to chunk_ CopyOut function. There, a number
of elements (1 << `chunk_qubits_`) of the underlying structure are copied to
this array/vector. The problem is that `chunk_qubits_` can be larger that `num_qubits`,
accessing values in the array or vector out of bounds. This is what was making
PR #1132 failing in CI.

### Details and comments

`chunk_qubits_` is initialized from maximum number of qubits in a list of circuit whereas `num_qubits` is initilaized as the number of qubits of a given circuit.

