### PR TITLE
Fix bug in extended stabilizer simulator

### DIFF
--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -524,7 +524,7 @@ class AerSimulator(AerBackend):
             extended_stabilizer_metropolis_mixing_time=5000,
             extended_stabilizer_approximation_error=0.05,
             extended_stabilizer_norm_estimation_samples=100,
-            extended_stabilizer_norm_estimation_repitions=3,
+            extended_stabilizer_norm_estimation_repetitions=3,
             extended_stabilizer_parallel_threshold=100,
             extended_stabilizer_probabilities_snapshot_samples=3000,
             # MPS options

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -413,7 +413,7 @@ class QasmSimulator(AerBackend):
             extended_stabilizer_metropolis_mixing_time=5000,
             extended_stabilizer_approximation_error=0.05,
             extended_stabilizer_norm_estimation_samples=100,
-            extended_stabilizer_norm_estimation_repitions=3,
+            extended_stabilizer_norm_estimation_repetitions=3,
             extended_stabilizer_parallel_threshold=100,
             extended_stabilizer_probabilities_snapshot_samples=3000,
             # MPS options

--- a/releasenotes/notes/fix-extended-stab-pauli-24eab8c4a7c6246c.yaml
+++ b/releasenotes/notes/fix-extended-stab-pauli-24eab8c4a7c6246c.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes bug in the "extended_stabilizer" simulation method where it
+    incorrectly treated some multi-qubit Pauli instructions as unsupported
+    instructions.
+  - |
+    Fixes typo in the `AerSimulator` and ``QasmSimulator`` options for the
+    ``extended_stabilizer_norm_estimation_repetitions`` option.

--- a/releasenotes/notes/fix-extended-stab-pauli-24eab8c4a7c6246c.yaml
+++ b/releasenotes/notes/fix-extended-stab-pauli-24eab8c4a7c6246c.yaml
@@ -2,8 +2,8 @@
 fixes:
   - |
     Fixes bug in the "extended_stabilizer" simulation method where it
-    incorrectly treated some multi-qubit Pauli instructions as unsupported
-    instructions.
+    incorrectly treated delay gate and multi-qubit Pauli instructions as
+    unsupported.
   - |
     Fixes typo in the `AerSimulator` and ``QasmSimulator`` options for the
     ``extended_stabilizer_norm_estimation_repetitions`` option.

--- a/src/simulators/extended_stabilizer/gates.hpp
+++ b/src/simulators/extended_stabilizer/gates.hpp
@@ -63,7 +63,9 @@ namespace CHSimulator
     {"swap", Gatetypes::clifford}, // SWAP gate
     // Three-qubit gates
     {"ccx", Gatetypes::non_clifford},    // Controlled-CX gate (Toffoli)
-    {"ccz", Gatetypes::non_clifford}     // Constrolled-CZ gate (H3 Toff H3)
+    {"ccz", Gatetypes::non_clifford},    // Constrolled-CZ gate (H3 Toff H3)
+    // General Pauli
+    {"pauli", Gatetypes::pauli},
   };
 
   using sample_branch_t = std::pair<complex_t, Gates>;

