### PR TITLE
Add PauliGate support to all simulation methods

### DIFF
--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -334,17 +334,17 @@ class AerSimulator(AerBackend):
         ]),
         'matrix_product_state': sorted([
             'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
-            'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay',
+            'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay', 'pauli',
             'r', 'rx', 'ry', 'rz', 'rxx', 'ryy', 'rzz', 'rzx', 'csx', 'cswap', 'diagonal',
             'initialize'
         ]),
         'stabilizer': sorted([
             'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'cx', 'cy', 'cz',
-            'swap', 'delay',
+            'swap', 'delay', 'pauli'
         ]),
         'extended_stabilizer': sorted([
             'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx',
-            'swap', 'u0', 't', 'tdg', 'u1', 'p', 'ccx', 'ccz', 'delay'
+            'swap', 'u0', 't', 'tdg', 'u1', 'p', 'ccx', 'ccz', 'delay', 'pauli'
         ]),
         'unitary': sorted([
             'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
@@ -358,7 +358,7 @@ class AerSimulator(AerBackend):
             'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
             'y', 'z', 'h', 's', 'sdg', 'sx', 't', 'tdg', 'swap', 'cx',
             'cy', 'cz', 'cp', 'cu1', 'rxx', 'ryy',
-            'rzz', 'rzx', 'ccx', 'unitary', 'diagonal', 'delay',
+            'rzz', 'rzx', 'ccx', 'unitary', 'diagonal', 'delay', 'pauli'
         ])
     }
     # Automatic method basis gates are the union of statevector,

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -560,19 +560,19 @@ class QasmSimulator(AerBackend):
         if method == 'matrix_product_state':
             return sorted([
                 'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
-                'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay',
+                'sdg', 'sx', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay', 'pauli',
                 'r', 'rx', 'ry', 'rz', 'rxx', 'ryy', 'rzz', 'rzx', 'csx', 'cswap', 'diagonal',
                 'initialize'
             ])
         if method == 'stabilizer':
             return sorted([
                 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'cx', 'cy', 'cz',
-                'swap', 'delay',
+                'swap', 'delay', 'pauli'
             ])
         if method == 'extended_stabilizer':
             return sorted([
                 'cx', 'cz', 'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx',
-                'swap', 'u0', 't', 'tdg', 'u1', 'p', 'ccx', 'ccz', 'delay'
+                'swap', 'u0', 't', 'tdg', 'u1', 'p', 'ccx', 'ccz', 'delay', 'pauli'
             ])
         return QasmSimulator._DEFAULT_BASIS_GATES
 

--- a/releasenotes/notes/pauli_gate-de858933657d7d21.yaml
+++ b/releasenotes/notes/pauli_gate-de858933657d7d21.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds support for N-qubit Pauli gate (
+    :class:`qiskit.circuit.library.generalized_gates.PauliGate`) to all
+    simulation methods of the
+    :class:`~qiskit.providers.aer.AerSimulator` and
+    :class:`~qiskit.providers.aer.QasmSimulator`.

--- a/src/simulators/extended_stabilizer/gates.hpp
+++ b/src/simulators/extended_stabilizer/gates.hpp
@@ -32,7 +32,7 @@ namespace CHSimulator
   enum class Gates {
     u0, u1, id, x, y, z, h, s, sdg, sx, t, tdg,
     cx, cz, swap,
-    ccx, ccz
+    ccx, ccz, pauli
   };
 
   enum class Gatetypes {

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -28,7 +28,8 @@ namespace MatrixProductState {
 enum Gates {
   id, h, x, y, z, s, sdg, sx, t, tdg, u1, u2, u3, r, rx, ry, rz, // single qubit
   cx, cy, cz, cu1, swap, su4, rxx, ryy, rzz, rzx, csx, // two qubit
-  ccx, cswap // three qubit
+  ccx, cswap, // three qubit
+  pauli
 };
 
   //enum class Direction {RIGHT, LEFT};

--- a/test/terra/backends/aer_simulator/instructions/test_pauli_gate.py
+++ b/test/terra/backends/aer_simulator/instructions/test_pauli_gate.py
@@ -1,0 +1,76 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+QasmSimulator Integration Tests for circuit library standard gates
+"""
+
+from ddt import ddt
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+from test.terra.backends.aer_simulator.aer_simulator_test_case import (
+    AerSimulatorTestCase, supported_methods)
+
+from qiskit import transpile
+import qiskit.quantum_info as qi
+
+
+@ddt
+class TestPauliGate(AerSimulatorTestCase):
+    """Test standard gate library."""
+
+    @supported_methods(
+        ["automatic", "stabilizer", "statevector", "density_matrix", "matrix_product_state",
+         "unitary", "superop"], ['I', 'X', 'Y', 'Z', 'XY', 'ZXY'])
+    def test_pauli_gate(self, method, device, pauli):
+        """Test multi-qubit Pauli gate."""
+        pauli = qi.Pauli(pauli)
+        circuit = QuantumCircuit(pauli.num_qubits)
+        circuit.append(pauli, range(pauli.num_qubits))
+
+        backend = self.backend(method=method, device=device)
+        label = 'final'
+        if method == 'density_matrix':
+            target = qi.DensityMatrix(circuit)
+            circuit.save_density_matrix(label=label)
+            state_fn = qi.DensityMatrix
+            fidelity_fn = qi.state_fidelity
+        elif method == 'stabilizer':
+            target = qi.Clifford(circuit)
+            circuit.save_stabilizer(label=label)
+            state_fn = qi.Clifford.from_dict
+            fidelity_fn = qi.process_fidelity
+        elif method == 'unitary':
+            target = qi.Operator(circuit)
+            circuit.save_unitary(label=label)
+            state_fn = qi.Operator
+            fidelity_fn = qi.process_fidelity
+        elif method == 'superop':
+            target = qi.SuperOp(circuit)
+            circuit.save_superop(label=label)
+            state_fn = qi.SuperOp
+            fidelity_fn = qi.process_fidelity
+        else:
+            target = qi.Statevector(circuit)
+            circuit.save_statevector(label=label)
+            state_fn = qi.Statevector
+            fidelity_fn = qi.state_fidelity
+
+        result = backend.run(transpile(
+            circuit, backend, optimization_level=0), shots=1).result()
+
+        # Check results
+        success = getattr(result, 'success', False)
+        self.assertTrue(success)
+        data = result.data(0)
+        self.assertIn(label, data)
+        value = state_fn(data[label])
+        fidelity = fidelity_fn(target, value)
+        self.assertGreater(fidelity, 0.9999)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Optimized PauliGate support was added last release for the statevector and density matrix simulators. This PR adds non-optimized support for these gates to the remaining simulation methods.

### Details and comments

Pauli gates are implemented by iterating over each single-qubit Pauli in the the PauliGate and applying the corresponding single qubit gate in the simulator.