### PR TITLE
Fix shots option

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -339,7 +339,7 @@ class AerBackend(Backend, ABC):
 
         # Add options
         for key, val in self.options.__dict__.items():
-            if val is not None and not hasattr(config, key):
+            if val is not None:
                 setattr(config, key, val)
 
         # Override with run-time options

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -133,8 +133,11 @@ class AerBackend(Backend, ABC):
                           PendingDeprecationWarning,
                           stacklevel=2)
             qobj = circuits
-            # Qobj values take precendence over run_options
-            # otherwise values from legacy assembly won't be preserved.
+            # A work around to support both qobj options and run options until
+            # qobj is deprecated is to copy all the set qobj.config fields into
+            # run_options that don't override existing fields. This means set
+            # run_options fields will take precidence of any option fields
+            # set in assemble.
             if not run_options:
                 run_options = qobj.config.__dict__
             else:

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -133,6 +133,12 @@ class AerBackend(Backend, ABC):
                           PendingDeprecationWarning,
                           stacklevel=2)
             qobj = circuits
+            # Qobj values take precendence over run_options for shots and memory,
+            # otherwise values from legacy assembly won't be preserved.
+            for key in ["shots", "memory"]:
+                value = getattr(qobj.config, key, None)
+                if value is not None:
+                    run_options[key] = value
         else:
             qobj = assemble(circuits, self)
 

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -136,8 +136,8 @@ class AerBackend(Backend, ABC):
             # A work around to support both qobj options and run options until
             # qobj is deprecated is to copy all the set qobj.config fields into
             # run_options that don't override existing fields. This means set
-            # run_options fields will take precidence of any option fields
-            # set in assemble.
+            # run_options fields will take precidence over the value for those
+            # fields that are set via assemble.
             if not run_options:
                 run_options = qobj.config.__dict__
             else:

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -133,12 +133,15 @@ class AerBackend(Backend, ABC):
                           PendingDeprecationWarning,
                           stacklevel=2)
             qobj = circuits
-            # Qobj values take precendence over run_options for shots and memory,
+            # Qobj values take precendence over run_options
             # otherwise values from legacy assembly won't be preserved.
-            for key in ["shots", "memory"]:
-                value = getattr(qobj.config, key, None)
-                if value is not None:
-                    run_options[key] = value
+            if not run_options:
+                run_options = qobj.config.__dict__
+            else:
+                run_options = copy.copy(run_options)
+                for key, value in qobj.config.__dict__.items():
+                    if key not in run_options and value is not None:
+                        run_options[key] = value
         else:
             qobj = assemble(circuits, self)
 

--- a/releasenotes/notes/fix-shots-option-245f6b05ffeb6d78.yaml
+++ b/releasenotes/notes/fix-shots-option-245f6b05ffeb6d78.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes issue where setting the ``shots`` option for a backend with
+    ``set_options(shots=k)`` was always running the default number of shots
+    rather than the specified value.

--- a/test/terra/backends/aer_simulator/test_options.py
+++ b/test/terra/backends/aer_simulator/test_options.py
@@ -66,7 +66,6 @@ class TestOptions(SimulatorTestCase):
         backend = self.backend(method=method, device=device)
         qc = QuantumCircuit(1)
         qc.x(0)
-        qc.measure_all()
         qc = transpile(qc, backend)
 
         # Target simulation method
@@ -87,7 +86,6 @@ class TestOptions(SimulatorTestCase):
         backend = self.backend(method=method, device=device)
         qc = QuantumCircuit(1)
         qc.x(0)
-        qc.measure_all()
         qc = transpile(qc, backend)
 
         result = backend.run(qc).result()

--- a/test/terra/backends/aer_simulator/test_options.py
+++ b/test/terra/backends/aer_simulator/test_options.py
@@ -61,11 +61,12 @@ class TestOptions(SimulatorTestCase):
     @supported_methods(
         ['automatic', 'stabilizer', 'statevector', 'density_matrix',
          'matrix_product_state', 'extended_stabilizer', 'unitary', 'superop'])
-    def test_method(self, method, device):
-        """Test seed_simulator option fixes measurement outcomes"""
+    def test_method_option(self, method, device):
+        """Test method option works"""
         backend = self.backend(method=method, device=device)
         qc = QuantumCircuit(1)
         qc.x(0)
+        qc.measure_all()
         qc = transpile(qc, backend)
 
         # Target simulation method
@@ -81,11 +82,12 @@ class TestOptions(SimulatorTestCase):
     @supported_methods(
         ['automatic', 'stabilizer', 'statevector', 'density_matrix',
          'matrix_product_state', 'extended_stabilizer', 'unitary', 'superop'])
-    def test_device(self, method, device):
-        """Test seed_simulator option fixes measurement outcomes"""
+    def test_device_option(self, method, device):
+        """Test device option works"""
         backend = self.backend(method=method, device=device)
         qc = QuantumCircuit(1)
         qc.x(0)
+        qc.measure_all()
         qc = transpile(qc, backend)
 
         result = backend.run(qc).result()
@@ -116,3 +118,32 @@ class TestOptions(SimulatorTestCase):
         sim2 = self.backend(noise_model=noise_model, method=method)
         basis_gates2 = sim2.configuration().basis_gates
         self.assertEqual(sorted(basis_gates1), sorted(basis_gates2))
+    @supported_methods(
+        ['automatic', 'stabilizer', 'statevector', 'density_matrix',
+         'matrix_product_state', 'extended_stabilizer'])
+    def test_shots_option(self, method, device):
+        """Test shots option is observed"""
+        shots = 99
+        backend = self.backend(method=method, device=device, shots=shots)
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.measure_all()
+        qc = transpile(qc, backend)
+        result = backend.run(qc).result()
+        value = sum(result.get_counts().values())
+        self.assertEqual(value, shots)
+
+    @supported_methods(
+        ['automatic', 'stabilizer', 'statevector', 'density_matrix',
+         'matrix_product_state', 'extended_stabilizer'])
+    def test_shots_run_option(self, method, device):
+        """Test shots option is observed"""
+        shots = 99
+        backend = self.backend(method=method, device=device)
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.measure_all()
+        qc = transpile(qc, backend)
+        result = backend.run(qc, shots=shots).result()
+        value = sum(result.get_counts().values())
+        self.assertEqual(value, shots)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes issue where setting a `shots` backend option was not working the same as setting it as a run option.

### Details and comments

Updated behavior
```python
backend = AerSimulator(shots=99)
counts = backend.run(circuit).result().get_counts(0)
# Total counts should be 99
```

