### PR TITLE
fix docstring for error_term

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -273,7 +273,7 @@ class QuantumError:
             position (int): the position of the error term.
 
         Returns:
-            tuple: A pair `(p, circuit)` for error term at `position` < size
+            tuple: A pair `(circuit, p)` for error term at `position` < size
             where `p` is the probability of the error term, and `circuit`
             is the list of qobj instructions for the error term.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix mistake in documentation of `error_term`

### Details and comments

The method returns `return self.circuits[position], self.probabilities[position]`, but the docstring said `(p, circuit)`.

