### PR TITLE
Disable GPU methods if no device is available

### DIFF
--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -502,6 +502,12 @@ void Controller::set_config(const json_t &config) {
         throw std::runtime_error(
             "Simulation device \"GPU\" is not supported on this system");
 #else
+        int nDev;
+        if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
+            cudaGetLastError();
+            throw std::runtime_error("No CUDA device available!");
+        }
+
         sim_device_ = Device::GPU;
 #endif
       }

--- a/src/controllers/controller.hpp
+++ b/src/controllers/controller.hpp
@@ -300,6 +300,20 @@ protected:
 //-------------------------------------------------------------------------
 
 void Controller::set_config(const json_t &config) {
+#ifdef AER_THRUST_CUDA
+  {
+    std::string method;
+    if (JSON::get_value(method, "method", config)) {
+      if(method.find("gpu") != std::string::npos){
+        int nDev;
+        if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
+          cudaGetLastError();
+          throw std::runtime_error("No CUDA device available!");
+        }
+      }
+    }
+  }
+#endif
 
   // Load validation threshold
   JSON::get_value(validation_threshold_, "validation_threshold", config);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

GPU methods are disabled if no device is available. An exception is thrown early in the process if no device is available.

Fixes the deploy failure we had in latest 0.8.0 release.


### Details and comments


