### PR TITLE
fix phase normalisation issue leading to #1269

### DIFF
--- a/src/simulators/extended_stabilizer/chlib/core.hpp
+++ b/src/simulators/extended_stabilizer/chlib/core.hpp
@@ -120,6 +120,9 @@ struct scalar_t {
     }
     std::complex<double> mag(std::pow(2, p/(double)2), 0.);
     std::complex<double> phase(RE_PHASE[e], IM_PHASE[e]);
+    if(e % 2){
+      phase /= std::sqrt(2);
+    }
     return mag*phase;
   }
 


### PR DESCRIPTION
### Summary
Previously the phase was unnormalised (indeed had norm sqrt(2)) for odd e. This lead to incorrect outcomes from the Runner::amplitude method 

### Details and comments

As far as I can tell this commit fixes issue #1269

