### PR TITLE
Fix density matrix expval_pauli

### DIFF
--- a/src/simulators/density_matrix/densitymatrix.hpp
+++ b/src/simulators/density_matrix/densitymatrix.hpp
@@ -130,14 +130,7 @@ public:
   //-----------------------------------------------------------------------
 
   // Return Pauli expectation value
-  double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
-  //for multi-chunk inter chunk expectation
-  double expval_pauli(const reg_t &qubits, const std::string &pauli,
-                      const QubitVector<data_t>& pair_chunk, 
-                      const uint_t z_count,
-                      const uint_t z_count_pair) const {
-    return BaseVector::expval_pauli(qubits, pauli, pair_chunk, z_count, z_count_pair);          
-  }
+  double expval_pauli(const reg_t &qubits, const std::string &pauli,const complex_t initial_phase=1.0) const;
 
 protected:
 
@@ -360,7 +353,7 @@ void DensityMatrix<data_t>::apply_toffoli(const uint_t qctrl0,
 
 template <typename data_t>
 double DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
-                                           const std::string &pauli) const {
+                                           const std::string &pauli,const complex_t initial_phase) const {
 
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = QV::pauli_masks_and_phase(qubits, pauli);
@@ -387,7 +380,7 @@ double DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
     return std::real(BaseVector::apply_reduction_lambda(std::move(lambda), size_t(0), nrows));
   }
 
-  auto phase = std::complex<data_t>(1.0);
+  auto phase = std::complex<data_t>(initial_phase);
   QV::add_y_phase(num_y, phase);
 
   const uint_t mask_u = ~MASKS[x_max + 1];

--- a/src/simulators/density_matrix/densitymatrix.hpp
+++ b/src/simulators/density_matrix/densitymatrix.hpp
@@ -394,11 +394,11 @@ double DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
   const uint_t mask_l = MASKS[x_max];
   auto lambda = [&](const int_t i, double &val_re, double &val_im)->void {
     (void)val_im; // unused
-    auto qubit_idx = ((i << 1) & mask_u) | (i & mask_l);
-    auto idx = qubit_idx ^ x_mask + nrows * qubit_idx;
+    auto idx_vec = ((i << 1) & mask_u) | (i & mask_l);
+    auto idx_mat = idx_vec ^ x_mask + nrows * idx_vec;
     // Since rho is hermitian rho[i, j] + rho[j, i] = 2 real(rho[i, j])
-    auto val = 2 * std::real(phase * BaseVector::data_[idx]);
-    if (z_mask && (AER::Utils::popcount(qubit_idx & z_mask) & 1)) {
+    auto val = 2 * std::real(phase * BaseVector::data_[idx_mat]);
+    if (z_mask && (AER::Utils::popcount(idx_vec & z_mask) & 1)) {
       val = - val;
     }
     val_re += val;

--- a/src/simulators/density_matrix/densitymatrix.hpp
+++ b/src/simulators/density_matrix/densitymatrix.hpp
@@ -372,12 +372,13 @@ double DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
 
   // Size of density matrix 
   const size_t nrows = BaseMatrix::rows_;
+  const size_t diag_stride = 1 + nrows;
 
   // specialize x_max == 0
   if (!x_mask) {
     auto lambda = [&](const int_t i, double &val_re, double &val_im)->void {
       (void)val_im; // unused
-      auto val = std::real(BaseVector::data_[i * (1 + nrows)]);
+      auto val = std::real(BaseVector::data_[i * diag_stride]);
       if (z_mask && (AER::Utils::popcount(i & z_mask) & 1)) {
         val = -val;
       }

--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -615,15 +615,11 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
   }
 
   if(qubits_out_chunk.size() > 0){  //there are bits out of chunk
-    std::complex<double> coeff = 1.0;
-
     std::reverse(pauli_out_chunk.begin(),pauli_out_chunk.end());
     std::reverse(pauli_in_chunk.begin(),pauli_in_chunk.end());
 
     uint_t x_mask, z_mask, num_y, x_max;
     std::tie(x_mask, z_mask, num_y, x_max) = AER::QV::pauli_masks_and_phase(qubits_out_chunk, pauli_out_chunk);
-
-    AER::QV::add_y_phase(num_y,coeff);
 
     if(x_mask != 0){    //pairing state is out of chunk
       bool on_same_process = true;
@@ -662,12 +658,12 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
           z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
 
           if(iProc == BaseState::distributed_rank_){  //pair is on the same process
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair);
           }
           else{
             BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
             //refer receive buffer to calculate expectation value
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair);
           }
         }
         else if(iProc == BaseState::distributed_rank_){  //pair is on this process
@@ -682,7 +678,7 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
         double sign = 1.0;
         if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
           sign = -1.0;
-        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk,coeff);
+        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk);
       }
     }
   }

