### PR TITLE
Fixed bug in MPS::apply_matrix 

### DIFF
--- a/releasenotes/notes/bug-fix-in-mps-unitary-835d77b381480fcd.yaml
+++ b/releasenotes/notes/bug-fix-in-mps-unitary-835d77b381480fcd.yaml
@@ -4,5 +4,4 @@ fixes:
   - |
     ``unitary`` gate in MPS did not support permutations in the ordering of the 
     qubits on which the gate is applied. Added support for permutations. 
-    This bug appeared when using ``fusion`` on MPS.
 

--- a/releasenotes/notes/bug-fix-in-mps-unitary-835d77b381480fcd.yaml
+++ b/releasenotes/notes/bug-fix-in-mps-unitary-835d77b381480fcd.yaml
@@ -1,0 +1,8 @@
+---
+
+fixes:
+  - |
+    ``unitary`` gate in MPS did not support permutations in the ordering of the 
+    qubits on which the gate is applied. Added support for permutations. 
+    This bug appeared when using ``fusion`` on MPS.
+

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -573,7 +573,6 @@ void State::apply_ops(const std::vector<Operations::Op> &ops,
                                       op.name + "\'.");
       }
     }
-    //qreg_.print(std::cout);
   }
 }
 

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -786,6 +786,7 @@ void MPS::apply_matrix_to_target_qubits(const reg_t &target_qubits,
   uint_t first = target_qubits.front();
   MPS_Tensor sub_tensor(state_vec_as_MPS(first, first+num_qubits-1));
   sub_tensor.apply_matrix(mat, is_diagonal);
+
   // state_mat is a matrix containing the flattened representation of the sub-tensor 
   // into a single matrix. E.g., sub_tensor will contain 8 matrices for 3-qubit
   // gates. state_mat will be the concatenation of them all.

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -777,7 +777,6 @@ void MPS::apply_unordered_multi_qubit_gate(const reg_t &qubits,
   reg_t new_qubits(qubits.size());
   centralize_qubits(qubits, new_qubits);
   apply_matrix_to_target_qubits(new_qubits, mat, is_diagonal);
-  reg_t temp = get_internal_qubits(qubits);
 }
 
 void MPS::apply_matrix_to_target_qubits(const reg_t &target_qubits,

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -774,16 +774,10 @@ void MPS::apply_multi_qubit_gate(const reg_t &qubits,
 void MPS::apply_unordered_multi_qubit_gate(const reg_t &qubits,
 					   const cmatrix_t &mat,
 					   bool is_diagonal){
-  std::cout << "in apply_unordered_multi_qubit_gate" << std::endl;
   reg_t new_qubits(qubits.size());
   centralize_qubits(qubits, new_qubits);
   apply_matrix_to_target_qubits(new_qubits, mat, is_diagonal);
   reg_t temp = get_internal_qubits(qubits);
-  std::cout << "new_qubits = ";
-  for (uint_t i=0; i<new_qubits.size(); i++)
-    std::cout << new_qubits[i] << " " ;
-  std::cout << std::endl;
-  std::cout <<"internal index of 0 " << get_qubit_index(0) << std::endl;
 }
 
 void MPS::apply_matrix_to_target_qubits(const reg_t &target_qubits,
@@ -792,11 +786,7 @@ void MPS::apply_matrix_to_target_qubits(const reg_t &target_qubits,
   uint_t num_qubits = target_qubits.size();
   uint_t first = target_qubits.front();
   MPS_Tensor sub_tensor(state_vec_as_MPS(first, first+num_qubits-1));
-  std::cout << "sub_tensor before apply= "<<std::endl;
-  sub_tensor.print(std::cout);
   sub_tensor.apply_matrix(mat, is_diagonal);
-  std::cout << "sub_tensor after apply= "<<std::endl;
-sub_tensor.print(std::cout);
   // state_mat is a matrix containing the flattened representation of the sub-tensor 
   // into a single matrix. E.g., sub_tensor will contain 8 matrices for 3-qubit
   // gates. state_mat will be the concatenation of them all.
@@ -931,15 +921,6 @@ void MPS::find_centralized_indices(const reg_t &qubits,
 
 void MPS::move_qubits_to_centralized_indices(const reg_t &sorted_indices,
 					     const reg_t &centralized_qubits) {
-  std::cout << "sorted_indices = ";
-  for (uint_t i=0; i<sorted_indices.size(); i++)
-    std::cout << sorted_indices[i] << " " ;
-  std::cout << std::endl;
-  std::cout << "centralized_qubits = ";
-  for (uint_t i=0; i<centralized_qubits.size(); i++)
-    std::cout << centralized_qubits[i] << " " ;
-  std::cout << std::endl;
-
   // We wish to minimize the number of swaps. Therefore we center the 
   // new indices around the median
   uint_t mid_index = (centralized_qubits.size()-1)/2;
@@ -971,7 +952,6 @@ void MPS::move_all_qubits_to_sorted_ordering() {
 }  
 
 void MPS::change_position(uint_t src, uint_t dst) {
-  std::cout<< "change position "<< src << " " << dst << std::endl;
    if(src == dst)
      return;
    if(src < dst)

--- a/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
+++ b/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
@@ -23,7 +23,7 @@ from qiskit.quantum_info.random import random_unitary
 from qiskit.quantum_info import Statevector
 
 import numpy as np
-
+import itertools
 
 class QasmUnitaryGateTests:
     """QasmSimulator unitary gate tests."""
@@ -59,13 +59,7 @@ class QasmUnitaryGateTests:
 
     def test_random_unitary_gate_with_permutations(self):
         """Test simulation with random unitary gate with permutations."""
-        all_permutations = [[0, 1, 2],
-                            [0, 2, 1],
-                            [1, 0, 2],
-                            [1, 2, 0],
-                            [2, 0, 1],
-                            [2, 1, 0]
-                            ]
+        all_permutations = list(itertools.permutations([0, 1, 2]))
         unitary_matrix = random_unitary(8, seed=8)
         n = 3
         shots = 2000

--- a/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
+++ b/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
@@ -63,17 +63,14 @@ class QasmUnitaryGateTests:
         unitary_matrix = random_unitary(8, seed=8)
         n = 3
         shots = 2000
-        qr = QuantumRegister(n, 'qr')
-        cr = ClassicalRegister(n, 'cr')
-        regs = (qr, cr)
     
         for perm in all_permutations:
-            circuit = QuantumCircuit(*regs)
+            circuit = QuantumCircuit(n, n)
             circuit.unitary(unitary_matrix, perm)
-            circuit.barrier(qr)
-            circuit.measure(qr, cr)
+            circuit.barrier(range(n))
+            circuit.measure(range(n), range(n))
             result = execute([circuit], self.SIMULATOR, shots=shots,
-                         **self.BACKEND_OPTS).result()
+                         optimization_level=0, **self.BACKEND_OPTS).result()
             
             state = Statevector.from_label(n * '0').evolve(unitary_matrix, perm)
             counts = state.sample_counts(shots=shots)

--- a/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
+++ b/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
@@ -63,7 +63,6 @@ class QasmUnitaryGateTests:
         unitary_matrix = random_unitary(8, seed=5)
         n = 3
         shots = 2000
-    
         for perm in all_permutations:
             circuit = QuantumCircuit(n, n)
             circuit.unitary(unitary_matrix, perm)

--- a/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
+++ b/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
@@ -60,7 +60,7 @@ class QasmUnitaryGateTests:
     def test_random_unitary_gate_with_permutations(self):
         """Test simulation with random unitary gate with permutations."""
         all_permutations = list(itertools.permutations([0, 1, 2]))
-        unitary_matrix = random_unitary(8, seed=8)
+        unitary_matrix = random_unitary(8, seed=5)
         n = 3
         shots = 2000
     

--- a/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
+++ b/test/terra/backends/qasm_simulator/qasm_unitary_gate.py
@@ -69,7 +69,7 @@ class QasmUnitaryGateTests:
             circuit.unitary(unitary_matrix, perm)
             circuit.barrier(range(n))
             circuit.measure(range(n), range(n))
-            result = execute([circuit], self.SIMULATOR, shots=shots,
+            result = execute(circuit, self.SIMULATOR, shots=shots,
                          optimization_level=0, **self.BACKEND_OPTS).result()
             
             state = Statevector.from_label(n * '0').evolve(unitary_matrix, perm)


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Bug in MPS::apply_matrix (aka unitary gate) when qubits are given in non-standard order.


### Details and comments
This bug was reported in issue #1256. It was initially thought to be a bug related to using Fusion in MPS.

