### PR TITLE
Allow measure sampling with compatible initialize

### DIFF
--- a/releasenotes/notes/fix-initialize-sampling-b6948e39112f6a46.yaml
+++ b/releasenotes/notes/fix-initialize-sampling-b6948e39112f6a46.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes bug where the initialize instruction would disable measurement
+    sampling optimization for the statevector and matrix product state
+    simulation methods even when it was the first circuit instruction or
+    applied to all qubits and hence deterministic.

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -2034,21 +2034,26 @@ bool Controller::check_measure_sampling_opt(const Circuit &circ,
     return false;
   }
 
-  // If density matrix or superop method all noise instructions allow
-  // Sampling
-  if (method == Method::density_matrix || method == Method::unitary) {
+  // If density matrix, unitary, superop method all supported instructions
+  // allow sampling
+  if (method == Method::density_matrix ||
+      method == Method::superop ||
+      method == Method::unitary) {
     return true;
+  }
+  
+  // If circuit contains a non-initial initialize that is not a full width
+  // instruction we can't sample
+  if (circ.can_sample_initialize == false) {
+    return false;
   }
 
   // Check if non-density matrix simulation and circuit contains
   // a stochastic instruction before measurement
-  // ie. initialize, reset, kraus, superop, conditional
+  // ie. reset, kraus, superop
   // TODO:
-  // * If initialize should be allowed if applied to product states (ie start of
-  // circuit)
   // * Resets should be allowed if applied to |0> state (no gates before).
   if (circ.opset().contains(Operations::OpType::reset) ||
-      circ.opset().contains(Operations::OpType::initialize) ||
       circ.opset().contains(Operations::OpType::kraus) ||
       circ.opset().contains(Operations::OpType::superop)) {
     return false;

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -1216,20 +1216,27 @@ bool QasmController::check_measure_sampling_opt(const Circuit& circ,
     return false;
   }
 
+  // If density matrix method all noise instructions allowSampling
+  if (method == Method::density_matrix ||
+      method == Method::density_matrix_thrust_gpu ||
+      method == Method::density_matrix_thrust_cpu) {
+    return true;
+  }
+
+  // If circuit contains a non-initial initialize that is not a full width
+  // instruction we can't sample
+  if (circ.can_sample_initialize == false) {
+    return false;
+  }
+
   // Check if non-density matrix simulation and circuit contains
   // a stochastic instruction before measurement
-  // ie. initialize, reset, kraus, superop, conditional
+  // ie. reset, kraus, superop
   // TODO:
-  // * If initialize should be allowed if applied to product states (ie start of
-  // circuit)
   // * Resets should be allowed if applied to |0> state (no gates before).
-  bool density_mat = (method == Method::density_matrix ||
-                      method == Method::density_matrix_thrust_gpu ||
-                      method == Method::density_matrix_thrust_cpu);
-  if (!density_mat && (circ.opset().contains(Operations::OpType::reset) ||
-                       circ.opset().contains(Operations::OpType::initialize) ||
-                       circ.opset().contains(Operations::OpType::kraus) ||
-                       circ.opset().contains(Operations::OpType::superop))) {
+  if (circ.opset().contains(Operations::OpType::reset) ||
+      circ.opset().contains(Operations::OpType::kraus) ||
+      circ.opset().contains(Operations::OpType::superop)) {
     return false;
   }
   // Otherwise true


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If initialize is the first instruction in a circuit, or is defined across the full width of a circuit, it is deterministic and hence is compatible with the measurement sampling optimization

### Details and comments

Fixes #1210 