--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -614,78 +614,60 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
     }
   }
 
+  int_t nrows = 1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)/2);
+
   if(qubits_out_chunk.size() > 0){  //there are bits out of chunk
+    std::complex<double> phase = 1.0;
+
     std::reverse(pauli_out_chunk.begin(),pauli_out_chunk.end());
     std::reverse(pauli_in_chunk.begin(),pauli_in_chunk.end());
 
     uint_t x_mask, z_mask, num_y, x_max;
     std::tie(x_mask, z_mask, num_y, x_max) = AER::QV::pauli_masks_and_phase(qubits_out_chunk, pauli_out_chunk);
 
-    if(x_mask != 0){    //pairing state is out of chunk
-      bool on_same_process = true;
-#ifdef AER_MPI
-      int proc_bits = 0;
-      uint_t procs = distributed_procs_;
-      while(procs > 1){
-        if((procs & 1) != 0){
-          proc_bits = -1;
-          break;
-        }
-        proc_bits++;
-        procs >>= 1;
-      }
-      if(x_mask & (~((1ull << (BaseState::num_qubits_/2 - proc_bits)) - 1)) != 0){    //data exchange between processes is required
-        on_same_process = false;
-      }
-#endif
-
+    z_mask >>= (BaseState::chunk_bits_/2);
+    if(x_mask != 0){
       x_mask >>= (BaseState::chunk_bits_/2);
-      z_mask >>= (BaseState::chunk_bits_/2);
       x_max -= (BaseState::chunk_bits_/2);
+
+      AER::QV::add_y_phase(num_y,phase);
 
       const uint_t mask_u = ~((1ull << (x_max + 1)) - 1);
       const uint_t mask_l = (1ull << x_max) - 1;
 
-#pragma omp parallel for if(BaseState::chunk_omp_parallel_ && on_same_process) private(i) reduction(+:expval)
-      for(i=0;i<BaseState::num_global_chunks_/2;i++){
-        uint_t iChunk = ((i << 1) & mask_u) | (i & mask_l);
-        uint_t pair_chunk = iChunk ^ x_mask;
-        uint_t iProc = BaseState::get_process_by_chunk(pair_chunk);
+#pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
+      for(i=0;i<nrows/2;i++){
+        uint_t irow = ((i << 1) & mask_u) | (i & mask_l);
+        uint_t iChunk = (irow ^ x_mask) + irow * nrows;
 
         if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-          uint_t z_count,z_count_pair;
-          z_count = AER::Utils::popcount(iChunk & z_mask);
-          z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
-
-          if(iProc == BaseState::distributed_rank_){  //pair is on the same process
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair);
-          }
-          else{
-            BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
-            //refer receive buffer to calculate expectation value
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair);
-          }
-        }
-        else if(iProc == BaseState::distributed_rank_){  //pair is on this process
-          BaseState::send_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+          double sign = 1.0;
+          if (z_mask && (AER::Utils::popcount(iChunk & z_mask) & 1))
+            sign = -1.0;
+          expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,phase);
         }
       }
     }
