### PR TITLE
Normalize statevector save and snapshot for extended stabilizer method 

### DIFF
--- a/releasenotes/notes/fix-normalize-statevector-extended-stabilizer-3811f44e003099f3.yaml
+++ b/releasenotes/notes/fix-normalize-statevector-extended-stabilizer-3811f44e003099f3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix issue #1196 by using the inner products with the computational basis states to calculate the norm rather than the norm estimation algorithm.

--- a/src/simulators/extended_stabilizer/ch_runner.hpp
+++ b/src/simulators/extended_stabilizer/ch_runner.hpp
@@ -142,7 +142,7 @@ public:
   std::vector<uint_t> stabilizer_sampler(uint_t n_shots, AER::RngEngine &rng);
   //Utilities for the state-vector snapshot.
   complex_t amplitude(uint_t x_measure);
-  AER::Vector<complex_t> statevector(uint_t default_samples, uint_t repetitions, AER::RngEngine &rng);
+  AER::Vector<complex_t> statevector();
 
 };
 
@@ -719,27 +719,24 @@ complex_t Runner::amplitude(uint_t x_measure)
   return {real_part, imag_part};
 }
 
-AER::Vector<complex_t> Runner::statevector(uint_t default_samples, uint_t repetitions, AER::RngEngine &rng)
+AER::Vector<complex_t> Runner::statevector()
 {
   uint_t ceil = 1ULL << n_qubits_;
-  uint_t n_samples = std::llrint(0.5 * std::pow(n_qubits_, 2));
-  if (n_samples < default_samples)
-  {
-    n_samples = default_samples;
-  }
-
   AER::Vector<complex_t> svector(ceil, false);
 
-  // double norm = 1;
-  double norm = 1;
-  if(num_states_ > 1)
-  {
-    norm = norm_estimation(n_samples, repetitions, rng);
-  }
+  double norm_squared = 0;
+
   for(uint_t i=0; i<ceil; i++)
   {
-    svector[i] = amplitude(i)/std::sqrt(norm);
+    svector[i] = amplitude(i);
+    norm_squared += svector[i].real()*svector[i].real() + svector[i].imag()*svector[i].imag();
   }
+  double norm = std::sqrt(norm_squared);
+  for(uint_t i=0; i<ceil; i++)
+  {
+    svector[i] /= norm;
+  }
+  
   return svector;
 }
 

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -133,7 +133,7 @@ protected:
 
   void apply_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
   //Convert a decomposition to a state-vector
-  void statevector_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
+  void statevector_snapshot(const Operations::Op &op, ExperimentResult &result);
   // //Compute probabilities from a stabilizer rank decomposition
   void probabilities_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
   const static stringmap_t<Gates> gateset_;
