### PR TITLE
Disable Fusion when running on MPS

### DIFF
--- a/releasenotes/notes/disable_fusion_with_mps-6757cbf8edb510a5.yaml
+++ b/releasenotes/notes/disable_fusion_with_mps-6757cbf8edb510a5.yaml
@@ -1,0 +1,8 @@
+---
+
+fixes:
+  - |
+    Disabled fusion when using the MPS simulation method, even when fusion is 
+    enabled in the config. Fusion does not run correctly on MPS so should
+    always be disabled. See issue #1253 for an example.
+

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -1761,8 +1761,8 @@ Transpile::Fusion Controller::transpile_fusion(Method method,
     break;
   }
   case Method::matrix_product_state: {
-    // Disable fusion by default, but allow it to be enabled by config settings
     fusion_pass.active = false;
+    return fusion_pass;  // Do not allow the config to set active for MPS
   }
   case Method::statevector: {
     if (fusion_pass.allow_kraus) {
@@ -1972,7 +1972,7 @@ void Controller::run_circuit_without_sampled_noise(Circuit &circ,
 
   auto fusion_pass = transpile_fusion(method, circ.opset(), config);
   fusion_pass.optimize_circuit(circ, dummy_noise, state.opset(), result);
-  
+
   // Check if measure sampling supported
   const bool can_sample = check_measure_sampling_opt(circ, method);
   
@@ -2041,7 +2041,7 @@ void Controller::run_circuit_with_sampled_noise(
     measure_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(),
                                   result);
     fusion_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(),
-                                 result);
+				 result);
     uint_t block_bits = 0;
     if (cache_blocking) {
       cache_block_pass.optimize_circuit(noise_circ, dummy_noise, state.opset(),

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -903,8 +903,9 @@ Transpile::Fusion QasmController::transpile_fusion(Method method,
       break;
     }
     case Method::matrix_product_state: {
-      // Disable fusion by default, but allow it to be enabled by config settings
       fusion_pass.active = false;
+      return fusion_pass; // Do not allow the config to set active for MPS
+
     }
     case Method::statevector:
     case Method::statevector_thrust_gpu:

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -905,7 +905,6 @@ Transpile::Fusion QasmController::transpile_fusion(Method method,
     case Method::matrix_product_state: {
       fusion_pass.active = false;
       return fusion_pass; // Do not allow the config to set active for MPS
-
     }
     case Method::statevector:
     case Method::statevector_thrust_gpu:

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -285,7 +285,7 @@ public:
 
   mps_container_t copy_to_mps_container();
   mps_container_t move_to_mps_container();
-  
+
 private:
 
   MPS_Tensor& get_qubit(uint_t index) {
@@ -452,7 +452,7 @@ private:
     // location_ stores the location of each qubit in the vector. It is derived from order_ 
     // at the end of every swap operation for performance reasons
     // for example: starting position order_ = location_ = 01234
-    // ccx(0,4) -> order_ = 04123, location_ = 02341
+    // cx(0,4) -> order_ = 04123, location_ = 02341
     reg_t order_;
     reg_t location_;
   } qubit_ordering_;

--- a/test/terra/backends/test_qasm_simulator_matrix_product_state.py
+++ b/test/terra/backends/test_qasm_simulator_matrix_product_state.py
@@ -55,6 +55,7 @@ from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabi
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliNCTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValMatrixTests
+from test.terra.backends.qasm_simulator.qasm_fusion import QasmMPSFusionTests
 
 
 @requires_method("qasm_simulator", "matrix_product_state")
@@ -88,7 +89,8 @@ class TestQasmMatrixProductStateSimulator(
         QasmDelayGateTests,
         QasmSaveDataTests,
         QasmSetMPSTests,
-        QasmSetStateTests
+        QasmSetStateTests,
+        QasmMPSFusionTests
 ):
     """QasmSimulator matrix product state method tests."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fusion optimization does not work correctly on the MPS simulation method. Therefore should be disabled, even when set in the config.


### Details and comments
See failure example in issue #1253.

