### PR TITLE
typo: initalize -> initialize

### DIFF
--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -151,7 +151,7 @@ class StatevectorSimulator(AerBackend):
 
         warn('The `StatevectorSimulator` backend will be deprecated in the'
              ' future. It has been superseded by the `AerSimulator`'
-             ' backend. To obtain legacy functionality initalize with'
+             ' backend. To obtain legacy functionality initialize with'
              ' `AerSimulator(method="statevector")` and append run circuits'
              ' with the `save_state` instruction.', PendingDeprecationWarning)
 

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -150,7 +150,7 @@ class UnitarySimulator(AerBackend):
 
         warn('The `UnitarySimulator` backend will be deprecated in the'
              ' future. It has been superseded by the `AerSimulator`'
-             ' backend. To obtain legacy functionality initalize with'
+             ' backend. To obtain legacy functionality initialize with'
              ' `AerSimulator(method="unitary")` and append run circuits'
              ' with the `save_state` instruction.', PendingDeprecationWarning)
 


### PR DESCRIPTION

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

### Summary
typo fix

### Details and comments
typo: initalize -> initialize