-    else{ //no exchange between chunks
-      z_mask >>= (BaseState::chunk_bits_/2);
+    else{
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
-      for(i=0;i<BaseState::num_local_chunks_;i++){
-        double sign = 1.0;
-        if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
-          sign = -1.0;
-        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk);
+      for(i=0;i<nrows;i++){
+        uint_t iChunk = i * (nrows+1);
+        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+          double sign = 1.0;
+          if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
+            sign = -1.0;
+          expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk);
+        }
       }
     }
   }
   else{ //all bits are inside chunk
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) reduction(+:expval)
-    for(i=0;i<BaseState::num_local_chunks_;i++){
-      expval += BaseState::qregs_[i].expval_pauli(qubits, pauli);
+    for(i=0;i<nrows;i++){
+      uint_t iChunk = i * (nrows+1);
+      if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+        expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits, pauli);
+      }
     }
   }
 

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -837,18 +837,18 @@ public:
     thrust::complex<data_t>* vec;
     thrust::complex<data_t> q0;
     double ret = 0.0;
-    uint_t qubit_idx, idx;
+    uint_t idx_vec, idx_mat;
 
     vec = this->data_;
 
-    qubit_idx = ((i << 1) & mask_u_) | (i & mask_l_);
-    idx = qubit_idx ^ x_mask_ + rows_ * qubit_idx;
+    idx_vec = ((i << 1) & mask_u_) | (i & mask_l_);
+    idx_mat = idx_vec ^ x_mask_ + rows_ * idx_vec;
 
-    q0 = vec[idx];
+    q0 = vec[idx_mat];
     q0 = 2 * phase_ * q0;
     ret = q0.real();
     if(z_mask_ != 0){
-      if(pop_count_kernel(qubit_idx & z_mask_) & 1)
+      if(pop_count_kernel(idx_vec & z_mask_) & 1)
         ret = -ret;
     }
     return ret;

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -142,13 +142,7 @@ public:
 
   // Return the expectation value of an N-qubit Pauli matrix.
   // The Pauli is input as a length N string of I,X,Y,Z characters.
-  double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
-  //for multi-chunk inter chunk expectation
-  double expval_pauli(const reg_t &qubits, const std::string &pauli,
-                      const QubitVectorThrust<data_t>& pair_chunk,
-                      const uint_t z_count,const uint_t z_count_pair) const {
-    return BaseVector::expval_pauli(qubits, pauli, pair_chunk, z_count, z_count_pair);               
-  }
+  double expval_pauli(const reg_t &qubits, const std::string &pauli,const complex_t initial_phase=1.0) const;
 
 protected:
   // Construct a vectorized superoperator from a vectorized matrix
@@ -786,6 +780,10 @@ public:
   {
     return true;
   }
+  uint_t size(int num_qubits)
+  {
+    return diag_stride_ - 1;
+  }
 
   __host__ __device__ double operator()(const uint_t &i) const
   {
@@ -832,6 +830,11 @@ public:
     mask_l_ = (1ull << x_max) - 1;
   }
 
+  uint_t size(int num_qubits)
+  {
+    return (rows_ >> 1);
+  }
+
   __host__ __device__ double operator()(const uint_t &i) const
   {
     thrust::complex<data_t>* vec;
@@ -861,7 +864,7 @@ public:
 
 template <typename data_t>
 double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
-                                                 const std::string &pauli) const 
+                                                 const std::string &pauli,const complex_t initial_phase) const 
 {
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -879,7 +882,7 @@ double DensityMatrixThrust<data_t>::expval_pauli(const reg_t &qubits,
 
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
-  auto phase = std::complex<data_t>(1.0);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
   return BaseVector::apply_function_sum(
     expval_pauli_XYZ_func_dm<data_t>(x_mask, z_mask, x_max, phase, BaseMatrix::rows_) );

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -308,12 +308,12 @@ public:
 
   // Return the expectation value of an N-qubit Pauli matrix.
   // The Pauli is input as a length N string of I,X,Y,Z characters.
-  double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
+  double expval_pauli(const reg_t &qubits, const std::string &pauli,const complex_t initial_phase=1.0) const;
   //for multi-chunk inter chunk expectation
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const QubitVector<data_t>& pair_chunk, 
                       const uint_t z_count,
-                      const uint_t z_count_pair) const;
+                      const uint_t z_count_pair,const complex_t initial_phase=1.0) const;
 
   //-----------------------------------------------------------------------
   // JSON configuration settings
