### PR TITLE
Suppress shadowed variable compiler warnings

### DIFF
--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -1369,11 +1369,11 @@ std::vector<reg_t> State<densmat_t>::sample_measure(const reg_t &qubits,
 
     if(nIn > 0){
       auto chunkSamples = BaseState::qregs_[i].sample_measure(vRnd);
-      uint_t irow;
-      irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
+      uint_t ir;
+      ir = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
 
       for(j=0;j<nIn;j++){
-        local_samples[vIdx[j]] = (irow << BaseState::chunk_bits_) + chunkSamples[j];
+        local_samples[vIdx[j]] = (ir << BaseState::chunk_bits_) + chunkSamples[j];
       }
     }
   }

--- a/src/simulators/statevector/qv_avx2.cpp
+++ b/src/simulators/statevector/qv_avx2.cpp
@@ -182,10 +182,10 @@ struct RealVectorView {
   RealVectorView() = delete;
   // Unfortunately, shared_ptr implies allocations and we cannot afford
   // them in this piece of code, so this is the reason to use raw pointers.
-  RealVectorView(FloatType* data) : data(data) {}
-  inline FloatType* operator[](size_t i) { return &data[i * 2]; }
-  inline const FloatType* operator[](size_t i) const { return &data[i * 2]; }
-  FloatType* data = nullptr;
+  RealVectorView(FloatType* data) : data_(data) {}
+  inline FloatType* operator[](size_t i) { return &data_[i * 2]; }
+  inline const FloatType* operator[](size_t i) const { return &data_[i * 2]; }
+  FloatType* data_ = nullptr;
 };
 
 template <typename FloatType>
