### PR TITLE
Fix initialization order of parent Instruction class

### DIFF
--- a/qiskit/providers/aer/extensions/snapshot.py
+++ b/qiskit/providers/aer/extensions/snapshot.py
@@ -47,11 +47,13 @@ class Snapshot(Instruction):
         """
         if not isinstance(label, str):
             raise ExtensionError('Snapshot label must be a string.')
-        self._label = label
-        self._snapshot_type = snapshot_type
         if params is None:
             params = []
+
         super().__init__('snapshot', num_qubits, num_clbits, params)
+
+        self._label = label
+        self._snapshot_type = snapshot_type
 
     def assemble(self):
         """Assemble a QasmQobjInstruction"""

--- a/qiskit/providers/aer/library/save_instructions/save_data.py
+++ b/qiskit/providers/aer/library/save_instructions/save_data.py
@@ -46,9 +46,6 @@ class SaveData(Instruction):
             The supported subtypes are 'single', 'list', 'c_list', 'average',
             'c_average', 'accum', 'c_accum'.
         """
-        if params is None:
-            params = {}
-
         if subtype not in self._allowed_subtypes:
             raise ExtensionError(
                 "Invalid data subtype for SaveData instruction.")
@@ -57,9 +54,13 @@ class SaveData(Instruction):
             raise ExtensionError(
                 f"Invalid label for save data instruction, {label} must be a string.")
 
+        if params is None:
+            params = {}
+
+        super().__init__(name, num_qubits, 0, params)
+
         self._label = label
         self._subtype = subtype
-        super().__init__(name, num_qubits, 0, params)
 
     def assemble(self):
         """Return the QasmQobjInstruction for the intructions."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fix is needed for Algorithm tests using Aer instructions into bass in https://github.com/Qiskit/qiskit-terra/pull/6626.

Adding label to Instruction in that PR is causing default initialization of the parent class to always set Snapshot and Save instruction labels to the default value.

### Details and comments


