### PR TITLE
Fix handling of bound ParameterExpressions

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -112,6 +112,10 @@ class AerBackend(Backend, ABC):
                     if param in binds:
                         parameterizations.append([[index, bind_pos], binds[param]])
                     elif isinstance(param, ParameterExpression):
+                        # If parameter expression has no unbound parameters
+                        # it's already bound and should be skipped
+                        if not param.parameters:
+                            continue
                         local_binds = {k: v for k, v in binds.items() if k in param.parameters}
                         bind_list = [dict(zip(local_binds, t)) for t in zip(*local_binds.values())]
                         bound_values = [float(param.bind(x)) for x in bind_list]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an oversight in the handling of the parameter binds
kwarg on backend.run(). To build the parameterizations representation
that aer's c++ code expects we need to iterate over all the instructions
to find any that are parameterized. In this check we were incorrectly
finding gates with ParameterExpressions that were already bound to a
value (and had no unbound parameters). This would often come up from the
transpiler when the basis translator uses a parameter expression to
adjust rotation angles when translating between 1q gates. This commit
fixes this by adding a check for fully bound parameter expressions and
not including them in the set of parameterizations we pass to the inner
simulator code.

### Details and comments

Fixes #1346