### PR TITLE
Improve handling of basis gates and configuration options

### DIFF
--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -118,20 +118,23 @@ class StatevectorSimulator(AerBackend):
         # so that the default shot value for execute
         # will not raise an error when trying to run
         # a simulation
-        'description': 'A C++ statevector simulator for QASM Qobj files',
+        'description': 'A C++ statevector circuit simulator',
         'coupling_map': None,
-        'basis_gates': [
+        'basis_gates': sorted([
             'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
             'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
             'cy', 'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy',
             'rzz', 'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx',
             'mcp', 'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz',
             'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
-            'initialize', 'kraus', 'roerror', 'delay', 'pauli',
+            'initialize', 'delay', 'pauli'
+        ]),
+        'custom_instructions': sorted([
+            'kraus', 'roerror',
             'save_expval', 'save_density_matrix', 'save_statevector',
             'save_probs', 'save_probs_ket', 'save_amplitudes',
             'save_amplitudes_sq', 'save_state'
-        ],
+        ]),
         'gates': []
     }
 
@@ -155,6 +158,10 @@ class StatevectorSimulator(AerBackend):
         if configuration is None:
             configuration = QasmBackendConfiguration.from_dict(
                 StatevectorSimulator._DEFAULT_CONFIGURATION)
+        elif not hasattr(configuration, 'custom_instructions'):
+            custom_inst = StatevectorSimulator._DEFAULT_CONFIGURATION['custom_instructions']
+            configuration.custom_instructions = custom_inst
+
         super().__init__(
             configuration,
             properties=properties,

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -124,17 +124,17 @@ class UnitarySimulator(AerBackend):
                                 # so that the default shot value for execute
                                 # will not raise an error when trying to run
                                 # a simulation
-        'description': 'A C++ unitary simulator for QASM Qobj files',
+        'description': 'A C++ unitary circuit simulator',
         'coupling_map': None,
-        'basis_gates': [
+        'basis_gates': sorted([
             'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
             'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
             'cy', 'cz', 'csx', 'cp', 'cu1', 'cu2', 'cu3', 'rxx', 'ryy',
             'rzz', 'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx',
             'mcp', 'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz',
             'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer', 'delay', 'pauli',
-            'save_unitary', 'save_state'
-        ],
+        ]),
+        'custom_instructions': sorted(['save_unitary', 'save_state']),
         'gates': []
     }
 
@@ -156,6 +156,9 @@ class UnitarySimulator(AerBackend):
         if configuration is None:
             configuration = QasmBackendConfiguration.from_dict(
                 UnitarySimulator._DEFAULT_CONFIGURATION)
+        elif not hasattr(configuration, 'custom_instructions'):
+            custom_inst = UnitarySimulator._DEFAULT_CONFIGURATION['custom_instructions']
+            configuration.custom_instructions = custom_inst
 
         super().__init__(configuration,
                          properties=properties,

--- a/test/terra/backends/qasm_simulator/qasm_cliffords.py
+++ b/test/terra/backends/qasm_simulator/qasm_cliffords.py
@@ -242,20 +242,11 @@ class QasmCliffordTests:
     # ---------------------------------------------------------------------
     def test_pauli_gate_deterministic(self):
         """Test pauli gate circuits"""
-        if 'method' in self.BACKEND_OPTS:
-            conf = self.SIMULATOR._method_configuration(self.BACKEND_OPTS['method'])
-            basis_gates = conf.basis_gates
-        else:
-            basis_gates = None
         shots = 100
         circuits = ref_1q_clifford.pauli_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.pauli_gate_counts_deterministic(shots)
-        job = execute(circuits,
-                      self.SIMULATOR,
-                      shots=shots,
-                      basis_gates=basis_gates,
-                      **self.BACKEND_OPTS, optimization_level=0)
+        job = execute(circuits, self.SIMULATOR, shots=shots, optimization_level=0)
         result = job.result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -265,20 +256,11 @@ class QasmCliffordTests:
     # ---------------------------------------------------------------------
     def test_id_gate_deterministic(self):
         """Test id gate circuits"""
-        if 'method' in self.BACKEND_OPTS:
-            conf = self.SIMULATOR._method_configuration(self.BACKEND_OPTS['method'])
-            basis_gates = conf.basis_gates
-        else:
-            basis_gates = None
         shots = 100
         circuits = ref_1q_clifford.id_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.id_gate_counts_deterministic(shots)
-        job = execute(circuits,
-                      self.SIMULATOR,
-                      shots=shots,
-                      basis_gates=basis_gates,
-                      **self.BACKEND_OPTS, optimization_level=0)
+        job = execute(circuits, self.SIMULATOR, shots=shots, optimization_level=0)
         result = job.result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0)
