### PR TITLE
Fix compiler errors when using MPI

### DIFF
--- a/contrib/standalone/qasm_simulator.cpp
+++ b/contrib/standalone/qasm_simulator.cpp
@@ -99,6 +99,7 @@ int main(int argc, char **argv) {
 
 #ifdef AER_MPI
   int prov;
+  int nprocs=1;
   MPI_Init_thread(&argc,&argv,MPI_THREAD_MULTIPLE,&prov);
   MPI_Comm_size(MPI_COMM_WORLD,&nprocs);
   MPI_Comm_rank(MPI_COMM_WORLD,&myrank);

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -1205,6 +1205,7 @@ template <class state_t>
 void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
 {
   int_t iChunk;
+  uint_t nLarge = 1;
 
 
   if(qubit < chunk_bits_*qubit_scale()){


### PR DESCRIPTION
### Summary
Fix compiler errors when using MPI


### Details and comments
This commit fixes compiler warnings that were caused by Commit
1a51d273dec6e00f62495d2dca97d7f09e72755f ("Fix various compiler warnings (#1201)").

Fixes: https://github.com/Qiskit/qiskit-aer/issues/1234

----
Sorry for causing this. I'll make sure to configure using `-DAER_MPI=True` and check other options in the future to avoid this. 