### PR TITLE
MPS: Added print to log of bond dimension after internal swaps

### DIFF
--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -511,14 +511,7 @@ void State::output_bond_dimensions(const Operations::Op &op) const {
   for (uint_t index=1; index<op.qubits.size(); index++) {
     MPS::print_to_log(",", op.qubits[index]);
   }
-  MPS::print_to_log(", BD=[");
-  reg_t bd = qreg_.get_bond_dimensions();
-  for (uint_t index=0; index<bd.size(); index++) {
-    MPS::print_to_log(bd[index]);
-      if (index < bd.size()-1)
-	MPS::print_to_log(" ");
-  }
-  MPS::print_to_log("],  ");
+  qreg_.print_bond_dimensions();
   instruction_number++;
 }
 

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -551,6 +551,13 @@ void MPS::apply_swap_internal(uint_t index_A, uint_t index_B, bool swap_gate) {
     // and the qubit at index_B (or index_A+1) is moved one position 
     //to the left
     std::swap(qubit_ordering_.order_[index_A], qubit_ordering_.order_[index_B]);    
+    // For logging purposes:
+    if (MPS::get_mps_log_data()) {
+      if (swap_gate)
+	print_to_log_internal_swap(index_A, index_B);
+      else
+	print_to_log_internal_swap(index_B, index_A);
+    }
 
     // update qubit locations after all the swaps
     for (uint_t i=0; i<num_qubits_; i++)
@@ -558,6 +565,21 @@ void MPS::apply_swap_internal(uint_t index_A, uint_t index_B, bool swap_gate) {
   }
 }
 
+void MPS::print_to_log_internal_swap(uint_t qubit0, uint_t qubit1) const {
+  print_to_log("internal_swap on qubits ", qubit0, ",", qubit1);
+  print_bond_dimensions();
+}
+
+void MPS::print_bond_dimensions() const {
+  print_to_log(", BD=[");
+  reg_t bd = get_bond_dimensions();
+  for (uint_t index=0; index<bd.size(); index++) {
+    print_to_log(bd[index]);
+      if (index < bd.size()-1)
+	print_to_log(" ");
+  }
+  print_to_log("],  ");
+}
 //-------------------------------------------------------------------------
 // MPS::apply_2_qubit_gate - outline of the algorithm
 // 1. Swap qubits A and B until they are consecutive

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -552,12 +552,7 @@ void MPS::apply_swap_internal(uint_t index_A, uint_t index_B, bool swap_gate) {
     //to the left
     std::swap(qubit_ordering_.order_[index_A], qubit_ordering_.order_[index_B]);    
     // For logging purposes:
-    if (MPS::get_mps_log_data()) {
-      if (swap_gate)
-	print_to_log_internal_swap(index_A, index_B);
-      else
-	print_to_log_internal_swap(index_B, index_A);
-    }
+    print_to_log_internal_swap(index_A, index_B);
 
     // update qubit locations after all the swaps
     for (uint_t i=0; i<num_qubits_; i++)
@@ -566,7 +561,9 @@ void MPS::apply_swap_internal(uint_t index_A, uint_t index_B, bool swap_gate) {
 }
 
 void MPS::print_to_log_internal_swap(uint_t qubit0, uint_t qubit1) const {
-  print_to_log("internal_swap on qubits ", qubit0, ",", qubit1);
+  if (mps_log_data_) {
+    print_to_log("internal_swap on qubits ", qubit0, ",", qubit1);
+  }
   print_bond_dimensions();
 }
 

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -320,6 +320,7 @@ public:
   void reset(const reg_t &qubits, RngEngine &rng);
 
   reg_t get_bond_dimensions() const;
+  void print_bond_dimensions() const;
   uint_t get_max_bond_dimensions() const;
 
   mps_container_t copy_to_mps_container();
@@ -346,6 +347,8 @@ private:
   // if swap_gate==false, this is an internal swap, necessary for
   // some internal algorithm
   void apply_swap_internal(uint_t index_A, uint_t index_B, bool swap_gate=false);
+  void print_to_log_internal_swap(uint_t qubit0, uint_t qubit1) const;
+
   void apply_2_qubit_gate(uint_t index_A, uint_t index_B, 
 			  Gates gate_type, const cmatrix_t &mat,
 			  bool is_diagonal=false);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Previously, bond dimensions were printed only for user-defined operations.  Here, we add similar prints after internal swap operations.


### Details and comments


