### PR TITLE
Fix issue 1351

### DIFF
--- a/releasenotes/notes/fix-empty-circuit-411ff41929d9b28f.yaml
+++ b/releasenotes/notes/fix-empty-circuit-411ff41929d9b28f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes `#1351 <https://github.com/Qiskit/qiskit-aer/issue/1351>`__
+    where running an empty QuantumCircuit with a noise model set
+    would cause the simulator to crash.

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -380,7 +380,12 @@ void Circuit::set_params(bool truncation) {
 
   // Counter for current position in ops as we shuffle ops
   size_t op_idx = 0;
-  const size_t head_end = (has_measure && can_sample) ? first_measure_pos : last_ancestor_pos + 1;
+  size_t head_end = 0;
+  if (has_measure && can_sample) {
+    head_end = first_measure_pos;
+  } else if (num_ancestors > 0) {
+    head_end = last_ancestor_pos + 1;
+  }
   for (size_t pos = 0; pos < head_end; ++pos) {
     if (ops_to_remove && !ancestor[pos]) {
       // Skip if not ancestor

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -252,7 +252,8 @@ void Circuit::add_op_metadata(const Op& op) {
 void Circuit::set_params(bool truncation) {
   // Clear current circuit metadata  
   reset_metadata();
-  
+  if (ops.empty()) return;
+
   // Analyze input ops from tail to head to get locations of ancestor,
   // first measurement position and last initialize position
   const auto size = ops.size();

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -265,27 +265,25 @@ void Circuit::set_params(bool truncation) {
   size_t last_initialize_pos = 0;
   bool ops_to_remove = false;
 
-  if (!ops.empty()) {
-    std::unordered_set<uint_t> ancestor_qubits;
-    for (size_t i = 0; i < size; ++ i) {
-      const size_t rpos = size - i - 1;
-      const auto& op = ops[rpos];
-      if (!truncation || check_result_ancestor(op, ancestor_qubits)) {
-        add_op_metadata(op);
-        ancestor[rpos] = true;
-        num_ancestors++;
-        if (op.type == OpType::measure) {
-          first_measure_pos = rpos;
-          has_measure = true;
-        } else if (op.type == OpType::initialize && last_initialize_pos == 0) {
-          last_initialize_pos = rpos;
-        }
-        if (last_ancestor_pos == 0) {
-          last_ancestor_pos = rpos;
-        }
-      } else if (truncation && !ops_to_remove){
-        ops_to_remove = true;
+  std::unordered_set<uint_t> ancestor_qubits;
+  for (size_t i = 0; i < size; ++ i) {
+    const size_t rpos = size - i - 1;
+    const auto& op = ops[rpos];
+    if (!truncation || check_result_ancestor(op, ancestor_qubits)) {
+      add_op_metadata(op);
+      ancestor[rpos] = true;
+      num_ancestors++;
+      if (op.type == OpType::measure) {
+        first_measure_pos = rpos;
+        has_measure = true;
+      } else if (op.type == OpType::initialize && last_initialize_pos == 0) {
+        last_initialize_pos = rpos;
       }
+      if (last_ancestor_pos == 0) {
+        last_ancestor_pos = rpos;
+      }
+    } else if (truncation && !ops_to_remove){
+      ops_to_remove = true;
     }
   }
 

--- a/src/noise/noise_model.hpp
+++ b/src/noise/noise_model.hpp
@@ -260,6 +260,10 @@ NoiseModel::param_gate_table_ = {
 Circuit NoiseModel::sample_noise(const Circuit &circ,
                                  RngEngine &rng,
                                  const Method method) const {
+  // Check edge case of empty circuit
+  if (circ.ops.empty()) {
+    return circ;
+  }
   // Check if sampling method is enabled
   if (enabled_methods_.find(method) == enabled_methods_.end()) {
     throw std::runtime_error(

--- a/test/terra/backends/aer_simulator/test_noise.py
+++ b/test/terra/backends/aer_simulator/test_noise.py
@@ -14,15 +14,17 @@ AerSimulator Integration Tests
 """
 
 from ddt import ddt
+
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import QFT
+from qiskit.providers.aer.noise import NoiseModel, depolarizing_error
+
+from test.terra.backends.simulator_test_case import (
+    SimulatorTestCase, supported_methods)
 from test.terra.reference import ref_readout_noise
 from test.terra.reference import ref_pauli_noise
 from test.terra.reference import ref_reset_noise
 from test.terra.reference import ref_kraus_noise
-
-from qiskit.circuit.library import QFT
-import qiskit.quantum_info as qi
-from test.terra.backends.simulator_test_case import (
-    SimulatorTestCase, supported_methods)
 
 ALL_METHODS = [
     'automatic', 'stabilizer', 'statevector', 'density_matrix',
@@ -33,6 +35,16 @@ ALL_METHODS = [
 @ddt
 class TestNoise(SimulatorTestCase):
     """AerSimulator readout error noise model tests."""
+
+    @supported_methods(ALL_METHODS)
+    def test_empty_circuit_noise(self, method, device):
+        """Test simulation with empty circuit and noise model."""
+        backend = self.backend(method=method, device=device)
+        noise_model = NoiseModel()
+        noise_model.add_all_qubit_quantum_error(depolarizing_error(0.1, 1), ['x'])
+        result = backend.run(
+            QuantumCircuit(), shots=1, noise_model=noise_model).result()
+        self.assertSuccess(result)
 
     @supported_methods(ALL_METHODS)
     def test_readout_noise(self, method, device):
@@ -120,7 +132,6 @@ class TestNoise(SimulatorTestCase):
             result = backend.run(circuit, shots=shots).result()
             self.assertSuccess(result)
             self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
-
 
     @supported_methods([
         'automatic', 'statevector', 'density_matrix', 'matrix_product_state'])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1351

### Details and comments

When loading a circuit in C++ the size of an empty circuit was being set to 1 and being populated with a default initialized Op. This caused a crash when this circuit was passed to the noise sampler. This is fixed by correctly initializing an empty to be size 0.