### PR TITLE
Update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -41,3 +41,12 @@ Shelly Garion <shelly@il.ibm.com> <46566946+ShellyGarion@users.noreply.github.co
 Wei Hu <weihu@cs.virginia.edu> <wh5a@virginia.edu>
 Yael Ben-Haim <yaelbh@il.ibm.com> 
 Yael Ben-Haim <yaelbh@il.ibm.com> <YAELBH@il.ibm.com>
+Jun Doi <doichan@jp.ibm.com>
+Georgios Tsilimigkounakis <45130028+georgios-ts@users.noreply.github.com>
+Ryota Yonekura <y.kurarrr@gmail.com>
+Oliver Reardon-Smith <oliverreardonsmith@gmail.com>
+Merav Aharoni <46567124+merav-aharoni@users.noreply.github.com>
+Victor Villar <vvilpas@gmail.com>
+Victor Villar <vvilpas@gmail.com> <59838221+vvilpas@users.noreply.github.com>
+Jessica Kane <39967034+kanejess@users.noreply.github.com>
+Soolu Thomas <soolu.thomas@ibm.com> <soolu.elto@gmail.com>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit makes updates to the mailmap file to map emails and real names
from the git log to a canonical form. Most of the additions made here
are for regular qiskit contributors who were using the used multiple names
or email addresses and standardizes on the form already in a mailmap file
(either in terra or other qiskit repositories).

### Details and comments


