### PR TITLE
Implementation of compute algorithm from arxiv:2101.12223

### DIFF
--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -346,6 +346,10 @@ class AerSimulator(AerBackend):
             'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx',
             'swap', 'u0', 't', 'tdg', 'u1', 'p', 'ccx', 'ccz', 'delay'
         ]),
+        'clifford_phase_compute': sorted([
+            'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 
+            'swap', 't', 'tdg',  'delay'
+        ]),
         'unitary': sorted([
             'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
             'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
@@ -402,6 +406,9 @@ class AerSimulator(AerBackend):
         'extended_stabilizer': sorted([
             'roerror', 'snapshot', 'save_statevector'
         ]),
+        'clifford_phase_compute':sorted([
+            'save_specific_probability'
+        ]),
         'unitary': sorted([
             'snapshot', 'save_state', 'save_unitary', 'set_unitary'
         ]),
@@ -440,7 +447,7 @@ class AerSimulator(AerBackend):
     _SIMULATION_METHODS = [
         'automatic', 'statevector', 'density_matrix',
         'stabilizer', 'matrix_product_state', 'extended_stabilizer',
-        'unitary', 'superop'
+        'unitary', 'superop', 'clifford_phase_compute'
     ]
 
     _AVAILABLE_METHODS = None

--- a/qiskit/providers/aer/library/save_instructions/save_probabilities.py
+++ b/qiskit/providers/aer/library/save_instructions/save_probabilities.py
@@ -73,6 +73,33 @@ class SaveProbabilitiesDict(SaveAverageData):
                          pershot=pershot,
                          conditional=conditional)
 
+class SaveSpecificProbability(SaveAverageData):
+    """Save measurement outcome probabilities vector."""
+    def __init__(self, num_qubits,
+                 states, qubits, 
+                 label="specific-probabilities",
+                 unnormalized=False,
+                 pershot=False,
+                 conditional=False):
+        """Instruction to save specific probabilities.
+
+        Args:
+            num_qubits (int): the number of qubits for the snapshot type.
+            label (str): the key for retrieving saved data from results.
+            unnormalized (bool): If True return save the unnormalized accumulated
+                                 probabilities over all shots [Default: False].
+            pershot (bool): if True save a list of probabilities for each shot
+                            of the simulation rather than the average over
+                            all shots [Default: False].
+            conditional (bool): if True save the probabilities data conditional
+                                on the current classical register values
+                                [Default: False].
+        """
+        
+        super().__init__("save_specific_prob", num_qubits, label,
+                         pershot=pershot,
+                         conditional=conditional,
+                         params=[qubits, states])
 
 def save_probabilities(self,
                        qubits=None,
@@ -139,6 +166,39 @@ def save_probabilities_dict(self,
                                   conditional=conditional)
     return self.append(instr, qubits)
 
+def save_specific_probability(self, states, qubits, label="specific_probability",
+                                 unnormalized=False,
+                                 pershot=False,
+                                 conditional=False):
+    """Save squared statevector amplitudes (probabilities).
+
+    Args:
+        states (List[int] or List[str]): the basis states to return amplitudes for.
+        qubits (List[int] or List[str]): the qubits to return amplitudes for.
+        label (str): the key for retrieving saved data from results.
+        unnormalized (bool): If True return save the unnormalized accumulated
+                             probabilities over all shots [Default: False].
+        pershot (bool): if True save a list of probability vectors for each
+                        shot of the simulation rather than the a single
+                        amplitude vector [Default: False].
+        conditional (bool): if True save the probability vector conditional
+                            on the current classical register values
+                            [Default: False].
+
+    Returns:
+        QuantumCircuit: with attached instruction.
+
+    Raises:
+        ExtensionError: if params is invalid for the specified number of qubits.
+    """
+    if qubits == None:
+        qubits = default_qubits(self)
+    instr = SaveSpecificProbability(len(qubits), states, qubits, label=label,
+                                    unnormalized=unnormalized,
+                                    pershot=pershot,
+                                    conditional=conditional)
+    return self.append(instr, qubits)
 
 QuantumCircuit.save_probabilities = save_probabilities
 QuantumCircuit.save_probabilities_dict = save_probabilities_dict
+QuantumCircuit.save_specific_probability = save_specific_probability

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -1499,9 +1499,9 @@ void Controller::run_circuit(const Circuit &circ,
         false, result);
   case Method::clifford_phase_compute:
     return run_circuit_helper<CliffPhaseCompute::State>(
-      circ, noise, config, shots, rng_seed, Method::extended_stabilizer_compute,
+      circ, noise, config, shots, rng_seed, Method::clifford_phase_compute,
       false, result
-      )
+      );
   default:
     throw std::runtime_error("Controller:Invalid simulation method");
   }

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -44,7 +44,7 @@ enum class OpType {
   // Save instructions
   save_state, save_expval, save_expval_var, save_statevec, save_statevec_dict,
   save_densmat, save_probs, save_probs_ket, save_amps, save_amps_sq,
-  save_stabilizer, save_unitary, save_mps, save_superop,
+  save_stabilizer, save_unitary, save_mps, save_superop, save_specific_prob,
   // Set instructions
   set_statevec, set_densmat, set_unitary, set_superop,
     set_stabilizer, set_mps
@@ -59,7 +59,7 @@ static const std::unordered_set<OpType> SAVE_TYPES = {
   OpType::save_statevec, OpType::save_statevec_dict,
   OpType::save_densmat, OpType::save_probs, OpType::save_probs_ket,
   OpType::save_amps, OpType::save_amps_sq, OpType::save_stabilizer,
-  OpType::save_unitary, OpType::save_mps, OpType::save_superop
+  OpType::save_unitary, OpType::save_mps, OpType::save_superop, OpType::save_specific_prob
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
@@ -120,6 +120,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
   case OpType::save_superop:
     stream << "save_superop";
     break;
+  case OpType::save_specific_prob:
+    stream << "save_specific_prob";
+    break;    
   case OpType::set_statevec:
     stream << "set_statevector";
     break;

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -529,6 +529,8 @@ template<typename inputdata_t>
 Op input_to_op_save_expval(const inputdata_t& input, bool variance);
 template<typename inputdata_t>
 Op input_to_op_save_amps(const inputdata_t& input, bool squared);
+template<typename inputdata_t>
+Op input_to_op_save_specific_prob(const inputdata_t& input);
 
 // Snapshots
 template<typename inputdata_t>
@@ -621,6 +623,9 @@ Op input_to_op(const inputdata_t& input) {
     return input_to_op_save_amps(input, false);
   if (name == "save_amplitudes_sq")
     return input_to_op_save_amps(input, true);
+  if (name == "save_specific_prob"){
+    return input_to_op_save_specific_prob(input);
+  }
   // Set
   if (name == "set_statevector")
     return input_to_op_set_vector(input, OpType::set_statevec);
@@ -1147,6 +1152,17 @@ Op input_to_op_save_amps(const inputdata_t& input, bool squared) {
   Parser<inputdata_t>::get_value(op.int_params, "params", input);
   return op;
 }
+
+template<typename inputdata_t>
+Op input_to_op_save_specific_prob(const inputdata_t& input) {
+  Op op = input_to_op_save_default(input, OpType::save_specific_prob);
+  const inputdata_t& params = Parser<inputdata_t>::get_value("params", input);
+  op.qubits = Parser<inputdata_t>::template get_list_elem<std::vector<uint_t>>(params, 0);
+  op.int_params = Parser<inputdata_t>::template get_list_elem<std::vector<uint_t>>(params, 1);
+
+  return op;
+}
+
 
 //------------------------------------------------------------------------------
 // Implementation: Snapshot deserialization

--- a/src/simulators/clifford_plus_phase/ag_state.hpp
+++ b/src/simulators/clifford_plus_phase/ag_state.hpp
@@ -1,0 +1,881 @@
+#ifndef _aer_extended_stabilizer_estimator_ag_hpp
+#define _aer_extended_stabilizer_estimator_ag_hpp
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+
+#include "framework/types.hpp"
+#include "framework/operations.hpp"
+#include "simulators/stabilizer/pauli.hpp"
+
+namespace AER{
+namespace CliffPhaseCompute{
+
+const double T_ANGLE = M_PI/4.;
+const double AG_CHOP_THRESHOLD = 1e-10; //if phases are closer to Clifford phases than this we say they are Clifford
+const uint_t ONE = 1u;
+/*
+ * We need a variant of the stabilizer tableau described in 
+ * Improved Simulation of Stabilizer Circuits
+ * Scott Aaronson, Daniel Gottesman (2004)
+ * 
+ * We only store the stabilizer part of the tableau because we don't need the destabilizer part
+ * We also add some extra subroutines they don't have which are useful for the Estimate and Compute algorithms
+ */
+
+class AGState{
+public:
+  //initialize such that the jth stabilizer is the Pauli Z_j
+  AGState(uint_t num_qubits, uint_t num_stabilizers) : num_qubits(num_qubits), num_stabilizers(num_stabilizers) {};
+  AGState() : num_qubits(0), num_stabilizers(0) {};
+  AGState(uint_t num_qubits) : num_qubits(num_qubits), num_stabilizers(num_qubits) {};
+
+  void initialize();
+  void initialize(uint_t num_qubits);
+  
+  size_t num_qubits;
+  size_t num_stabilizers; //we can represent mixed states so we may have fewer stabilizers than qubits
+
+  std::vector<Pauli::Pauli> table;
+  std::vector< unsigned char > phases;
+
+  std::vector<double> magic_phases; //each T or non-Clifford Z-rotation gate we add comes with a phase in [0, pi/4)
+  virtual ~AGState() = default; //TODO I'm not actually certain the default destructor is correct here
+
+  void Print();
+
+  // CX controlled on a and targetted on b
+  void applyCX(size_t a, size_t b);
+  // CZ controlled on a and targetted on b
+  void applyCZ(size_t a, size_t b);
+  void applyH(size_t a);
+  void applyS(size_t a);
+  void applyX(size_t a);
+  void applyY(size_t a);
+  void applyZ(size_t a);
+  void applySwap(size_t a, size_t b);
+  //this adds a new magic qubit initialised in the |0> state and applies the CX gate required for out gadget
+  void gadgetized_phase_gate(size_t a, double phase);
+  
+  // "add" row i onto row h
+  // this group operation is equivalent to the multiplication of Pauli matrices
+  void rowsum(size_t h, size_t i);
+
+  /* Does not change the table at all
+   * updates the "tableau row" given to be row * table_i
+   * returns the update to the phase of row (0 or 1)
+   */
+  bool rowsum2(Pauli::Pauli row, bool phase, size_t i);
+
+  //return the bool you get at index (stabilizer, column) of the matrix obtained by joining the X and Z matrix as two blocks
+  //i.e. if column < num_qubits return X[stabilizer][column] otherwise return Z[stabilizer][column-num_qubits]
+  bool tableau_element(size_t stabilizer, size_t column);
+  
+  std::pair<bool,size_t> first_non_zero_in_col(size_t col, size_t startpoint);
+  std::pair<bool,size_t> first_non_zero_in_row(size_t col, size_t startpoint);
+
+  void swap_rows(size_t i, size_t j);
+  void delete_row(size_t i);
+/*
+ * create a QCircuit that brings the state represented by this table to the state |0><0|^k \otimes I^(n-k) / (2^(n-k))
+ * Explicitly num_stabilizers stabilisers on num_qubits qubits with the jth stabilzier being a +z on the jth qubit
+ * Note that in addition to returning the circuit that does the simplification this method also brings the state into the simplified form
+ * if you need the state after calling this method then either use the circuit to rebuild it, or make a copy
+ */ 
+  std::vector<Operations::Op> simplifying_unitary();
+
+  /*
+   * attempt to find a Pauli X operator acting on qubit q in a stabilizer with an index at least a and at most this->num_stabilizer-2 (we ignore the last stabilizer)
+   */  
+  std::pair<bool,size_t> find_x_on_q(size_t q, size_t a);
+  /*
+   * attempt to find a Pauli Y operator acting on qubit q in a stabilizer with an index at least a and at most this->num_stabilizer-2 (we ignore the last stabilizer)
+   */  
+  std::pair<bool,size_t> find_y_on_q(size_t q, size_t a);
+  /*
+   * attempt to find a Pauli Z operator acting on qubit q in a stabilizer with an index at least a and at most this->num_stabilizer-2 (we ignore the last stabilizer)
+   */  
+  std::pair<bool,size_t> find_z_on_q(size_t q, size_t a);
+
+  bool independence_test(int q);
+
+  /*
+   * Apply constraints arising from the fact that we measure the first w qubits and project the last t onto T gates
+   * In particular we remove stabilisers if qubits [0, w) get killed by taking the expectation value <0| P |0>
+   * and we remove stabilisers if qubits in [w, this->num_qubits-t) aren't the identity
+   * we do not remove any qubits from the table
+   */
+  std::pair<bool, size_t> apply_constraints(size_t w, size_t t);
+  size_t apply_T_constraints();
+  /*	
+   * Go through our stabilizer table and delete every qubit for which every stabilizer is the identity on that qubit
+   * In other words delete every column from the X and Z matrices if both are 0 for every element in that column
+   * intended only for use when we have restricted our table to only have magic qubits
+   * also deletes magic_phases elements to reflect deletion of the magic qubits
+   */
+  void delete_identity_magic_qubits();
+  
+};
+
+// Implementation
+void AGState::initialize() 
+{
+  this->table = std::vector<Pauli::Pauli>();
+
+  for(size_t i = 0; i < this->num_stabilizers; i++){
+    this->table.push_back(Pauli::Pauli(num_qubits));
+    this->table[i].Z.set1(i);
+    this->phases.push_back(0);
+  }
+}
+
+// Implementation
+void AGState::initialize(uint_t num_qubits)
+{
+  this->num_qubits = num_qubits;
+  this->num_stabilizers = num_qubits;
+  this->initialize();
+}
+
+
+void AGState::Print(){
+  for(size_t i = 0; i < this->num_stabilizers; i++){
+    for(size_t j = 0; j < this->num_qubits; j++){
+      std::cout << this->table[i].X[j];
+    }
+    std::cout  << "|";
+    for(size_t j = 0; j < this->num_qubits; j++){
+      std::cout << this->table[i].Z[j];
+    }
+    std::cout << " " << this->phases[i] << std::endl;
+  }
+}
+
+void AGState::applyCX(size_t a, size_t b){
+  for(size_t i = 0; i < this->num_stabilizers; i++){
+    this->phases[i] ^= this->table[i].X[a] & this->table[i].Z[a] & (this->table[i].X[b] ^ this->table[i].Z[a] ^ true);
+    this->table[i].X.xorAt(this->table[i].X[a], b);
+    this->table[i].Z.xorAt(this->table[i].Z[b], a);
+  }
+}
+
+void AGState::applyCZ(size_t a, size_t b){
+  for(size_t i = 0; i < this->num_stabilizers; i++){
+    this->phases[i] ^= this->table[i].X[a] & this->table[i].X[b] & (this->table[i].Z[a] ^ this->table[i].Z[b]);      
+    this->table[i].Z.xorAt(this->table[i].X[b], a);
+    this->table[i].Z.xorAt(this->table[i].X[a], b);
+  }
+}
+
+void AGState::applySwap(size_t a, size_t b){
+  for(size_t i = 0; i < this->num_stabilizers; i++){
+    this->table[i].X.xorAt(this->table[i].X[a], b);
+    this->table[i].X.xorAt(this->table[i].X[b], a);
+    this->table[i].X.xorAt(this->table[i].X[a], b);
+    
+    this->table[i].Z.xorAt(this->table[i].Z[b], a);
+    this->table[i].Z.xorAt(this->table[i].Z[a], b);
+    this->table[i].Z.xorAt(this->table[i].Z[b], a);
+  }
+}
+
+void AGState::applyH(size_t a){
+  bool scratch;  
+  for(size_t i = 0; i < this->num_stabilizers; i++){
+    this->phases[i] ^= this->table[i].X[a] & this->table[i].Z[a];
+    scratch = this->table[i].X[a];
+    this->table[i].X.setValue(this->table[i].Z[a], a);
+    this->table[i].Z.setValue(scratch, a);   
+  }
+}
+
+void AGState::applyS(size_t a){
+  for(size_t i = 0; i < this->num_stabilizers; i++){
+    this->phases[i] ^= this->table[i].X[a] & this->table[i].Z[a];
+    this->table[i].Z.xorAt(this->table[i].X[a], a);
+  }
+}
+
+void AGState::applyX(size_t a){
+  //TODO write a proper X implementation
+  this->applyH(a);
+  this->applyS(a);
+  this->applyS(a);
+  this->applyH(a);
+}
+
+void AGState::applyY(size_t a){
+  //TODO write a proper Y implementation
+  this->applyS(a);
+  this->applyX(a);
+  this->applyS(a);
+  this->applyS(a);
+  this->applyS(a);  
+}
+
+void AGState::applyZ(size_t a){
+  //TODO write a proper Z implementation
+  this->applyS(a);
+  this->applyS(a);
+}
+
+void AGState::gadgetized_phase_gate(size_t a, double phase){
+  for(size_t i = 0; i < this->num_stabilizers; i++){
+    this->table[i].X.resize(this->num_qubits + 1);
+    this->table[i].Z.resize(this->num_qubits + 1);
+  }
+  this->table.push_back(Pauli::Pauli(this->num_qubits + 1));
+  this->table[this->num_stabilizers].Z.set1(this->num_qubits);
+  this->num_stabilizers += 1;
+  this->num_qubits += 1;
+
+  
+
+  phase = fmod(phase , M_PI*2);
+  if(phase < 0){
+    phase += M_PI*2;
+  }
+
+  //now phase is in [0, 2*pi)
+  while(phase > M_PI/2){
+    phase -= M_PI/2;
+    this->applyS(a);      
+  }
+  //now phase is in [0, M_PI/2.]
+
+  if(fabs(phase) < AG_CHOP_THRESHOLD){
+    //phase on gate is zero so it is an identity
+  }else if(fabs(phase - M_PI/2.) < AG_CHOP_THRESHOLD){
+    //phase on gate is pi/2 so it is an S
+    this->applyS(a);
+    this->applyCX(a, this->num_stabilizers-1);
+  }else{
+    //its actually non-Clifford
+    //we want our phases to be in [0, pi/4]
+    if(phase > T_ANGLE){
+      phase -= M_PI/2 - phase;
+      this->applyX(a);
+      this->applyCX(a, this->num_stabilizers-1);
+      this->applyX(a);
+    }else{
+      this->applyCX(a, this->num_stabilizers-1);
+    }
+  }  
+  this->magic_phases.push_back(phase);  
+}
+
+void AGState::rowsum(size_t h, size_t i){
+  unsigned char sum = 2*(this->phases[h] + this->phases[i]) + Pauli::Pauli::phase_exponent(this->table[i], this->table[h]);
+  
+  sum %= 4u;
+  
+  if(sum == 0){
+    this->phases[h] = false;
+  }
+  if(sum == 2){
+    this->phases[h] = true;
+  }
+  
+  this->table[h].X += this->table[i].X;
+  this->table[h].Z += this->table[i].Z;
+    
+}
+bool AGState::rowsum2(Pauli::Pauli row, bool phase, size_t i){
+  unsigned char sum = 2*(phase + this->phases[i])  + Pauli::Pauli::phase_exponent(this->table[i], row);
+  sum %= 4u;
+  row.X += this->table[i].X;
+  row.Z += this->table[i].Z;
+
+  if(sum == 0){
+    return false;
+  }
+  if(sum == 2){
+    return true;
+  }
+  
+  //we should never reach here - maybe printing a warning or throwing an exception would be sensible
+  return false;
+}
+
+
+void AGState::delete_identity_magic_qubits(){
+  //indended for use when we've already restricted our table to only contain the magic qubits
+  size_t qubits_deleted = 0;
+  for(size_t q = 0; q < this->num_qubits; q++){
+    size_t non_identity_paulis = 0;
+    for(size_t s = 0; (s < this->num_stabilizers) && (non_identity_paulis == 0); s++){
+      if(this->table[s].X[q] || this->table[s].Z[q]){
+	non_identity_paulis += 1;
+      }
+    }
+    if(non_identity_paulis == 0){
+      //every stabiliser is identity on this qubit
+      //so we can just delete this qubit
+      qubits_deleted += 1;
+    }else{
+      if(qubits_deleted > 0){
+	for(size_t s = 0; s < this->num_stabilizers; s++){
+	  this->table[s].X.setValue(this->table[s].X[q], q-qubits_deleted);
+	  this->table[s].Z.setValue(this->table[s].Z[q], q-qubits_deleted);
+	}
+	magic_phases[q - qubits_deleted] = magic_phases[q];
+      }
+    }
+  }
+  this->num_qubits = this->num_qubits - qubits_deleted;
+  for(size_t s = 0; s < this->num_stabilizers; s++){
+    this->table[s].X.resize(this->num_qubits);
+    this->table[s].Z.resize(this->num_qubits);
+  }
+  magic_phases.resize(magic_phases.size() - qubits_deleted);
+  this->num_qubits -= qubits_deleted;
+}
+
+bool AGState::tableau_element(size_t stabilizer, size_t column){
+  if(column < this->num_qubits){
+    return this->table[stabilizer].X[column];
+  }else{
+    return this->table[stabilizer].Z[column-num_qubits];
+  }
+}
+
+std::pair<bool, size_t> AGState::first_non_zero_in_col(size_t col, size_t startpoint){
+  for(size_t i = startpoint; i < this->num_stabilizers; i++){
+    if(this->tableau_element(i, col)){
+      return std::pair<bool, size_t>(true, i);
+    }
+  }
+  return std::pair<bool, size_t>(false, 0);
+}
+std::pair<bool,size_t> AGState::first_non_zero_in_row(size_t row, size_t startpoint){
+  for(size_t i = startpoint; i < 2*this->num_qubits; i++){
+    if(this->tableau_element(row, i) != 0){
+      return std::pair<bool, size_t>(true, i);
+    }
+  }
+  
+  return std::pair<bool, size_t>(false, 0);
+}
+
+void AGState::swap_rows(size_t i, size_t j){
+  
+  //this->table[i].X.swap(this->table[j].X);
+  //this->table[i].Z.swap(this->table[j].Z);
+  std::swap(this->table[i], this->table[j]);
+  std::swap(this->phases[i], this->phases[j]);
+}
+
+void AGState::delete_row(size_t i){  
+  this->table.erase(this->table.begin() + i);
+  this->phases.erase(this->phases.begin() + i);
+  this->num_stabilizers -= 1;
+}
+
+Operations::Op make_H(uint_t a){
+  return {.type=Operations::OpType::gate, .name="h", .qubits={a}};
+}
+
+Operations::Op make_S(uint_t a){
+  return {.type=Operations::OpType::gate, .name="s", .qubits={a}};
+}
+
+Operations::Op make_CX(uint_t a, uint_t b){
+  return {.type=Operations::OpType::gate, .name="cx", .qubits={a, b}};
+}
+
+Operations::Op make_CZ(uint_t a, uint_t b){
+  return {.type=Operations::OpType::gate, .name="cz", .qubits={a, b}};
+}
+
+
+std::vector<Operations::Op> AGState::simplifying_unitary(){
+  std::vector<Operations::Op> circuit;
+  //first we do "augmented gaussian elimination" on the circuit
+  //augmented here means that if we don't find a pivot in our column
+  //we will hadamard that qubit and try again
+  //in other words bring in a pivot from the z part if necessary
+  
+  size_t h = 0;
+  size_t k = 0;
+  while(h < this->num_stabilizers && k < this->num_qubits){
+    std::pair<bool, size_t> poss_pivot = this->first_non_zero_in_col(k, h);
+    if(!poss_pivot.first){
+      this->applyH(k);
+      circuit.push_back(make_H(k));
+      poss_pivot = this->first_non_zero_in_col(k, h);
+    }
+    if(!poss_pivot.first){
+      k += 1;
+    }else{
+      size_t pivot = poss_pivot.second; //now known to exist
+      if(pivot != h){
+	//swap rows h and pivot of the table
+	this->swap_rows(h,pivot);
+      }
+      for(size_t j = 0; j < this->num_stabilizers; j++){
+	if((j != h) && this->table[j].X[k]){
+	  this->rowsum(j,h);
+	}
+      }
+      h += 1;
+      k += 1;
+    }
+  }
+  
+  //so now we have a reduced row echelon form with the X part of the table having full rank
+  
+  //we swap columns (using CX) to make the X part into a kxk identity followed by a "junk" block
+  
+  for(int r = 0; r < this->num_stabilizers; r++){
+    if(!this->table[r].X[r]){
+      size_t col = this->first_non_zero_in_row(r, 0).second;
+      
+      this->applyCX(r, col);
+      circuit.push_back(make_CX(r,col));
+      this->applyCX(col, r);
+      circuit.push_back(make_CX(col,r));
+      this->applyCX(r, col);
+      circuit.push_back(make_CX(r,col));
+    }
+  }
+
+
+  //now we use CX to clear out the "junk" block at the end of the X table
+  for(size_t r = 0; r < this->num_stabilizers; r++){
+    for(size_t col = this->num_stabilizers; col < this->num_qubits; col++){
+      if(this->table[r].X[col]){
+	this->applyCX(r, col);
+	circuit.push_back(make_CX(r,col));
+      }
+    }
+  }
+  
+  //now we clear the leading diagonal of the z block
+  for(size_t r = 0; r < this->num_stabilizers; r++){
+    if(this->table[r].Z[r]){
+      this->applyS(r);
+      circuit.push_back(make_S(r));
+    }
+  }
+
+  //clear out the last k x (n-k) block of the z matrix
+  for(size_t col = this->num_stabilizers; col < this->num_qubits; col++){
+    for(size_t r = 0; r < this->num_stabilizers; r++){
+      if(this->table[r].Z[col]){
+	this->applyCZ(r, col);
+	circuit.push_back(make_CZ(r, col));
+      }
+    }
+  }
+  
+  //clear out the first k x k block of the Z matrix, using that it is symmetric
+  for(size_t col = 0; col < this->num_stabilizers; col++){
+    for(size_t r = 0; r < col; r++){
+      if(this->table[r].Z[col]){
+	this->applyCZ(r, col);
+	circuit.push_back(make_CZ(r, col));
+      }
+    }
+  }
+
+  //fix the phases
+  for(size_t r = 0; r < this->num_stabilizers; r++){
+    if(this->phases[r]){
+      this->applyS(r);
+      circuit.push_back(make_S(r));
+      this->applyS(r);
+      circuit.push_back(make_S(r));
+    }
+  }
+
+  //swap the identity matrix to the z part
+  for(size_t r = 0; r < this->num_stabilizers; r++){
+    this->applyH(r);
+    circuit.push_back(make_H(r));
+  }
+  
+  return circuit;
+}
+
+std::pair<bool, size_t> AGState::find_x_on_q(size_t q, size_t a){
+  for(size_t row = a; row < this->num_stabilizers-1; row++){
+    if(this->table[row].X[q] && !this->table[row].Z[q]){
+      return std::pair<bool, size_t>(true, row);
+    }
+  }
+  return std::pair<bool, size_t>(false, 0);
+}
+
+std::pair<bool, size_t> AGState::find_y_on_q(size_t q, size_t a){
+  for(size_t row = a; row < this->num_stabilizers-1; row++){
+    if(this->table[row].X[q] && this->table[row].Z[q]){
+      return std::pair<bool, size_t>(true, row);
+    }
+  }
+  return std::pair<bool, size_t>(false, 0);
+}
+
+std::pair<bool, size_t> AGState::find_z_on_q(size_t q, size_t a){
+  for(size_t row = a; row < this->num_stabilizers-1; row++){
+    if(!this->table[row].X[q] && this->table[row].Z[q]){
+      return std::pair<bool, size_t>(true, row);
+    }
+  }
+  return std::pair<bool, size_t>(false, 0);
+}
+
+/*
+ * we test that if you ignore the first q+1 qubits whether that last (n-q-1) part of the last stabiliser in the table can be generated (up to phase)
+ * by the other stabilisers
+ * for use in the apply_constraints code
+ */
+bool AGState::independence_test(int q){
+  //we basically do gaussian elimination
+  
+  size_t a = 0;
+  size_t b = q+1;
+  while(a < this->num_stabilizers-1 && b < this->num_qubits){
+    std::pair<bool,size_t> x = this->find_x_on_q(b, a);
+    std::pair<bool,size_t> y = this->find_y_on_q(b, a);
+    std::pair<bool,size_t> z = this->find_z_on_q(b, a);
+    
+    if(y.first && x.first){
+      this->rowsum(y.second, x.second);
+      z = y;
+      y = std::pair<bool,size_t>(false,0);
+    }
+    if(y.first && z.first){
+      this->rowsum(y.second, z.second);
+      x = y;
+      y = std::pair<bool,size_t>(false,0);
+    }
+    
+    if(x.first){
+      if(x.second != a){
+	this->swap_rows(a, x.second);
+      }
+      if(z.first && (z.second == a)){
+	z = x;
+      }
+      for(size_t j = 0; j < this->num_stabilizers; j++){
+	if((j != a) && this->table[j].X[b]){
+	  this->rowsum(j,a);
+	}
+      }
+      a += 1;
+    }
+    if(y.first){
+      if(y.second != a){
+	this->swap_rows(a,y.second);
+      }
+      for(size_t j = 0; j < this->num_stabilizers; j++){
+	if((j != a) && this->table[j].X[b] && this->table[j].Z[b]){
+	  this->rowsum(j,a);
+	}
+      }
+      a += 1;
+    }
+    if(z.first){
+      if(z.second != a){
+	this->swap_rows(a,z.second);
+      }
+      for(size_t j = 0; j < this->num_stabilizers; j++){
+	if((j != a) && this->table[j].Z[b]){
+	  this->rowsum(j,a);
+	}
+      }
+      a += 1;
+    }
+    b += 1;
+  }
+  
+  for(size_t p = q+1; p < this->num_qubits; p++){
+    if((this->table[this->num_stabilizers-1].X[p] == 1) || (this->table[this->num_stabilizers-1].Z[p] == 1)){
+      return true;
+    }
+  } 
+  return false;
+}
+
+
+/*
+ * Apply constraints arising from the fact that we measure the first w qubits and project the last t onto T gates
+ * In particular we kill stabilisers if qubits [0, w) get killed by taking the expectation value <0| P |0>
+ * and we kill stabilisers if qubits in [w, table->n-t) aren't the identity
+ * we do not remove any qubits from the table
+ * note that it is possible for the region a constraints to be "inconsistent" - this means that the probability we were calculating is zero
+ * in that case we return pair(false, 0)
+ * in other cases we return pair(true, v) where v is as defined in the paper
+ */
+std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
+  size_t v = 0;
+  
+  //first apply region a constraints (measurement)
+  for(size_t q=0; q < w; q++){ //iterate over all the measured qubits	
+    std::pair<bool,size_t> y_stab = std::pair<bool,size_t>(false, 0); //store the index of the first stab we come to with both x and z = 1 on this qubit
+    std::pair<bool,size_t> x_stab = std::pair<bool,size_t>(false, 0); //store the index of the first stab we come to with x=1, z=0
+    std::pair<bool,size_t> z_stab = std::pair<bool,size_t>(false, 0); //store the index of the first stab we come to with z=1, x=0
+    
+    for(size_t s=0; s < this->num_stabilizers && (((!y_stab.first) + (!x_stab.first) + (!z_stab.first)) > 1); s++){//iterate over all stabilisers and find interesting stabilisers
+      if(this->table[s].X[q] && this->table[s].Z[q]){
+	y_stab.first = true;
+	y_stab.second = s;
+      }
+      if(this->table[s].X[q] && !this->table[s].Z[q]){
+	x_stab.first = true;
+	x_stab.second = s;
+      }
+      if(!this->table[s].X[q] && this->table[s].Z[q]){
+	z_stab.first = true;
+	z_stab.second = s;
+      }
+    }
+    
+    //there are several cases here
+    //either a single z, a single x, a single y or we can generate the whole Pauli group on this qubit
+    
+    //case 1) we generate the whole group
+    //put things in standard form (first stab is x then z)    
+    if((y_stab.first + x_stab.first + z_stab.first) >= 2){ //we have at least two of the set
+      if(!x_stab.first){//we don't have a generator for x alone, but we can make one
+	this->rowsum(y_stab.second, z_stab.second);
+	//now we have a z and an x but not a y
+	x_stab = y_stab;
+	y_stab = std::pair<bool, size_t>(false,0);
+      }else if(!z_stab.first){//we don't have a generator for z alone, but we can make one
+	this->rowsum(y_stab.second, x_stab.second);
+	//now we have a z and an x but not a y
+	z_stab = y_stab;
+	y_stab = std::pair<bool, size_t>(false,0);
+      }
+    }
+    
+    if(y_stab.first && x_stab.first && z_stab.first){ //we have all 3
+      //ignore the y one if we have all 3
+      y_stab = std::pair<bool, size_t>(false,0);
+    }
+    
+    //now the only possibilities are that we have an an x, y or z or both an x and a z
+    //zero everything else on this qubit
+    for(size_t s = 0; s < this->num_stabilizers; s++){
+      if((!y_stab.first || s != y_stab.second) && (!x_stab.first || s != x_stab.second) && (!z_stab.first || s != z_stab.second)){
+	if(this->table[s].X[q] && this->table[s].Z[q] && y_stab.first){
+	  this->rowsum(s, y_stab.second);
+	}
+	
+	if(this->table[s].X[q]){
+	  this->rowsum(s, x_stab.first);
+	}
+	
+	if(this->table[s].Z[q]){
+	  this->rowsum(s, z_stab.first);
+	}
+      }
+    }    
+    
+    //case 1 - there is a generator which does not commute with Z_q
+    if(y_stab.first || x_stab.first){
+      //we can't have both >= 0
+      size_t non_commuting_generator = y_stab.first ? y_stab.second : x_stab.second;
+      
+      //we delete the non-commuting guy
+      this->swap_rows(non_commuting_generator, this->num_stabilizers-1);
+      this->delete_row(this->num_stabilizers-1);
+      
+    }else{
+      //case 2 - all generators commute with Z_q
+      //our generating set contains either Z_q or -Z_q
+      //we need to work out which one it is
+      
+      //swap our Z_q guy to the end 
+      this->swap_rows(z_stab.second, this->num_stabilizers-1);
+      
+      bool independent = this->independence_test(q);
+      
+      if(!independent){
+	if(this->phases[this->num_stabilizers-1] == 0){
+	  // +Z_q
+	  v += 1;
+	  this->delete_row(this->num_stabilizers-1);
+	}else{
+	  //our chosen measurement outcome is impossible
+	  return std::pair<bool, size_t>(false,0);
+	}
+      }else{
+	//if we get here there has been an error
+	//TODO decide if we're going to throw an exception or print an error message here
+      }
+    }
+  }
+  
+  //time to impose region b constraints
+  
+  for(size_t q=w; q < this->num_qubits - t ; q++){ //iterate over all the non-measured non-magic qubits
+    std::pair<bool, size_t> y_stab = std::pair<bool, size_t>(false,0); //store the index of the first stab we come to with both x and z = 1 on this qubit
+    std::pair<bool, size_t> x_stab = std::pair<bool, size_t>(false,0); //store the index of the first stab we come to with x=1, z=0
+    std::pair<bool, size_t> z_stab = std::pair<bool, size_t>(false,0); //store the index of the first stab we come to with z=1, x=0
+
+    for(size_t s=0; s < this->num_stabilizers && (((!y_stab.first) + (!x_stab.first) + (!z_stab.first)) > 1); s++){//iterate over all stabilisers and find interesting stabilisers
+      if(this->table[s].X[q] && this->table[s].Z[q]){
+	y_stab.first = true;
+	y_stab.second = s;
+      }
+      if(this->table[s].X[q] && !this->table[s].Z[q]){
+	x_stab.first = true;
+	x_stab.second = s;
+      }
+      if(!this->table[s].X[q] && this->table[s].Z[q]){
+	z_stab.first = true;
+	z_stab.second = s;
+      }
+    }
+
+    //there are several cases here
+    //either a single z, a single x, a single y or we can generate the whole Pauli group on this qubit
+    
+    //case 1) we generate the whole group
+    //put things in standard form (first stab is x then z)    
+    if((y_stab.first + x_stab.first + z_stab.first) >= 2){ //we have at least two of the set
+      if(!x_stab.first){//we don't have a generator for x alone, but we can make one
+	this->rowsum(y_stab.second, z_stab.second);
+	//now we have a z and an x but not a y
+	x_stab = y_stab;
+	y_stab = std::pair<bool, size_t>(false,0);
+      }else if(!z_stab.first){//we don't have a generator for z alone, but we can make one
+	this->rowsum(y_stab.second, x_stab.second);
+	//now we have a z and an x but not a y
+	z_stab = y_stab;
+	y_stab = std::pair<bool, size_t>(false,0);
+      }
+    }
+    
+    if(y_stab.first && x_stab.first && z_stab.first){ //we have all 3
+      //ignore the y one if we have all 3
+      y_stab = std::pair<bool, size_t>(false,0);
+    }
+    
+    //now the only possibilities are that we have an x_and_z, an x a z or an x and a z
+    //zero everything else on this qubit
+    for(size_t s = 0; s < this->num_stabilizers; s++){
+      if((!y_stab.first || s != y_stab.second) && (!x_stab.first || s != x_stab.second) && (!z_stab.first || s != z_stab.second)){
+	if(this->table[s].X[q] && this->table[s].Z[q] && y_stab.first){
+	  this->rowsum(s, y_stab.second);
+	}
+	
+	if(this->table[s].X[q]){
+	  this->rowsum(s, x_stab.second);
+	}
+	
+	if(this->table[s].Z[q]){
+	  this->rowsum(s, z_stab.second);
+	}
+      }
+    }        
+    
+    //now we just delete the non-identity guys on this qubit
+    
+    int num_to_delete = 0;
+    if(y_stab.first){
+      //if we have a Y stab we don't have either of the others
+      this->swap_rows(y_stab.second, this->num_stabilizers-1);
+      num_to_delete += 1;
+    }else{
+      if(x_stab.first){
+	this->swap_rows(x_stab.second, this->num_stabilizers-1);
+	if(z_stab.first && this->num_stabilizers - 1 == z_stab.second){
+	  z_stab = x_stab;
+	}
+	num_to_delete += 1;
+      }
+      if(z_stab.first){
+	this->swap_rows(z_stab.second, this->num_stabilizers-1-num_to_delete);
+	num_to_delete += 1;
+      }
+    }
+    //delete the last num_to_delete rows
+    //TODO should we implement an erase method that works like the std::vector one so you can pass a range?
+    for(size_t deletes = 0; deletes < num_to_delete; deletes++){
+      this->delete_row(this->num_stabilizers-1);	
+    }
+  }
+  
+  return std::pair<bool, size_t>(true, v);
+}
+
+
+/*
+ * Our magic states are equatorial
+ * so <T|Z|T> = 0
+ * here we delete any stabilisers with a Z in the magic region
+ * which we assume now all the qubits
+ * we return the number of qubits which have identities on them in every generator after this deletion
+ */
+size_t AGState::apply_T_constraints(){
+  size_t starting_rows = this->num_stabilizers;
+  size_t deleted_rows = 0;
+  for(size_t reps = 0; reps < starting_rows; reps++){	
+    for(size_t q=0; q < this->num_qubits; q++){ //iterate over all the magic qubits
+      std::pair<bool, size_t> y_stab = std::pair<bool, size_t>(false,0); //store the index of the first stab we come to with both x and z = 1 on this qubit
+      std::pair<bool, size_t> x_stab = std::pair<bool, size_t>(false,0); //store the index of the first stab we come to with x=1, z=0
+      std::pair<bool, size_t> z_stab = std::pair<bool, size_t>(false,0); //store the index of the first stab we come to with z=1, x=0
+      
+      for(size_t s=0; s < this->num_stabilizers && (((!y_stab.first) + (!x_stab.first) + (!z_stab.first)) > 1); s++){//iterate over all stabilisers and find interesting stabi	lisers
+	if(this->table[s].X[q] && this->table[s].Z[q]){
+	  y_stab.first = true;
+	  y_stab.second = s;
+      }
+	if(this->table[s].X[q] && !this->table[s].Z[q]){
+	  x_stab.first = true;
+	  x_stab.second = s;
+	}
+	if(!this->table[s].X[q] && this->table[s].Z[q]){
+	  z_stab.first = true;
+	  z_stab.second = s;
+	}
+      }
+      
+      //there are several cases here
+      //either a single z, a single x, a single y or we can generate the whole Pauli group on this qubit
+      
+      //case 1) we generate the whole group
+      //put things in standard form (first stab is x then z)    
+      if((y_stab.first + x_stab.first + z_stab.first) >= 2){ //we have at least two of the set
+	if(!x_stab.first){//we don't have a generator for x alone, but we can make one
+	  this->rowsum(y_stab.second, z_stab.second);
+	  //now we have a z and an x but not a y
+	  x_stab = y_stab;
+	  y_stab = std::pair<bool, size_t>(false,0);
+	}else if(!z_stab.first){//we don't have a generator for z alone, but we can make one
+	  this->rowsum(y_stab.second, x_stab.second);
+	  //now we have a z and an x but not a y
+	  z_stab = y_stab;
+	  y_stab = std::pair<bool, size_t>(false,0);
+	}
+      }
+      
+      if(y_stab.first && x_stab.first && z_stab.first){ //we have all 3
+	//ignore the y one if we have all 3
+	y_stab = std::pair<bool, size_t>(false,0);
+      }
+      
+      if(z_stab.first && !x_stab.first){
+	//kill all other z stuff on this qubit	
+	for(size_t s = 0; s < this->num_qubits; s++){
+	  if((s != z_stab.second) && this->table[s].Z[q]){
+	    this->rowsum(s, z_stab.second);
+	  }
+	}
+	//now delete the z guy
+	this->swap_rows(z_stab.second, this->num_stabilizers-1);
+	this->delete_row(this->num_stabilizers-1);
+	deleted_rows += 1;
+      }
+    }
+  }
+  return deleted_rows;
+}
+
+}
+}
+#endif

--- a/src/simulators/clifford_plus_phase/compute.hpp
+++ b/src/simulators/clifford_plus_phase/compute.hpp
@@ -94,6 +94,7 @@ const stringmap_t<Gates> State::gateset_({
 
 
 void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &result, RngEngine &rng, bool final_ops){
+
   for(const auto &op: ops){
     switch(op.type){
     case Operations::OpType::gate:

--- a/src/simulators/clifford_plus_phase/compute.hpp
+++ b/src/simulators/clifford_plus_phase/compute.hpp
@@ -109,7 +109,7 @@ void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &
   }
 }
 
-void State::apply_gate(const Operations::Op &op){
+void State::apply_gate(const Operations::Op &op){  
   auto it = gateset_.find(op.name);
   if (it == gateset_.end())
   {
@@ -159,7 +159,7 @@ void State::apply_gate(const Operations::Op &op){
 }
 
 void State::apply_save_specific_prob(const Operations::Op &op, ExperimentResult &result){  
-  std::vector<double> v;  
+  std::vector<double> v;
   double p = this->compute_probability(op.qubits, op.int_params);
   v.push_back(p);
 
@@ -261,25 +261,26 @@ double State::compute_probability(std::vector<size_t> measured_qubits, std::vect
 
   size_t w = measured_qubits.size();
   size_t t = copied_ag.magic_phases.size();
-    
-  //now all the measured qubits are at the start and the magic qubits are at the end 
+
+  //now all the measured qubits are at the start and the magic qubits are at the end
   std::pair<bool, size_t> v_pair = copied_ag.apply_constraints(w, t);
   if(!v_pair.first){
     return 0.;
   }
 
   size_t v = v_pair.second;
+
   //at this point we can delete all the non-magic qubits
   for(size_t q = 0; q < t; q++){
     copied_ag.applySwap(q, q+t);
   }
+
   for(size_t s = 0; s < copied_ag.num_stabilizers; s++){
     copied_ag.table[s].X.resize(t);
     copied_ag.table[s].Z.resize(t);
   }
 
   copied_ag.num_qubits = t;
-  
   copied_ag.apply_T_constraints();
   copied_ag.delete_identity_magic_qubits();
 
@@ -296,7 +297,7 @@ double State::compute_probability(std::vector<size_t> measured_qubits, std::vect
     return powl(2., (double)v - (double)w);
   }
 
-  return compute_algorithm_all_phases_T(copied_ag) * powl(2., v - w);
+  return compute_algorithm_all_phases_T(copied_ag) * powl(2., (double)v - w);
   
 }
 

--- a/src/simulators/clifford_plus_phase/compute.hpp
+++ b/src/simulators/clifford_plus_phase/compute.hpp
@@ -24,7 +24,7 @@ const Operations::OpSet StateOpSet(
   {Operations::OpType::gate, Operations::OpType::save_specific_prob},
   // Gates
   {"CX", "cx", "cz", "swap", "id", "x", "y", "z", "h",
-   "s", "sdg", "t","p", "rz"},
+   "s", "sdg", "t","p", "rz", "u1"},
   // Snapshots
   {}
 );
@@ -32,7 +32,7 @@ const Operations::OpSet StateOpSet(
 
 
 enum class Gates {
-  id, x, y, z, h, s, sdg, sx, t, tdg, cx, cz, swap, u1,
+id, x, y, z, h, s, sdg, sx, t, tdg, cx, cz, swap,  p, rz, u1,
 };
 
 
@@ -83,7 +83,8 @@ const stringmap_t<Gates> State::gateset_({
   {"h", Gates::h},       // Hadamard gate (X + Z / sqrt(2))
   {"t", Gates::t},       // T-gate (sqrt(S))
   {"rz", Gates::rz}, // Pauli-Z rotation gate
-  {"p", Gates::p},   // Parameterized phase gate 
+  {"p", Gates::rz},   // Parameterized phase gate
+  {"u1", Gates::rz}, 
   {"tdg", Gates::tdg},   // Conjguate-transpose of T gate
   // Two-qubit gates
   {"CX", Gates::cx},     // Controlled-X gate (CNOT)
@@ -146,6 +147,8 @@ void State::apply_gate(const Operations::Op &op){
   case Gates::tdg:
     this->qreg_.gadgetized_phase_gate(op.qubits[0], -T_ANGLE);
     break;
+  case Gates::rz:
+    this->qreg_.gadgetized_phase_gate(op.qubits[0], op.params[0].real());
   case Gates::cx:
     this->qreg_.applyCX(op.qubits[0],op.qubits[1]);
     break;

--- a/src/simulators/clifford_plus_phase/compute.hpp
+++ b/src/simulators/clifford_plus_phase/compute.hpp
@@ -1,0 +1,352 @@
+#ifndef _aer_extended_stabilizer_compute_hpp
+#define _aer_extended_stabilizer_compute_hpp
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+#include <complex>
+#include <vector>
+#include <algorithm>
+
+#include "simulators/state.hpp"
+#include "framework/json.hpp"
+#include "framework/types.hpp"
+
+#include "ag_state.hpp"
+#include "simulators/stabilizer/pauli.hpp"
+
+namespace AER{
+namespace CliffPhaseCompute{
+
+// OpSet of supported instructions
+const Operations::OpSet StateOpSet(
+  // Op types
+  {Operations::OpType::gate, Operations::OpType::save_specific_prob},
+  // Gates
+  {"CX", "cx", "cz", "swap", "id", "x", "y", "z", "h",
+    "s", "sdg", "t"},
+  // Snapshots
+  {}
+);
+
+
+
+enum class Gates {
+  id, x, y, z, h, s, sdg, sx, t, tdg, cx, cz, swap,
+};
+
+
+using agstate_t = CliffPhaseCompute::AGState;
+
+
+class State: public Base::State<agstate_t>{
+public:
+  using BaseState = Base::State<agstate_t>;
+  
+  State() : BaseState(StateOpSet) {};
+  virtual ~State() = default;
+
+  std::string name() const override {return "clifford_phase_compute";}
+
+  //Apply a sequence of operations to the cicuit.
+  //We just store these operations in _circuit because we can't implement them
+  //until we know how many non-Clifford gates and what the measurements are
+  virtual void apply_ops(const std::vector<Operations::Op> &ops,
+                         ExperimentResult &result,
+                         RngEngine &rng,
+                         bool final_ops = false) override;
+  
+  void apply_gate(const Operations::Op &op);
+
+  void initialize_qreg(uint_t num_qubits) override;
+  void initialize_qreg(uint_t num_qubits, const agstate_t &state) override;
+  size_t required_memory_mb(uint_t num_qubits, const std::vector<Operations::Op> &ops) const override;
+
+  void apply_save_specific_probs(const Operations::Op &op, ExperimentResult &result);
+  double expval_pauli(const reg_t &qubits, const std::string& pauli);
+private:  
+  const static stringmap_t<Gates> gateset_;
+  const static stringmap_t<Snapshots> snapshotset_;
+  size_t num_code_qubits; //out AG state has code+magic qubits
+  double compute_probability(std::vector<size_t> measured_qubits, std::vector<uint_t> outcomes);
+  //void apply_save_specific_probs(const Operations::Op &op, ExperimentResult &result);
+  //void apply_snapshot(const Operations::Op &ops, ExperimentResult &result);
+  //void probabilities_snapshot(const Operations::Op &op, ExperimentResult &result);
+};
+
+const stringmap_t<Snapshots> State::snapshotset_({
+  {"probabilities", Snapshots::probs},
+});
+
+
+const stringmap_t<Gates> State::gateset_({
+  // Single qubit gates
+  {"delay", Gates::id},  // Delay gate
+  {"id", Gates::id},     // Pauli-Identity gate
+  {"x", Gates::x},       // Pauli-X gate
+  {"y", Gates::y},       // Pauli-Y gate
+  {"z", Gates::z},       // Pauli-Z gate
+  {"s", Gates::s},       // Phase gate (aka sqrt(Z) gate)
+  {"sdg", Gates::sdg},   // Conjugate-transpose of Phase gate
+  {"h", Gates::h},       // Hadamard gate (X + Z / sqrt(2))
+  {"t", Gates::t},       // T-gate (sqrt(S))
+  {"tdg", Gates::tdg},   // Conjguate-transpose of T gate
+  // Two-qubit gates
+  {"CX", Gates::cx},     // Controlled-X gate (CNOT)
+  {"cx", Gates::cx},     // Controlled-X gate (CNOT)
+  {"CZ", Gates::cz},     // Controlled-Z gate
+  {"cz", Gates::cz},     // Controlled-Z gate
+  {"swap", Gates::swap}, // SWAP gate
+  // Three-qubit gates
+});
+
+
+void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &result, RngEngine &rng, bool final_ops){
+  std::cout << "2" << std::endl;
+  for(const auto &op: ops){
+    std::cout << op.type << std::endl;
+    switch(op.type){
+    case Operations::OpType::gate:
+      std::cout << "Operations::OpType::gate" << std::endl;
+      this->apply_gate(op);
+      break;
+    case Operations::OpType::save_specific_probs:
+      std::cout << "Operations::OpType::save_specific_probs" << std::endl;
+      this->apply_save_specific_probs(op, result);
+      break;
+    default:
+      throw std::invalid_argument("Compute::State::invalid instruction \'" + op.name + "\'.");  
+    } 
+  }
+}
+
+void State::apply_gate(const Operations::Op &op){
+  std::cout << "State::apply_gate " << op.name << ":  " << op.qubits[0] << std::endl;
+  auto it = gateset_.find(op.name);
+  if (it == gateset_.end())
+  {
+    throw std::invalid_argument("Compute::State: Invalid gate operation \'"
+                                +op.name + "\'.");
+  }
+  switch(it->second){
+  case Gates::id:
+    break;
+  case Gates::x:
+    this->qreg_.applyX(op.qubits[0]);
+    break;
+  case Gates::y:
+    this->qreg_.applyY(op.qubits[0]);
+    break;
+  case Gates::z:
+    this->qreg_.applyZ(op.qubits[0]);
+    break;
+  case Gates::s:
+    this->qreg_.applyS(op.qubits[0]);
+    break;
+  case Gates::sdg:
+    this->qreg_.applyZ(op.qubits[0]);
+    this->qreg_.applyS(op.qubits[0]);
+    break;
+  case Gates::h:    
+    this->qreg_.applyH(op.qubits[0]);
+    break;
+  case Gates::t:
+    this->qreg_.gadgetized_phase_gate(op.qubits[0], T_ANGLE);
+    break;
+  case Gates::tdg:
+    this->qreg_.gadgetized_phase_gate(op.qubits[0], -T_ANGLE);
+    break;
+  case Gates::cx:
+    this->qreg_.applyCX(op.qubits[0],op.qubits[1]);
+    break;
+  case Gates::cz:
+    this->qreg_.applyCZ(op.qubits[0],op.qubits[1]);
+    break;
+  case Gates::swap:
+    this->qreg_.applySwap(op.qubits[0],op.qubits[1]);
+    break;
+  default: //u0 or Identity
+    break;
+  }
+}
+
+void State::apply_save_specific_probs(const Operations::Op &op, ExperimentResult &result){  
+  std::vector<double> v;
+  std::cout << "qubits = ";
+  for(size_t i = 0; i < op.qubits.size(); i++){
+    std::cout << op.qubits[i] << " ";
+  }
+  std::cout << std::endl;
+
+  std::cout << "states = ";
+  for(size_t i = 0; i < op.int_params.size(); i++){
+    std::cout << op.int_params[i] << " ";
+  }
+  std::cout << std::endl;
+  
+  double p = this->compute_probability(op.qubits, op.int_params);
+  std::cout << p << std::endl;
+  v.push_back(p);
+  std::cout << v[0] << std::endl;
+
+  BaseState::save_data_average(result, op.string_params[0], std::move(v), Operations::DataSubType::list);
+}
+
+// This function converts an unsigned binary number to reflected binary Gray code.
+uint_t BinaryToGray(uint_t num)
+{
+  return num ^ (num >> 1); // The operator >> is shift right. The operator ^ is exclusive or.
+}
+
+
+double compute_algorithm_all_phases_T(AGState &state){
+  uint_t full_mask = 0u;
+  for(size_t i = 0; i < state.num_stabilizers; i++){
+    full_mask |= (ONE << i);
+  }
+  double acc = 1.;
+  Pauli::Pauli row(state.num_qubits);
+  unsigned char phase = 0;
+  
+  for(uint_t mask = 1u; mask <= full_mask; mask++){
+    uint_t mask_with_bit_to_flip = BinaryToGray(mask) ^ BinaryToGray(mask - 1);
+    size_t bit_to_flip = 0;
+    for(size_t j = 0; j < state.num_stabilizers; j++){
+      if((mask_with_bit_to_flip >> j) & ONE){
+	bit_to_flip = j;
+	break;
+      }
+    }
+    phase += Pauli::Pauli::phase_exponent(row, state.table[bit_to_flip]);
+    row += state.table[bit_to_flip];
+    
+    size_t XCount = 0;
+    size_t YCount = 0;
+    size_t ZCount = 0;
+    
+    for(size_t j = 0; j < state.num_qubits; j++){
+      //if((row[j] == 0) && (row[j+state.n] == 0)){
+      //    ICount += 1;
+      //}
+      if(row.X[j] && !row.Z[j]){
+	XCount += 1;
+      }
+      if(!row.X[j] && row.Z[j]){
+	ZCount += 1;
+	break;
+      }
+      if(row.X[j] && row.Z[j]){
+	YCount += 1;
+      }
+    }
+    
+    if(ZCount == 0){
+      if(((phase + YCount) % 2) == 0){
+	acc += powl(1./2., (XCount + YCount)/2.);;
+      }else{
+	acc -= powl(1./2., (XCount + YCount)/2.);;
+      }
+    }      
+  }
+  
+  if(full_mask == 0u){
+    return 1.;
+  }
+  return acc;
+}
+
+double State::compute_probability(std::vector<size_t> measured_qubits, std::vector<uint_t> outcomes){
+  AGState copied_ag = this->qreg_; //copy constructor TODO check this
+  //first reorder things so the first w qubits are measured
+  std::vector<size_t> measured_qubits_sorted = measured_qubits;
+  std::sort(measured_qubits_sorted.begin(), measured_qubits_sorted.end());
+  
+  //size_t qubits_swapped = 0;
+  for(size_t i = 0; i < measured_qubits.size(); i++){
+    size_t w = measured_qubits_sorted[i];
+    size_t idx = 0;
+    for(size_t j = 0; j < measured_qubits.size(); j++){
+      if(measured_qubits[j] == w){
+	idx = j;
+	break;
+      }
+    }
+    //now swap element w with element idx    
+    if(measured_qubits[i] != i){
+      copied_ag.applySwap(w, idx);
+    }
+  }
+
+  //from this point on we will assume we're looking for the measurement outcome 0 on all measured qubits
+  //so apply X gates to measured qubits where we're looking for outcome 1 to correct this
+  for(size_t i = 0; i < outcomes.size(); i++){
+    if(outcomes[i] == 1){
+      copied_ag.applyX(i);
+    }
+  }
+
+  size_t w = measured_qubits.size();
+  size_t t = copied_ag.magic_phases.size();
+    
+  //now all the measured qubits are at the start and the magic qubits are at the end 
+  std::pair<bool, size_t> v_pair = copied_ag.apply_constraints(w, t);
+  if(!v_pair.first){
+    return 0.;
+  }
+
+  size_t v = v_pair.second;
+  //at this point we can delete all the non-magic qubits
+  for(size_t q = 0; q < t; q++){
+    copied_ag.applySwap(q, q+t);
+  }
+  for(size_t s = 0; s < copied_ag.num_stabilizers; s++){
+    copied_ag.table[s].X.resize(t);
+    copied_ag.table[s].Z.resize(t);
+  }
+
+  copied_ag.num_qubits = t;
+  
+  copied_ag.apply_T_constraints();
+  copied_ag.delete_identity_magic_qubits();
+
+  //we can make the compute algorithm much faster if all of our non-Clifford gates are in fact T gates (pi/4 rotations)
+
+  bool all_phases_are_T = true;
+  for(size_t i = 0; i < copied_ag.num_qubits; i++){
+    if(fabs(copied_ag.magic_phases[i] - T_ANGLE) > AG_CHOP_THRESHOLD){
+      all_phases_are_T  = false;
+      break;
+    }
+  }
+  if(copied_ag.num_qubits == 0){
+    return powl(2., (double)v - (double)w);
+  }
+
+  return compute_algorithm_all_phases_T(copied_ag) * powl(2., v - w);
+  
+}
+
+void State::initialize_qreg(uint_t num_qubits){
+  this->qreg_.initialize(num_qubits);
+  this->num_code_qubits = num_qubits;
+}
+void State::initialize_qreg(uint_t num_qubits, const agstate_t &state){
+  if(BaseState::qreg_.num_qubits != num_qubits){
+    throw std::invalid_argument("CH::State::initialize: initial state does not match qubit number.");
+  }
+  BaseState::qreg_ = state;  
+}
+
+size_t State::required_memory_mb(uint_t num_qubits, const std::vector<Operations::Op> &ops) const {
+  return 0; //TODO update this!
+}
+
+
+double State::expval_pauli(const reg_t &qubits, const std::string& pauli){
+  return 0; //TODO fix this
+}
+
+} //close namespace CliffPhaseCompute
+} //close namespace AER
+
+#endif

--- a/src/simulators/stabilizer/binary_vector.hpp
+++ b/src/simulators/stabilizer/binary_vector.hpp
@@ -57,7 +57,8 @@ public:
   void set1(uint64_t pos) { setValue(ONE_, pos); };
 
   void flipAt(uint64_t pos);
-
+  void xorAt(bool value, uint64_t pos);
+  
   BinaryVector &operator+=(const BinaryVector &rhs);
 
   bool operator[](const uint64_t pos) const;
@@ -211,6 +212,11 @@ void BinaryVector::flipAt(const uint64_t pos) {
   m_data[q] ^= (ONE_ << r);
 }
 
+void BinaryVector::xorAt(bool value, uint64_t pos) {
+  auto q = pos / BLOCK_SIZE;
+  auto r = pos % BLOCK_SIZE;
+  m_data[q] ^= ((value & ONE_) << r);
+}
 
 BinaryVector &BinaryVector::operator+=(const BinaryVector &rhs) {
   const auto size = m_data.size();

--- a/src/simulators/stabilizer/binary_vector.hpp
+++ b/src/simulators/stabilizer/binary_vector.hpp
@@ -46,6 +46,10 @@ public:
 
   void setLength(uint64_t length);
 
+  //preserves the vector up to the new length
+  //and pads with zeros if necessary
+  void resize(uint64_t length);
+  
   void setVector(std::string);
   void setValue(bool value, uint64_t pos);
 
@@ -180,6 +184,16 @@ void BinaryVector::setLength(uint64_t length) {
   m_data.assign((length - 1) / BLOCK_SIZE + 1, ZERO_);
 }
 
+void BinaryVector::resize(uint64_t new_length) {
+  m_data.resize((new_length - 1) / BLOCK_SIZE + 1, ZERO_);
+  //zero the rest of the last block if necessary
+  if((new_length < m_length) && (new_length % BLOCK_SIZE) > 0){
+    for(size_t i = (new_length % BLOCK_SIZE) ; i < BLOCK_SIZE; i++){
+      m_data[m_data.size() - 1] &= ~(ONE_ << i);
+    }
+  }
+  m_length = new_length;
+}
 
 void BinaryVector::setValue(bool value, uint64_t pos) {
   auto q = pos / BLOCK_SIZE;

--- a/src/simulators/stabilizer/binary_vector.hpp
+++ b/src/simulators/stabilizer/binary_vector.hpp
@@ -186,7 +186,12 @@ void BinaryVector::setLength(uint64_t length) {
 }
 
 void BinaryVector::resize(uint64_t new_length) {
-  m_data.resize((new_length - 1) / BLOCK_SIZE + 1, ZERO_);
+  if(new_length == 0){
+    m_data.resize(0);
+  } else {
+    m_data.resize((new_length - 1) / BLOCK_SIZE + 1, ZERO_);
+  }
+  
   //zero the rest of the last block if necessary
   if((new_length < m_length) && (new_length % BLOCK_SIZE) > 0){
     for(size_t i = (new_length % BLOCK_SIZE) ; i < BLOCK_SIZE; i++){

--- a/src/simulators/stabilizer/pauli.hpp
+++ b/src/simulators/stabilizer/pauli.hpp
@@ -46,6 +46,8 @@ public:
 
   // exponent g of i such that P(x1,z1) P(x2,z2) = i^g P(x1+x2,z1+z2)
   static int8_t phase_exponent(const Pauli& pauli1, const Pauli& pauli2);
+
+  Pauli &operator+=(const Pauli &rhs);
 };
 
 
@@ -112,6 +114,12 @@ int8_t Pauli::phase_exponent(const Pauli& pauli1, const Pauli& pauli2) {
   if (exponent < 0)
       exponent += 4;
   return exponent;
+}
+
+Pauli &Pauli::operator+=(const Pauli &rhs) {
+  this->X += rhs.X;
+  this->Z += rhs.Z;
+  return (*this);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
The paper https://arxiv.org/abs/2101.12223 contains two algorithms for finding Born rule probabilities of Clifford+phase gate circuits. This pull request contains the  compute algorithm (and everything it depends on). 

This is not suitable to be merged currently. Documentation, tests and are missing, and there are some problems (see below), but I open it to get some feedback.

### Details and comments

In addition to the compute algorithm a new save instruction is added to the quantumcircuit class. The instruction
`save_specific_probability(outcomes, measured_qubits)` to save the Born rule probability of a particular measurement outcome of a computational basis measurement applied to a subset of the qubits. 

##Example usage

`qc.save_specific_probability([0,1,0], [0,1,2]) # save the probability of the obtaining the outcome (0,1,0) when measuring qubits (0,1,0)`

`qc.save_specific_probability([0,1], [5,1]) # save the probability of the obtaining the outcome (0,1) when measuring qubits 5 and 1`

It would also be reasonable to add support for this instruction to other simulators - e.g. the statevector simulator.

##Known problems
1. Currently the `CliffPhaseCompute::State` class does not correctly report it's memory usage
2. Currently the Compute algorithm implementation is not parallel 



