### PR TITLE
Refactor State apply_ops to use iterators

### DIFF
--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -230,8 +230,8 @@ protected:
 
   // Sample measurement outcomes for the input measure ops from the
   // current state of the input State_t
-  template <class State_t>
-  void measure_sampler(const std::vector<Operations::Op> &meas_ops,
+  template <typename InputIterator, class State_t>
+  void measure_sampler(InputIterator first_meas, InputIterator last_meas,
                        uint_t shots, State_t &state, ExperimentResult &result,
                        RngEngine &rng) const;
 
@@ -1782,17 +1782,13 @@ void Controller::run_circuit_without_sampled_noise(Circuit &circ,
     auto first_meas = circ.first_measure_pos; // Position of first measurement op
     bool final_ops = (first_meas == ops.size());
 
-    // Get measurement opts
-    std::vector<Operations::Op> meas_ops;
-    std::move(ops.begin() + first_meas, ops.end(), std::back_inserter(meas_ops));
-
     // Run circuit instructions before first measure
     state.initialize_qreg(circ.num_qubits);
     state.initialize_creg(circ.num_memory, circ.num_registers);
     state.apply_ops(ops.cbegin(), ops.cbegin() + first_meas, result, rng, final_ops);
 
     // Get measurement operations and set of measured qubits
-    measure_sampler(meas_ops, shots, state, result, rng);
+    measure_sampler(circ.ops.begin() + first_meas, circ.ops.end(), shots, state, result, rng);
 
     // Add measure sampling metadata
     result.metadata.add(true, "measure_sampling");
@@ -1880,12 +1876,12 @@ bool Controller::check_measure_sampling_opt(const Circuit &circ,
   return true;
 }
 
-template <class State_t>
+template <typename InputIterator, class State_t>
 void Controller::measure_sampler(
-    const std::vector<Operations::Op> &meas_roerror_ops, uint_t shots,
+    InputIterator first_meas, InputIterator last_meas, uint_t shots,
     State_t &state, ExperimentResult &result, RngEngine &rng) const {
   // Check if meas_circ is empty, and if so return initial creg
-  if (meas_roerror_ops.empty()) {
+  if (first_meas == last_meas) {
     while (shots-- > 0) {
       save_count_data(result, state.creg());
     }
@@ -1894,11 +1890,13 @@ void Controller::measure_sampler(
 
   std::vector<Operations::Op> meas_ops;
   std::vector<Operations::Op> roerror_ops;
-  for (const Operations::Op &op : meas_roerror_ops)
-    if (op.type == Operations::OpType::roerror)
-      roerror_ops.push_back(op);
-    else /*(op.type == Operations::OpType::measure) */
-      meas_ops.push_back(op);
+  for (auto op = first_meas; op != last_meas; op++) {
+    if (op->type == Operations::OpType::roerror) {
+      roerror_ops.push_back(*op);
+    } else { /*(op.type == Operations::OpType::measure) */
+      meas_ops.push_back(*op);
+    }
+  }
 
   // Get measured qubits from circuit sort and delete duplicates
   std::vector<uint_t> meas_qubits; // measured qubits
@@ -1919,8 +1917,8 @@ void Controller::measure_sampler(
   }
 
   // Maps of memory and register to qubit position
-  std::unordered_map<uint_t, uint_t> memory_map;
-  std::unordered_map<uint_t, uint_t> register_map;
+  std::map<uint_t, uint_t> memory_map;
+  std::map<uint_t, uint_t> register_map;
   for (const auto &op : meas_ops) {
     for (size_t j = 0; j < op.qubits.size(); ++j) {
       auto pos = qubit_map[op.qubits[j]];
@@ -1932,13 +1930,12 @@ void Controller::measure_sampler(
   }
 
   // Process samples
-  // Convert opts to circuit so we can get the needed creg sizes
-  // NB: this function could probably be moved somewhere else like Utils or Ops
-  Circuit meas_circ(meas_roerror_ops);
+  uint_t num_memory = (memory_map.empty()) ? 0ULL : 1 + memory_map.rbegin()->first;
+  uint_t num_registers = (register_map.empty()) ? 0ULL : 1 + register_map.rbegin()->first;
   ClassicalRegister creg;
   while (!all_samples.empty()) {
     auto sample = all_samples.back();
-    creg.initialize(meas_circ.num_memory, meas_circ.num_registers);
+    creg.initialize(num_memory, num_registers);
 
     // process memory bit measurements
     for (const auto &pair : memory_map) {

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -265,8 +265,9 @@ class QasmController : public Base::Controller {
 
   // Sample measurement outcomes for the input measure ops from the
   // current state of the input State_t
-  template <class State_t>
-  void measure_sampler(const std::vector<Operations::Op>& meas_ops,
+  template <typename InputIterator, class State_t>
+  void measure_sampler(InputIterator first_meas,
+                       InputIterator last_meas,
                        uint_t shots,
                        State_t& state,
                        ExperimentResult& result,
@@ -1093,9 +1094,7 @@ void QasmController::run_multi_shot(const Circuit& circ,
     state.apply_ops(ops.cbegin(), ops.cend(), result, rng, final_ops);
 
     // Get measurement operations and set of measured qubits
-    ops = std::vector<Operations::Op>(circ.ops.begin() + pos,
-                                      circ.ops.end());
-    measure_sampler(ops, shots, state, result, rng);
+    measure_sampler(circ.ops.begin() + pos, circ.ops.end(), shots, state, result, rng);
 
     // Add measure sampling metadata
     result.metadata.add(true, "measure_sampling");
@@ -1187,15 +1186,16 @@ bool QasmController::check_measure_sampling_opt(const Circuit& circ,
   return true;
 }
 
-template <class State_t>
+template <typename InputIterator, class State_t>
 void QasmController::measure_sampler(
-    const std::vector<Operations::Op>& meas_roerror_ops,
+    InputIterator first_meas,
+    InputIterator last_meas,
     uint_t shots,
     State_t& state,
     ExperimentResult& result,
     RngEngine& rng) const {
   // Check if meas_circ is empty, and if so return initial creg
-  if (meas_roerror_ops.empty()) {
+  if (first_meas == last_meas) {
     while (shots-- > 0) {
       Base::Controller::save_count_data(result, state.creg());
     }
@@ -1204,11 +1204,13 @@ void QasmController::measure_sampler(
 
   std::vector<Operations::Op> meas_ops;
   std::vector<Operations::Op> roerror_ops;
-  for (const Operations::Op& op : meas_roerror_ops)
-    if (op.type == Operations::OpType::roerror)
-      roerror_ops.push_back(op);
-    else /*(op.type == Operations::OpType::measure) */
-      meas_ops.push_back(op);
+  for (auto op = first_meas; op != last_meas; op++) {
+    if (op->type == Operations::OpType::roerror) {
+      roerror_ops.push_back(*op);
+    } else { /*(op.type == Operations::OpType::measure) */
+      meas_ops.push_back(*op);
+    }
+  }
 
   // Get measured qubits from circuit sort and delete duplicates
   std::vector<uint_t> meas_qubits;  // measured qubits
@@ -1229,8 +1231,8 @@ void QasmController::measure_sampler(
   }
 
   // Maps of memory and register to qubit position
-  std::unordered_map<uint_t, uint_t> memory_map;
-  std::unordered_map<uint_t, uint_t> register_map;
+  std::map<uint_t, uint_t> memory_map;
+  std::map<uint_t, uint_t> register_map;
   for (const auto &op : meas_ops) {
     for (size_t j = 0; j < op.qubits.size(); ++j) {
       auto pos = qubit_map[op.qubits[j]];
@@ -1242,13 +1244,12 @@ void QasmController::measure_sampler(
   }
 
   // Process samples
-  // Convert opts to circuit so we can get the needed creg sizes
-  // NB: this function could probably be moved somewhere else like Utils or Ops
-  Circuit meas_circ(meas_roerror_ops);
+  uint_t num_memory = (memory_map.empty()) ? 0ULL : 1 + memory_map.rbegin()->first;
+  uint_t num_registers = (register_map.empty()) ? 0ULL : 1 + register_map.rbegin()->first;
   ClassicalRegister creg;
   while (!all_samples.empty()) {
     auto sample = all_samples.back();
-    creg.initialize(meas_circ.num_memory, meas_circ.num_registers);
+    creg.initialize(num_memory, num_registers);
 
     // process memory bit measurements
     for (const auto &pair : memory_map) {
@@ -1262,7 +1263,7 @@ void QasmController::measure_sampler(
     }
 
     // process read out errors for memory and registers
-    for (const Operations::Op& roerror : roerror_ops) {
+    for (const auto& roerror : roerror_ops) {
       creg.apply_roerror(roerror, rng);
     }
 

--- a/src/controllers/qasm_controller.hpp
+++ b/src/controllers/qasm_controller.hpp
@@ -1068,7 +1068,7 @@ void QasmController::run_single_shot(const Circuit& circ,
                                      ExperimentResult& result,
                                      RngEngine& rng) const {
   initialize_state(circ, state, initial_state);
-  state.apply_ops(circ.ops, result, rng, true);
+  state.apply_ops(circ.ops.cbegin(), circ.ops.cend(), result, rng, true);
   Base::Controller::save_count_data(result, state.creg());
 }
 
@@ -1090,7 +1090,7 @@ void QasmController::run_multi_shot(const Circuit& circ,
                                     circ.ops.begin() + pos);
     bool final_ops = (pos == circ.ops.size());
     initialize_state(circ, state, initial_state);
-    state.apply_ops(ops, result, rng, final_ops);
+    state.apply_ops(ops.cbegin(), ops.cend(), result, rng, final_ops);
 
     // Get measurement operations and set of measured qubits
     ops = std::vector<Operations::Op>(circ.ops.begin() + pos,

--- a/src/controllers/statevector_controller.hpp
+++ b/src/controllers/statevector_controller.hpp
@@ -371,7 +371,7 @@ void StatevectorController::run_circuit_helper(
     state.initialize_qreg(circ.num_qubits, initial_state_);
   }
   state.initialize_creg(circ.num_memory, circ.num_registers);
-  state.apply_ops(opt_circ.ops, result, rng);
+  state.apply_ops(opt_circ.ops.cbegin(), opt_circ.ops.cend(), result, rng);
   Base::Controller::save_count_data(result, state.creg());
 
   // Add final state to the data

--- a/src/controllers/unitary_controller.hpp
+++ b/src/controllers/unitary_controller.hpp
@@ -357,7 +357,7 @@ void UnitaryController::run_circuit_helper(
     state.initialize_qreg(circ.num_qubits, initial_unitary_);
   }
   state.initialize_creg(circ.num_memory, circ.num_registers);
-  state.apply_ops(opt_circ.ops, result, rng);
+  state.apply_ops(opt_circ.ops.cbegin(), opt_circ.ops.cend(), result, rng);
   Base::Controller::save_count_data(result, state.creg());
 
   // Add final state unitary to the data

--- a/src/noise/quantum_error.hpp
+++ b/src/noise/quantum_error.hpp
@@ -364,7 +364,7 @@ void QuantumError::compute_superoperator() {
     // We don't need output data or RNG for this
     ExperimentResult data;
     RngEngine rng;
-    superop.apply_ops(circuits_[j], data, rng);
+    superop.apply_ops(circuits_[j].cbegin(), circuits_[j].cend(), data, rng);
     superoperator_ += probabilities_[j] * superop.move_to_matrix();
   }
 }

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -100,12 +100,12 @@ public:
   // Return the string name of the State class
   virtual std::string name() const override { return densmat_t::name(); }
 
-  // Apply a sequence of operations by looping over list
-  // If the input is not in allowed_ops an exeption will be raised.
-  virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         ExperimentResult &result,
-                         RngEngine &rng,
-                         bool final_ops = false) override;
+  // Apply an operation
+  // If the op is not in allowed_ops an exeption will be raised.
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine &rng,
+                        bool final_op = false) override;
 
   // Initializes an n-qubit state to the all |0> state
   virtual void initialize_qreg(uint_t num_qubits) override;
@@ -449,75 +449,70 @@ void State<densmat_t>::set_config(const json_t &config) {
 //=========================================================================
 
 template <class densmat_t>
-void State<densmat_t>::apply_ops(const std::vector<Operations::Op> &ops,
+void State<densmat_t>::apply_op(const Operations::Op &op,
                                  ExperimentResult &result,
                                  RngEngine &rng,
-                                 bool final_ops) {
-  // Simple loop over vector of input operations
-  for (size_t i = 0; i < ops.size(); ++i) {
-    const auto& op = ops[i];
-    // If conditional op check conditional
-    if (BaseState::creg_.check_conditional(op)) {
-      switch (op.type) {
-        case OpType::barrier:
-          break;
-        case OpType::reset:
-          apply_reset(op.qubits);
-          break;
-        case OpType::measure:
-          apply_measure(op.qubits, op.memory, op.registers, rng);
-          break;
-        case OpType::bfunc:
-          BaseState::creg_.apply_bfunc(op);
-          break;
-        case OpType::roerror:
-          BaseState::creg_.apply_roerror(op, rng);
-          break;
-        case OpType::gate:
-          apply_gate(op);
-          break;
-        case OpType::snapshot:
-          apply_snapshot(op, result, final_ops && ops.size() == i + 1);
-          break;
-        case OpType::matrix:
-          apply_matrix(op.qubits, op.mats[0]);
-          break;
-        case OpType::diagonal_matrix:
-          BaseState::qreg_.apply_diagonal_unitary_matrix(op.qubits, op.params);
-          break;
-        case OpType::superop:
-          BaseState::qreg_.apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
-          break;
-        case OpType::kraus:
-          apply_kraus(op.qubits, op.mats);
-          break;
-        case OpType::set_statevec:
-          BaseState::qreg_.initialize_from_vector(op.params);
-          break;
-        case OpType::set_densmat:
-          BaseState::qreg_.initialize_from_matrix(op.mats[0]);
-          break;
-        case OpType::save_expval:
-        case OpType::save_expval_var:
-          BaseState::apply_save_expval(op, result);
-          break;
-        case OpType::save_state:
-          apply_save_state(op, result, final_ops && ops.size() == i + 1);
-          break;
-        case OpType::save_densmat:
-          apply_save_density_matrix(op, result, final_ops && ops.size() == i + 1);
-          break;
-        case OpType::save_probs:
-        case OpType::save_probs_ket:
-          apply_save_probs(op, result);
-          break;
-        case OpType::save_amps_sq:
-          apply_save_amplitudes_sq(op, result);
-          break;
-        default:
-          throw std::invalid_argument("DensityMatrix::State::invalid instruction \'" +
-                                      op.name + "\'.");
-      }
+                                 bool final_op) {
+  if (BaseState::creg_.check_conditional(op)) {
+    switch (op.type) {
+      case OpType::barrier:
+        break;
+      case OpType::reset:
+        apply_reset(op.qubits);
+        break;
+      case OpType::measure:
+        apply_measure(op.qubits, op.memory, op.registers, rng);
+        break;
+      case OpType::bfunc:
+        BaseState::creg_.apply_bfunc(op);
+        break;
+      case OpType::roerror:
+        BaseState::creg_.apply_roerror(op, rng);
+        break;
+      case OpType::gate:
+        apply_gate(op);
+        break;
+      case OpType::snapshot:
+        apply_snapshot(op, result, final_op);
+        break;
+      case OpType::matrix:
+        apply_matrix(op.qubits, op.mats[0]);
+        break;
+      case OpType::diagonal_matrix:
+        BaseState::qreg_.apply_diagonal_unitary_matrix(op.qubits, op.params);
+        break;
+      case OpType::superop:
+        BaseState::qreg_.apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
+        break;
+      case OpType::kraus:
+        apply_kraus(op.qubits, op.mats);
+        break;
+      case OpType::set_statevec:
+        BaseState::qreg_.initialize_from_vector(op.params);
+        break;
+      case OpType::set_densmat:
+        BaseState::qreg_.initialize_from_matrix(op.mats[0]);
+        break;
+      case OpType::save_expval:
+      case OpType::save_expval_var:
+        BaseState::apply_save_expval(op, result);
+        break;
+      case OpType::save_state:
+        apply_save_state(op, result, final_op);
+        break;
+      case OpType::save_densmat:
+        apply_save_density_matrix(op, result, final_op);
+        break;
+      case OpType::save_probs:
+      case OpType::save_probs_ket:
+        apply_save_probs(op, result);
+        break;
+      case OpType::save_amps_sq:
+        apply_save_amplitudes_sq(op, result);
+        break;
+      default:
+        throw std::invalid_argument("DensityMatrix::State::invalid instruction \'" +
+                                    op.name + "\'.");
     }
   }
 }

--- a/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state_chunk.hpp
@@ -575,8 +575,7 @@ template <class densmat_t>
 void State<densmat_t>::apply_op(const int_t iChunk,const Operations::Op &op,
                          ExperimentResult &result,
                          RngEngine &rng,
-                         bool final_ops)
-{
+                         bool final_ops) {
   if (BaseState::creg_.check_conditional(op)) {
     switch (op.type) {
       case Operations::OpType::barrier:

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -77,10 +77,18 @@ public:
 
   //Apply a sequence of operations to the cicuit. For each operation,
   //we loop over the terms in the decomposition in parallel
-  virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         ExperimentResult &result,
-                         RngEngine &rng,
-                         bool final_ops = false) override;
+  template <typename InputIterator>
+  void apply_ops(InputIterator first, InputIterator last,
+                  ExperimentResult &result,
+                  RngEngine &rng,
+                  bool final_ops = false);
+
+  // Apply a single operation
+  // If the op is not in allowed_ops an exeption will be raised.
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine &rng,
+                        bool final_op = false) override;
 
   void initialize_qreg(uint_t num_qubits) override;
 
@@ -93,24 +101,27 @@ public:
   void set_config(const json_t &config) override;
 
   std::vector<reg_t> sample_measure(const reg_t& qubits,
-                                            uint_t shots,
-                                            RngEngine &rng) override;
+                                    uint_t shots,
+                                    RngEngine &rng) override;
 
 protected:
 
   //Alongside the sample measure optimisaiton, we can parallelise
   //circuit applicaiton over the states. This reduces the threading overhead
   //as we only have to fork once per circuit.
-  void apply_ops_parallel(const std::vector<Operations::Op> &ops,
-                                  ExperimentResult &result,
-                                  RngEngine &rng);
+  template <typename InputIterator>
+  void apply_ops_parallel(InputIterator first, InputIterator last,
+                          ExperimentResult &result,
+                          RngEngine &rng);
 
   //Small routine that eschews any parallelisation/decomposition and applies a stabilizer
   //circuit to a single state. This is used to optimize a circuit with a large
   //initial clifford fraction, or for running stabilizer circuits.
-  void apply_stabilizer_circuit(const std::vector<Operations::Op> &ops,
-                                      ExperimentResult &result,
-                                      RngEngine &rng);
+  template <typename InputIterator>
+  void apply_stabilizer_circuit(InputIterator first, InputIterator last,
+                                ExperimentResult &result,
+                                RngEngine &rng);
+
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
   // TODO: Investigate OMP synchronisation over stattes to remove these different versions
@@ -191,19 +202,21 @@ protected:
 
   SamplingMethod sampling_method_ = SamplingMethod::resampled_metropolis;
 
-  // Compute the required stabilizer rank of the circuit
-  uint_t compute_chi(const std::vector<Operations::Op> &ops) const;
+  template <typename InputIterator>
+  uint_t compute_chi(InputIterator first, InputIterator last) const;
+
   // Add the given operation to the extent
   void compute_extent(const Operations::Op &op, double &xi) const;
 
-  //Compute the required chi, and count the number of three qubit gates
-  std::pair<uint_t, uint_t> decomposition_parameters(const std::vector<Operations::Op> &ops);
+  template <typename InputIterator>
+  std::pair<uint_t, uint_t> decomposition_parameters(InputIterator first, InputIterator last);
   
-  //Check if this is a stabilizer circuit, for the locaiton of the first non-CLifford gate
-  std::pair<bool, size_t> check_stabilizer_opt(const std::vector<Operations::Op> &ops) const;
+  template <typename InputIterator>
+  std::pair<bool, size_t> check_stabilizer_opt(InputIterator first, InputIterator last) const;
 
-  //Check if we can use the sample_measure optimisation
-  bool check_measurement_opt(const std::vector<Operations::Op> &ops) const;
+  template <typename InputIterator>
+  bool check_measurement_opt(InputIterator first, InputIterator last) const;
+
 };
 
 //=========================================================================
@@ -306,17 +319,18 @@ void State::set_config(const json_t &config)
   }
 }
 
-std::pair<uint_t, uint_t> State::decomposition_parameters(const std::vector<Operations::Op> &ops)
+template <typename InputIterator>
+std::pair<uint_t, uint_t> State::decomposition_parameters(InputIterator first, InputIterator last)
 {
   double xi=1.;
   unsigned three_qubit_gate_count = 0;
-  for (const auto &op: ops)
+  for (auto op = first; op != last; op++)
   {
-    if (op.type == Operations::OpType::gate)
+    if (op->type == Operations::OpType::gate)
     {
       compute_extent(op, xi);
-      auto it = CHSimulator::gate_types_.find(op.name);
-      if (it->second == CHSimulator::Gatetypes::non_clifford && op.qubits.size() == 3)
+      auto it = CHSimulator::gate_types_.find(op->name);
+      if (it->second == CHSimulator::Gatetypes::non_clifford && op->qubits.size() == 3)
       { //We count the number of 3 qubit gates for normalisation purposes
         three_qubit_gate_count++;
       }
@@ -331,9 +345,10 @@ std::pair<uint_t, uint_t> State::decomposition_parameters(const std::vector<Oper
   return std::pair<uint_t, uint_t>({chi, three_qubit_gate_count});
 }
 
-std::pair<bool, size_t> State::check_stabilizer_opt(const std::vector<Operations::Op> &ops) const
+template <typename InputIterator>
+std::pair<bool, size_t> State::check_stabilizer_opt(InputIterator first, InputIterator last) const
 {
-  for(auto op = ops.cbegin(); op != ops.cend(); op++)
+  for(auto op = first; op != last; op++)
   {
     if (op->type != Operations::OpType::gate)
     {
@@ -347,25 +362,26 @@ std::pair<bool, size_t> State::check_stabilizer_opt(const std::vector<Operations
     }
     if(it->second == CHSimulator::Gatetypes::non_clifford)
     {
-      return std::pair<bool, size_t>({false, op - ops.cbegin()});
+      return std::pair<bool, size_t>({false, op - first});
     }
   }
   return std::pair<bool, size_t>({true, 0});
 }
 
-bool State::check_measurement_opt(const std::vector<Operations::Op> &ops) const
+template <typename InputIterator>
+bool State::check_measurement_opt(InputIterator first, InputIterator last) const
 {
-  for (const auto &op: ops)
+  for (auto op = first; op != last; op++)
   {
-    if (op.conditional)
+    if (op->conditional)
     {
       return false;
     }
-    if (op.type == Operations::OpType::measure ||
-        op.type == Operations::OpType::bfunc ||
-        op.type == Operations::OpType::snapshot ||
-        op.type == Operations::OpType::save_statevec ||
-        op.type == Operations::OpType::save_expval)
+    if (op->type == Operations::OpType::measure ||
+        op->type == Operations::OpType::bfunc ||
+        op->type == Operations::OpType::snapshot ||
+        op->type == Operations::OpType::save_statevec ||
+        op->type == Operations::OpType::save_expval)
     {
       return false;
     }
@@ -376,15 +392,20 @@ bool State::check_measurement_opt(const std::vector<Operations::Op> &ops) const
 //-------------------------------------------------------------------------
 // Implementation: Operations
 //-------------------------------------------------------------------------
+void State::apply_op(const Operations::Op &op, ExperimentResult &result,
+                     RngEngine &rng, bool final_op) {
+  apply_ops(&op, &op+1, result, rng, final_op);
+}
 
-void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &result,
-                         RngEngine &rng, bool final_ops)
+template <typename InputIterator>
+void State::apply_ops(InputIterator first, InputIterator last, ExperimentResult &result,
+                      RngEngine &rng, bool final_ops)
 {
-  std::pair<bool, size_t> stabilizer_opts = check_stabilizer_opt(ops);
+  std::pair<bool, size_t> stabilizer_opts = check_stabilizer_opt(first, last);
   bool is_stabilizer = stabilizer_opts.first;
   if(is_stabilizer)
   {
-    apply_stabilizer_circuit(ops, result, rng);
+    apply_stabilizer_circuit(first, last, result, rng);
   }
   else
   {
@@ -394,23 +415,26 @@ void State::apply_ops(const std::vector<Operations::Op> &ops, ExperimentResult &
     {
       //Apply the stabilizer circuit first. This optimisaiton avoids duplicating the application
       //of the initial stabilizer circuit chi times.
-      std::vector<Operations::Op> stabilizer_circuit(ops.cbegin(), ops.cbegin()+first_non_clifford);
-      apply_stabilizer_circuit(stabilizer_circuit, result, rng);
+      apply_stabilizer_circuit(first, first+first_non_clifford, result, rng);
     }
-    std::vector<Operations::Op> non_stabilizer_circuit(ops.cbegin()+first_non_clifford, ops.cend());
-    uint_t chi = compute_chi(non_stabilizer_circuit);
+
+    auto it_nonstab_begin = first+first_non_clifford;
+
+    uint_t chi = compute_chi(it_nonstab_begin, last);
     double delta = std::pow(approximation_error_, -2);
     BaseState::qreg_.initialize_decomposition(chi, delta);
     //Check for measurement optimisaitons
-    bool measurement_opt = check_measurement_opt(ops);
+    bool measurement_opt = check_measurement_opt(first, last);
+
     if(measurement_opt)
     {
-      apply_ops_parallel(non_stabilizer_circuit, result, rng);
+      apply_ops_parallel(it_nonstab_begin, last, result, rng);
     }
     else
     {
-      for (const auto &op: non_stabilizer_circuit)
+      for (auto it = it_nonstab_begin; it != last; it++)
       {
+        const auto op = *it;
         if(BaseState::creg_.check_conditional(op)) {
           switch (op.type) {
             case Operations::OpType::gate:
@@ -511,7 +535,8 @@ std::vector<reg_t> State::sample_measure(const reg_t& qubits,
 //-------------------------------------------------------------------------
 
 //Method with slighty optimized parallelisation for the case of a sample_measure circuit
-void State::apply_ops_parallel(const std::vector<Operations::Op> &ops, ExperimentResult &result, RngEngine &rng)
+template <typename InputIterator>
+void State::apply_ops_parallel(InputIterator first, InputIterator last, ExperimentResult &result, RngEngine &rng)
 {
   const int_t NUM_STATES = BaseState::qreg_.get_num_states();
   #pragma omp parallel for if(BaseState::qreg_.check_omp_threshold() && BaseState::threads_>1) num_threads(BaseState::threads_)
@@ -521,65 +546,66 @@ void State::apply_ops_parallel(const std::vector<Operations::Op> &ops, Experimen
     {
       continue;
     }
-    for(const auto &op: ops)
+    for(auto it = first; it != last; it++)
     {
-      switch (op.type)
+      switch (it->type)
       {
         case Operations::OpType::gate:
-          apply_gate(op, rng, i);
+          apply_gate(*it, rng, i);
           break;
         case Operations::OpType::barrier:
           break;
         default:
           throw std::invalid_argument("CH::State::apply_ops_parallel does not support operations of the type \'" + 
-                                       op.name + "\'.");
+                                       it->name + "\'.");
           break;
       }
     }
   }
 }
 
-void State::apply_stabilizer_circuit(const std::vector<Operations::Op> &ops,
-                                      ExperimentResult &result, RngEngine &rng)
+template <typename InputIterator>
+void State::apply_stabilizer_circuit(InputIterator first, InputIterator last,
+                                     ExperimentResult &result, RngEngine &rng)
 {
-  for (const auto &op: ops)
+  for (auto it = first; it != last; ++it)
   {
-    switch (op.type)
-    {
-      case Operations::OpType::gate:
-        if(BaseState::creg_.check_conditional(op))
-        {
+    const Operations::Op op = *it;
+    if(BaseState::creg_.check_conditional(op)) {
+      switch (op.type)
+      {
+        case Operations::OpType::gate:
           apply_gate(op, rng, 0);
-        }
-        break;
-      case Operations::OpType::reset:
-        apply_reset(op.qubits, rng);
-        break;
-      case Operations::OpType::barrier:
-        break;
-      case Operations::OpType::measure:
-        apply_measure(op.qubits, op.memory, op.registers, rng);
-        break;
-      case Operations::OpType::roerror:
-        BaseState::creg_.apply_roerror(op, rng);
-        break;
-      case Operations::OpType::bfunc:
-        BaseState::creg_.apply_bfunc(op);
-        break;
-      case Operations::OpType::snapshot:
-        apply_snapshot(op, result, rng);
-        break;
-      case Operations::OpType::save_statevec:
-        apply_save_statevector(op, result);
-        break;
-      case Operations::OpType::save_expval:
-      case Operations::OpType::save_expval_var:
-        apply_save_expval(op, result, rng);
-        break;
-      default:
-        throw std::invalid_argument("CH::State::apply_stabilizer_circuit does not support operations of the type \'" + 
-                                     op.name + "\'.");
-        break;
+          break;
+        case Operations::OpType::reset:
+          apply_reset(op.qubits, rng);
+          break;
+        case Operations::OpType::barrier:
+          break;
+        case Operations::OpType::measure:
+          apply_measure(op.qubits, op.memory, op.registers, rng);
+          break;
+        case Operations::OpType::roerror:
+          BaseState::creg_.apply_roerror(op, rng);
+          break;
+        case Operations::OpType::bfunc:
+          BaseState::creg_.apply_bfunc(op);
+          break;
+        case Operations::OpType::snapshot:
+          apply_snapshot(op, result, rng);
+          break;
+        case Operations::OpType::save_statevec:
+          apply_save_statevector(op, result);
+          break;
+        case Operations::OpType::save_expval:
+        case Operations::OpType::save_expval_var:
+          apply_save_expval(op, result, rng);
+          break;
+        default:
+          throw std::invalid_argument("CH::State::apply_stabilizer_circuit does not support operations of the type \'" + 
+                                      op.name + "\'.");
+          break;
+      }
     }
   }
 }
@@ -982,13 +1008,13 @@ inline void to_json(json_t &js, cvector_t vec)
   }
 }
 
-//
-uint_t State::compute_chi(const std::vector<Operations::Op> &ops) const
+template <typename InputIterator>
+uint_t State::compute_chi(InputIterator first, InputIterator last) const
 {
   double xi = 1;
-  for (const auto &op: ops)
+  for (auto op = first; op != last; op++)
   {
-    compute_extent(op, xi);
+    compute_extent(*op, xi);
   }
   double err_scaling = std::pow(approximation_error_, -2);
   return std::llrint(std::ceil(xi*err_scaling));
@@ -1030,7 +1056,7 @@ void State::compute_extent(const Operations::Op &op, double &xi) const
 size_t State::required_memory_mb(uint_t num_qubits,
                                  const std::vector<Operations::Op> &ops) const
 {
-  size_t required_chi = compute_chi(ops);
+  size_t required_chi = compute_chi(ops.cbegin(), ops.cend());
   // 5 vectors of num_qubits*8byte words
   // Plus 2*CHSimulator::scalar_t which has 3 4 byte words
   // Plus 2*CHSimulator::pauli_t which has 2 8 byte words and one 4 byte word;

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -114,12 +114,12 @@ public:
     return qreg_.empty();
   }
 
-  // Apply a sequence of operations by looping over list
-  // If the input is not in allowed_ops an exception will be raised.
-  virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         ExperimentResult &result,
-                         RngEngine &rng,
-                         bool final_ops = false) override;
+  // Apply an operation
+  // If the op is not in allowed_ops an exeption will be raised.
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine &rng,
+                        bool final_op = false) override;
 
   // Initializes an n-qubit state to the all |0> state
   virtual void initialize_qreg(uint_t num_qubits) override;
@@ -528,91 +528,85 @@ void State::output_bond_dimensions(const Operations::Op &op) const {
 // Implementation: apply operations
 //=========================================================================
 
-void State::apply_ops(const std::vector<Operations::Op> &ops,
+void State::apply_op(const Operations::Op &op,
                       ExperimentResult &result,
-                      RngEngine &rng, bool final_ops) {
-
-  // Simple loop over vector of input operations
-  for (size_t i = 0; i < ops.size(); ++i) {
-    const auto& op = ops[i];
-    if(BaseState::creg_.check_conditional(op)) {
-      switch (op.type) {
-        case OpType::barrier:
+                      RngEngine &rng, bool final_op) {
+  if (BaseState::creg_.check_conditional(op)) {
+    switch (op.type) {
+      case OpType::barrier:
+        break;
+      case OpType::reset:
+        apply_reset(op.qubits, rng);
+        break;
+      case OpType::initialize:
+        apply_initialize(op.qubits, op.params, rng);
+        break;
+      case OpType::measure:
+        apply_measure(op.qubits, op.memory, op.registers, rng);
+        break;
+      case OpType::bfunc:
+        BaseState::creg_.apply_bfunc(op);
+        break;
+      case OpType::roerror:
+        BaseState::creg_.apply_roerror(op, rng);
+        break;
+      case OpType::gate:
+        apply_gate(op);
+        break;
+      case OpType::snapshot:
+        apply_snapshot(op, result);
+        break;
+      case OpType::matrix:
+        apply_matrix(op.qubits, op.mats[0]);
+        break;
+      case OpType::diagonal_matrix:
+        BaseState::qreg_.apply_diagonal_matrix(op.qubits, op.params);
+        break;
+      case OpType::kraus:
+        apply_kraus(op.qubits, op.mats, rng);
+        break;
+      case OpType::set_statevec: {
+          reg_t all_qubits(qreg_.num_qubits());
+          std::iota(all_qubits.begin(), all_qubits.end(), 0);
+          qreg_.apply_initialize(all_qubits, op.params, rng);
           break;
-        case OpType::reset:
-          apply_reset(op.qubits, rng);
-          break;
-        case OpType::initialize:
-          apply_initialize(op.qubits, op.params, rng);
-          break;
-        case OpType::measure:
-          apply_measure(op.qubits, op.memory, op.registers, rng);
-          break;
-        case OpType::bfunc:
-          BaseState::creg_.apply_bfunc(op);
-          break;
-        case OpType::roerror:
-          BaseState::creg_.apply_roerror(op, rng);
-          break;
-        case OpType::gate:
-          apply_gate(op);
-          break;
-        case OpType::snapshot:
-          apply_snapshot(op, result);
-          break;
-        case OpType::matrix:
-          apply_matrix(op.qubits, op.mats[0]);
-          break;
-        case OpType::diagonal_matrix:
-          BaseState::qreg_.apply_diagonal_matrix(op.qubits, op.params);
-          break;
-        case OpType::kraus:
-          apply_kraus(op.qubits, op.mats, rng);
-          break;
-	case OpType::set_statevec:
-	  {
-	    reg_t all_qubits(qreg_.num_qubits());
-	    std::iota(all_qubits.begin(), all_qubits.end(), 0);
-	    qreg_.apply_initialize(all_qubits, op.params, rng);
-	    break;
-	  }
-	case OpType::set_mps:
-          qreg_.initialize_from_mps(op.mps);
-          break;
-        case OpType::save_expval:
-        case OpType::save_expval_var:
-          BaseState::apply_save_expval(op, result);
-          break;
-        case OpType::save_densmat:
-          apply_save_density_matrix(op, result);
-          break;
-        case OpType::save_statevec:
-          apply_save_statevector(op, result);
-          break;
-        case OpType::save_state:
-        case OpType::save_mps:
-          apply_save_mps(op, result, final_ops && ops.size() == i + 1);
-          break;
-        case OpType::save_probs:
-        case OpType::save_probs_ket:
-          apply_save_probs(op, result);
-          break;
-        case OpType::save_amps:
-        case OpType::save_amps_sq:
-          apply_save_amplitudes(op, result);
-          break;
-        default:
-          throw std::invalid_argument("MatrixProductState::State::invalid instruction \'" +
-                                      op.name + "\'.");
-      }
+        }
+      case OpType::set_mps:
+        qreg_.initialize_from_mps(op.mps);
+        break;
+      case OpType::save_expval:
+      case OpType::save_expval_var:
+        BaseState::apply_save_expval(op, result);
+        break;
+      case OpType::save_densmat:
+        apply_save_density_matrix(op, result);
+        break;
+      case OpType::save_statevec:
+        apply_save_statevector(op, result);
+        break;
+      case OpType::save_state:
+      case OpType::save_mps:
+        apply_save_mps(op, result, final_op);
+        break;
+      case OpType::save_probs:
+      case OpType::save_probs_ket:
+        apply_save_probs(op, result);
+        break;
+      case OpType::save_amps:
+      case OpType::save_amps_sq:
+        apply_save_amplitudes(op, result);
+        break;
+      default:
+        throw std::invalid_argument("MatrixProductState::State::invalid instruction \'" +
+                                    op.name + "\'.");
     }
     //qreg_.print(std::cout);
     // print out bond dimensions only if they may have changed since previous print
-    if (MPS::get_mps_log_data() && 
-	(op.type == OpType::gate ||op.type == OpType::measure || 
-	 op.type == OpType::initialize || op.type == OpType::reset || 
-	 op.type == OpType::matrix) && 
-	op.qubits.size() > 1) {
+    if (MPS::get_mps_log_data()
+        && (op.type == OpType::gate ||op.type == OpType::measure || 
+            op.type == OpType::initialize || op.type == OpType::reset || 
+            op.type == OpType::matrix) && 
+            op.qubits.size() > 1) {
       output_bond_dimensions(op);
     }
   }

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -81,12 +81,12 @@ public:
   // Return the string name of the State class
   virtual std::string name() const override {return "stabilizer";}
 
-  // Apply a sequence of operations by looping over list
-  // If the input is not in allowed_ops an exeption will be raised.
-  virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         ExperimentResult &result,
-                         RngEngine &rng,
-                         bool final_ops = false) override;
+  // Apply an operation
+  // If the op is not in allowed_ops an exeption will be raised.
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine &rng,
+                        bool final_op = false) override;
 
   // Initializes an n-qubit state to the all |0> state
   virtual void initialize_qreg(uint_t num_qubits) override;
@@ -315,55 +315,52 @@ void State::set_config(const json_t &config) {
 // Implementation: apply operations
 //=========================================================================
 
-void State::apply_ops(const std::vector<Operations::Op> &ops,
-                      ExperimentResult &result,
-                      RngEngine &rng, bool final_ops) {
-  // Simple loop over vector of input operations
-  for (const auto &op: ops) {
-    if(BaseState::creg_.check_conditional(op)) {
-      switch (op.type) {
-        case OpType::barrier:
-          break;
-        case OpType::reset:
-          apply_reset(op.qubits, rng);
-          break;
-        case OpType::measure:
-          apply_measure(op.qubits, op.memory, op.registers, rng);
-          break;
-        case OpType::bfunc:
-          BaseState::creg_.apply_bfunc(op);
-          break;
-        case OpType::roerror:
-          BaseState::creg_.apply_roerror(op, rng);
-          break;
-        case OpType::gate:
-          apply_gate(op);
-          break;
-        case OpType::snapshot:
-          apply_snapshot(op, result);
-          break;
-        case OpType::set_stabilizer:
-          apply_set_stabilizer(op.clifford);
-          break;
-        case OpType::save_expval:
-        case OpType::save_expval_var:
-          apply_save_expval(op, result);
-          break;
-        case OpType::save_probs:
-        case OpType::save_probs_ket:
-          apply_save_probs(op, result);
-          break;
-        case OpType::save_amps_sq:
-          apply_save_amplitudes_sq(op, result);
-          break;
-        case OpType::save_state:
-        case OpType::save_stabilizer:
-          apply_save_stabilizer(op, result);
-          break;
-        default:
-          throw std::invalid_argument("Stabilizer::State::invalid instruction \'" +
-                                      op.name + "\'.");
-      }
+void State::apply_op(const Operations::Op &op,
+                     ExperimentResult &result,
+                     RngEngine &rng, bool final_op) {
+  if (BaseState::creg_.check_conditional(op)) {
+    switch (op.type) {
+      case OpType::barrier:
+        break;
+      case OpType::reset:
+        apply_reset(op.qubits, rng);
+        break;
+      case OpType::measure:
+        apply_measure(op.qubits, op.memory, op.registers, rng);
+        break;
+      case OpType::bfunc:
+        BaseState::creg_.apply_bfunc(op);
+        break;
+      case OpType::roerror:
+        BaseState::creg_.apply_roerror(op, rng);
+        break;
+      case OpType::gate:
+        apply_gate(op);
+        break;
+      case OpType::snapshot:
+        apply_snapshot(op, result);
+        break;
+      case OpType::set_stabilizer:
+        apply_set_stabilizer(op.clifford);
+        break;
+      case OpType::save_expval:
+      case OpType::save_expval_var:
+        apply_save_expval(op, result);
+        break;
+      case OpType::save_probs:
+      case OpType::save_probs_ket:
+        apply_save_probs(op, result);
+        break;
+      case OpType::save_amps_sq:
+        apply_save_amplitudes_sq(op, result);
+        break;
+      case OpType::save_state:
+      case OpType::save_stabilizer:
+        apply_save_stabilizer(op, result);
+        break;
+      default:
+        throw std::invalid_argument("Stabilizer::State::invalid instruction \'" +
+                                    op.name + "\'.");
     }
   }
 }

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -101,19 +101,6 @@ public:
   // Return a string name for the State type
   virtual std::string name() const = 0;
 
-  // Apply a sequence of operations to the current state of the State class.
-  // It is up to the State subclass to decide how this sequence should be
-  // executed (ie in sequence, or some other execution strategy.)
-  // If this sequence contains operations not in the supported opset
-  // an exeption will be thrown.
-  // The `final_ops` flag indicates no more instructions will be applied
-  // to the state after this sequence, so the state can be modified at the
-  // end of the instructions.
-  virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         ExperimentResult &result,
-                         RngEngine &rng,
-                         bool final_ops = false)  = 0;
-
   // Initializes the State to the default state.
   // Typically this is the n-qubit all |0> state
   virtual void initialize_qreg(uint_t num_qubits) = 0;
@@ -171,6 +158,34 @@ public:
   //
   // These methods should not be modified in any State subclasses
   //=======================================================================
+
+  //-----------------------------------------------------------------------
+  // Apply circuits and ops
+  //-----------------------------------------------------------------------
+
+  // Apply a single operation
+  // The `final_op` flag indicates no more instructions will be applied
+  // to the state after this sequence, so the state can be modified at the
+  // end of the instructions.
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine &rng,
+                        bool final_op = false) = 0;
+  
+  // Apply a sequence of operations to the current state of the State class.
+  // It is up to the State subclass to decide how this sequence should be
+  // executed (ie in sequence, or some other execution strategy.)
+  // If this sequence contains operations not in the supported opset
+  // an exeption will be thrown.
+  // The `final_ops` flag indicates no more instructions will be applied
+  // to the state after this sequence, so the state can be modified at the
+  // end of the instructions.
+  template <typename InputIterator>
+  void apply_ops(InputIterator first,
+                 InputIterator last,
+                 ExperimentResult &result,
+                 RngEngine &rng,
+                 bool final_ops = false);
 
   //-----------------------------------------------------------------------
   // ClassicalRegister methods
@@ -308,6 +323,18 @@ void State<state_t>::set_global_phase(const double &phase_angle) {
   else {
     has_global_phase_ = true;
     global_phase_ = std::exp(complex_t(0.0, phase_angle));
+  }
+}
+
+template <class state_t>
+template <typename InputIterator>
+void State<state_t>::apply_ops(InputIterator first, InputIterator last,
+                               ExperimentResult &result,
+                               RngEngine &rng,
+                               bool final_ops) {
+  // Simple loop over vector of input operations
+  for (auto it = first; it != last; ++it) {
+    apply_op(*it, result, rng, final_ops && (it + 1 == last));
   }
 }
 

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -24,6 +24,7 @@
 #include <mpi.h>
 #endif
 
+#include <iterator>
 #include <omp.h>
 
 namespace AER {
@@ -112,10 +113,11 @@ public:
   // executed (ie in sequence, or some other execution strategy.)
   // If this sequence contains operations not in the supported opset
   // an exeption will be thrown.
-  virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         ExperimentResult &result,
-                         RngEngine &rng,
-                         bool final_ops = false);
+  template <typename InputIterator>
+  void apply_ops(InputIterator first, InputIterator last,
+                ExperimentResult &result,
+                RngEngine &rng,
+                bool final_ops = false);
 
   //memory allocation (previously called before inisitalize_qreg)
   virtual void allocate(uint_t num_qubits,uint_t block_bits);
@@ -547,7 +549,8 @@ bool StateChunk<state_t>::is_applied_to_each_chunk(const Operations::Op &op)
 }
 
 template <class state_t>
-void StateChunk<state_t>::apply_ops(const std::vector<Operations::Op> &ops,
+template <typename InputIterator>
+void StateChunk<state_t>::apply_ops(InputIterator first, InputIterator last,
                          ExperimentResult &result,
                          RngEngine &rng,
                          bool final_ops)
@@ -555,19 +558,21 @@ void StateChunk<state_t>::apply_ops(const std::vector<Operations::Op> &ops,
   int_t iChunk;
   uint_t iOp,nOp;
 
-  nOp = ops.size();
+  nOp = std::distance(first, last);
   iOp = 0;
   while(iOp < nOp){
-    if(ops[iOp].type == Operations::OpType::gate && ops[iOp].name == "swap_chunk"){
+    const Operations::Op op_iOp = *(first + iOp);
+    if(op_iOp.type == Operations::OpType::gate && op_iOp.name == "swap_chunk"){
       //apply swap between chunks
-      apply_chunk_swap(ops[iOp].qubits);
+      apply_chunk_swap(op_iOp.qubits);
     }
-    else if(ops[iOp].type == Operations::OpType::sim_op && ops[iOp].name == "begin_blocking"){
+    else if(op_iOp.type == Operations::OpType::sim_op && op_iOp.name == "begin_blocking"){
       //applying sequence of gates inside each chunk
 
       uint_t iOpEnd = iOp;
       while(iOpEnd < nOp){
-        if(ops[iOpEnd].type == Operations::OpType::sim_op && ops[iOpEnd].name == "end_blocking"){
+        const Operations::Op op_iOpEnd = *(first + iOpEnd);
+        if(op_iOpEnd.type == Operations::OpType::sim_op && op_iOpEnd.name == "end_blocking"){
           break;
         }
         iOpEnd++;
@@ -580,7 +585,7 @@ void StateChunk<state_t>::apply_ops(const std::vector<Operations::Op> &ops,
         //fecth chunk in cache
         if(qregs_[iChunk].fetch_chunk()){
           while(iOpBlock < iOpEnd){
-            apply_op(iChunk,ops[iOpBlock],result,rng,final_ops);
+            apply_op(iChunk,*(first + iOpBlock),result,rng,final_ops);
             iOpBlock++;
           }
 
@@ -591,15 +596,15 @@ void StateChunk<state_t>::apply_ops(const std::vector<Operations::Op> &ops,
 
       iOp = iOpEnd;
     }
-    else if(is_applied_to_each_chunk(ops[iOp])){
+    else if(is_applied_to_each_chunk(op_iOp)){
 #pragma omp parallel for if(chunk_omp_parallel_) private(iChunk) 
       for(iChunk=0;iChunk<num_local_chunks_;iChunk++){
-        apply_op(iChunk,ops[iOp],result,rng,final_ops && nOp == iOp + 1);
+        apply_op(iChunk,op_iOp,result,rng,final_ops && nOp == iOp + 1);
       }
     }
     else{
       //parallelize inside state implementations
-      apply_op(-1,ops[iOp],result,rng,final_ops && nOp == iOp + 1);
+      apply_op(-1,op_iOp,result,rng,final_ops && nOp == iOp + 1);
     }
     iOp++;
   }

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -77,12 +77,12 @@ public:
   // Return the string name of the State class
   virtual std::string name() const override { return "superop"; }
 
-  // Apply a sequence of operations by looping over list
-  // If the input is not in allowed_ops an exeption will be raised.
-  virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         ExperimentResult &result,
-                         RngEngine &rng,
-                         bool final_ops = false) override;
+  // Apply an operation
+  // If the op is not in allowed_ops an exeption will be raised.
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine &rng,
+                        bool final_op = false) override;
 
   // Initializes an n-qubit unitary to the identity matrix
   virtual void initialize_qreg(uint_t num_qubits) override;
@@ -239,20 +239,16 @@ const stringmap_t<Gates> State<data_t>::gateset_({
 //============================================================================
 
 template <class data_t>
-void State<data_t>::apply_ops(const std::vector<Operations::Op> &ops,
-                              ExperimentResult &result,
-                              RngEngine &rng,
-                              bool final_ops) {
-  // Simple loop over vector of input operations
-  for (size_t i = 0; i < ops.size(); ++i) {
-    const auto& op = ops[i];
+void State<data_t>::apply_op(const Operations::Op &op,
+                             ExperimentResult &result,
+                             RngEngine &rng,
+                             bool final_op) {
+  if (BaseState::creg_.check_conditional(op)) {
     switch (op.type) {
       case Operations::OpType::barrier:
         break;
       case Operations::OpType::gate:
-        // Note conditionals will always fail since no classical registers
-        if (BaseState::creg_.check_conditional(op))
-          apply_gate(op);
+        apply_gate(op);
         break;
       case Operations::OpType::bfunc:
           BaseState::creg_.apply_bfunc(op);
@@ -285,7 +281,7 @@ void State<data_t>::apply_ops(const std::vector<Operations::Op> &ops,
         break;
       case Operations::OpType::save_state:
       case Operations::OpType::save_superop:
-        apply_save_state(op, result, final_ops && ops.size() == i + 1);
+        apply_save_state(op, result, final_op);
         break;
       default:
         throw std::invalid_argument(

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -81,11 +81,12 @@ public:
   // Return the string name of the State class
   virtual std::string name() const override { return "unitary"; }
 
-  // Apply a sequence of operations by looping over list
-  // If the input is not in allowed_ops an exeption will be raised.
-  virtual void apply_ops(const std::vector<Operations::Op> &ops,
-                         ExperimentResult &result, RngEngine &rng,
-                         bool final_ops = false) override;
+  // Apply an operation
+  // If the op is not in allowed_ops an exeption will be raised.
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine &rng,
+                        bool final_op = false) override;
 
   // Initializes an n-qubit unitary to the identity matrix
   virtual void initialize_qreg(uint_t num_qubits) override;
@@ -268,32 +269,28 @@ void State<unitary_matrix_t>::allocate(uint_t num_qubits,uint_t block_bits)
 //============================================================================
 
 template <class unitary_matrix_t>
-void State<unitary_matrix_t>::apply_ops(
-    const std::vector<Operations::Op> &ops, ExperimentResult &result,
-    RngEngine &rng, bool final_ops) {
-  // Simple loop over vector of input operations
-  for (size_t i = 0; i < ops.size(); ++i) {
-    const auto& op = ops[i];
+void State<unitary_matrix_t>::apply_op(
+    const Operations::Op &op, ExperimentResult &result,
+    RngEngine &rng, bool final_op) {
+  if (BaseState::creg_.check_conditional(op)) {
     switch (op.type) {
       case Operations::OpType::barrier:
         break;
       case Operations::OpType::bfunc:
-          BaseState::creg_.apply_bfunc(op);
+        BaseState::creg_.apply_bfunc(op);
         break;
       case Operations::OpType::roerror:
-          BaseState::creg_.apply_roerror(op, rng);
+        BaseState::creg_.apply_roerror(op, rng);
         break;
       case Operations::OpType::gate:
-        // Note conditionals will always fail since no classical registers
-        if (BaseState::creg_.check_conditional(op))
-          apply_gate(op);
+        apply_gate(op);
         break;
       case Operations::OpType::set_unitary:
         BaseState::qreg_.initialize_from_matrix(op.mats[0]);
         break;
       case Operations::OpType::save_state:
       case Operations::OpType::save_unitary:
-        apply_save_unitary(op, result, final_ops && ops.size() == i + 1);
+        apply_save_unitary(op, result, final_op);
         break;
       case Operations::OpType::snapshot:
         apply_snapshot(op, result);

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -130,7 +130,7 @@ public:
     // Unitary simulation
     QubitUnitary::State<> unitary_simulator;
     unitary_simulator.initialize_qreg(qubits.size());
-    unitary_simulator.apply_ops(fusioned_ops, dummy_result, dummy_rng);
+    unitary_simulator.apply_ops(fusioned_ops.cbegin(), fusioned_ops.cend(), dummy_result, dummy_rng);
     return Operations::make_unitary(qubits, unitary_simulator.qreg().move_to_matrix(),
                                     std::string("fusion"));
   };
@@ -174,7 +174,7 @@ public:
     // simulator
     QubitSuperoperator::State<> superop_simulator;
     superop_simulator.initialize_qreg(qubits.size());
-    superop_simulator.apply_ops(fusioned_ops, dummy_result, dummy_rng);
+    superop_simulator.apply_ops(fusioned_ops.cbegin(), fusioned_ops.cend(), dummy_result, dummy_rng);
     auto superop = superop_simulator.qreg().move_to_matrix();
 
     return Operations::make_superop(qubits, std::move(superop));
@@ -220,7 +220,7 @@ public:
     // simulator
     QubitSuperoperator::State<> superop_simulator;
     superop_simulator.initialize_qreg(qubits.size());
-    superop_simulator.apply_ops(fusioned_ops, dummy_result, dummy_rng);
+    superop_simulator.apply_ops(fusioned_ops.cbegin(), fusioned_ops.cend(), dummy_result, dummy_rng);
     auto superop = superop_simulator.qreg().move_to_matrix();
 
     // If Kraus method we convert superop to canonical Kraus representation


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This refactors the simulator `State` C++ classes `apply_ops` method:
* Changes signature of `apply_ops` to use iterators instead of a vector of Ops. This will allow applying pieces of a circuit without first copying all the operations (eg for measure sampling).
* Adds an abstract `apply_op` method class to base State
* Adds a concrete implementation of `apply_ops` that loops over calls to `apply_op`, since all but the extended stabilizer state perform this same loop to apply a sequence of ops.

### Details and comments