@@ -145,8 +145,7 @@ protected:
 
   // Compute and save the statevector for the current simulator state
   void apply_save_statevector(const Operations::Op &op,
-                              ExperimentResult &result,
-                              RngEngine &rng);
+                              ExperimentResult &result);
 
   // Compute and save the expval for the current simulator state
   void apply_save_expval(const Operations::Op &op,
@@ -430,7 +429,7 @@ void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &
               apply_snapshot(op, result, rng);
               break;
             case Operations::OpType::save_statevec:
-              apply_save_statevector(op, result, rng);
+              apply_save_statevector(op, result);
               break;
             case Operations::OpType::save_expval:
             case Operations::OpType::save_expval_var:
@@ -565,7 +564,7 @@ void State::apply_stabilizer_circuit(const std::vector<Operations::Op> &ops,
         apply_snapshot(op, result, rng);
         break;
       case Operations::OpType::save_statevec:
-        apply_save_statevector(op, result, rng);
+        apply_save_statevector(op, result);
         break;
       case Operations::OpType::save_expval:
       case Operations::OpType::save_expval_var:
@@ -750,8 +749,7 @@ void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank)
 }
 
 void State::apply_save_statevector(const Operations::Op &op,
-                                   ExperimentResult &result,
-                                   RngEngine& rng) {
+                                   ExperimentResult &result) {
   if (op.qubits.size() != BaseState::qreg_.get_n_qubits()) {
     throw std::invalid_argument(
         "Save statevector was not applied to all qubits."
@@ -759,7 +757,7 @@ void State::apply_save_statevector(const Operations::Op &op,
   }
   BaseState::save_data_pershot(
     result, op.string_params[0],
-    BaseState::qreg_.statevector(norm_estimation_samples_, 3, rng),
+    BaseState::qreg_.statevector(),
     op.save_type);
 }
 
@@ -812,7 +810,7 @@ void State::apply_snapshot(const Operations::Op &op, ExperimentResult &result, R
       BaseState::snapshot_creg_register(op, result);
       break;
     case Snapshots::statevector:
-      statevector_snapshot(op, result, rng);
+      statevector_snapshot(op, result);
       break;
     case Snapshots::probs:
       probabilities_snapshot(op, result, rng);
@@ -824,10 +822,10 @@ void State::apply_snapshot(const Operations::Op &op, ExperimentResult &result, R
   }
 }
 
-void State::statevector_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng)
+void State::statevector_snapshot(const Operations::Op &op, ExperimentResult &result)
 {
   result.legacy_data.add_pershot_snapshot("statevector", op.string_params[0],
-     BaseState::qreg_.statevector(norm_estimation_samples_, 3, rng));
+		      BaseState::qreg_.statevector());
 }
 
 double State::expval_pauli(const reg_t &qubits,

--- a/test/terra/backends/aer_simulator/instructions/test_save_statevector.py
+++ b/test/terra/backends/aer_simulator/instructions/test_save_statevector.py
@@ -24,7 +24,8 @@ from test.terra.backends.aer_simulator.aer_simulator_test_case import (
 class TestSaveStatevector(AerSimulatorTestCase):
     """SaveStatevector instruction tests."""
 
-    @supported_methods(['automatic', 'statevector', 'matrix_product_state'])
+    @supported_methods(['automatic', 'statevector', 'matrix_product_state',
+                        'extended_stabilizer'])
     def test_save_statevector(self, method, device):
         """Test save statevector instruction"""
         backend = self.backend(method=method, device=device)
@@ -52,7 +53,8 @@ class TestSaveStatevector(AerSimulatorTestCase):
         value = qi.Statevector(simdata[label])
         self.assertEqual(value, target)
 
-    @supported_methods(['automatic', 'statevector', 'matrix_product_state'])
+    @supported_methods(['automatic', 'statevector', 'matrix_product_state',
+                        'extended_stabilizer'])
     def test_save_statevector_conditional(self, method, device):
         """Test conditional save statevector instruction"""
 
@@ -82,10 +84,10 @@ class TestSaveStatevector(AerSimulatorTestCase):
             self.assertIn(key, target)
             self.assertEqual(qi.Statevector(vec), target[key])
 
-    @supported_methods(['automatic', 'statevector', 'matrix_product_state'])
+    @supported_methods(['automatic', 'statevector', 'matrix_product_state',
+                        'extended_stabilizer'])
     def test_save_statevector_pershot(self, method, device):
         """Test pershot save statevector instruction"""
-        print(method)
         backend = self.backend(method=method, device=device)
 
         # Stabilizer test circuit
@@ -114,8 +116,9 @@ class TestSaveStatevector(AerSimulatorTestCase):
         for vec in value:
             self.assertEqual(qi.Statevector(vec), target)
 
-    @supported_methods(['automatic', 'statevector', 'matrix_product_state'])
-    def test_save_statevector_pershot2_conditional(self, method, device):
+    @supported_methods(['automatic', 'statevector', 'matrix_product_state',
+                        'extended_stabilizer'])
+    def test_save_statevector_pershot_conditional(self, method, device):
         """Test pershot conditional save statevector instruction"""
 
         backend = self.backend(method=method, device=device)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix issue #1196. Since the statevector method of CHSimulator::Runner already computes the inner product with all 2^n computational basis states we can use this information to exactly compute the norm rather than using the fast norm estimation algorithm.


### Details and comments

Since the CHSimulator::Runner::statevector does not use the fast norm estimation algorithm anymore it does not need to take the parameters relating to it. This required changes everywhere this method is called which seems to just be in extended_stabilizer_state.hpp.

I don't think this change requires any additional tests unless we want to add a test that that confirms the output of this method is normalized.

