### PR TITLE
Deprecate run(qobj)

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -179,10 +179,12 @@ class AerBackend(Backend, ABC):
             ValueError: if run is not implemented
         """
         if isinstance(circuits, (QasmQobj, PulseQobj)):
-            warnings.warn('Using a qobj for run() is deprecated and will be '
-                          'removed in a future release.',
-                          PendingDeprecationWarning,
-                          stacklevel=2)
+            warnings.warn(
+                'Using a qobj for run() is deprecated as of qiskit-aer 0.9.0'
+                ' and will be removed no sooner than 3 months from that release'
+                ' date. Transpiled circuits should now be passed directly using'
+                ' `backend.run(circuits, **run_options).',
+                DeprecationWarning, stacklevel=2)
             if parameter_binds:
                 raise AerError("Parameter binds can't be used with an input qobj")
             # A work around to support both qobj options and run options until

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -221,15 +221,16 @@ class PulseSimulator(AerBackend):
               of the same kwarg specified in the simulator options, the
               ``backend_options`` and the ``Qobj.config``.
         """
-        if not isinstance(schedules, list):
-            schedules = [schedules]
-        new_schedules = []
-        for circuit in schedules:
-            if isinstance(circuit, QuantumCircuit):
-                new_schedules.append(schedule(circuit, self))
-            else:
-                new_schedules.append(circuit)
-        schedules = new_schedules
+        if isinstance(schedules, list):
+            new_schedules = []
+            for i in schedules:
+                if isinstance(i, QuantumCircuit):
+                    new_schedules.append(schedule(i, self))
+                else:
+                    new_schedules.append(i)
+            schedules = new_schedules
+        elif isinstance(schedules, QuantumCircuit):
+            schedules = schedule(schedules, self)
         return super().run(schedules, validate=validate, **run_options)
 
     @property

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -220,26 +220,17 @@ class PulseSimulator(AerBackend):
             * kwarg options specified in ``run_options`` will override options
               of the same kwarg specified in the simulator options, the
               ``backend_options`` and the ``Qobj.config``.
