### PR TITLE
Fix stabilizer simulator expval function

### DIFF
--- a/releasenotes/notes/fix-stabilizer-expval-8649ee03f4b4b82d.yaml
+++ b/releasenotes/notes/fix-stabilizer-expval-8649ee03f4b4b82d.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes a bug in the ``stabilizer`` simulator method of the
+    :class:`~qiskit.providers.aer.QasmSimulator` and
+    :class:`~qiskit.providers.aer.AerSimulator` where the expectation value
+    for the ``save_expectation_value`` and ``snapshot_expectation_value``
+    could have the wrong sign for certain ``Y`` Pauli's.

--- a/src/simulators/stabilizer/clifford.hpp
+++ b/src/simulators/stabilizer/clifford.hpp
@@ -338,33 +338,51 @@ bool Clifford::measure_and_update(const uint64_t qubit, const uint64_t randint) 
 }
 
 int64_t Clifford::expectation_value(const std::vector<uint64_t>& qubits) {
-  // Check if there is a row that anti-commutes with an odd number of qubits
+  // Check if there is a stabilizer that anti-commutes with an odd number of qubits
   // If so expectation value is 0
-  for (uint64_t p = num_qubits_; p < 2 * num_qubits_; p++) {
-    uint64_t num_of_x = 0;
-    for (auto qubit : qubits) {
-      if (table_[p].X[qubit])
-	num_of_x ++;
+  for (size_t row = num_qubits_; row < 2 * num_qubits_; row++) {
+    size_t num_of_x = 0;
+    for (const auto& qubit : qubits) {
+      if (table_[row].X[qubit]) {
+	      num_of_x++;
+      }
     }
     if(num_of_x % 2 == 1)
       return 0;
   }
 
-  // Otherwise the expectation value is +1 or -1
-  uint64_t sum_of_outcomes = 0;
+  // Otherwise P is (-1)^a prod_j S_j^b_j for Clifford stabilizers
+  // If P anti-commutes with D_j then b_j = 1.  
+  
+  // Get Pauli rep for Z on input qubits
+  uint64_t phase = 0;
+  BV::BinaryVector z(num_qubits_);
   for (auto qubit : qubits) {
-    Pauli::Pauli accum(num_qubits_);
-    phase_t outcome = 0;
-    for (uint64_t i = 0; i < num_qubits_; i++) {
-      if (table_[i].X[qubit]) {
-        rowsum_helper(table_[i + num_qubits_], phases_[i + num_qubits_],
-                      accum, outcome);
-      }
-    }
-    sum_of_outcomes += outcome;
+    z.set1(qubit);
   }
 
-  return (sum_of_outcomes % 2 == 0) ? 1 : -1;
+  // Multiply P by stabilizers with anti-commuting destabilizers
+  for (size_t row = 0; row < num_qubits_; row++) {
+    // Check if destabilizer anti-commutes
+    size_t num_of_x = 0;
+    for (auto qubit : qubits) {
+      if (table_[row].X[qubit]) {
+	      num_of_x++;
+      }
+    }
+    if(num_of_x % 2 == 0) continue;
+
+    // If anti-commutes multiply Pauli by stabilizer
+    auto xi = table_[row + num_qubits_].X;
+    auto zi = table_[row + num_qubits_].Z;
+    phase += 2 * phases_[row + num_qubits_];
+    for (size_t i = 0; i < num_qubits_; i++) {
+      phase += zi[i] & xi[i];
+      phase += 2 * (z[i] & xi[i]);
+      z.setValue(z[i] ^ zi[i], i);
+    }
+  }
+  return (phase % 4) ? -1 : 1;
 }
 
 void Clifford::rowsum_helper(const Pauli::Pauli &row, const phase_t row_phase,

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -558,36 +558,73 @@ void State::apply_save_amplitudes_sq(const Operations::Op &op,
 
 double State::expval_pauli(const reg_t &qubits,
                            const std::string& pauli) {
-  // Compute expval components
-  auto state_cpy = BaseState::qreg_;
-  reg_t measured_qubits;
-  for (uint_t pos = 0; pos < qubits.size(); ++pos) {
-    const auto& qubit = qubits[pos];
-    switch (pauli[pauli.size() - 1 - pos]) {
-      case 'I':
-        break;
+  // Construct Pauli on N-qubits
+  const auto num_qubits = BaseState::qreg_.num_qubits();
+  Pauli::Pauli P(num_qubits);
+  uint_t phase = 0;
+  for (size_t i = 0; i < qubits.size(); ++i) {
+    switch (pauli[pauli.size() - 1 - i]) {
       case 'X':
-        state_cpy.append_h(qubit);
-        measured_qubits.push_back(qubit);
+        P.X.set1(qubits[i]);
         break;
       case 'Y':
-        state_cpy.append_s(qubit);
-        state_cpy.append_z(qubit);
-        state_cpy.append_h(qubit);
-        measured_qubits.push_back(qubit);
+        P.X.set1(qubits[i]);
+        P.Z.set1(qubits[i]);
+        phase += 1;
         break;
       case 'Z':
-        measured_qubits.push_back(qubit);
+        P.Z.set1(qubits[i]);
         break;
-      default: {
-        std::stringstream msg;
-        msg << "Invalid Pauli string \'" << pauli[pos]
-            << "\'.";
-        throw std::invalid_argument(msg.str());
+      default:
+        break;
+    };
+  }
+
+  // Check if there is a stabilizer that anti-commutes with an odd number of qubits
+  // If so expectation value is 0
+  for (size_t i = 0; i < num_qubits; i++) {
+    const auto& stabi = BaseState::qreg_.stabilizer(i);
+    size_t num_anti = 0;
+    for (const auto& qubit : qubits) {
+      if (P.Z[qubit] & stabi.X[qubit]) {
+	      num_anti++;
+      }
+      if (P.X[qubit] & stabi.Z[qubit]) {
+	      num_anti++;
       }
     }
+    if(num_anti % 2 == 1)
+      return 0.0;
   }
-  return state_cpy.expectation_value(measured_qubits);
+
+  // Otherwise P is (-1)^a prod_j S_j^b_j for Clifford stabilizers
+  // If P anti-commutes with D_j then b_j = 1.
+  // Multiply P by stabilizers with anti-commuting destabilizers
+  auto PZ = P.Z; // Make a copy of P.Z 
+  for (size_t i = 0; i < num_qubits; i++) {
+    // Check if destabilizer anti-commutes
+    const auto& destabi = BaseState::qreg_.destabilizer(i);
+    size_t num_anti = 0;
+    for (const auto& qubit : qubits) {
+      if (P.Z[qubit] & destabi.X[qubit]) {
+	      num_anti++;
+      }
+      if (P.X[qubit] & destabi.Z[qubit]) {
+	      num_anti++;
+      }
+    }
+    if (num_anti % 2 == 0) continue;
+
+    // If anti-commutes multiply Pauli by stabilizer
+    const auto& stabi = BaseState::qreg_.stabilizer(i);
+    phase += 2 * BaseState::qreg_.phases()[i + num_qubits];
+    for (size_t k = 0; k < num_qubits; k++) {
+      phase += stabi.Z[k] & stabi.X[k];
+      phase += 2 * (PZ[k] & stabi.X[k]);
+      PZ.setValue(PZ[k] ^ stabi.Z[k], k);
+    }
+  }
+  return (phase % 4) ? -1.0 : 1.0;
 }
 
 static void set_value_helper(std::map<std::string, double>& probs,

--- a/test/terra/backends/aer_simulator/instructions/test_save_expval.py
+++ b/test/terra/backends/aer_simulator/instructions/test_save_expval.py
@@ -65,13 +65,14 @@ class TestSaveExpectationValueTests(AerSimulatorTestCase):
         [
             'automatic', 'stabilizer', 'statevector', 'density_matrix',
             'matrix_product_state'
-        ],  # , 'extended_stabilizer'],
+        ],
         PAULI2)
-    def test_save_expval_stabilizer_pauli(self, method, device, pauli):
-        """Test Pauli expval for stabilizer circuit"""
-        SEED = 5832
-        circ = qi.random_clifford(2, seed=SEED).to_circuit()
-        oper = qi.Operator(qi.Pauli(pauli))
+    def test_save_expval_bell_pauli(self, method, device, pauli):
+        """Test Pauli expval for Bell state circuit"""
+        circ = QuantumCircuit(2)
+        circ.h(0)
+        circ.cx(0, 1)
+        oper = qi.Pauli(pauli)
         qubits = [0, 1]
         self._test_save_expval(circ,
                                oper,
@@ -84,13 +85,32 @@ class TestSaveExpectationValueTests(AerSimulatorTestCase):
         [
             'automatic', 'stabilizer', 'statevector', 'density_matrix',
             'matrix_product_state'
-        ],  # , 'extended_stabilizer'],
+        ],
+        PAULI2)
+    def test_save_expval_stabilizer_pauli(self, method, device, pauli):
+        """Test Pauli expval for stabilizer circuit"""
+        SEED = 5832
+        circ = qi.random_clifford(2, seed=SEED).to_circuit()
+        oper = qi.Pauli(pauli)
+        qubits = [0, 1]
+        self._test_save_expval(circ,
+                               oper,
+                               qubits,
+                               False,
+                               method=method,
+                               device=device)
+                        
+    @supported_methods(
+        [
+            'automatic', 'stabilizer', 'statevector', 'density_matrix',
+            'matrix_product_state'
+        ],
         PAULI2)
     def test_save_expval_var_stabilizer_pauli(self, method, device, pauli):
         """Test Pauli expval_var for stabilizer circuit"""
         SEED = 5832
         circ = qi.random_clifford(2, seed=SEED).to_circuit()
-        oper = qi.Operator(qi.Pauli(pauli))
+        oper = qi.Pauli(pauli)
         qubits = [0, 1]
         self._test_save_expval(circ,
                                oper,
@@ -103,7 +123,7 @@ class TestSaveExpectationValueTests(AerSimulatorTestCase):
         [
             'automatic', 'stabilizer', 'statevector', 'density_matrix',
             'matrix_product_state'
-        ],  # , 'extended_stabilizer'],
+        ],
         [[0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1]])
     def test_save_expval_stabilizer_hermitian(self, method, device, qubits):
         """Test expval for stabilizer circuit and Hermitian operator"""
@@ -159,7 +179,7 @@ class TestSaveExpectationValueTests(AerSimulatorTestCase):
         """Test Pauli expval_var for non-stabilizer circuit"""
         SEED = 7382
         circ = QuantumVolume(2, 1, seed=SEED)
-        oper = qi.Operator(qi.Pauli(pauli))
+        oper = qi.Pauli(pauli)
         qubits = [0, 1]
         self._test_save_expval(circ,
                                oper,
@@ -237,7 +257,7 @@ class TestSaveExpectationValueTests(AerSimulatorTestCase):
         """Test Pauli expval for stabilizer circuit"""
         SEED = 5832
         circ = qi.random_clifford(2, seed=SEED).to_circuit()
-        oper = qi.Operator(qi.Pauli(pauli))
+        oper = qi.Pauli(pauli)
         qubits = [0, 1]
         self._test_save_expval(circ,
                                oper,
@@ -254,7 +274,7 @@ class TestSaveExpectationValueTests(AerSimulatorTestCase):
         """Test Pauli expval_var for stabilizer circuit"""
         SEED = 5832
         circ = qi.random_clifford(2, seed=SEED).to_circuit()
-        oper = qi.Operator(qi.Pauli(pauli))
+        oper = qi.Pauli(pauli)
         qubits = [0, 1]
         self._test_save_expval(circ,
                                oper,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Partially fix for #1227 for the stabilizer simulator method.

### Details and comments

Corrects the algorithm used to compute the expectation value in the Clifford class. The new algorithm is also more efficient since it avoids copying the full Clifford table for each Pauli term.

Adds an extra test for previously failing example.

