### PR TITLE
CMake: Use built-in DL Lib variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,14 +227,6 @@ endif()
 
 message(STATUS "BLAS library found: ${BLAS_LIBRARIES}")
 
-# Windows don't have a DL library (dlopen, dlclose, etc...)
-if(NOT MSVC)
-	find_library(DL_LIB NAMES dl)
-	if(${DL_LIB} MATCHES "DL_LIB-NOTFOUND")
-		message(FATAL_ERROR "No dl lib found")
-	endif()
-endif()
-
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
 	if(APPLE OR UNIX)
 		set(SIMD_FLAGS_LIST "-mfma;-mavx2")
@@ -319,7 +311,7 @@ set(AER_LIBRARIES
 	AER_DEPENDENCY_PKG::nlohmann_json
 	AER_DEPENDENCY_PKG::spdlog
 	Threads::Threads
-	${DL_LIB}
+	${CMAKE_DL_LIBS}
 	${THRUST_DEPENDANT_LIBS}
 	${MPI_DEPENDANT_LIBS})
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Uses the built-in CMake variable CMAKE_DL_LIBS, see https://cmake.org/cmake/help/latest/variable/CMAKE_DL_LIBS.html.
No new tests should be needed, I assume the Windows tests will test this.

### Details and comments

Creating this PR to test against Windows CI, don't have a dev environment to test this change.
