### PR TITLE
Add missing classmethod decorators from setUpClass

### DIFF
--- a/test/terra/extensions/test_snapshot_density_matrix.py
+++ b/test/terra/extensions/test_snapshot_density_matrix.py
@@ -23,6 +23,7 @@ from ..common import QiskitAerTestCase
 class TestSnapshotDensityMatrixExtension(QiskitAerTestCase):
     """SnapshotDensityMatrix extension tests"""
 
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         filterwarnings(

--- a/test/terra/extensions/test_snapshot_expectation_value.py
+++ b/test/terra/extensions/test_snapshot_expectation_value.py
@@ -26,6 +26,7 @@ from ..common import QiskitAerTestCase
 class TestSnapshotExpectationValueExtension(QiskitAerTestCase):
     """SnapshotExpectationValue extension tests"""
 
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         filterwarnings(

--- a/test/terra/extensions/test_snapshot_probabilities.py
+++ b/test/terra/extensions/test_snapshot_probabilities.py
@@ -23,6 +23,7 @@ from ..common import QiskitAerTestCase
 class TestSnapshotProbabilitiesExtension(QiskitAerTestCase):
     """SnapshotProbabilities extension tests"""
 
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         filterwarnings(

--- a/test/terra/extensions/test_snapshot_stabilizer.py
+++ b/test/terra/extensions/test_snapshot_stabilizer.py
@@ -23,6 +23,7 @@ from ..common import QiskitAerTestCase
 class TestSnapshotStabilizerExtension(QiskitAerTestCase):
     """SnapshotStbilizer extension tests"""
 
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         filterwarnings(

--- a/test/terra/extensions/test_snapshot_statevector.py
+++ b/test/terra/extensions/test_snapshot_statevector.py
@@ -23,6 +23,7 @@ from ..common import QiskitAerTestCase
 class TestSnapshotStatevectorExtension(QiskitAerTestCase):
     """SnapshotStatevector extension tests"""
 
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         filterwarnings(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Some of the deprecated snapshot tests had missing `@classmethod` decorators, causing test failures on my machine.  Not 100% sure why they weren't also causing failures in CI, to be honest.


### Details and comments


