### PR TITLE
Avoid deprecated bit index lookup in insert_noise

### DIFF
--- a/qiskit/providers/aer/utils/noise_model_inserter.py
+++ b/qiskit/providers/aer/utils/noise_model_inserter.py
@@ -47,11 +47,12 @@ def insert_noise(circuits, noise_model, transpile=False):
                                                            basis_gates=noise_model.basis_gates)
         else:
             transpiled_circuit = circuit
+        qubit_indices = {bit: index for index, bit in enumerate(transpiled_circuit.qubits)}
         result_circuit = circuit.copy(name=transpiled_circuit.name + '_with_noise')
         result_circuit.data = []
         for inst, qargs, cargs in transpiled_circuit.data:
             result_circuit.data.append((inst, qargs, cargs))
-            qubits_string = ",".join([str(q.index) for q in qargs])
+            qubits_string = ",".join([str(qubit_indices[q]) for q in qargs])
             # Priority for error model used:
             # nonlocal error > local error > default error
             if inst.name in nonlocal_errors and qubits_string in nonlocal_errors[inst.name]:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the insert_noise function where it was
using a deprecated bit index lookup by accessing the .index attribute of
a Qubit object. Besides fixing the depercation warning this will fix a
potential issue with registerless circuits where the .index attribute
isn't set.

### Details and comments

Fixes #1296