-
-            * The entries in the ``backend_options`` will be combined with
-              the ``Qobj.config`` dictionary with the values of entries in
-              ``backend_options`` taking precedence. This kwarg is deprecated
-              and direct kwarg's should be used for options to pass them to
-              ``run_options``.
         """
-        qobj = schedules
-
-        if isinstance(qobj, list):
-            new_qobj = []
-            for circuit in qobj:
-                if isinstance(circuit, QuantumCircuit):
-                    new_qobj.append(schedule(circuit, self))
-                else:
-                    new_qobj.append(circuit)
-            qobj = new_qobj
-        elif isinstance(qobj, QuantumCircuit):
-            qobj = schedule(qobj, self)
-        return super().run(qobj, validate=validate, **run_options)
+        if not isinstance(schedules, list):
+            schedules = [schedules]
+        new_schedules = []
+        for circuit in schedules:
+            if isinstance(circuit, QuantumCircuit):
+                new_schedules.append(schedule(circuit, self))
+            else:
+                new_schedules.append(circuit)
+        schedules = new_schedules
+        return super().run(schedules, validate=validate, **run_options)
 
     @property
     def _system_model(self):

--- a/releasenotes/notes/deprecate-run-qobj-1a88c5bf0d1c0323.yaml
+++ b/releasenotes/notes/deprecate-run-qobj-1a88c5bf0d1c0323.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    Passing an assembled qobj directly to the
+    :meth:`~qiskit.providers.aer.AerSimulator.run` method of the Aer simulator
+    backends has been deprecated in favor of passing transpiled circuits
+    directly as `backend.run(circuits, **run_options)`.

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -129,7 +129,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         parameter_binds = [{theta: [0, pi, 2 * pi]}]
         res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
-        self.assertEqual(counts, [{'00': 1000}, {'11': 1000}, {'00': 1000}])
+        self.assertEqual(counts, [{'00': shots}, {'11': shots}, {'00': shots}])
 
     def test_run_path_with_expressions(self):
         """Test parameterized circuit path via backed.run()"""
@@ -145,7 +145,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         parameter_binds = [{theta: [0, pi, 2 * pi]}]
         res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
-        self.assertEqual(counts, [{'00': 1000}, {'11': 1000}, {'00': 1000}])
+        self.assertEqual(counts, [{'00': shots}, {'11': shots}, {'00': shots}])
 
     def test_run_path_with_expressions_multiple_params_per_instruction(self):
         """Test parameterized circuit path via backed.run()"""
@@ -162,11 +162,11 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         parameter_binds = [{theta: [0, pi, 2 * pi]}]
         res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
-        self.assertEqual(counts, [{'00': 1000}, {'01': 1000}, {'00': 1000}])
+        self.assertEqual(counts, [{'00': shots}, {'01': shots}, {'00': shots}])
 
     def test_run_path_with_more_params_than_expressions(self):
         """Test parameterized circuit path via backed.run()"""
-        shots = 1000
+        shots = 2000
         backend = AerSimulator()
         circuit = QuantumCircuit(2)
         theta = Parameter('theta')
@@ -180,8 +180,8 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         parameter_binds = [{theta: [0, pi, 2 * pi], phi: [0, 1, pi]}]
         res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
-        for index, expected in enumerate([{'00': 1000}, {'01': 250, '11': 750}, {'10': 1000}]):
-            self.assertDictAlmostEqual(counts[index], expected, delta=50)
+        for index, expected in enumerate([{'00': shots}, {'01': 0.25*shots, '11': 0.75*shots}, {'10': shots}]):
+            self.assertDictAlmostEqual(counts[index], expected, delta=0.05*shots)
 
     def test_run_path_multiple_circuits(self):
         """Test parameterized circuit path via backed.run()"""
@@ -195,7 +195,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         parameter_binds = [{theta: [0, pi, 2 * pi]}]*3
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
-        self.assertEqual(counts, [{'00': 1000}, {'11': 1000}, {'00': 1000}] * 3)
+        self.assertEqual(counts, [{'00': shots}, {'11': shots}, {'00': shots}] * 3)
 
     def test_run_path_with_expressions_multiple_circuits(self):
         """Test parameterized circuit path via backed.run()"""
@@ -211,7 +211,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         parameter_binds = [{theta: [0, pi, 2 * pi]}]*3
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
-        self.assertEqual(counts, [{'00': 1000}, {'11': 1000}, {'00': 1000}] * 3)
+        self.assertEqual(counts, [{'00': shots}, {'11': shots}, {'00': shots}] * 3)
 
     def test_run_path_with_expressions_multiple_params_per_instruction(self):
         """Test parameterized circuit path via backed.run()"""
@@ -228,7 +228,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         parameter_binds = [{theta: [0, pi, 2 * pi]}]*3
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
-        self.assertEqual(counts, [{'00': 1000}, {'01': 1000}, {'00': 1000}] * 3)
+        self.assertEqual(counts, [{'00': shots}, {'01': shots}, {'00': shots}] * 3)
 
     def test_run_path_with_more_params_than_expressions_multiple_circuits(self):
         """Test parameterized circuit path via backed.run()"""
@@ -246,8 +246,8 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         parameter_binds = [{theta: [0, pi, 2 * pi], phi: [0, 1, pi]}]*3
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
-        for index, expected in enumerate([{'00': 1000}, {'01': 250, '11': 750}, {'10': 1000}] * 3):
-            self.assertDictAlmostEqual(counts[index], expected, delta=0.08*shots)
+        for index, expected in enumerate([{'00': shots}, {'01': 0.25*shots, '11': 0.75*shots}, {'10': shots}] * 3):
+            self.assertDictAlmostEqual(counts[index], expected, delta=0.05*shots)
 
     def test_run_path_multiple_circuits_mismatch_length(self):
         """Test parameterized circuit path via backed.run()"""

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -78,7 +78,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
                                        measure=True,
                                        snapshot=True)
         self.assertIn('parameterizations', qobj.to_dict()['config'])
-        with self.assertRaises(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             job = backend.run(qobj, **self.BACKEND_OPTS)
             result = job.result()
             success = getattr(result, 'success', False)
@@ -104,7 +104,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
             backend=backend, measure=False, snapshot=False, save_state=True,
         )
         self.assertIn('parameterizations', qobj.to_dict()['config'])
-        with self.assertRaises(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             job = backend.run(qobj, **self.BACKEND_OPTS)
             result = job.result()
             success = getattr(result, 'success', False)

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -232,7 +232,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
 
     def test_run_path_with_more_params_than_expressions_multiple_circuits(self):
         """Test parameterized circuit path via backed.run()"""
-        shots = 1000
+        shots = 2000
         backend = AerSimulator()
         circuit = QuantumCircuit(2)
         theta = Parameter('theta')
@@ -247,7 +247,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         for index, expected in enumerate([{'00': 1000}, {'01': 250, '11': 750}, {'10': 1000}] * 3):
-            self.assertDictAlmostEqual(counts[index], expected, delta=50)
+            self.assertDictAlmostEqual(counts[index], expected, delta=0.08*shots)
 
     def test_run_path_multiple_circuits_mismatch_length(self):
         """Test parameterized circuit path via backed.run()"""

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -78,20 +78,22 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
                                        measure=True,
                                        snapshot=True)
         self.assertIn('parameterizations', qobj.to_dict()['config'])
-        job = backend.run(qobj, **self.BACKEND_OPTS)
-        result = job.result()
-        success = getattr(result, 'success', False)
-        num_circs = len(result.to_dict()['results'])
-        self.assertTrue(success)
-        self.compare_counts(result,
-                            range(num_circs),
-                            counts_targets,
-                            delta=0.1 * shots)
-        # Check snapshots
-        for j, target in enumerate(value_targets):
-            data = result.data(j)
-            for label in labels:
-                self.assertAlmostEqual(data[label], target[label], delta=1e-7)
+        with self.assertRaises(DeprecationWarning):
+            job = backend.run(qobj, **self.BACKEND_OPTS)
+            result = job.result()
+            success = getattr(result, 'success', False)
+            num_circs = len(result.to_dict()['results'])
+            self.assertTrue(success)
+            self.compare_counts(result,
+                                range(num_circs),
+                                counts_targets,
+                                delta=0.1 * shots)
+            # Check snapshots
+            for j, target in enumerate(value_targets):
+                data = result.data(j)
+                for label in labels:
+                    self.assertAlmostEqual(
+                        data[label], target[label], delta=1e-7)
 
     def test_parameterized_qobj_statevector(self):
         """Test parameterized qobj with Expectation Value snapshot and qasm simulator."""
@@ -102,15 +104,17 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
             backend=backend, measure=False, snapshot=False, save_state=True,
         )
         self.assertIn('parameterizations', qobj.to_dict()['config'])
-        job = backend.run(qobj, **self.BACKEND_OPTS)
-        result = job.result()
-        success = getattr(result, 'success', False)
-        num_circs = len(result.to_dict()['results'])
-        self.assertTrue(success)
+        with self.assertRaises(DeprecationWarning):
+            job = backend.run(qobj, **self.BACKEND_OPTS)
+            result = job.result()
+            success = getattr(result, 'success', False)
+            num_circs = len(result.to_dict()['results'])
+            self.assertTrue(success)
 
-        for j in range(num_circs):
-            statevector = result.get_statevector(j)
-            np.testing.assert_array_almost_equal(statevector, statevec_targets[j].data, decimal=7)
+            for j in range(num_circs):
+                statevector = result.get_statevector(j)
+                np.testing.assert_array_almost_equal(
+                    statevector, statevec_targets[j].data, decimal=7)
 
     def test_run_path(self):
         """Test parameterized circuit path via backed.run()"""

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -15,6 +15,7 @@ statevector_simulator, and expectation value snapshots.
 """
 
 import unittest