--- a/src/simulators/extended_stabilizer/gates.hpp
+++ b/src/simulators/extended_stabilizer/gates.hpp
@@ -42,30 +42,31 @@ namespace CHSimulator
   };
 
   const AER::stringmap_t<Gatetypes> gate_types_ = {
-    {"id", Gatetypes::pauli},     // Pauli-Identity gate
-    {"x", Gatetypes::pauli},       // Pauli-X gate
-    {"y", Gatetypes::pauli},       // Pauli-Y gate
-    {"z", Gatetypes::pauli},       // Pauli-Z gate
+    // One-qubit gates
+    {"u0", Gatetypes::pauli},         // Pauli-Identity gate
+    {"delay", Gatetypes::pauli},      // Pauli-Identity gate
+    {"id", Gatetypes::pauli},         // Pauli-Identity gate
+    {"x", Gatetypes::pauli},          // Pauli-X gate
+    {"y", Gatetypes::pauli},          // Pauli-Y gate
+    {"z", Gatetypes::pauli},          // Pauli-Z gate
     {"s", Gatetypes::clifford},       // Phase gate (aka sqrt(Z) gate)
-    {"sdg", Gatetypes::clifford},   // Conjugate-transpose of Phase gate
-    {"sx", Gatetypes::clifford},    // Sqrt(X) gate
+    {"sdg", Gatetypes::clifford},     // Conjugate-transpose of Phase gate
+    {"sx", Gatetypes::clifford},      // Sqrt(X) gate
     {"h", Gatetypes::clifford},       // Hadamard gate (X + Z / sqrt(2))
-    {"t", Gatetypes::non_clifford},       // T-gate (sqrt(S))
-    {"tdg", Gatetypes::non_clifford},   // Conjguate-transpose of T gate
-    // Waltz Gates
-    {"u0", Gatetypes::pauli},     // idle gate in multiples of X90
-    {"u1", Gatetypes::non_clifford},     // zero-X90 pulse waltz gate
-    {"p", Gatetypes::non_clifford},     // zero-X90 pulse waltz gate
+    {"t", Gatetypes::non_clifford},   // T-gate (sqrt(S))
+    {"tdg", Gatetypes::non_clifford}, // Conjguate-transpose of T gate
+    {"u1", Gatetypes::non_clifford},  // zero-X90 pulse waltz gate
+    {"p", Gatetypes::non_clifford},   // zero-X90 pulse waltz gate
     // Two-qubit gates
-    {"CX", Gatetypes::clifford},     // Controlled-X gate (CNOT)
-    {"cx", Gatetypes::clifford},     // Controlled-X gate (CNOT)
-    {"cz", Gatetypes::clifford},     // Controlled-Z gate
-    {"swap", Gatetypes::clifford}, // SWAP gate
+    {"CX", Gatetypes::clifford},      // Controlled-X gate (CNOT)
+    {"cx", Gatetypes::clifford},      // Controlled-X gate (CNOT)
+    {"cz", Gatetypes::clifford},      // Controlled-Z gate
+    {"swap", Gatetypes::clifford},    // SWAP gate
     // Three-qubit gates
-    {"ccx", Gatetypes::non_clifford},    // Controlled-CX gate (Toffoli)
-    {"ccz", Gatetypes::non_clifford},    // Constrolled-CZ gate (H3 Toff H3)
-    // General Pauli
-    {"pauli", Gatetypes::pauli},
+    {"ccx", Gatetypes::non_clifford}, // Controlled-CX gate (Toffoli)
+    {"ccz", Gatetypes::non_clifford}, // Constrolled-CZ gate (H3 Toff H3)
+    // N-qubit gates
+    {"pauli", Gatetypes::pauli},      // N-qubit Pauli gate
   };
 
   using sample_branch_t = std::pair<complex_t, Gates>;

--- a/src/simulators/extended_stabilizer/gates.hpp
+++ b/src/simulators/extended_stabilizer/gates.hpp
@@ -64,7 +64,7 @@ namespace CHSimulator
     {"swap", Gatetypes::clifford},    // SWAP gate
     // Three-qubit gates
     {"ccx", Gatetypes::non_clifford}, // Controlled-CX gate (Toffoli)
-    {"ccz", Gatetypes::non_clifford}, // Constrolled-CZ gate (H3 Toff H3)
+    {"ccz", Gatetypes::non_clifford}, // Controlled-CZ gate (H3 Toff H3)
     // N-qubit gates
     {"pauli", Gatetypes::pauli},      // N-qubit Pauli gate
   };


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Fixes bug in the "extended_stabilizer" simulation method where it
    incorrectly treated some multi-qubit Pauli instructions as unsupported
    instructions.
 * Fixes typo in the `AerSimulator` and ``QasmSimulator`` options for the
    ``extended_stabilizer_norm_estimation_repetitions`` option.

### Details and comments


