### PR TITLE
Fixing pulse simulator measurement bug

### DIFF
--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -24,8 +24,7 @@ from .pulse_utils import oplist_to_array
 
 
 class DigestedPulseQobj:
-    """Container class for information extracted from PulseQobj
-    """
+    """Container class for information extracted from PulseQobj."""
 
     def __init__(self):
 

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -390,7 +390,7 @@ class PulseInternalDEModel:
             H_noise = Operator(np.zeros(self.noise[0].data.shape))
             for kk in range(self.c_num):
                 c_op = self.noise[kk]
-                n_op = c_op.adjoint() @ c_op
+                n_op = c_op.adjoint() & c_op
                 # collapse ops
                 self.c_ops_data.append(c_op.data)
                 # norm ops

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -140,7 +140,7 @@ def pulse_controller(qobj):
     if qubit_lo_freq is None:
         qubit_lo_freq = system_model.hamiltonian.get_qubit_lo_from_drift()
         warn('Warning: qubit_lo_freq was not specified in PulseQobj and there is no default, '
-             'so it is beign automatically determined from the drift Hamiltonian.')
+             'so it is being automatically determined from the drift Hamiltonian.')
 
     pulse_de_model.freqs = system_model.calculate_channel_frequencies(qubit_lo_freq=qubit_lo_freq)
     pulse_de_model.calculate_channel_frequencies = system_model.calculate_channel_frequencies

--- a/qiskit/providers/aer/pulse/system_models/string_model_parser/gen_operator.py
+++ b/qiskit/providers/aer/pulse/system_models/string_model_parser/gen_operator.py
@@ -138,4 +138,4 @@ def fock_dm(dim, n=0):
         Operator: Density matrix Operator representation of Fock state.
     """
     psi = basis(dim, n)
-    return psi * psi.adjoint()
+    return psi.adjoint() & psi

--- a/qiskit/providers/aer/pulse/system_models/string_model_parser/operator_generators.py
+++ b/qiskit/providers/aer/pulse/system_models/string_model_parser/operator_generators.py
@@ -16,6 +16,7 @@
 """Operators to use in simulator"""
 
 import numpy as np
+from qiskit.quantum_info import Operator
 from . import gen_operator
 
 
@@ -143,15 +144,15 @@ def qubit_occ_oper_dressed(target_qubit, estates, h_osc, h_qub, level=0):
         states.append(basis(dd, 0))
     for ii, dd in rev_h_qub:
         if ii == target_qubit:
-            states.append(basis(dd, level))
+            states.append(Operator(basis(dd, level).data.flatten()))
         else:
-            states.append(state(np.ones(dd)))
+            states.append(Operator(np.ones(dd)))
 
     out_state = tensor(states)
 
     for ii, estate in enumerate(estates):
         if out_state.data.flatten()[ii] == 1:
-            proj_op += estate @ estate.adjoint()
+            proj_op += estate & estate.adjoint()
 
     return proj_op
 

--- a/qiskit/providers/aer/pulse/system_models/string_model_parser/string_model_parser.py
+++ b/qiskit/providers/aer/pulse/system_models/string_model_parser/string_model_parser.py
@@ -19,6 +19,7 @@ import re
 import copy
 from collections import namedtuple, OrderedDict
 import numpy as np
+from qiskit.quantum_info import Operator
 from .apply_str_func_to_qobj import apply_func
 from .operator_from_string import gen_oper
 
@@ -277,7 +278,10 @@ class HamiltonianParser:
                 elif token.name == '-':
                     stack.append(op1 - op2)
                 elif token.name == '*':
-                    stack.append(op1 * op2)
+                    if isinstance(op1, Operator) and isinstance(op2, Operator):
+                        stack.append(op1 & op2)
+                    else:
+                        stack.append(op1 * op2)
                 elif token.name == '/':
                     stack.append(op1 / op2)
             elif token.type in ['Func', 'Ext']:

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -233,7 +233,7 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         qobj = assemble([self._1Q_schedule(num_acquires=2)],
                         backend=test_sim,
                         meas_level=2,
-                        qubit_lo_freq=[0.],
+                        qubit_lo_freq=test_sim.defaults().qubit_freq_est,
                         meas_return='single',
                         shots=256)
 
@@ -246,7 +246,7 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         qobj = assemble([self._1Q_schedule(num_acquires=0)],
                         backend=test_sim,
                         meas_level=2,
-                        qubit_lo_freq=[0.],
+                        qubit_lo_freq=test_sim.defaults().qubit_freq_est,
                         meas_return='single',
                         shots=256)
 

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -1174,6 +1174,60 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         self.assertDictAlmostEqual(result.get_counts(1), {'1': 128})
         self.assertDictAlmostEqual(result.get_counts(2), {'0': 128})
 
+    def test_3_level_measurement(self):
+        """Test correct measurement outcomes for a pair of 3 level systems."""
+
+        q_freqs = [5., 5.1]
+        r = 0.02
+        j = 0.02
+        total_samples = 25
+
+        hamiltonian = {}
+        hamiltonian['h_str'] = [
+            '2*np.pi*v0*0.5*Z0', '2*np.pi*v1*0.5*Z1', '2*np.pi*r*0.5*X0||D0',
+            '2*np.pi*r*0.5*X1||D1', '2*np.pi*j*0.5*I0*I1',
+            '2*np.pi*j*0.5*X0*X1', '2*np.pi*j*0.5*Y0*Y1', '2*np.pi*j*0.5*Z0*Z1'
+        ]
+        hamiltonian['vars'] = {
+            'v0': q_freqs[0],
+            'v1': q_freqs[1],
+            'r': r,
+            'j': j
+        }
+        hamiltonian['qub'] = {'0': 3, '1': 3}
+        ham_model = HamiltonianModel.from_dict(hamiltonian)
+
+        # set the U0 to have frequency of drive channel 0
+        u_channel_lo = []
+        subsystem_list = [0, 1]
+        dt = 1.
+
+        system_model = PulseSystemModel(hamiltonian=ham_model,
+                                        u_channel_lo=u_channel_lo,
+                                        subsystem_list=subsystem_list,
+                                        dt=dt)
+
+        schedule = Schedule()
+        schedule |= Acquire(total_samples, AcquireChannel(0),
+                            MemorySlot(0)) << 3 * total_samples
+        schedule |= Acquire(total_samples, AcquireChannel(1),
+                            MemorySlot(1)) << 3 * total_samples
+
+        y0 = np.array([1., 1., 0., 0., 0., 0., 0., 0., 0.])/np.sqrt(2)
+        pulse_sim = PulseSimulator(system_model=system_model,
+                                   initial_state=y0,
+                                   seed=9000)
+
+        qobj = assemble([schedule],
+                        backend=pulse_sim,
+                        meas_level=2,
+                        meas_return='single',
+                        meas_map=[[0]],
+                        qubit_lo_freq=q_freqs,
+                        memory_slots=2,
+                        shots=1000)
+        result = pulse_sim.run(qobj).result()
+
 
     def _system_model_1Q(self, omega_0, r):
         """Constructs a standard model for a 1 qubit system.

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -1213,10 +1213,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         schedule |= Acquire(total_samples, AcquireChannel(1),
                             MemorySlot(1)) << 3 * total_samples
 
