### PR TITLE
fix a bug to generate a diagonal gate in the end of circuit

### DIFF
--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -658,8 +658,10 @@ bool DiagonalFusion::aggregate_operations(oplist_t& ops,
       continue;
 
     std::vector<uint_t> fusing_op_idxs;
-    for (; op_idx < next_diagonal_start; ++op_idx)
+    while(op_idx < next_diagonal_start && op_idx < fusion_end) {
       fusing_op_idxs.push_back(op_idx);
+      ++op_idx;
+    }
 
     --op_idx;
     allocate_new_operation(ops, op_idx, fusing_op_idxs, method, true);

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -542,32 +542,6 @@ class QasmFusionTests:
                 break
             self.assertEqual(op_name, 'diagonal')
 
-    def test_fusion_diagonal_only_circuit(self):
-        """Test diagonal fusion for issue 1289"""
-        shots = 100
-        num_qubits = 16
-
-        circuit = QuantumCircuit(num_qubits)
-        circuit.barrier()
-
-        for q0 in range(num_qubits):
-            for q1 in range(q0 + 1, num_qubits):
-                circuit.rzz(np.pi/3, q0, q1)
-        circuit.barrier()
-
-        circuit = transpile(circuit,
-                            backend=self.SIMULATOR,
-                            optimization_level=0)
-        
-        qobj = assemble([circuit],
-                        self.SIMULATOR,
-                        shots=shots,
-                        seed_simulator=1)
-
-        backend_options = { 'fusion_enable': True }
-        self.SIMULATOR.run(qobj, **backend_options).result()
-        # success if no segmentation fault is occurred
-
 class QasmMPSFusionTests:
     """QasmSimulator MPS fusion tests."""
 

--- a/test/terra/backends/qasm_simulator/qasm_fusion.py
+++ b/test/terra/backends/qasm_simulator/qasm_fusion.py
@@ -542,6 +542,32 @@ class QasmFusionTests:
                 break
             self.assertEqual(op_name, 'diagonal')
 
+    def test_fusion_diagonal_only_circuit(self):
+        """Test diagonal fusion for issue 1289"""
+        shots = 100
+        num_qubits = 16
+
+        circuit = QuantumCircuit(num_qubits)
+        circuit.barrier()
+
+        for q0 in range(num_qubits):
+            for q1 in range(q0 + 1, num_qubits):
+                circuit.rzz(np.pi/3, q0, q1)
+        circuit.barrier()
+
+        circuit = transpile(circuit,
+                            backend=self.SIMULATOR,
+                            optimization_level=0)
+        
+        qobj = assemble([circuit],
+                        self.SIMULATOR,
+                        shots=shots,
+                        seed_simulator=1)
+
+        backend_options = { 'fusion_enable': True }
+        self.SIMULATOR.run(qobj, **backend_options).result()
+        # success if no segmentation fault is occurred
+
 class QasmMPSFusionTests:
     """QasmSimulator MPS fusion tests."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes the issue #1289 

### Details and comments

Fusion to generate diagonal gates has a bug to look up operations in a circuit and this PR fix this bug.
