### PR TITLE
Add concurrency limit on GHA jobs for a PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, 'stable/*']
   pull_request:
     branches: [main, 'stable/*']
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   standalone:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main, 'stable/*']
 concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   standalone:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, 'stable/*']
   pull_request:
     branches: [main, 'stable/*']
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main, 'stable/*']
 concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   docs:

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, 'stable/*']
   pull_request:
     branches: [main, 'stable/*']
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main, 'stable/*']
 concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   lint:

--- a/.github/workflows/tests_mac.yml
+++ b/.github/workflows/tests_mac.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main, 'stable/*']
 concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   lint:

--- a/.github/workflows/tests_mac.yml
+++ b/.github/workflows/tests_mac.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, 'stable/*']
   pull_request:
     branches: [main, 'stable/*']
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     runs-on: macOS-latest

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, 'stable/*']
   pull_request:
     branches: [main, 'stable/*']
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     runs-on: windows-latest

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main, 'stable/*']
 concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   lint:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a concurrency limit for jobs running from a single PR.
This means that on PR updates github actions will cancel any currently
running jobs for that because they exceed the concurrency limit on the
PR.

### Details and comments