### PR TITLE
Fix memory_leak due to shared_ptr circular references.

### DIFF
--- a/src/framework/linalg/vector.hpp
+++ b/src/framework/linalg/vector.hpp
@@ -203,6 +203,7 @@ template <class T>
 Vector<T>::Vector(Vector<T> &&other) noexcept
     : size_(other.size_), data_(other.data_) {
   other.data_ = nullptr;
+  other.size_ = 0;
 }
 
 //-----------------------------------------------------------------------
@@ -214,6 +215,7 @@ template <class T> Vector<T> &Vector<T>::operator=(Vector<T> &&other) noexcept {
   size_ = other.size_;
   data_ = other.data_;
   other.data_ = nullptr;
+  other.size_ = 0;
   return *this;
 }
 

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -129,7 +129,7 @@ public:
   virtual std::vector<reg_t> sample_measure(const reg_t &qubits, uint_t shots,
                                             RngEngine &rng) override;
 
-  virtual void allocate(uint_t num_qubits);
+  virtual void allocate(uint_t num_qubits) override;
 
   //-----------------------------------------------------------------------
   // Additional methods

--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -124,10 +124,10 @@ protected:
   virtual void apply_op(const int_t iChunk,const Operations::Op &op,
                          ExperimentResult &result,
                          RngEngine &rng,
-                         bool final_ops);
+                         bool final_ops) override;
 
   //swap between chunks
-  virtual void apply_chunk_swap(const reg_t &qubits);
+  virtual void apply_chunk_swap(const reg_t &qubits) override;
 
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
@@ -253,7 +253,7 @@ protected:
   // Threshold for chopping small values to zero in JSON
   double json_chop_threshold_ = 1e-10;
 
-  int qubit_scale(void)
+  int qubit_scale() override
   {
     return 2;
   }

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -130,7 +130,7 @@ public:
 
   // Return the Z-basis measurement outcome probabilities [P(0), ..., P(2^N-1)]
   // for measurement of N-qubits.
-  virtual std::vector<double> probabilities(const reg_t &qubits) const;
+  virtual std::vector<double> probabilities(const reg_t &qubits) const override;
 
   // Return M sampled outcomes for Z-basis measurement of all qubits
   // The input is a length M list of random reals between [0, 1) used for

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -149,7 +149,7 @@ public:
   virtual std::vector<reg_t> sample_measure(const reg_t &qubits, uint_t shots,
                                             RngEngine &rng) override;
 
-  virtual void allocate(uint_t num_qubits);
+  virtual void allocate(uint_t num_qubits) override;
 
   //-----------------------------------------------------------------------
   // Additional methods

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -128,7 +128,7 @@ protected:
   virtual void apply_op(const int_t iChunk,const Operations::Op &op,
                          ExperimentResult &result,
                          RngEngine &rng,
-                         bool final_ops = false);
+                         bool final_ops = false) override;
 
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
@@ -455,7 +455,7 @@ template <class statevec_t>
 auto State<statevec_t>::move_to_vector()
 {
   if(BaseState::num_global_chunks_ == 1){
-    return BaseState::qregs_[0].move_to_vector();
+      return BaseState::qregs_[0].move_to_vector();
   }
   else{
     int_t iChunk;

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -104,7 +104,7 @@ public:
   // Config: {"omp_qubit_threshold": 7}
   virtual void set_config(const json_t &config) override;
 
-  virtual void allocate(uint_t num_qubits);
+  virtual void allocate(uint_t num_qubits) override;
 
   //-----------------------------------------------------------------------
   // Additional methods

--- a/src/simulators/unitary/unitary_state_chunk.hpp
+++ b/src/simulators/unitary/unitary_state_chunk.hpp
@@ -111,7 +111,7 @@ protected:
   virtual void apply_op(const int_t iChunk,const Operations::Op &op,
                          ExperimentResult &result,
                          RngEngine &rng,
-                         bool final_ops = false);
+                         bool final_ops = false) override;
 
   // Applies a Gate operation to the state class.
   // This should support all and only the operations defined in
@@ -166,7 +166,7 @@ protected:
   // Threshold for chopping small values to zero in JSON
   double json_chop_threshold_ = 1e-10;
 
-  int qubit_scale(void)
+  int qubit_scale() override
   {
     return 2;
   }

--- a/src/simulators/unitary/unitarymatrix_thrust.hpp
+++ b/src/simulators/unitary/unitarymatrix_thrust.hpp
@@ -58,7 +58,7 @@ public:
 #endif
 
   // Set the size of the vector in terms of qubit number
-  void set_num_qubits(size_t num_qubits);
+  void set_num_qubits(size_t num_qubits) override;
 
   // Return the number of rows in the matrix
   size_t num_rows() const {return rows_;}

--- a/src/transpile/cacheblocking.hpp
+++ b/src/transpile/cacheblocking.hpp
@@ -54,7 +54,7 @@ public:
                         const opset_t &allowed_opset,
                         ExperimentResult &result) const override;
 
-  void set_config(const json_t &config);
+  void set_config(const json_t &config) override;
   bool enabled()
   {
     return blocking_enabled_;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- The chunk objects hold a shared_ptr to a chunk_container and the chunk_container
holds shared_ptrs to the chunks. This creates a circular reference problem which
avoids the destructions of chunks and chunk_containers.

- Some override warnings fixed

- Set other AER::Vector size to zero when performing moving operations.

### Details and comments


