### PR TITLE
Add reading of qubit_lo_freq from pulse Schedule config

### DIFF
--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -290,6 +290,13 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds, pulse_to_int, dt, q
     structs['snapshot'] = []
     structs['tlist'] = []
     structs['can_sample'] = True
+
+    # set an experiment qubit_lo_freq if present in experiment
+    structs['qubit_lo_freq'] = None
+    if 'config' in experiment:
+        freq_list = experiment['config'].get('qubit_lo_freq', None)
+        freq_list = [freq * 1e9 for freq in freq_list]
+        structs['qubit_lo_freq'] = freq_list
     # This is a list that tells us whether
     # the last PV pulse on a channel needs to
     # be assigned a final time based on the next pulse on that channel

--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -294,9 +294,11 @@ def experiment_to_structs(experiment, ham_chans, pulse_inds, pulse_to_int, dt, q
     # set an experiment qubit_lo_freq if present in experiment
     structs['qubit_lo_freq'] = None
     if 'config' in experiment:
-        freq_list = experiment['config'].get('qubit_lo_freq', None)
-        freq_list = [freq * 1e9 for freq in freq_list]
-        structs['qubit_lo_freq'] = freq_list
+        if ('qubit_lo_freq' in experiment['config'] and
+                experiment['config']['qubit_lo_freq'] is not None):
+            freq_list = experiment['config']['qubit_lo_freq']
+            freq_list = [freq * 1e9 for freq in freq_list]
+            structs['qubit_lo_freq'] = freq_list
     # This is a list that tells us whether
     # the last PV pulse on a channel needs to
     # be assigned a final time based on the next pulse on that channel

--- a/qiskit/providers/aer/pulse/controllers/pulse_de_solver.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_de_solver.py
@@ -39,5 +39,6 @@ def setup_de_solver(exp, y0, pulse_de_model, de_options):
     method = method_from_string(de_options.method)
 
     rhs = pulse_de_model.init_rhs(exp)
+
     solver = method(0.0, y0, rhs, de_options)
     return solver

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -1128,6 +1128,42 @@ class TestPulseSimulator(common.QiskitAerTestCase):
 
         self.assertGreaterEqual(state_fidelity(pulse_sim_yf, approx_yf), 0.99)
 
+    def test_schedule_freqs(self):
+        """Test simulation when each schedule has its own frequencies."""
+        """Test a schedule for a pi pulse on a 2 level system."""
+
+        # qubit frequency and drive frequency
+        omega_0 = 1.1329824
+        omega_d = omega_0
+
+        # drive strength and length of pulse
+        r = 0.01
+        total_samples = 100
+
+        # initial state and seed
+        y0 = np.array([1.0, 0.0])
+        seed = 9000
+
+        # set up simulator
+        pulse_sim = PulseSimulator(system_model=self._system_model_1Q(omega_0, r))
+
+        # set up constant pulse for doing a pi pulse
+        schedule = self._1Q_constant_sched(total_samples)
+        frequencies = np.array([0.5, 1.0, 1.5]) * omega_d
+        qobj = assemble(schedule,
+                        pulse_sim,
+                        schedule_los=[{DriveChannel(0): freq} for freq in frequencies],
+                        shots=128)
+
+        result = pulse_sim.run(qobj, initial_state=y0, seed=seed).result()
+
+        # check that the off-resonant drives fail to excite the system,
+        # while the on resonance drive does
+        self.assertDictAlmostEqual(result.get_counts(0), {'0': 128})
+        self.assertDictAlmostEqual(result.get_counts(1), {'1': 128})
+        self.assertDictAlmostEqual(result.get_counts(2), {'0': 128})
+
+
     def _system_model_1Q(self, omega_0, r):
         """Constructs a standard model for a 1 qubit system.
 

--- a/test/terra/pulse/controllers/__init__.py
+++ b/test/terra/pulse/controllers/__init__.py
@@ -1,0 +1,32 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+'''
+Pulse simulator controllers tests
+'''
+
+import os
+
+
+def load_tests(loader, standard_tests, pattern):
+    """
+    test suite for unittest discovery
+    """
+    this_dir = os.path.dirname(__file__)
+    if pattern in ['test*.py', '*_test.py']:
+        package_tests = loader.discover(start_dir=this_dir, pattern=pattern)
+        standard_tests.addTests(package_tests)
+    elif pattern in ['profile*.py', '*_profile.py']:
+        loader.testMethodPrefix = 'profile'
+        package_tests = loader.discover(start_dir=this_dir, pattern='test*.py')
+        standard_tests.addTests(package_tests)
+    return standard_tests

--- a/test/terra/pulse/controllers/test_pulse_controller.py
+++ b/test/terra/pulse/controllers/test_pulse_controller.py
@@ -1,0 +1,63 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""tests for pulse_controller.py"""
+
+import unittest
+import numpy as np
+from qiskit.providers.aer.pulse.controllers.pulse_controller import setup_rhs_dict_freqs
+
+from ...common import QiskitAerTestCase
+
+
+class TestSetupRHSDictFreqs(QiskitAerTestCase):
+    """Tests for setup_rhs_dict_freqs"""
+
+    def setUp(self):
+        super().setUp()
+        self.default_dict = {'freqs': [1., 2., 3.]}
+
+        def calculate_channel_frequencies(qubit_lo_freq):
+            return {'D0': qubit_lo_freq[0],
+                    'U0': qubit_lo_freq[0] - qubit_lo_freq[1],
+                    'D1': qubit_lo_freq[1]}
+
+        self.calculate_channel_frequencies = calculate_channel_frequencies
+
+    def test_without_override(self):
+        """Test maintenance of default values if no frequencies specified in exp."""
+
+        output_dict = setup_rhs_dict_freqs(self.default_dict,
+                                           {},
+                                           self.calculate_channel_frequencies)
+
+        self.assertAlmostEqual(np.array(output_dict['freqs']),
+                               np.array(self.default_dict['freqs']))
+
+        output_dict = setup_rhs_dict_freqs(self.default_dict,
+                                           {'qubit_lo_freq': None},
+                                           self.calculate_channel_frequencies)
+
+        self.assertAlmostEqual(np.array(output_dict['freqs']),
+                               np.array(self.default_dict['freqs']))
+
+    def test_with_override(self):
+        """Test overriding of default values with qubit_lo_freq in exp."""
+
+        output_dict = setup_rhs_dict_freqs(self.default_dict,
+                                           {'qubit_lo_freq': [5, 11]},
+                                           self.calculate_channel_frequencies)
+        self.assertAlmostEqual(np.array(output_dict['freqs']),
+                               np.array([5, -6, 11]))
+
+    def assertAlmostEqual(self, A, B, tol=10**-15):
+        self.assertTrue(np.abs(A - B).max() < tol)

--- a/test/terra/pulse/de/test_de_methods.py
+++ b/test/terra/pulse/de/test_de_methods.py
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """tests for DE_Methods.py"""
 
 import unittest

--- a/test/terra/pulse/de/test_type_utils.py
+++ b/test/terra/pulse/de/test_type_utils.py
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """tests for type_utils.py"""
 
 import numpy as np


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #1179

Follows logic as suggested in #1179 by @nkanazawa1989 : a global `qubit_lo_freq` field is populated as before, either from the qobj config or from the Hamiltonian. When simulating a specific schedule, if no `qubit_lo_freq` is present in the schedule config, the global default is used, otherwise the schedule's `qubit_lo_freq` is used.


### Details and comments

When each schedule is parsed (in dict format in `experiment_to_struct`) it checks if it has a `'config'` key, and if so, will check for a `qubit_lo_freq` field. If it's there, this will be stored in the "experiment struct" dictionary, otherwise, the `struct['qubit_lo_freq']` is set to `None`. When setting up the RHS function before solving, if `struct['qubit_lo_freq'] is not None`, this value will be subbed in, otherwise the default is maintained.

A test has been added to `test_pulse_simulator` with the same syntax as the example given by @nkanazawa1989  in #1179. A schedule which should do a perfect pi pulse (if on resonance) is run on a model with 3 different `qubit_lo_freq` values: the first below resonance, the second on resonance, and the third above resonance. The test verifies that the two off-resonant schedules fail to excite the system by checking that all measurement counts are in the ground state, whereas the on-resonance schedule returns all counts in the excited state.

### Question

Pending CI tests, this PR should be done. One potential issue that could arise with the current code is to do with formatting of the `qubit_lo_freq` field in the schedule config. The pulse simulator stores the default frequencies as a list of floats, which I believe are assumed to be canonically ordered, first with all drive frequencies in ascending order, then with all control channels. The `qubit_lo_freq` in the schedule config seems to just be a list (i.e. it doesn't contain channel name information) - is it safe to assume that it is also ordered in this way, or is there some other way to figure out the order in this list?  @nkanazawa1989 
