### PR TITLE
Add CI job to run unittests under MPI

### DIFF
--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -83,7 +83,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     needs: [sdist, lint]
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -124,10 +124,57 @@ jobs:
           pip check
           stestr run --slowest
         shell: bash
+  tests-mpi:
+    runs-on: ${{ matrix.os }}
+    needs: [sdist, lint]
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        python-version: [3.9]
+        os: ["ubuntu-latest"]
+    env:
+      AER_THRUST_BACKEND: OMP
+      QISKIT_TEST_CAPTURE_STREAMS: 1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version}}-pip-test-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version}}-pip-test-
+            ${{ runner.os }}-${{ matrix.python-version}}-pip-
+            ${{ runner.os }}-${{ matrix.python-version}}-
+      - name: Install Deps
+        run: python -m pip install -U -c constraints.txt -r requirements-dev.txt wheel git+https://github.com/Qiskit/qiskit-terra
+      - name: Install openblas and openmpi
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev openmpi-bin openmpi-dev
+        shell: bash
+      - name: Install Aer
+        run: |
+          set -e
+          python setup.py bdist_wheel -- -DAER_MPI=True
+          pip install --find-links=dist qiskit-aer
+       - name: Run Tests
+        env:
+          QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y
+        run: |
+          set -e
+          pip check
+          /usr/bin/mpirun.openmpi -host localhost:2 -np 2 python -m unittest discover ./test/terra
+        shell: bash
   tests-json-input:
     runs-on: ${{ matrix.os }}
     needs: [sdist, lint]
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [3.9]

--- a/.github/workflows/tests_mac.yml
+++ b/.github/workflows/tests_mac.yml
@@ -77,7 +77,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     needs: [sdist, lint]
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -130,7 +130,7 @@ jobs:
   tests-json-input:
     runs-on: ${{ matrix.os }}
     needs: [sdist, lint]
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [3.9]

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -83,7 +83,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     needs: ["lint"]
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -128,7 +128,7 @@ jobs:
   tests-json-input:
     runs-on: ${{ matrix.os }}
     needs: ["lint"]
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [3.9]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1242 we added a basic smoke test job for MPI builds using standalone
mode. That job builds aer in standalone mode with MPI and then runs a
qobj of a grovers circuit with mpi enabled and validate it works (and
the result metadata has the mpi fields set). That was useful to provide
a quick smoke test to verify that a proposed change doesn't completely
break MPI builds. However, it doesn't fully validate aer's usage with MPI
enabled. This commit adds a new CI job that runs the full python unittest
suite under mpi run using a aer binary built with mpi support. The
tradeoff there though is we have to run the tests serially using the
stdlib python unittest runner (since stestr runs tests in parallel
processes) the process is running under mpirun.

Additionally, this commit bumps the timeout for the unit test jobs to 1
hour as we've been regularly hitting the timeout on the CI test jobs.
The timeout for the new mpi job is double that (120 min) since it is
running tests serially instead of in 2 or 4 processes.

### Details and comments