### PR TITLE
fixed broken link in README.md - Next steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ We use [GitHub issues](https://github.com/Qiskit/qiskit-aer/issues) for tracking
 ## Next Steps
 
 Now you're set up and ready to check out some of the other examples from our
-[Qiskit IQX Tutorials](https://github.com/Qiskit/qiskit-iqx-tutorials/tree/master/qiskit/advanced/aer) or [Qiskit Community Tutorials](https://github.com/Qiskit/qiskit-community-tutorials/tree/master/aer) repositories.
+[Qiskit IQX Tutorials](https://github.com/Qiskit/qiskit-tutorials/tree/master/tutorials/simulators) or [Qiskit Community Tutorials](https://github.com/Qiskit/qiskit-community-tutorials/tree/master/aer) repositories.
 
 ## Authors and Citation
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
There was a **broken link** in the **Next steps** section of **README.md** file.
![image](https://user-images.githubusercontent.com/73487005/120659008-909f3b80-c4a3-11eb-9765-5ac4c317c79d.png)



### Details and comments
Hence, the link has been updated to [/qiskit-tutorials/tree/master/tutorials/simulators](https://github.com/Qiskit/qiskit-tutorials/tree/master/tutorials/simulators)