@@ -288,18 +270,11 @@ class QasmCliffordTests:
     # ---------------------------------------------------------------------
     def test_delay_gate_deterministic(self):
         """Test delay gate circuits"""
-        if 'method' in self.BACKEND_OPTS:
-            conf = self.SIMULATOR._method_configuration(self.BACKEND_OPTS['method'])
-            basis_gates = conf.basis_gates
-        else:
-            basis_gates = None
         shots = 100
         circuits = ref_1q_clifford.delay_gate_circuits_deterministic(
             final_measure=True)
         targets = ref_1q_clifford.delay_gate_counts_deterministic(shots)
-        qobj = assemble(circuits, self.SIMULATOR, shots=shots,
-                        basis_gates=basis_gates,
-                        **self.BACKEND_OPTS)
+        qobj = assemble(circuits, self.SIMULATOR, shots=shots, optimization_level=0)
         result = self.SIMULATOR.run(qobj).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0)

--- a/test/terra/backends/qasm_simulator/qasm_method.py
+++ b/test/terra/backends/qasm_simulator/qasm_method.py
@@ -344,7 +344,7 @@ class QasmMethodTests:
             config.custom_instructions))
 
         sim = QasmSimulator(method=method, noise_model=noise_model)
-        basis_gates = sim.configuration().basis_gates
+        basis_gates = sorted(sim.configuration().basis_gates)
         self.assertEqual(basis_gates, target_gates)
 
     @data('automatic', 'statevector', 'density_matrix', 'stabilizer',

--- a/test/terra/backends/qasm_simulator/qasm_method.py
+++ b/test/terra/backends/qasm_simulator/qasm_method.py
@@ -19,7 +19,6 @@ from test.terra.reference import ref_2q_clifford
 from test.terra.reference import ref_non_clifford
 from qiskit.compiler import assemble
 from qiskit.providers.aer import QasmSimulator
-from qiskit.providers.aer import AerError
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors import QuantumError
 from qiskit.providers.aer.noise.errors import pauli_error
@@ -340,12 +339,12 @@ class QasmMethodTests:
         config = QasmSimulator(method=method).configuration()
         noise_gates = ['id', 'sx', 'x', 'cx']
         noise_model = NoiseModel(basis_gates=noise_gates)
-        target_gates = sorted(set(config.basis_gates).intersection(noise_gates).union(
-            config.custom_instructions))
+        target_gates = (sorted(set(config.basis_gates).intersection(noise_gates))
+                        + config.custom_instructions)
 
         sim = QasmSimulator(method=method, noise_model=noise_model)
-        basis_gates = sorted(sim.configuration().basis_gates)
-        self.assertEqual(basis_gates, target_gates)
+        basis_gates = sim.configuration().basis_gates
+        self.assertEqual(sorted(basis_gates), sorted(target_gates))
 
     @data('automatic', 'statevector', 'density_matrix', 'stabilizer',
           'matrix_product_state', 'extended_stabilizer')
@@ -356,4 +355,4 @@ class QasmMethodTests:
         basis_gates1 = sim1.configuration().basis_gates
         sim2 = QasmSimulator(noise_model=noise_model, method=method)
         basis_gates2 = sim2.configuration().basis_gates
-        self.assertEqual(basis_gates1, basis_gates2)
+        self.assertEqual(sorted(basis_gates1), sorted(basis_gates2))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Updates how simulator options deal with option values belonging to the simulator configuration, properties and defaults.
* Improves how basis gates are reported in `backend.configuration()`

This is to address some of the issues discussed in #1181 

### Details and comments

*UPDATED:* Updates simulators to store separate option dictionaries for set options belonging to configuration, properties, and defaults, rather than a full copy of those objects with new values inserted. Now when the accessor methods are called (ie. `backend.configuration()`) a copy of these structures is generated and any custom option values are inserted when it is returned. In the specific case of basis gates, the value inserted will depend on any custom set values, the init config, the simulation method, and the noise model.