### PR TITLE
Suppress warnings from build_tests target

### DIFF
--- a/src/framework/matrix.hpp
+++ b/src/framework/matrix.hpp
@@ -477,7 +477,8 @@ template <class T> inline std::vector<T> matrix<T>::row_index(size_t row) const 
   ret.reserve(cols_);
   for(size_t i = 0; i < cols_; i++)
     ret.emplace_back(data_[i * rows_ + row]);
-  return std::move(ret);
+  // Allow for Named Return Value Optimization (NRVO) by not using std::move
+  return ret;
 }
 template <class T> inline std::vector<T> matrix<T>::col_index(size_t col) const {
 #ifdef DEBUG
@@ -492,7 +493,8 @@ template <class T> inline std::vector<T> matrix<T>::col_index(size_t col) const 
   // we want the elements for all rows i..rows_ and column col
   for(size_t i = 0; i < rows_; i++)
     ret.emplace_back(data_[col * rows_ + i]);
-  return std::move(ret);
+  // Allow for Named Return Value Optimization (NRVO) by not using std::move
+  return ret;
 }
 
 template <class T> inline size_t matrix<T>::GetRows() const {

--- a/test/src/test_linalg.cpp
+++ b/test/src/test_linalg.cpp
@@ -327,7 +327,7 @@ bool check_eigenvector(const std::vector<std::complex<T>>& expected_eigen,
     auto div = expected_eigen[0] / actual_eigen[0];
     T r = std::abs(div);
     T angle = std::arg(div);
-    for (int j = 1; j < expected_eigen.size(); j++) {
+    for (size_t j = 1; j < expected_eigen.size(); j++) {
         auto div_2 = expected_eigen[j] / actual_eigen[j];
         T r_2 = std::abs(div_2);
         T angle_2 = std::arg(div_2);
@@ -348,7 +348,7 @@ bool check_all_eigenvectors(const matrix<std::complex<T>>& expected,
     if (expected.size() != actual.size() || expected.GetColumns() != expected.GetColumns()) {
         return false;
     }
-    for (int i = 0; i < col_num; i++) {
+    for (size_t i = 0; i < col_num; i++) {
         auto expected_eigen = expected.col_index(i);
         auto actual_eigen = actual.col_index(i);
 


### PR DESCRIPTION
### Summary
Suppress warnings from build_tests target


### Details and comments
Currently, there are a number of warnings generated by the build_tests
target.

This commit removes two std::move calls where these would prevent Named
Return Value Optimization (NRVO) taking place (where the compiler can
omit any copy/move and construct the object directly on the caller
stack). Also, two index types are changed from int to size_t.

