### PR TITLE
Fix ``backend.configuration`` performance issue

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -181,7 +181,7 @@ class AerBackend(Backend, ABC):
         # If config has custom instructions add them to
         # basis gates to include them for the terra transpiler
         if hasattr(config, 'custom_instructions'):
-            config.basis_gates += config.custom_instructions
+            config.basis_gates = config.basis_gates + config.custom_instructions
         return config
 
     def properties(self):

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -344,6 +344,10 @@ class QasmSimulator(AerBackend):
         else:
             configuration.open_pulse = False
 
+        # Cache basis gates since computing the intersection
+        # of noise model, method, and config gates is expensive.
+        self._cached_basis_gates = self._DEFAULT_BASIS_GATES
+
         super().__init__(configuration,
                          properties=properties,
                          available_methods=QasmSimulator._AVAILABLE_METHODS,
@@ -445,13 +449,13 @@ class QasmSimulator(AerBackend):
         Returns:
             BackendConfiguration: the configuration for the backend.
         """
+        config = copy.copy(self._configuration)
+        for key, val in self._options_configuration.items():
+            setattr(config, key, val)
         # Update basis gates based on custom options, config, method,
         # and noise model
-        basis_gates = self._basis_gates()
-        custom_inst = self._custom_instructions()
-        config = super().configuration()
-        config.custom_instructions = custom_inst
-        config.basis_gates = basis_gates + custom_inst
+        config.custom_instructions = self._custom_instructions()
+        config.basis_gates = self._cached_basis_gates + config.custom_instructions
         return config
 
     def _execute(self, qobj):
@@ -467,15 +471,22 @@ class QasmSimulator(AerBackend):
 
     def set_options(self, **fields):
         out_options = {}
+        update_basis_gates = False
         for key, value in fields.items():
             if key == 'method':
                 self._set_method_config(value)
+                update_basis_gates = True
+                out_options[key] = value
+            elif key in ['noise_model', 'basis_gates']:
+                update_basis_gates = True
                 out_options[key] = value
             elif key == 'custom_instructions':
                 self._set_configuration_option(key, value)
             else:
                 out_options[key] = value
         super().set_options(**out_options)
+        if update_basis_gates:
+            self._cached_basis_gates = self._basis_gates()
 
     def _validate(self, qobj):
         """Semantic validations of the qobj which cannot be done via schemas.
@@ -511,21 +522,22 @@ class QasmSimulator(AerBackend):
         if 'basis_gates' in self._options_configuration:
             return self._options_configuration['basis_gates']
 
-        # Set basis gates to be the intersection of config, method, and noise model
-        # basis gates
+        # Compute intersection with method basis gates
+        method_gates = self._method_basis_gates()
         config_gates = self._configuration.basis_gates
-        basis_gates = set(config_gates)
-        if self._options.noise_model:
-            noise_gates = self._options.noise_model.basis_gates
+        if config_gates:
+            basis_gates = set(config_gates).intersection(
+                method_gates)
+        else:
+            basis_gates = method_gates
+
+        # Compute intersection with noise model basis gates
+        noise_model = getattr(self.options, 'noise_model', None)
+        if noise_model:
+            noise_gates = noise_model.basis_gates
             basis_gates = basis_gates.intersection(noise_gates)
         else:
             noise_gates = None
-
-        if self._options.method:
-            method_gates = self._method_basis_gates()
-            basis_gates = basis_gates.intersection(method_gates)
-        else:
-            method_gates = None
 
         if not basis_gates:
             logger.warning(

--- a/releasenotes/notes/basis-gates-perf-aba3fe10a154a19a.yaml
+++ b/releasenotes/notes/basis-gates-perf-aba3fe10a154a19a.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes performance issue with how the ``basis_gates`` configuration
+    attribute was set. Previously there were unintended side-effects to the
+    backend class which could cause repeated simulation runtime to
+    incrementally increase. Refer to
+    `#1229 <https://github.com/Qiskit/qiskit-aer/issues/1229>` for more
+    information and examples.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1229 

### Details and comments

There was a bug with how basis gates were computed in `backend.configuration` with the unintended side-effect of causing the basis gates list to grow larger each time `backend.configuration` was called (eg in transpile or execute). 

Further profiling also showed that a lot of overhead was being spent in set-comparison functions for computing the basis gates as the intersection of method, noise model and backend basis gates. This now greadily computes the basis gates and stores the value each time one of these options is set so that it isn't unnecessarily repeated each time at runtime.
