### PR TITLE
Suppress uninitialized variable warnings

### DIFF
--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -791,7 +791,7 @@ void QubitVector<data_t>::allocate_mem(size_t data_size){
   // Allocate memory for new vector
   if (data_ == nullptr) {
 #if !defined(_WIN64) && !defined(_WIN32)
-    void* data;
+    void* data = nullptr;
     posix_memalign(&data, 64, sizeof(std::complex<data_t>) * data_size);
     data_ = reinterpret_cast<std::complex<data_t>*>(data);
 #else
@@ -804,7 +804,7 @@ template <typename data_t>
 void QubitVector<data_t>::allocate_checkpoint(size_t data_size){
   free_checkpoint();
 #if !defined(_WIN64) && !defined(_WIN32)
-  void* data;
+  void* data = nullptr;
   posix_memalign(&data, 64, sizeof(std::complex<data_t>) * data_size);
   checkpoint_ = reinterpret_cast<std::complex<data_t>*>(data);
 #else

--- a/src/simulators/statevector/qv_avx2.cpp
+++ b/src/simulators/statevector/qv_avx2.cpp
@@ -1180,7 +1180,7 @@ Avx apply_diagonal_matrix_avx<double>(double* qv_data_,
 #pragma omp parallel if (omp_threads > 1) num_threads(omp_threads)
   {
 #if !defined(_WIN64) && !defined(_WIN32)
-    void* data;
+    void* data = nullptr;
     posix_memalign(&data, 64, sizeof(std::complex<double>) * 2);
     tmps[_omp_get_thread_num()] = reinterpret_cast<std::complex<double>*>(data);
 #else
@@ -1241,7 +1241,7 @@ Avx apply_diagonal_matrix_avx<float>(float* qv_data_,
 #pragma omp parallel if (omp_threads > 1) num_threads(omp_threads)
   {
   #if !defined(_WIN64) && !defined(_WIN32)
-    void* data;
+    void* data = nullptr;
     posix_memalign(&data, 64, sizeof(std::complex<float>) * 4);
     tmps[_omp_get_thread_num()] = reinterpret_cast<std::complex<float>*>(data);
   #else


### PR DESCRIPTION
### Summary
Suppress uninitialized variable warnings


### Details and comments
Currently, there are a few compiler warnings generated like the
following:
```console
/qiskit-aer/src/simulators/statevector/qubitvector.hpp:810:3: warning:
‘data’ may be used uninitialized in this function
[-Wmaybe-uninitialized]
  810 |   checkpoint_ = reinterpret_cast<std::complex<data_t>*>(data);
      |   ^~~~~~~~~~~
/qiskit-aer/src/simulators/statevector/qubitvector.hpp:808:9: note:
‘data’ was declared here
  808 |   void* data;
      |         ^~~~
````
This commit initializes these pointers in question to nullptr to
suppress these warnings.

