### PR TITLE
Disable all warnings emitted from thrust headers

### DIFF
--- a/src/misc/warnings.hpp
+++ b/src/misc/warnings.hpp
@@ -30,9 +30,10 @@
   DISABLE_WARNING(-Wall)                                                       \
   DISABLE_WARNING(-Wextra)                                                     \
   DISABLE_WARNING(-Wshadow)                                                    \
-  DISABLE_WARNING(-Wfloat-equal)                                             \
+  DISABLE_WARNING(-Wfloat-equal)                                               \
   DISABLE_WARNING(-Wundef)                                                     \
   DISABLE_WARNING(-Wpedantic)                                                  \
+  DISABLE_WARNING(-Wredundant-decls)                                           \
   DISABLE_WARNING(-Wsign-compare)
 
 #define DISABLE_WARNING_POP DO_PRAGMA(GCC diagnostic pop)

--- a/src/misc/wrap_thrust.hpp
+++ b/src/misc/wrap_thrust.hpp
@@ -1,0 +1,49 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2020.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_misc_wrap_thrust_hpp_
+#define _aer_misc_wrap_thrust_hpp_
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC system_header
+#endif
+
+#include "misc/warnings.hpp"
+DISABLE_WARNING_PUSH
+#include <thrust/for_each.h>
+#include <thrust/complex.h>
+#include <thrust/inner_product.h>
+#include <thrust/transform.h>
+#include <thrust/transform_scan.h>
+#include <thrust/binary_search.h>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/tuple.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/detail/vector_base.h>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/permutation_iterator.h>
+#include <thrust/fill.h>
+
+#ifdef AER_THRUST_CUDA
+#include <thrust/device_vector.h>
+#endif
+#include <thrust/host_vector.h>
+
+#include <thrust/system/omp/execution_policy.h>
+DISABLE_WARNING_POP
+
+#endif // inclusion guard

--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -16,34 +16,15 @@
 #ifndef _qv_chunk_container_hpp_
 #define _qv_chunk_container_hpp_
 
+#include "misc/warnings.hpp"
+DISABLE_WARNING_PUSH
 #ifdef AER_THRUST_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
 #endif
+DISABLE_WARNING_POP
 
-#include <thrust/for_each.h>
-#include <thrust/complex.h>
-#include <thrust/inner_product.h>
-#include <thrust/transform.h>
-#include <thrust/transform_scan.h>
-#include <thrust/binary_search.h>
-#include <thrust/execution_policy.h>
-#include <thrust/functional.h>
-#include <thrust/tuple.h>
-#include <thrust/iterator/constant_iterator.h>
-#include <thrust/detail/vector_base.h>
-
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/iterator/permutation_iterator.h>
-#include <thrust/fill.h>
-
-#ifdef AER_THRUST_CUDA
-#include <thrust/device_vector.h>
-#endif
-#include <thrust/host_vector.h>
-
-#include <thrust/system/omp/execution_policy.h>
+#include "misc/wrap_thrust.hpp"
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Thrust headers are included from chunk_container. Not all warnings could
be disabled for gcc with our usual method (because a known issue in
gcc). Thus, I've made a wrapper including all the needed thrust
libraries and set it as system header in the case of gcc, which really
disables all warnings.

### Details and comments


