### PR TITLE
Set utf8 character encoding in windows CI

### DIFF
--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -119,8 +119,11 @@ jobs:
       - name: Run Tests
         env:
           QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y
+          LANG: 'C.UTF-8'
+          PYTHONIOENCODING: 'utf-8:backslashreplace'
         run: |
           set -e
+          chcp.com 65001
           pip check
           stestr run --slowest
         shell: bash
@@ -164,8 +167,11 @@ jobs:
       - name: Run Tests
         env:
           QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y
+          LANG: 'C.UTF-8'
+          PYTHONIOENCODING: 'utf-8:backslashreplace'
         run: |
           set -e
           pip check
+          chcp.com 65001
           stestr run --slowest
         shell: bash


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We've recently started seeing a failure in windows CI jobs recently
while the test runner is trying to print some text qiskit is emitting
that is outside the default windows code page. This commit configures
the windows ci test jobs to use utf8 instead of the default windows code
page as that is the default encoding for qiskit. This should hopefully
fix the ci failures (or at least be able to print any errors emitted).

### Details and comments


