### PR TITLE
generate random numbers before parallel apply_measure in MPS

### DIFF
--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -1006,7 +1006,11 @@ void State::apply_measure(const reg_t &qubits,
                           const reg_t &cmemory,
                           const reg_t &cregister,
                           RngEngine &rng) {
-  reg_t outcome = qreg_.apply_measure(qubits, rng);
+  rvector_t rands;
+  rands.reserve(qubits.size());
+  for (int_t i = 0; i < qubits.size(); ++i)
+    rands.push_back(rng.rand(0., 1.));
+  reg_t outcome = qreg_.apply_measure(qubits, rands);
   creg_.store_measure(outcome, cmemory, cregister);
 }
 
@@ -1073,7 +1077,7 @@ sample_measure_using_probabilities(const reg_t &qubits,
   rvector_t rnds;
   rnds.reserve(shots);
   for (uint_t i = 0; i < shots; ++i)
-    rnds.push_back(rng.rand(0, 1));
+    rnds.push_back(rng.rand(0., 1.));
 
   auto allbit_samples = qreg_.sample_measure_using_probabilities(rnds, qubits);
 
@@ -1100,13 +1104,23 @@ std::vector<reg_t> State::
   std::vector<reg_t> all_samples;
   all_samples.resize(shots);
 
+  std::vector<rvector_t> rnds_list;
+  rnds_list.reserve(shots);
+  for (int_t i = 0; i < shots; ++i) {
+    rvector_t rands;
+    rands.reserve(qubits.size());
+    for (int_t j = 0; j < qubits.size(); ++j)
+      rands.push_back(rng.rand(0., 1.));
+    rnds_list.push_back(rands);
+  }
+
 #pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
   {
     MPS temp;
 #pragma omp for
     for (int_t i=0; i<static_cast<int_t>(shots);  i++) {
       temp.initialize(qreg_);
-      auto single_result = temp.apply_measure(qubits, rng);
+      auto single_result = temp.apply_measure(qubits, rnds_list[i]);
       all_samples[i] = single_result;
     }
   }

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -300,7 +300,7 @@ public:
   reg_t sample_measure_using_probabilities(const rvector_t &rnds, 
 					   const reg_t &qubits);
 
-  reg_t apply_measure(const reg_t &qubits, RngEngine &rng);
+  reg_t apply_measure(const reg_t &qubits, const rvector_t &rnds);
 
   //----------------------------------------------------------------
   // Function name: initialize_from_statevector_internal
@@ -410,10 +410,9 @@ private:
 
   void get_probabilities_vector_internal(rvector_t& probvector, const reg_t &qubits) const;
 
-  reg_t apply_measure_internal(const reg_t &qubits,
-			       RngEngine &rng);
+  reg_t apply_measure_internal(const reg_t &qubits, const rvector_t &rands);
 
-  uint_t apply_measure_internal_single_qubit(uint_t qubit, RngEngine &rng, 
+  uint_t apply_measure_internal_single_qubit(uint_t qubit, const double rnd,
 					     bool measure_all=false);
 
   reg_t sample_measure_using_probabilities_internal(const rvector_t &rnds, 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

random numbers should be generated before apply_measure in MPS to reproduce results

### Details and comments

This PR is to generate random numbers before calling `apply_measure` in a single-thread for sampling.
