### PR TITLE
Remove unnecessary buffer allocation at chunk manager initialization (Thrust)

### DIFF
--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -487,6 +487,7 @@ protected:
 
   //allocate storage for chunk classes
   void allocate_chunks(void);
+  void deallocate_chunks(void);
 };
 
 template <typename data_t>
@@ -705,20 +706,52 @@ template <typename data_t>
 void ChunkContainer<data_t>::allocate_chunks(void)
 {
   uint_t i;
-  chunks_.resize(num_chunks_);
-  buffers_.resize(num_buffers_);
-  checkpoints_.resize(num_checkpoint_);
 
-  for(i=0;i<num_chunks_;i++){
-    chunks_[i] = std::make_shared<Chunk<data_t>>(this->shared_from_this(),i);
+  if(num_chunks_ > 0){
+    chunks_.resize(num_chunks_);
+    for(i=0;i<num_chunks_;i++){
+      chunks_[i] = std::make_shared<Chunk<data_t>>(this->shared_from_this(),i);
+    }
   }
-  for(i=0;i<num_buffers_;i++){
-    buffers_[i] = std::make_shared<Chunk<data_t>>(this->shared_from_this(),num_chunks_+i);
+  if(num_buffers_ > 0){
+    buffers_.resize(num_buffers_);
+    for(i=0;i<num_buffers_;i++){
+      buffers_[i] = std::make_shared<Chunk<data_t>>(this->shared_from_this(),num_chunks_+i);
+    }
   }
-  for(i=0;i<num_checkpoint_;i++){
-    checkpoints_[i] = std::make_shared<Chunk<data_t>>(this->shared_from_this(),num_chunks_+num_buffers_+i);
+  if(num_checkpoint_ > 0){
+    checkpoints_.resize(num_checkpoint_);
+    for(i=0;i<num_checkpoint_;i++){
+      checkpoints_[i] = std::make_shared<Chunk<data_t>>(this->shared_from_this(),num_chunks_+num_buffers_+i);
+    }
   }
 }
+
+template <typename data_t>
+void ChunkContainer<data_t>::deallocate_chunks(void)
+{
+  uint_t i;
+
+  if(num_chunks_ > 0){
+    for(i=0;i<num_chunks_;i++){
+      chunks_[i].reset();
+    }
+    chunks_.clear();
+  }
+  if(num_buffers_ > 0){
+    for(i=0;i<num_buffers_;i++){
+      buffers_[i].reset();
+    }
+    buffers_.clear();
+  }
+  if(num_checkpoint_ > 0){
+    for(i=0;i<num_checkpoint_;i++){
+      checkpoints_[i].reset();
+    }
+    checkpoints_.clear();
+  }
+}
+
 
 //------------------------------------------------------------------------------
 } // end namespace QV

--- a/src/simulators/statevector/chunk/chunk_manager.hpp
+++ b/src/simulators/statevector/chunk/chunk_manager.hpp
@@ -173,7 +173,6 @@ uint_t ChunkManager<data_t>::Allocate(int chunk_bits,int nqubits,uint_t nchunks)
   char* str;
   bool multi_gpu = false;
   bool hybrid = false;
-  uint_t num_checkpoint,total_checkpoint = 0;
   bool multi_shot = false;
 
   //--- for test
@@ -253,19 +252,7 @@ uint_t ChunkManager<data_t>::Allocate(int chunk_bits,int nqubits,uint_t nchunks)
           nc /= 2;
         }
 
-        num_checkpoint = 0;
         chunks_[iDev] = std::make_shared<DeviceChunkContainer<data_t>>();
-
-#ifdef AER_THRUST_CUDA
-        size_t freeMem,totalMem;
-        cudaSetDevice(iDev);
-        cudaMemGetInfo(&freeMem,&totalMem);
-        if(freeMem <= ( ((uint_t)sizeof(thrust::complex<data_t>) * (nc + num_buffers)) << chunk_bits_)){
-          num_checkpoint = 0;
-        }
-#endif
-
-        total_checkpoint += num_checkpoint;
         num_chunks_ += chunks_[iDev]->Allocate(iDev,chunk_bits,nc,num_buffers);
       }
       if(num_chunks_ < nchunks){

--- a/src/simulators/statevector/chunk/chunk_manager.hpp
+++ b/src/simulators/statevector/chunk/chunk_manager.hpp
@@ -137,7 +137,7 @@ ChunkManager<data_t>::ChunkManager()
 
 #endif
 
-  chunks_.resize(num_places_*2 + 1);
+  chunks_.resize(num_places_*2 + 1,nullptr);
 
   iplace_host_ = num_places_ ;
 
@@ -283,9 +283,11 @@ void ChunkManager<data_t>::Free(void)
   int i;
 
   for(i=0;i<chunks_.size();i++){
-    if(chunks_[i])
+    if(chunks_[i]){
       chunks_[i]->Deallocate();
-    chunks_[i].reset();
+      chunks_[i].reset();
+      chunks_[i] = nullptr;
+    }
   }
 
   chunk_bits_ = 0;

--- a/src/simulators/statevector/chunk/device_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/device_chunk_container.hpp
@@ -373,6 +373,8 @@ void DeviceChunkContainer<data_t>::Deallocate(void)
   }
   stream_.clear();
 #endif
