### PR TITLE
Deprecate non-local quantum errors

### DIFF
--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -15,6 +15,7 @@ Noise model class for Qiskit Aer simulators.
 
 import json
 import logging
+from warnings import warn
 
 from qiskit.circuit import Instruction
 from qiskit.providers import BaseBackend, Backend
@@ -560,7 +561,7 @@ class NoiseModel:
                                    noise_qubits,
                                    warnings=True):
         """
-        Add a non-local quantum error to the noise model.
+        Add a non-local quantum error to the noise model (DEPRECATED).
 
         Args:
             error (QuantumError): the quantum error object.
@@ -580,6 +581,12 @@ class NoiseModel:
         Additional Information:
             If the error object is ideal it will not be added to the model.
         """
+        warn('Adding nonlocal noise to a noise model is deprecated as of'
+             ' qiskit-aer 0.9.0 and will be removed no earlier than 3'
+             ' months from that release date. To add non-local noise to'
+             ' a circuit you should write a custom qiskit transpiler pass.',
+             DeprecationWarning)
+
         if not isinstance(noise_qubits, (list, tuple)):
             raise NoiseError("Noise qubits must be a list of integers.")
         # Error checking

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -563,6 +563,13 @@ class NoiseModel:
         """
         Add a non-local quantum error to the noise model (DEPRECATED).
 
+        .. warning::
+
+            Adding nonlocal noise to a noise model is deprecated as of
+            qiskit-aer 0.9.0 and will be removed no earlier than 3
+            months from that release date. To add non-local noise to
+            a circuit you should write a custom qiskit transpiler pass.
+
         Args:
             error (QuantumError): the quantum error object.
             instructions (str or list[str] or

--- a/releasenotes/notes/deprecate-nonlocal-noise-fb30b2a4c387fe61.yaml
+++ b/releasenotes/notes/deprecate-nonlocal-noise-fb30b2a4c387fe61.yaml
@@ -1,0 +1,8 @@
+---
+deprecations:
+  - |
+    Adding non-local quantum errors to a
+    :class:`~qiskit.providers.aer.noise.NoiseModel` has been deprecated due to
+    inconsistencies in how this noise is applied to the optimized circuit.
+    Non-local noise should be manually added to a scheduled circuit in Qiskit
+    using a custom transpiler pass before being run on the simulator.

--- a/test/terra/backends/aer_simulator/test_noise.py
+++ b/test/terra/backends/aer_simulator/test_noise.py
@@ -61,7 +61,8 @@ class QasmReadoutNoiseTests(SimulatorTestCase):
         backend = self.backend(method=method, device=device)
         shots = 1000
         circuits = ref_pauli_noise.pauli_gate_error_circuits()
-        noise_models = ref_pauli_noise.pauli_gate_error_noise_models()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_gate_error_noise_models()
         targets = ref_pauli_noise.pauli_gate_error_counts(shots)
 
         for circuit, noise_model, target in zip(circuits, noise_models,
@@ -79,7 +80,8 @@ class QasmReadoutNoiseTests(SimulatorTestCase):
         backend = self.backend(method=method, device=device)
         shots = 1000
         circuits = ref_pauli_noise.pauli_reset_error_circuits()
-        noise_models = ref_pauli_noise.pauli_reset_error_noise_models()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_reset_error_noise_models()
         targets = ref_pauli_noise.pauli_reset_error_counts(shots)
 
         for circuit, noise_model, target in zip(circuits, noise_models,
@@ -95,7 +97,8 @@ class QasmReadoutNoiseTests(SimulatorTestCase):
         backend = self.backend(method=method, device=device)
         shots = 1000
         circuits = ref_pauli_noise.pauli_measure_error_circuits()
-        noise_models = ref_pauli_noise.pauli_measure_error_noise_models()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_measure_error_noise_models()
         targets = ref_pauli_noise.pauli_measure_error_counts(shots)
 
         for circuit, noise_model, target in zip(circuits, noise_models,

--- a/test/terra/backends/aer_simulator/test_truncate.py
+++ b/test/terra/backends/aer_simulator/test_truncate.py
@@ -185,7 +185,8 @@ class TestTruncateQubits(SimulatorTestCase):
         # that acts on qubits [4, 6] when X applied to qubit 5
         noise_model = NoiseModel()
         error = depolarizing_error(0.1, 2)
-        noise_model.add_nonlocal_quantum_error(error, ['x'], [5], [4, 6])
+        with self.assertWarns(DeprecationWarning):
+            noise_model.add_nonlocal_quantum_error(error, ['x'], [5], [4, 6])
 
         run_options = {
             "noise_model": noise_model,

--- a/test/terra/backends/qasm_simulator/qasm_noise.py
+++ b/test/terra/backends/qasm_simulator/qasm_noise.py
@@ -59,7 +59,8 @@ class QasmPauliNoiseTests:
         """Test simulation with Pauli gate error noise model."""
         shots = 1000
         circuits = ref_pauli_noise.pauli_gate_error_circuits()
-        noise_models = ref_pauli_noise.pauli_gate_error_noise_models()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_gate_error_noise_models()
         targets = ref_pauli_noise.pauli_gate_error_counts(shots)
 
         for circuit, noise_model, target in zip(circuits, noise_models,
@@ -75,7 +76,8 @@ class QasmPauliNoiseTests:
         """Test simulation with Pauli reset error noise model."""
         shots = 1000
         circuits = ref_pauli_noise.pauli_reset_error_circuits()
-        noise_models = ref_pauli_noise.pauli_reset_error_noise_models()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_reset_error_noise_models()
         targets = ref_pauli_noise.pauli_reset_error_counts(shots)
 
         for circuit, noise_model, target in zip(circuits, noise_models,
@@ -91,7 +93,8 @@ class QasmPauliNoiseTests:
         """Test simulation with Pauli measure error noise model."""
         shots = 1000
         circuits = ref_pauli_noise.pauli_measure_error_circuits()
-        noise_models = ref_pauli_noise.pauli_measure_error_noise_models()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_measure_error_noise_models()
         targets = ref_pauli_noise.pauli_measure_error_counts(shots)
 
         for circuit, noise_model, target in zip(circuits, noise_models,

--- a/test/terra/backends/qasm_simulator/qasm_truncate.py
+++ b/test/terra/backends/qasm_simulator/qasm_truncate.py
@@ -181,7 +181,8 @@ class QasmQubitsTruncateTests:
         # that acts on qubits [4, 6] when X applied to qubit 5
         noise_model = NoiseModel()
         error = depolarizing_error(0.1, 2)
-        noise_model.add_nonlocal_quantum_error(error, ['x'], [5], [4, 6])
+        with self.assertWarns(DeprecationWarning):
+            noise_model.add_nonlocal_quantum_error(error, ['x'], [5], [4, 6])
 
         qasm_sim = Aer.get_backend('qasm_simulator')
         backend_options = self.BACKEND_OPTS.copy()

--- a/test/terra/noise/test_noise_inserter.py
+++ b/test/terra/noise/test_noise_inserter.py
@@ -98,7 +98,8 @@ class TestNoiseInserter(QiskitAerTestCase):
 
         error_x = pauli_error([('Y', 0.25), ('I', 0.75)])
         noise_model = NoiseModel()
-        noise_model.add_nonlocal_quantum_error(error_x, 'x', [0], [1])
+        with self.assertWarns(DeprecationWarning):
+            noise_model.add_nonlocal_quantum_error(error_x, 'x', [0], [1])
 
         target_circuit = QuantumCircuit(qr)
         target_circuit.x(qr[0])

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -142,7 +142,8 @@ class TestNoise(common.QiskitAerTestCase):
 
         # Check adding a non-local error adds to noise qubits
         model = NoiseModel()
-        model.add_nonlocal_quantum_error(pauli_error([['XX', 1]]), ['label'], [0], [1, 2], False)
+        with self.assertWarns(DeprecationWarning):
+            model.add_nonlocal_quantum_error(pauli_error([['XX', 1]]), ['label'], [0], [1, 2], False)
         target = sorted([0, 1, 2])
         self.assertEqual(model.noise_qubits, target)
 
@@ -167,14 +168,16 @@ class TestNoise(common.QiskitAerTestCase):
         model1 = NoiseModel()
         model1.add_all_qubit_quantum_error(error1, ['u3'], False)
         model1.add_quantum_error(error1, ['u3'], [2], False)
-        model1.add_nonlocal_quantum_error(error1, ['cx'], [0, 1], [3], False)
+        with self.assertWarns(DeprecationWarning):
+            model1.add_nonlocal_quantum_error(error1, ['cx'], [0, 1], [3], False)
         model1.add_all_qubit_readout_error(roerror, False)
         model1.add_readout_error(roerror, [0], False)
 
         model2 = NoiseModel()
         model2.add_all_qubit_quantum_error(error2, ['u3'], False)
         model2.add_quantum_error(error2, ['u3'], [2], False)
-        model2.add_nonlocal_quantum_error(error2, ['cx'], [0, 1], [3], False)
+        with self.assertWarns(DeprecationWarning):
+            model2.add_nonlocal_quantum_error(error2, ['cx'], [0, 1], [3], False)
         model2.add_all_qubit_readout_error(roerror, False)
         model2.add_readout_error(roerror, [0], False)
         self.assertEqual(model1, model2)

--- a/test/terra/noise/test_noise_remapper.py
+++ b/test/terra/noise/test_noise_remapper.py
@@ -52,13 +52,13 @@ class TestNoiseRemapper(common.QiskitAerTestCase):
         model = NoiseModel()
         error1 = depolarizing_error(0.5, 1)
         error2 = depolarizing_error(0.5, 2)
-        model.add_nonlocal_quantum_error(error1, ['u3'], [0], [1], False)
-        model.add_nonlocal_quantum_error(error2, ['cx'], [1, 2], [3, 0], False)
-
-        remapped_model = remap_noise_model(model, [[0, 1], [1, 2], [2, 0]], warnings=False)
-        target = NoiseModel()
-        target.add_nonlocal_quantum_error(error1, ['u3'], [1], [2], False)
-        target.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
+        with self.assertWarns(DeprecationWarning):
+            model.add_nonlocal_quantum_error(error1, ['u3'], [0], [1], False)
+            model.add_nonlocal_quantum_error(error2, ['cx'], [1, 2], [3, 0], False)
+            remapped_model = remap_noise_model(model, [[0, 1], [1, 2], [2, 0]], warnings=False)
+            target = NoiseModel()
+            target.add_nonlocal_quantum_error(error1, ['u3'], [1], [2], False)
+            target.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
         self.assertEqual(remapped_model, target)
 
     def test_remap_all_qubit_readout_errors(self):
@@ -94,7 +94,8 @@ class TestNoiseRemapper(common.QiskitAerTestCase):
         model = NoiseModel()
         model.add_all_qubit_quantum_error(error1, ['u3'], False)
         model.add_quantum_error(error1, ['u3'], [1], False)
-        model.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
+        with self.assertWarns(DeprecationWarning):
+            model.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
         model.add_all_qubit_readout_error(roerror1, False)
         model.add_readout_error(roerror2, [0, 2], False)
 
@@ -116,7 +117,8 @@ class TestNoiseRemapper(common.QiskitAerTestCase):
         model = NoiseModel()
         model.add_all_qubit_quantum_error(error1, ['u3'], False)
         model.add_quantum_error(error1, ['u3'], [1], False)
-        model.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
+        with self.assertWarns(DeprecationWarning):
+            model.add_nonlocal_quantum_error(error2, ['cx'], [2, 0], [3, 1], False)
         model.add_all_qubit_readout_error(roerror1, False)
         model.add_readout_error(roerror2, [0, 2], False)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adding non-local quantum errors to a `NoiseModel` has been deprecated due to inconsistencies in how this noise is applied to the optimized circuit. Non-local noise should be manually added to a scheduled circuit in Qiskit using a custom transpiler pass before being run on the simulator.

### Details and comments

Closes #1302 
