### PR TITLE
Configurable backend parametric pulse fix for PulseSimulator

### DIFF
--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -46,7 +46,8 @@ DEFAULT_CONFIGURATION = {
     'max_shots': int(1e6),
     'description': 'A Pulse-based Hamiltonian simulator for Pulse Qobj files',
     'gates': [],
-    'basis_gates': []
+    'basis_gates': [],
+    'parametric_pulses': []
 }
 
 
@@ -147,6 +148,7 @@ class PulseSimulator(AerBackend):
             configuration = copy.copy(configuration)
             configuration.meas_levels = self._meas_levels(configuration.meas_levels)
             configuration.open_pulse = True
+            configuration.parametric_pulses = []
 
         if defaults is None:
             defaults = PulseDefaults(qubit_freq_est=[inf],

--- a/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
+++ b/qiskit/providers/aer/pulse/controllers/digest_pulse_qobj.py
@@ -144,6 +144,11 @@ def _unsupported_errors(qobj_dict):
     if _contains_pv_instruction(qobj_dict['experiments']):
         raise AerError(warning_str.format('PersistentValue instructions'))
 
+    error_str = '''{} are not directly supported by PulseSimulator. Convert to
+                explicit WaveForms to simulate.'''
+    if _contains_parametric_pulse(qobj_dict['experiments']):
+        raise AerError(error_str.format('Parametric Pulses'))
+
     required_str = '{} are required for simulation, and none were specified.'
     if not _contains_acquire_instruction(qobj_dict['experiments']):
         raise AerError(required_str.format('Acquire instructions'))
@@ -177,6 +182,22 @@ def _contains_pv_instruction(experiments):
     for exp in experiments:
         for inst in exp['instructions']:
             if inst['name'] == 'pv':
+                return True
+    return False
+
+
+def _contains_parametric_pulse(experiments):
+    """Return True if the list of experiments contains a parametric pulse.
+
+    Parameters:
+        experiments (list): list of schedules
+    Returns:
+        True or False: whether or not the schedules contain a PersistentValue command
+    Raises:
+    """
+    for exp in experiments:
+        for inst in exp['instructions']:
+            if inst['name'] == 'parametric_pulse':
                 return True
     return False
 

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -202,6 +202,13 @@ def pulse_controller(qobj):
         if not exp['can_sample']:
             pulse_sim_desc.can_sample = False
 
+    meas_ops_hack = []
+    for op in pulse_sim_desc.measurement_ops:
+        if op is not None:
+            meas_ops_hack.append(op)
+
+    pulse_sim_desc.measurement_ops = meas_ops_hack
+
     run_experiments = (run_unitary_experiments if pulse_sim_desc.can_sample
                        else run_monte_carlo_experiments)
     exp_results, exp_times = run_experiments(pulse_sim_desc, pulse_de_model, solver_options)

--- a/qiskit/providers/aer/pulse/controllers/pulse_controller.py
+++ b/qiskit/providers/aer/pulse/controllers/pulse_controller.py
@@ -202,12 +202,12 @@ def pulse_controller(qobj):
         if not exp['can_sample']:
             pulse_sim_desc.can_sample = False
 
-    meas_ops_hack = []
+    # trim measurement operators to relevant qubits once constructed
+    meas_ops_reduced = []
     for op in pulse_sim_desc.measurement_ops:
         if op is not None:
-            meas_ops_hack.append(op)
-
-    pulse_sim_desc.measurement_ops = meas_ops_hack
+            meas_ops_reduced.append(op)
+    pulse_sim_desc.measurement_ops = meas_ops_reduced
 
     run_experiments = (run_unitary_experiments if pulse_sim_desc.can_sample
                        else run_monte_carlo_experiments)

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -19,6 +19,7 @@ import warnings
 import numpy as np
 from test.terra import common
 
+from qiskit import QuantumCircuit, transpile, schedule
 from qiskit.test.mock.backends.armonk.fake_armonk import FakeArmonk
 from qiskit.test.mock.backends.athens.fake_athens import FakeAthens
 
@@ -111,6 +112,39 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
         sim_attr = athens_sim.configuration().dt
         model_attr = athens_sim._system_model.dt
         self.assertTrue(sim_attr == set_attr and model_attr == set_attr)
+
+    def test_from_backend_parametric_pulses(self):
+        """Verify that the parametric_pulses parameter is overriden in the PulseSimulator.
+        Results don't matter, just need to check that it runs.
+        """
+
+        backend = PulseSimulator.from_backend(FakeAthens())
+
+        qc = QuantumCircuit(2)
+        qc.x(0)
+        qc.h(1)
+        qc.measure_all()
+
+        sched = schedule(transpile(qc, backend), backend)
+        res = backend.run(sched)
+
+    def test_parametric_pulses_error(self):
+        """Verify error is raised if a parametric pulse makes it into the digest."""
+
+        fake_backend = FakeAthens()
+        backend = PulseSimulator.from_backend(fake_backend)
+
+        # reset parametric_pulses option
+        backend.set_option('parametric_pulses', fake_backend.configuration().parametric_pulses)
+
+        qc = QuantumCircuit(2)
+        qc.x(0)
+        qc.h(1)
+        qc.measure_all()
+        sched = schedule(transpile(qc, backend), backend)
+
+        with self.assertRaises(AerError):
+            res = backend.run(sched).result()
 
     def test_set_meas_levels(self):
         """Test setting of meas_levels."""

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -58,6 +58,8 @@ class TestConfigPulseSimulator(common.QiskitAerTestCase):
                 self.assertTrue(sim_dict[key])
             elif key == 'local':
                 self.assertTrue(sim_dict[key])
+            elif key == 'parametric_pulses':
+                self.assertEqual(sim_dict[key], [])
             else:
                 self.assertEqual(sim_dict[key], backend_dict[key])
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #1246

~Depends on #1262 (no direct code dependency but this code was written as a continuation of that for testing purposes)~ (#1262 has been merged now)

### Details and comments

Added `parametric_pulses=[]` to the default `PulseSimulator` configuration, as well as an override of `parametric_pulses` to `[]` in the `PulseSimulator.from_backend` method. This ensures that assembly and calling `run` will convert parametric pulses into explicit waveform pulses. Added a check in the pulse digest so that, if a parametric pulse makes it into the pulse simulator, an error is raised.

Added two tests:
1. Instantiates a `PulseSimulator` instance from a fake backend with parametric pulse support, and verifies that a pulse schedule containing parametric pulses still runs.
2. Verifies that the error gets raised if a parametric pulse makes it into the pulse digest: a `PulseSimulator` instance with non-trivial `parametric_pulses` attribute is instantiated, and a schedule with a parametric pulse is fed into `run`.