### PR TITLE
Cap cvxpy version to avoid CI failures

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ cmake!=3.17.1,!=3.17.0
 conan>=1.31.2
 scikit-build>=0.11.0
 asv
-cvxpy>=1.0.0
+cvxpy>=1.0.0,<1.1.15
 pylint
 pycodestyle
 Sphinx>=1.8.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

cvxpy 1.15.0 was recently released [1][2] and it has started causing CI
failures in the noise transformer tests. It fails with an error:
"The objective is not DCP. Its following subexpressions are not:"
(and then lists all the subexpressions which it doesn't like). To
unblock CI this commit caps the cvxpy version we run in CI until this
can be fixed either upstream in cvxpy or in the noise transformer.

### Details and comments

[1] https://pypi.org/project/cvxpy/1.1.15/
[2] https://github.com/cvxpy/cvxpy/releases/tag/v1.1.15