+from math import pi
 import numpy as np
 
 from test.terra import common
@@ -125,7 +126,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.rx(theta, 0)
         circuit.cx(0, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28]}]
+        parameter_binds = [{theta: [0, pi, 2 * pi]}]
         res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         self.assertEqual(counts, [{'00': 1000}, {'11': 1000}, {'00': 1000}])
@@ -141,7 +142,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.cx(0, 1)
         circuit.rz(theta_squared, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28]}]
+        parameter_binds = [{theta: [0, pi, 2 * pi]}]
         res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         self.assertEqual(counts, [{'00': 1000}, {'11': 1000}, {'00': 1000}])
@@ -158,7 +159,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.rz(theta_squared, 1)
         circuit.u(theta, theta_squared, theta, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28]}]
+        parameter_binds = [{theta: [0, pi, 2 * pi]}]
         res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         self.assertEqual(counts, [{'00': 1000}, {'01': 1000}, {'00': 1000}])
@@ -176,7 +177,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.rz(theta_squared, 1)
         circuit.ry(phi, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28], phi: [0, 1, 3.14]}]
+        parameter_binds = [{theta: [0, pi, 2 * pi], phi: [0, 1, pi]}]
         res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         for index, expected in enumerate([{'00': 1000}, {'01': 250, '11': 750}, {'10': 1000}]):
@@ -191,7 +192,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.rx(theta, 0)
         circuit.cx(0, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28]}]*3
+        parameter_binds = [{theta: [0, pi, 2 * pi]}]*3
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         self.assertEqual(counts, [{'00': 1000}, {'11': 1000}, {'00': 1000}] * 3)
@@ -207,7 +208,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.cx(0, 1)
         circuit.rz(theta_squared, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28]}]*3
+        parameter_binds = [{theta: [0, pi, 2 * pi]}]*3
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         self.assertEqual(counts, [{'00': 1000}, {'11': 1000}, {'00': 1000}] * 3)
@@ -224,7 +225,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.rz(theta_squared, 1)
         circuit.u(theta, theta_squared, theta, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28]}]*3
+        parameter_binds = [{theta: [0, pi, 2 * pi]}]*3
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         self.assertEqual(counts, [{'00': 1000}, {'01': 1000}, {'00': 1000}] * 3)
@@ -242,7 +243,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.rz(theta_squared, 1)
         circuit.ry(phi, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28], phi: [0, 1, 3.14]}]*3
+        parameter_binds = [{theta: [0, pi, 2 * pi], phi: [0, 1, pi]}]*3
         res = backend.run([circuit]*3, shots=shots, parameter_binds=parameter_binds).result()
         counts = res.get_counts()
         for index, expected in enumerate([{'00': 1000}, {'01': 250, '11': 750}, {'10': 1000}] * 3):
@@ -257,7 +258,7 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.rx(theta, 0)
         circuit.cx(0, 1)
         circuit.measure_all()
-        parameter_binds = [{theta: [0, 3.14, 6.28]}]
+        parameter_binds = [{theta: [0, pi, 2 * pi]}]
         with self.assertRaises(AerError):
             backend.run([circuit]*3, shots=shots, parameter_binds=[parameter_binds]).result()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Deprecate passing qobj directly to `backend.run`

### Details and comments