+
+  ChunkContainer<data_t>::deallocate_chunks();
 }
 
 template <typename data_t>

--- a/src/simulators/statevector/chunk/host_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/host_chunk_container.hpp
@@ -131,12 +131,16 @@ uint_t HostChunkContainer<data_t>::Allocate(int idev,int bits,uint_t chunks,uint
   ChunkContainer<data_t>::num_buffers_ = buffers;
   ChunkContainer<data_t>::num_checkpoint_ = checkpoint;
   ChunkContainer<data_t>::num_chunks_ = nc;
-  data_.resize((nc + buffers + checkpoint) << bits);
-  matrix_.resize(nc + buffers);
-  params_.resize(nc + buffers);
+  if(nc + buffers + checkpoint > 0)
+    data_.resize((nc + buffers + checkpoint) << bits);
+  if(nc + buffers > 0){
+    matrix_.resize(nc + buffers);
+    params_.resize(nc + buffers);
+  }
 
   //allocate chunk classes
-  ChunkContainer<data_t>::allocate_chunks();
+  if(nc + buffers + checkpoint > 0)
+    ChunkContainer<data_t>::allocate_chunks();
 
   return nc;
 }
@@ -147,9 +151,12 @@ uint_t HostChunkContainer<data_t>::Resize(uint_t chunks,uint_t buffers,uint_t ch
   uint_t i;
 
   if(chunks + buffers + checkpoint > this->num_chunks_ + this->num_buffers_ + this->num_checkpoint_){
-    data_.resize((chunks + buffers + checkpoint) << this->chunk_bits_);
-    matrix_.resize(chunks + buffers);
-    params_.resize(chunks + buffers);
+    if(chunks + buffers + checkpoint > 0)
+      data_.resize((chunks + buffers + checkpoint) << this->chunk_bits_);
+    if(chunks + buffers > 0){
+      matrix_.resize(chunks + buffers);
+      params_.resize(chunks + buffers);
+    }
   }
 
   this->num_chunks_ = chunks;
@@ -157,7 +164,8 @@ uint_t HostChunkContainer<data_t>::Resize(uint_t chunks,uint_t buffers,uint_t ch
   this->num_checkpoint_ = checkpoint;
 
   //allocate chunk classes
-  ChunkContainer<data_t>::allocate_chunks();
+  if(chunks + buffers + checkpoint > 0)
+    ChunkContainer<data_t>::allocate_chunks();
 
   return chunks + buffers + checkpoint;
 }

--- a/src/simulators/statevector/chunk/host_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/host_chunk_container.hpp
@@ -179,6 +179,8 @@ void HostChunkContainer<data_t>::Deallocate(void)
   matrix_.shrink_to_fit();
   params_.clear();
   params_.shrink_to_fit();
+
+  ChunkContainer<data_t>::deallocate_chunks();
 }
 
 

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -517,6 +517,7 @@ QubitVectorThrust<data_t>::QubitVectorThrust(size_t num_qubits) : num_qubits_(0)
   chunk_ = nullptr;
   chunk_index_ = 0;
   multi_chunk_distribution_ = false;
+  buffer_chunk_ = nullptr;
   checkpoint_ = nullptr;
 
 #ifdef AER_DEBUG

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -519,6 +519,8 @@ QubitVectorThrust<data_t>::QubitVectorThrust(size_t num_qubits) : num_qubits_(0)
   multi_chunk_distribution_ = false;
   buffer_chunk_ = nullptr;
   checkpoint_ = nullptr;
+  send_chunk_ = nullptr;
+  recv_chunk_ = nullptr;
 
 #ifdef AER_DEBUG
   debug_count = 0;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is the fix for issue #1224 

### Details and comments
Chunk manager allocated buffers for MPI and buffers for checkpoint at the initialization.
However these are unnecessary for most cases. (MPI host buffer is only required for environments without GPUDirectRDMA)
So I removed these allocations and allocate checkpoint buffer when checkpoint is used.