@@ -1964,7 +1964,7 @@ void add_y_phase(uint_t num_y, std::complex<data_t>& coeff){
 
 template <typename data_t>
 double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
-                                         const std::string &pauli) const {
+                                         const std::string &pauli,const complex_t initial_phase) const {
 
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -1973,7 +1973,7 @@ double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
   if (x_mask + z_mask == 0) {
     return norm();
   }
-  auto phase = std::complex<data_t>(1.0);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
 
   // specialize x_max == 0
@@ -2015,13 +2015,13 @@ template <typename data_t>
 double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
                                          const std::string &pauli,
                                          const QubitVector<data_t>& pair_chunk,
-                                         const uint_t z_count,const uint_t z_count_pair) const 
+                                         const uint_t z_count,const uint_t z_count_pair,const complex_t initial_phase) const 
 {
 
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
 
-  auto phase = std::complex<data_t>(1.0);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
 
   std::complex<data_t>* pair_ptr = pair_chunk.data();

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -308,14 +308,12 @@ public:
 
   // Return the expectation value of an N-qubit Pauli matrix.
   // The Pauli is input as a length N string of I,X,Y,Z characters.
-  double expval_pauli(const reg_t &qubits, const std::string &pauli,
-                      const complex_t &coeff = 1) const;
+  double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
   //for multi-chunk inter chunk expectation
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const QubitVector<data_t>& pair_chunk, 
                       const uint_t z_count,
-                      const uint_t z_count_pair,
-                      const complex_t &coeff = 1) const;
+                      const uint_t z_count_pair) const;
 
   //-----------------------------------------------------------------------
   // JSON configuration settings
@@ -1966,8 +1964,7 @@ void add_y_phase(uint_t num_y, std::complex<data_t>& coeff){
 
 template <typename data_t>
 double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
-                                         const std::string &pauli,
-                                         const complex_t &coeff) const {
+                                         const std::string &pauli) const {
 
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -1976,7 +1973,7 @@ double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
   if (x_mask + z_mask == 0) {
     return norm();
   }
-  auto phase = std::complex<data_t>(coeff);
+  auto phase = std::complex<data_t>(1.0);
   add_y_phase(num_y, phase);
 
   // specialize x_max == 0
@@ -2018,14 +2015,13 @@ template <typename data_t>
 double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
                                          const std::string &pauli,
                                          const QubitVector<data_t>& pair_chunk,
-                                         const uint_t z_count,const uint_t z_count_pair,
-                                         const complex_t &coeff) const 
+                                         const uint_t z_count,const uint_t z_count_pair) const 
 {
 
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
 
-  auto phase = std::complex<data_t>(coeff);
+  auto phase = std::complex<data_t>(1.0);
   add_y_phase(num_y, phase);
 
   std::complex<data_t>* pair_ptr = pair_chunk.data();

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -3457,12 +3457,11 @@ class expval_pauli_Z_func : public GateFuncBase<data_t>
 {
 protected:
   uint_t z_mask_;
-  thrust::complex<data_t> phase_;
+
 public:
-  expval_pauli_Z_func(uint_t z,std::complex<data_t> p)
+  expval_pauli_Z_func(uint_t z)
   {
     z_mask_ = z;
-    phase_ = p;
   }
 
   bool is_diagonal(void)
@@ -3479,7 +3478,6 @@ public:
     vec = this->data_;
 
     q0 = vec[i];
-    q0 = phase_ * q0;
     ret = q0.real()*q0.real() + q0.imag()*q0.imag();
 
     if(z_mask_ != 0){
@@ -3570,17 +3568,16 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
   if (x_mask + z_mask == 0) {
     return norm();
   }
+  
+  // specialize x_max == 0
+  if(x_mask == 0) {
+    return apply_function_sum( expval_pauli_Z_func<data_t>(z_mask) );
+  }
 
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
   auto phase = std::complex<data_t>(1.0);
   add_y_phase(num_y, phase);
-
-  // specialize x_max == 0
-  if(x_mask == 0) {
-    return apply_function_sum( expval_pauli_Z_func<data_t>(z_mask, phase) );
-  }
-
   return apply_function_sum( expval_pauli_XYZ_func<data_t>(x_mask, z_mask, x_max, phase) );
 }
 

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -313,11 +313,11 @@ public:
 
   // Return the expectation value of an N-qubit Pauli matrix.
   // The Pauli is input as a length N string of I,X,Y,Z characters.
-  double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
+  double expval_pauli(const reg_t &qubits, const std::string &pauli,const complex_t initial_phase=1.0) const;
   //for multi-chunk inter chunk expectation
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const QubitVectorThrust<data_t>& pair_chunk,
-                      const uint_t z_count,const uint_t z_count_pair) const;
+                      const uint_t z_count,const uint_t z_count_pair,const complex_t initial_phase=1.0) const;
 
 
   //-----------------------------------------------------------------------
