### PR TITLE
Disable save expectation value for ext stabilizer

### DIFF
--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -400,8 +400,7 @@ class AerSimulator(AerBackend):
             'set_stabilizer'
         ]),
         'extended_stabilizer': sorted([
-            'roerror', 'snapshot', 'save_statevector',
-            'save_expval', 'save_expval_var'
+            'roerror', 'snapshot', 'save_statevector'
         ]),
         'unitary': sorted([
             'snapshot', 'save_state', 'save_unitary', 'set_unitary'

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -613,8 +613,7 @@ class QasmSimulator(AerBackend):
                 'set_stabilizer'
             ])
         if method == 'extended_stabilizer':
-            return sorted(['roerror', 'snapshot', 'save_statevector',
-                           'save_expval', 'save_expval_var'])
+            return sorted(['roerror', 'snapshot', 'save_statevector'])
         return QasmSimulator._DEFAULT_CUSTOM_INSTR
 
     def _set_method_config(self, method=None):

--- a/qiskit/providers/aer/library/instructions_table.csv
+++ b/qiskit/providers/aer/library/instructions_table.csv
@@ -2,8 +2,8 @@
 :class:`SaveAmplitudes`,✔,✔,✘,✔,✘,✘,✘,✘
 :class:`SaveAmplitudesSquared`,✔,✔,✔,✔,✔,✘,✘,✘
 :class:`SaveDensityMatrix`,✔,✔,✔,✔,✘,✘,✘,✘
-:class:`SaveExpectationValue`,✔,✔,✔,✔,✔,✔,✘,✘
-:class:`SaveExpectationValueVariance`,✔,✔,✔,✔,✔,✔,✘,✘
+:class:`SaveExpectationValue`,✔,✔,✔,✔,✔,✘,✘,✘
+:class:`SaveExpectationValueVariance`,✔,✔,✔,✔,✔,✘,✘,✘
 :class:`SaveMatrixProductState`,✘,✘,✘,✔,✘,✘,✘,✘
 :class:`SaveProbabilities`,✔,✔,✔,✔,✔,✘,✘,✘
 :class:`SaveProbabilitiesDict`,✔,✔,✔,✔,✔,✘,✘,✘

--- a/releasenotes/notes/ext-stab-expval-b205dcf3a26707d4.yaml
+++ b/releasenotes/notes/ext-stab-expval-b205dcf3a26707d4.yaml
@@ -1,0 +1,11 @@
+---
+issues:
+  - |
+    The :class:`~qiskit.providers.aer.library.SaveExpectationValue` and
+    :class:`~qiskit.providers.aer.library.SaveExpectationValueVariance` have
+    been disabled for the `extended_stabilizer` method of the
+    :class:`~qiskit.providers.aer.QasmSimulator` and
+    :class:`~qiskit.providers.aer.AerSimulator` due to returning the
+    incorrect value for certain Pauli operator components. Refer to
+    `#1227 <https://github.com/Qiskit/qiskit-aer/issues/1227>` for more
+    information and examples.

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -37,7 +37,7 @@ const Operations::OpSet StateOpSet(
     Operations::OpType::reset, Operations::OpType::barrier,
     Operations::OpType::roerror, Operations::OpType::bfunc,
     Operations::OpType::snapshot, Operations::OpType::save_statevec,
-    Operations::OpType::save_expval, Operations::OpType::save_expval_var},
+    }, //Operations::OpType::save_expval, Operations::OpType::save_expval_var},
   // Gates
   {"CX", "u0", "u1", "p", "cx", "cz", "swap", "id", "x", "y", "z", "h",
     "s", "sdg", "t", "tdg", "ccx", "ccz", "delay"},
@@ -431,10 +431,11 @@ void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &
             case Operations::OpType::save_statevec:
               apply_save_statevector(op, result);
               break;
-            case Operations::OpType::save_expval:
-            case Operations::OpType::save_expval_var:
-              apply_save_expval(op, result, rng);
-              break;
+            // Disabled until can fix bug in expval
+            // case Operations::OpType::save_expval:
+            // case Operations::OpType::save_expval_var:
+            //   apply_save_expval(op, result, rng);
+            //   break;
             default:
               throw std::invalid_argument("CH::State::apply_ops does not support operations of the type \'" + 
                                           op.name + "\'.");


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Disables the save expectation value instructions for the extended stabilizer method until Issue #1227 can be resolved.

### Details and comments