### PR TITLE
Fix base test class parent

### DIFF
--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -30,7 +30,7 @@ from qiskit.quantum_info import Operator, Statevector
 from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.providers.aer import __path__ as main_path
-from qiskit.test import QiskitTestCase
+from qiskit.test.base import FullQiskitTestCase
 
 
 class Path(Enum):
@@ -41,7 +41,7 @@ class Path(Enum):
     EXAMPLES = os.path.join(MAIN, '../examples')
 
 
-class QiskitAerTestCase(QiskitTestCase):
+class QiskitAerTestCase(FullQiskitTestCase):
     """Helper class that contains common functionality."""
 
     def setUp(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue when trying to run the aer unittests without
setting the QISKIT_TEST_CAPTURE_STREAMS env variable. Since
Qiskit/qiskit-terra#6037 the QiskitTestCase class won't use the full
base test class with fixture support unles you set the env variable to
use it. This commit fixes the parent class to always use the
FullQiskitTestCase since we use fixtures in the aer tests regardless of
the env variable.

### Details and comments


