### PR TITLE
Fix extended stabilizer method basis gates

### DIFF
--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -524,8 +524,8 @@ class QasmSimulator(AerBackend):
             config.custom_instructions = sorted(['roerror', 'snapshot', 'save_statevector',
                                                  'save_expval', 'save_expval_var'])
             config.basis_gates = sorted([
-                'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'swap',
-                'u0', 'u1', 'p', 'ccx', 'ccz', 'delay'
+                'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx',
+                'swap', 'u0', 't', 'tdg', 'u1', 'p', 'ccx', 'ccz', 'delay'
             ] + config.custom_instructions)
 
         return config


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds missing `t` and `tdg` basis gates list for extended stabilizer simulator method.

### Details and comments

Note that these gates were always supported, but were being unrolled to u1 gates previously due to the name strings being missing from the backends basis gates.

