### PR TITLE
Adjust setup.py setup_requires to only include build dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,16 +68,12 @@ from skbuild import setup
 # of requirements
 common_requirements = [
     'numpy>=1.16.3',
-    'scipy>=1.0',
-    'pybind11>=2.6'  # This isn't really an install requirement,
-                     # Pybind11 is required to be pre-installed for
-                     # CMake to successfully find header files.
-                     # This should be fixed in the CMake build files.
 ]
 
 setup_requirements = common_requirements + [
     'scikit-build>=0.11.0',
     'cmake!=3.17,!=3.17.0',
+    'pybind11>=2.6',
 ]
 
 extras_requirements = {
@@ -87,7 +83,7 @@ extras_requirements = {
 if not _DISABLE_CONAN:
     setup_requirements.append('conan>=1.22.2')
 
-requirements = common_requirements + ['qiskit-terra>=0.17.0']
+requirements = common_requirements + ['qiskit-terra>=0.17.0', 'scipy>=1.0']
 
 if not hasattr(setuptools,
                'find_namespace_packages') or not inspect.ismethod(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the setup.py setup_requires field to only include
build dependencies. Previously we were a bit aggresive in the set of
packages we specified as build dependencies in the setup.py. This dates
back to early issues building packages from sdist where things were not
properly being installed. However, this results in requiring people have
a working scipy (that setuptools/scikit-build) can find at build time.
This commit updates the setup.py to be more explicit about the packages
it requires for build time and for run time so that when users are
building from source (or sdist) it is more likely to work correctly.

### Details and comments