@@ -194,24 +194,24 @@ struct ImaginaryVectorView : std::false_type {};
 template <>
 struct ImaginaryVectorView<double> {
   ImaginaryVectorView() = delete;
-  ImaginaryVectorView(double* data) : data(data) {}
+  ImaginaryVectorView(double* data) : data_(data) {}
   // SIMD vectorization takes n bytes depending on the underlaying type, so
   // for doubles, SIMD loads 4 consecutive values (4 * sizeof(double) = 32
   // bytes)
-  inline double* operator[](size_t i) { return &data[i * 2 + 4]; }
-  inline const double* operator[](size_t i) const { return &data[i * 2 + 4]; }
-  double* data = nullptr;
+  inline double* operator[](size_t i) { return &data_[i * 2 + 4]; }
+  inline const double* operator[](size_t i) const { return &data_[i * 2 + 4]; }
+  double* data_ = nullptr;
 };
 
 template <>
 struct ImaginaryVectorView<float> {
   ImaginaryVectorView() = delete;
-  ImaginaryVectorView(float* data) : data(data) {}
+  ImaginaryVectorView(float* data) : data_(data) {}
   // SIMD vectorization takes n bytes depending on the underlaying type, so
   // for floats, SIMD loads 8 consecutive (8 * sizeof(float) = 32 bytes)
-  inline float* operator[](size_t i) { return &data[i * 2 + 8]; }
-  inline const float* operator[](size_t i) const { return &data[i * 2 + 8]; }
-  float* data = nullptr;
+  inline float* operator[](size_t i) { return &data_[i * 2 + 8]; }
+  inline const float* operator[](size_t i) const { return &data_[i * 2 + 8]; }
+  float* data_ = nullptr;
 };
 
 static auto _mm256_mul(const m256_t<double>& left,
@@ -951,29 +951,29 @@ inline Avx _apply_avx_kernel(const uint64_t* qregs,
   ImaginaryVectorView<float> img = {data};
 
   if (num_qubits > 2 && qregs[2] == 2) {
-    auto lambda = [&](const uint64_t index0, const float* mat) -> void {
-      _apply_matrix_float_avx_q0q1q2<num_qubits>(real, img, mat, qregs, index0);
+    auto lambda = [&](const uint64_t index0, const float* m) -> void {
+      _apply_matrix_float_avx_q0q1q2<num_qubits>(real, img, m, qregs, index0);
     };
 
     avx_apply_lambda<num_qubits>(data_size, 1, lambda, qregs, omp_threads, mat);
 
   } else if (num_qubits > 1 && qregs[1] < 3) {
-    auto lambda = [&](const uint64_t index0, const float* mat) -> void {
-      _apply_matrix_float_avx_qLqL<num_qubits>(real, img, mat, qregs, index0);
+    auto lambda = [&](const uint64_t index0, const float* m) -> void {
+      _apply_matrix_float_avx_qLqL<num_qubits>(real, img, m, qregs, index0);
     };
 
     avx_apply_lambda<num_qubits>(data_size, 2, lambda, qregs, omp_threads, mat);
 
   } else if (qregs[0] < 3) {
-    auto lambda = [&](const uint64_t index0, const float* mat) -> void {
-      _apply_matrix_float_avx_qL<num_qubits>(real, img, mat, qregs, index0);
+    auto lambda = [&](const uint64_t index0, const float* m) -> void {
+      _apply_matrix_float_avx_qL<num_qubits>(real, img, m, qregs, index0);
     };
 
     avx_apply_lambda<num_qubits>(data_size, 4, lambda, qregs, omp_threads, mat);
 
   } else {
-    auto lambda = [&](const uint64_t index0, const float* mat) -> void {
-      _apply_matrix_float_avx<num_qubits>(real, img, mat, qregs, index0);
+    auto lambda = [&](const uint64_t index0, const float* m) -> void {
+      _apply_matrix_float_avx<num_qubits>(real, img, m, qregs, index0);
     };
 
     avx_apply_lambda<num_qubits>(data_size, 8, lambda, qregs, omp_threads, mat);
@@ -991,22 +991,22 @@ inline Avx _apply_avx_kernel(const uint64_t* qregs,
   ImaginaryVectorView<double> img = {data};
 
   if (num_qubits > 1 && qregs[1] == 1) {
-    auto lambda = [&](const uint64_t index0, const double* mat) -> void {
-      _apply_matrix_double_avx_q0q1<num_qubits>(real, img, mat, qregs, index0);
+    auto lambda = [&](const uint64_t index0, const double* m) -> void {
+      _apply_matrix_double_avx_q0q1<num_qubits>(real, img, m, qregs, index0);
     };
 
     avx_apply_lambda<num_qubits>(data_size, 1, lambda, qregs, omp_threads, mat);
 
   } else if (qregs[0] < 2) {
-    auto lambda = [&](const uint64_t index0, const double* mat) -> void {
-      _apply_matrix_double_avx_qL<num_qubits>(real, img, mat, qregs, index0);
+    auto lambda = [&](const uint64_t index0, const double* m) -> void {
+      _apply_matrix_double_avx_qL<num_qubits>(real, img, m, qregs, index0);
     };
 
     avx_apply_lambda<num_qubits>(data_size, 2, lambda, qregs, omp_threads, mat);
 
   } else {
-    auto lambda = [&](const uint64_t index0, const double* mat) -> void {
-      _apply_matrix_double_avx<num_qubits>(real, img, mat, qregs, index0);
+    auto lambda = [&](const uint64_t index0, const double* m) -> void {
+      _apply_matrix_double_avx<num_qubits>(real, img, m, qregs, index0);
     };
 
     avx_apply_lambda<num_qubits>(data_size, 4, lambda, qregs, omp_threads, mat);
@@ -1198,13 +1198,13 @@ Avx apply_diagonal_matrix_avx<double>(double* qv_data_,
   const size_t q0_mask = q0_mask_;
   const auto batch = (data_size <= (1UL << 5) ? 0 : 4);
 
-  auto lambda = [&](const uint64_t i_, const std::complex<double>* input_vec) -> void {
+  auto lambda = [&](const uint64_t i_, const std::complex<double>* in_vec) -> void {
     const auto base = i_ << (batch + 1);
     const auto until = base + (1UL << (batch + 1));
     std::complex<double>* tmp = tmps[_omp_get_thread_num()];
     for (auto i = base; i < until; i+=2) {
       auto tgt_qv_data = _mm256_load(reinterpret_cast<double*>(&(qv_data[i])));
-      auto input_data = _load_diagonal_input(input_vec, tmp, i, qregs, qregs_size, q0_mask);
+      auto input_data = _load_diagonal_input(in_vec, tmp, i, qregs, qregs_size, q0_mask);
       _mm_complex_multiply<double>(tgt_qv_data, input_data);
       _mm256_store(reinterpret_cast<double*>(&(qv_data[i])), tgt_qv_data);
     }
@@ -1263,13 +1263,13 @@ Avx apply_diagonal_matrix_avx<float>(float* qv_data_,
   const size_t q1_mask = q1_mask_;
   const auto batch = (data_size <= (1UL << 6) ? 0 : 4);
 
-  auto lambda = [&](const uint64_t i_, const std::complex<float>* input_vec) -> void {
+  auto lambda = [&](const uint64_t i_, const std::complex<float>* in_vec) -> void {
     const auto base = i_ << (batch + 2);
     const auto until = base + (1UL << (batch + 2));
     std::complex<float>* tmp = tmps[_omp_get_thread_num()];
     for (auto i = base; i < until; i+=4) {
       m256_t<float> tgt_qv_data = _mm256_load(reinterpret_cast<float*>(&(qv_data[i])));
-      auto input_data = _load_diagonal_input(input_vec, tmp, i, qregs, qregs_size, q0_mask, q1_mask);
+      auto input_data = _load_diagonal_input(in_vec, tmp, i, qregs, qregs_size, q0_mask, q1_mask);
       _mm_complex_multiply<float>(tgt_qv_data, input_data);
       _mm256_store(reinterpret_cast<float*>(&(qv_data[i])), tgt_qv_data);
     }

--- a/src/simulators/statevector/statevector_state_chunk.hpp
+++ b/src/simulators/statevector/statevector_state_chunk.hpp
@@ -387,9 +387,8 @@ void State<statevec_t>::initialize_qreg(uint_t num_qubits,
 
   initialize_omp();
 
-  int_t iChunk;
   if(BaseState::chunk_bits_ == BaseState::num_qubits_){
-    for(iChunk=0;iChunk<BaseState::num_local_chunks_;iChunk++){
+    for(int_t iChunk=0;iChunk<BaseState::num_local_chunks_;iChunk++){
       BaseState::qregs_[iChunk].set_num_qubits(BaseState::chunk_bits_);
       BaseState::qregs_[iChunk].initialize_from_vector(state);
     }
@@ -1675,7 +1674,7 @@ void State<statevec_t>::apply_kraus(const reg_t &qubits,
   double accum = 0.;
   bool complete = false;
 
-  int_t i,j;
+  int_t i;
   cvector_t vmat;
   double local_accum;
 

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -309,7 +309,7 @@ void Fuser::allocate_new_operation(oplist_t& ops,
 class CostBasedFusion : public Fuser {
 public:
   CostBasedFusion() {
-    std::fill_n(costs, 64, -1);
+    std::fill_n(costs_, 64, -1);
   };
 
   virtual std::string name() const override { return "cost_base"; };
@@ -338,7 +338,7 @@ private:
 private:
   bool active = true;
   double cost_factor = 1.8;
-  double costs[64];
+  double costs_[64];
 };
 
 template<size_t N>
@@ -487,7 +487,7 @@ private:
 
   int get_next_diagonal_end(const oplist_t& ops, const int from, std::set<uint_t>& fusing_qubits) const;
 
-  const std::shared_ptr<FusionMethod> method;
+  const std::shared_ptr<FusionMethod> method_;
   uint_t min_qubit = 3;
   bool active = true;
 };
@@ -647,12 +647,12 @@ bool DiagonalFusion::aggregate_operations(oplist_t& ops,
 
     int cnt = 0;
     while (true) {
-      auto next_diagonal_end = get_next_diagonal_end(ops, next_diagonal_start, checking_qubits_set);
-      if (next_diagonal_end < 0)
+      auto nde = get_next_diagonal_end(ops, next_diagonal_start, checking_qubits_set);
+      if (nde < 0)
         break;
       if (checking_qubits_set.size() > max_fused_qubits)
         break;
-      next_diagonal_start = next_diagonal_end + 1;
+      next_diagonal_start = nde + 1;
     }
 
     if (checking_qubits_set.size() < min_qubit)
@@ -909,7 +909,7 @@ void CostBasedFusion::set_config(const json_t &config) {
   for (int i = 0; i < 64; ++i) {
     auto prop_name = "fusion_cost." + std::to_string(i + 1);
     if (JSON::check_key(prop_name, config))
-      JSON::get_value(costs[i], prop_name, config);
+      JSON::get_value(costs_[i], prop_name, config);
   }
 }
 
@@ -1023,7 +1023,7 @@ double CostBasedFusion::estimate_cost(const std::vector<op_t>& ops,
   for (uint_t i = from; i <= until; ++i)
     add_fusion_qubits(fusion_qubits, ops[i]);
 
-  auto configured_cost = costs[fusion_qubits.size() - 1];
+  auto configured_cost = costs_[fusion_qubits.size() - 1];
   if (configured_cost > 0)
     return configured_cost;
 


### PR DESCRIPTION
### Summary
Suppress shadowed variable compiler warnings


### Details and comments
Currently there are a few compiler warnings about shadowed variables.
For example:
```console
/qiskit-aer/src/simulators/statevector/qv_avx2.cpp:185:35:
warning: declaration of ‘data’ shadows a member of
‘{anonymous}::RealVectorView<FloatType>’ [-Wshadow]
  185 |   RealVectorView(FloatType* data) : data(data) {}
      |                                   ^
/qiskit-aer/src/simulators/statevector/qv_avx2.cpp:188:14: note:
shadowed declaration is here
  188 |   FloatType* data = nullptr;
````
This commit renames the parameter to functions/lambdas, and local
variables and class members to avoid these compiler warnings.