@@ -3559,7 +3559,7 @@ public:
 
 template <typename data_t>
 double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
-                                               const std::string &pauli) const 
+                                               const std::string &pauli,const complex_t initial_phase) const 
 {
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -3576,7 +3576,7 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
 
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
-  auto phase = std::complex<data_t>(1.0);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
   return apply_function_sum( expval_pauli_XYZ_func<data_t>(x_mask, z_mask, x_max, phase) );
 }
@@ -3649,7 +3649,7 @@ template <typename data_t>
 double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
                                                const std::string &pauli,
                                                const QubitVectorThrust<data_t>& pair_chunk,
-                                               const uint_t z_count,const uint_t z_count_pair) const 
+                                               const uint_t z_count,const uint_t z_count_pair,const complex_t initial_phase) const 
 {
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -3702,7 +3702,7 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
 
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
-  auto phase = std::complex<data_t>(1.0);
+  auto phase = std::complex<data_t>(initial_phase);
   add_y_phase(num_y, phase);
 
   ret = apply_function_sum( expval_pauli_inter_chunk_func<data_t>(x_mask, z_mask, phase, pair_ptr,z_count,z_count_pair) );

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -313,13 +313,11 @@ public:
 
   // Return the expectation value of an N-qubit Pauli matrix.
   // The Pauli is input as a length N string of I,X,Y,Z characters.
-  double expval_pauli(const reg_t &qubits, const std::string &pauli,
-                      const complex_t &coeff = 1) const;
+  double expval_pauli(const reg_t &qubits, const std::string &pauli) const;
   //for multi-chunk inter chunk expectation
   double expval_pauli(const reg_t &qubits, const std::string &pauli,
                       const QubitVectorThrust<data_t>& pair_chunk,
-                      const uint_t z_count,const uint_t z_count_pair,
-                      const complex_t &coeff = 1) const;
+                      const uint_t z_count,const uint_t z_count_pair) const;
 
 
   //-----------------------------------------------------------------------
@@ -3563,8 +3561,7 @@ public:
 
 template <typename data_t>
 double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