-        y0 = np.array([1., 1., 0., 0., 0., 0., 0., 0., 0.])/np.sqrt(2)
+        y0 = np.array([1., 1., 0., 0., 0., 0., 0., 0., 0.]) / np.sqrt(2)
         pulse_sim = PulseSimulator(system_model=system_model,
                                    initial_state=y0,
-                                   seed=9000)
+                                  seed=50)
 
         qobj = assemble([schedule],
                         backend=pulse_sim,
@@ -1227,6 +1227,10 @@ class TestPulseSimulator(common.QiskitAerTestCase):
                         memory_slots=2,
                         shots=1000)
         result = pulse_sim.run(qobj).result()
+        counts = result.get_counts()
+        exp_counts = {'00': 479, '01': 502, '10': 9, '11': 10}
+        self.assertDictAlmostEqual(counts, exp_counts)
+
 
 
     def _system_model_1Q(self, omega_0, r):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #1257

### Details and comments

As described in the comments in #1257, there was an issue with the way measurement operators were being constructed, which was introduced when switching from using the qutip `Qobj` to using the `qiskit.quantum_info.Operator` class. In particular, the error came from a line in the measurement operator construction function in which a tensor product of `Operator`s is taken. These operators represent "states", but were being stored as "column vectors" (i.e. 2d arrays with shape `(n, 1)`), but the tensor product code produced incorrect results for this case. The problem was solved just be reshaping the initial vectors to be properly 1 dimensional before inputting to the tensor code. 

The existing tests didn't catch this because it seemed to be outputting the correct values when everything started out 2 dimensional, and we didn't have any tests directly testing measurement outcomes for higher than 2 dimensional subsystems (for higher dimensional systems, we only checked the final output state, not the sampled probabilities).

Additionally:
- A test was added that would have caught this.
- A few additional lines were changed to eliminate deprecation warnings being raised by `Operator` relating to the use of `*` and `@` for multiplication.