### PR TITLE
Prepare for renaming default branch to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: Build
 on:
   push:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
   pull_request:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
 jobs:
   standalone:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: Docs and Tutorial
 on:
   push:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
   pull_request:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -1,9 +1,9 @@
 name: Tests Linux
 on:
   push:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
   pull_request:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests_mac.yml
+++ b/.github/workflows/tests_mac.yml
@@ -1,9 +1,9 @@
 name: Tests MacOS
 on:
   push:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
   pull_request:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
 jobs:
   lint:
     runs-on: macOS-latest

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -1,9 +1,9 @@
 name: Tests Windows
 on:
   push:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
   pull_request:
-    branches: [master, 'stable/*']
+    branches: [main, 'stable/*']
 jobs:
   lint:
     runs-on: windows-latest

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -42,7 +42,7 @@ After the completion of the tests, you will see the results with a format simila
 · Creating environments
 · Discovering benchmarks
 · Running 3 total benchmarks (1 commit * 1 environment * 3 benchmarks)
-[  0.00%] · For qiskit-aer commit 8b4f4de1 <master>:
+[  0.00%] · For qiskit-aer commit 8b4f4de1 <main>:
 [  0.00%] ·· Benchmarking conda-py3.7
 [ 16.67%] ··· Running (quantum_volume_benchmarks.QuantumVolumeTimeSuite.time_quantum_volume--)..
 [ 50.00%] ··· Running (simple_benchmarks.SimpleU3TimeSuite.time_simple_u3--).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,11 +196,11 @@ previous version in the release notes.
 
 ### Branches
 
-* `master`:
+* `main`:
 
-The master branch is used for development of the next version of qiskit-aer.
+The main branch is used for development of the next version of qiskit-aer.
 It will be updated frequently and should not be considered stable. The API
-can and will change on master as we introduce and refine new features.
+can and will change on main as we introduce and refine new features.
 
 * `stable/*` branches:
 Branches under `stable/*` are used to maintain released versions of qiskit-aer.
@@ -214,13 +214,13 @@ merged to it are bugfixes.
 When it is time to release a new minor version of qiskit-aer, we will:
 
 1.  Create a new tag with the version number and push it to github
-2.  Change the `master` version to the next release version.
+2.  Change the `main` version to the next release version.
 
 The release automation processes will be triggered by the new tag and perform
 the following steps:
 
 1.  Create a stable branch for the new minor version from the release tag
-    on the `master` branch
+    on the `main` branch
 2.  Build and upload binary wheels to pypi
 3.  Create a GitHub release page with a generated changelog
 4.  Generate a PR on the meta-repository to bump the Aer version and

--- a/qiskit/providers/aer/version.py
+++ b/qiskit/providers/aer/version.py
@@ -42,7 +42,7 @@ def _minimal_ext_cmd(cmd):
 
 def git_version():
     """Get the current git head sha1."""
-    # Determine if we're at master
+    # Determine if we're at main
     try:
         out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
         git_revision = out.strip().decode('ascii')

--- a/test/asv.linux.conf.json
+++ b/test/asv.linux.conf.json
@@ -51,9 +51,9 @@
         "python setup.py bdist_wheel --dist-dir={build_cache_dir} -- -DCMAKE_CXX_COMPILER=g++ -- -j"
     ],
 
-    // List of branches to benchmark. If not provided, defaults to "master"
+    // List of branches to benchmark. If not provided, defaults to "main"
     // (for git) or "default" (for mercurial).
-    // "branches": ["master"], // for git
+    // "branches": ["main"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/test/asv.linux.cuda.conf.json
+++ b/test/asv.linux.cuda.conf.json
@@ -51,9 +51,9 @@
         "python setup.py bdist_wheel --dist-dir={build_cache_dir} -- -DCMAKE_CXX_COMPILER=g++ -DAER_THRUST_BACKEND=CUDA -- -j"
     ],
 
-    // List of branches to benchmark. If not provided, defaults to "master"
+    // List of branches to benchmark. If not provided, defaults to "main"
     // (for git) or "default" (for mercurial).
-    // "branches": ["master"], // for git
+    // "branches": ["main"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -334,7 +334,7 @@ def _is_ci_fork_pull_request():
 
     Returns:
         bool: True if the tests are executed inside a CI tool, and the changes
-            are not against the "master" branch.
+            are not against the "main" branch.
     """
     if os.getenv('TRAVIS'):
         # Using Travis CI.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the recent support added to qiskit-bot for configurable default
branches in Qiskit/qiskit-bot#9 we're able to rename the default branch
for the repository to 'main'. However, when we do that several things
will need to be updated, most importantly the CI trigger was hardcoded
to the previous default branch 'master. This commit fixes these
references and should be merged after we rename the branch to re-enable
CI.

### Details and comments