-                                               const std::string &pauli,
-                                               const complex_t &coeff) const 
+                                               const std::string &pauli) const 
 {
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -3576,7 +3573,7 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
 
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
-  auto phase = std::complex<data_t>(coeff);
+  auto phase = std::complex<data_t>(1.0);
   add_y_phase(num_y, phase);
 
   // specialize x_max == 0
@@ -3655,8 +3652,7 @@ template <typename data_t>
 double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
                                                const std::string &pauli,
                                                const QubitVectorThrust<data_t>& pair_chunk,
-                                               const uint_t z_count,const uint_t z_count_pair,
-                                               const complex_t &coeff) const 
+                                               const uint_t z_count,const uint_t z_count_pair) const 
 {
   uint_t x_mask, z_mask, num_y, x_max;
   std::tie(x_mask, z_mask, num_y, x_max) = pauli_masks_and_phase(qubits, pauli);
@@ -3709,7 +3705,7 @@ double QubitVectorThrust<data_t>::expval_pauli(const reg_t &qubits,
 
   // Compute the overall phase of the operator.
   // This is (-1j) ** number of Y terms modulo 4
-  auto phase = std::complex<data_t>(coeff);
+  auto phase = std::complex<data_t>(1.0);
   add_y_phase(num_y, phase);
 
   ret = apply_function_sum( expval_pauli_inter_chunk_func<data_t>(x_mask, z_mask, phase, pair_ptr,z_count,z_count_pair) );

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -571,15 +571,12 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
   }
 
   if(qubits_out_chunk.size() > 0){  //there are bits out of chunk
-    std::complex<double> coeff = 1.0;
 
     std::reverse(pauli_out_chunk.begin(),pauli_out_chunk.end());
     std::reverse(pauli_in_chunk.begin(),pauli_in_chunk.end());
 
     uint_t x_mask, z_mask, num_y, x_max;
     std::tie(x_mask, z_mask, num_y, x_max) = AER::QV::pauli_masks_and_phase(qubits_out_chunk, pauli_out_chunk);
-
-    AER::QV::add_y_phase(num_y,coeff);
 
     if(x_mask != 0){    //pairing state is out of chunk
       bool on_same_process = true;
@@ -618,12 +615,12 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
           z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
 
           if(iProc == BaseState::distributed_rank_){  //pair is on the same process
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair);
           }
           else{
             BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
             //refer receive buffer to calculate expectation value
-            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,coeff);
+            expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair);
           }
         }
         else if(iProc == BaseState::distributed_rank_){  //pair is on this process
@@ -638,7 +635,7 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
         double sign = 1.0;
         if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
           sign = -1.0;
-        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk,coeff);
+        expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk);
       }
     }
   }

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -571,12 +571,15 @@ double State<statevec_t>::expval_pauli(const reg_t &qubits,
   }
 
   if(qubits_out_chunk.size() > 0){  //there are bits out of chunk
+    std::complex<double> phase = 1.0;
 
     std::reverse(pauli_out_chunk.begin(),pauli_out_chunk.end());
     std::reverse(pauli_in_chunk.begin(),pauli_in_chunk.end());
 
     uint_t x_mask, z_mask, num_y, x_max;
     std::tie(x_mask, z_mask, num_y, x_max) = AER::QV::pauli_masks_and_phase(qubits_out_chunk, pauli_out_chunk);
+
+    AER::QV::add_y_phase(num_y,phase);
 
     if(x_mask != 0){    //pairing state is out of chunk
       bool on_same_process = true;

--- a/test/terra/backends/qasm_simulator/qasm_save_expval.py
+++ b/test/terra/backends/qasm_simulator/qasm_save_expval.py
@@ -16,10 +16,14 @@ QasmSimulator Integration Tests for SaveExpval instruction
 from ddt import ddt, data
 from numpy import allclose
 import qiskit.quantum_info as qi
+from qiskit import QuantumCircuit
 from qiskit.circuit.library import QuantumVolume
 from qiskit.compiler import transpile, assemble
 
 from qiskit.providers.aer import QasmSimulator
+
+PAULI2 = ['II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
+          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ']
 
 
 @ddt
@@ -29,8 +33,7 @@ class QasmSaveExpectationValueTests:
     SIMULATOR = QasmSimulator()
     BACKEND_OPTS = {}
 
-    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
-          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    @data(*PAULI2)
     def test_save_expval_stabilizer_pauli(self, pauli):
         """Test Pauli expval for stabilizer circuit"""
 
@@ -62,8 +65,7 @@ class QasmSaveExpectationValueTests:
             value = result.data(0)['expval']
             self.assertAlmostEqual(value, target)
 
-    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
-          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    @data(*PAULI2)
     def test_save_expval_var_stabilizer_pauli(self, pauli):
         """Test Pauli expval_var for stabilizer circuit"""
 
@@ -163,8 +165,7 @@ class QasmSaveExpectationValueTests:
             value = result.data(0)['expval']
             self.assertTrue(allclose(value, target))
 
-    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
-          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    @data(*PAULI2)
     def test_save_expval_nonstabilizer_pauli(self, pauli):
         """Test Pauli expval for non-stabilizer circuit"""
 
@@ -195,8 +196,7 @@ class QasmSaveExpectationValueTests:
             value = result.data(0)['expval']
             self.assertAlmostEqual(value, target)
 
-    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
-          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ')
+    @data(*PAULI2)
     def test_save_expval_var_nonstabilizer_pauli(self, pauli):
         """Test Pauli expval_var for non-stabilizer circuit"""
 
@@ -289,6 +289,72 @@ class QasmSaveExpectationValueTests:
         if method not in SUPPORTED_METHODS:
             self.assertFalse(result.success)
         else:
+            self.assertTrue(result.success)
+            value = result.data(0)['expval']
+            self.assertTrue(allclose(value, target))
+
+    @data(*PAULI2)
+    def test_save_expval_cptp_pauli(self, pauli):
+        """Test Pauli expval for stabilizer circuit"""
+
+        SUPPORTED_METHODS = [
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust'
+        ]
+        SEED = 5832
+
+        opts = self.BACKEND_OPTS.copy()
+        if opts.get('method') in SUPPORTED_METHODS:
+
+            oper = qi.Pauli(pauli)
+
+            # CPTP channel test circuit
+            channel = qi.random_quantum_channel(4, seed=SEED)
+            state_circ = QuantumCircuit(2)
+            state_circ.append(channel, range(2))
+
+            state = qi.DensityMatrix(state_circ)
+            target = state.expectation_value(oper).real.round(10)
+
+            # Snapshot circuit
+            circ = transpile(state_circ, self.SIMULATOR)
+            circ.save_expectation_value(oper, [0, 1], label='expval')
+            qobj = assemble(circ)
+            result = self.SIMULATOR.run(qobj, **opts).result()
+
+            self.assertTrue(result.success)
+            value = result.data(0)['expval']
+            self.assertAlmostEqual(value, target)
+
+    @data(*PAULI2)
+    def test_save_expval_var_cptp_pauli(self, pauli):
+        """Test Pauli expval_var for stabilizer circuit"""
+
+        SUPPORTED_METHODS = [
+            'density_matrix', 'density_matrix_gpu', 'density_matrix_thrust'
+        ]
+        SEED = 5832
+
+        opts = self.BACKEND_OPTS.copy()
+        if opts.get('method') in SUPPORTED_METHODS:
+
+            oper = qi.Pauli(pauli)
+
+            # CPTP channel test circuit
+            channel = qi.random_quantum_channel(4, seed=SEED)
+            state_circ = QuantumCircuit(2)
+            state_circ.append(channel, range(2))
+
+            state = qi.DensityMatrix(state_circ)
+            expval = state.expectation_value(oper).real
+            variance = state.expectation_value(oper ** 2).real - expval ** 2
+            target = [expval, variance]
+
+            # Snapshot circuit
+            circ = transpile(state_circ, self.SIMULATOR)
+            circ.save_expectation_value_variance(oper, [0, 1], label='expval')
+            qobj = assemble(circ)
+            result = self.SIMULATOR.run(qobj, **opts).result()
+
             self.assertTrue(result.success)
             value = result.data(0)['expval']
             self.assertTrue(allclose(value, target))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Somewhere in the refactors since the 0.7 release he way the `expval_pauli` function was removed from the density matrix method leading to incorrect computation of expectation values for noisy circuits. This restores the density matrix specific implementation of the expval_pauli function.

### Details and comments

On master expval_pauli was actually computing `Tr[O.rho^2]` instead of `Tr[O.rho]`, so was incorrect unless the simulation was ideal.

This PR also adds some extra tests including noise for testing expvals on the density matrix simulators.

@doichanj can you check the chunk versions still work in the way I updated them?
