### PR TITLE
Add support for running QuantumCircuits to PulseSimulator

### DIFF
--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -19,6 +19,8 @@ import logging
 from warnings import warn
 from numpy import inf
 
+from qiskit.circuit import QuantumCircuit
+from qiskit.compiler import schedule
 from qiskit.providers.options import Options
 from qiskit.providers.models import BackendConfiguration, PulseDefaults
 from qiskit.utils import deprecate_arguments
@@ -239,6 +241,16 @@ class PulseSimulator(AerBackend):
                 validate = args[0]
                 if len(args) > 1:
                     backend_options = args[1]
+        if isinstance(qobj, list):
+            new_qobj = []
+            for circuit in qobj:
+                if isinstance(circuit, QuantumCircuit):
+                    new_qobj.append(schedule(circuit, self))
+                else:
+                    new_qobj.append(circuit)
+            qobj = new_qobj
+        elif isinstance(qobj, QuantumCircuit):
+            qobj = schedule(qobj, self)
         return super().run(qobj, backend_options=backend_options, validate=validate,
                            **run_options)
 

--- a/releasenotes/notes/pulse-sim-circuits-4b4b6f6a9f00dc77.yaml
+++ b/releasenotes/notes/pulse-sim-circuits-4b4b6f6a9f00dc77.yaml
@@ -1,0 +1,26 @@
+---
+features:
+  - |
+    The :class:`~qiskit.providers.aer.backends.PulseSimulator` can now take
+    :class:`~qiskit.circuit.QuantumCircuit` objects on the
+    :meth:`~qiskit.providers.aer.backends.PulseSimulator.run`. Previously,
+    it only would except :class:`~qiskit.pulse.Schedule` objects as input to
+    :meth:`~qiskit.providers.aer.backends.PulseSimulator.run`. When a circuit
+    or list of circuits is passed to the simulator it will call
+    :func:`~qiskit.compiler.schedule` to convert the circuits to a schedule
+    before executing the circuit. For example::
+
+      from qiskit.circuit import QuantumCircuit
+      from qiskit.compiler import transpile
+      from qiskit.test.mock import FakeVigo
+      from qiskit.providers.aer.backends import PulseSimulator
+
+      backend = PulseSimulator.from_backend(FakeVigo())
+
+      circuit = QuantumCircuit(2)
+      circuit.h(0)
+      circuit.cx(0, 1)
+      circuit.measure_all()
+
+      transpiled_circuit = transpile(circuit, backend)
+      backend.run(circuit)

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -24,7 +24,8 @@ from scipy.special import erf
 
 from qiskit.providers.aer.backends import PulseSimulator
 
-from qiskit.compiler import assemble
+from qiskit.circuit import QuantumCircuit
+from qiskit.compiler import assemble, transpile
 from qiskit.quantum_info import state_fidelity
 from qiskit.pulse import (Schedule, Play, ShiftPhase, SetPhase, Delay, Acquire,
                           Waveform, DriveChannel, ControlChannel,
@@ -35,6 +36,7 @@ from qiskit.providers.aer.pulse.system_models.pulse_system_model import PulseSys
 from qiskit.providers.aer.pulse.system_models.hamiltonian_model import HamiltonianModel
 from qiskit.providers.models.backendconfiguration import UchannelLO
 from qiskit.providers.aer.aererror import AerError
+from qiskit.test.mock import FakeArmonk
 
 from .pulse_sim_independent import (simulate_1q_model,
                                     simulate_2q_exchange_model,
@@ -52,6 +54,32 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         self.X = np.array([[0., 1.], [1., 0.]])
         self.Y = np.array([[0., -1j], [1j, 0.]])
         self.Z = np.array([[1., 0.], [0., -1.]])
+
+    def test_circuit_conversion(self):
+        pulse_sim = PulseSimulator.from_backend(FakeArmonk())
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        qc.t(0)
+        qc.measure_all()
+        tqc = transpile(qc, pulse_sim)
+        result = pulse_sim.run(tqc, shots=1024).result()
+        self.assertDictAlmostEqual(result.get_counts(0), {'0': 512, '1': 512},
+                                   delta=100)
+
+    def test_multiple_circuit_conversion(self):
+        pulse_sim = PulseSimulator.from_backend(FakeArmonk())
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        qc.t(0)
+        qc.measure_all()
+        circs = [qc]*5
+        tqc = transpile(circs, pulse_sim)
+        result = pulse_sim.run(tqc, shots=1024).result()
+        counts = result.get_counts()
+        self.assertEqual(5, len(counts))
+        for i in range(5):
+            self.assertDictAlmostEqual(result.get_counts(i), {'0': 512, '1': 512},
+                                       delta=100)
 
     # ---------------------------------------------------------------------
     # Test single qubit gates

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -64,7 +64,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         tqc = transpile(qc, pulse_sim)
         result = pulse_sim.run(tqc, shots=1024).result()
         self.assertDictAlmostEqual(result.get_counts(0), {'0': 512, '1': 512},
-                                   delta=100)
+                                   delta=128)
 
     def test_multiple_circuit_conversion(self):
         pulse_sim = PulseSimulator.from_backend(FakeArmonk())
@@ -79,7 +79,7 @@ class TestPulseSimulator(common.QiskitAerTestCase):
         self.assertEqual(5, len(counts))
         for i in range(5):
             self.assertDictAlmostEqual(result.get_counts(i), {'0': 512, '1': 512},
-                                       delta=100)
+                                       delta=128)
 
     # ---------------------------------------------------------------------
     # Test single qubit gates


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support for the PulseSimulator to run QuantumCircuit
objects. Previously the PulseSimulator only would accept pulse Schedule
objects requiring users to call the scheduler before running circuits on
the pulse simulator. This commit makes it so if you need to do a pulse
simulation but have an input circuit you can pass that circuit to pulse
simulator's run method and it will schedule it (using the default
settings on the pulse scheduler) before executing it.

### Details and comments


