### PR TITLE
Fix job mission pickle error for Dask Client executor

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -362,11 +362,6 @@ class AerBackend(Backend, ABC):
         for key, val in run_options.items():
             setattr(qobj.config, key, val)
 
-        # We need to remove the executor from the qobj config
-        # since it can't be serialized though JSON/Pybind.
-        if hasattr(qobj.config, 'executor'):
-            delattr(qobj.config, 'executor')
-
         return qobj
 
     @abstractmethod

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -100,8 +100,6 @@ class AerBackend(Backend, ABC):
         self._options_defaults = {}
         self._options_properties = {}
 
-        self._executor = None
-
         # Set options from backend_options dictionary
         if backend_options is not None:
             self.set_options(**backend_options)
@@ -213,11 +211,19 @@ class AerBackend(Backend, ABC):
         if validate:
             self._validate(qobj)
 
+        # Get executor from qobj config and delete attribute so qobj can still be serialized
+        executor = getattr(qobj.config, 'executor', None)
+        if hasattr(qobj.config, 'executor'):
+            delattr(qobj.config, 'executor')
+
         # Optionally split the job
         experiments = split_qobj(qobj, max_size=getattr(qobj.config, 'max_job_size', None))
 
-        # Get the executor
-        executor = self._get_executor(**run_options) or self._executor
+        # Temporarily remove any executor from options so that job submission
+        # can work with Dask client executors which can't be pickled
+        opts_executor = getattr(self._options, 'executor', None)
+        if hasattr(self._options, 'executor'):
+            self._options.executor = None
 
         # Submit job
         job_id = str(uuid.uuid4())
@@ -226,7 +232,11 @@ class AerBackend(Backend, ABC):
         else:
             aer_job = AerJob(self, job_id, self._run, experiments, executor)
         aer_job.submit()
-        self._executor = executor
+
+        # Restore removed executor after submission
+        if hasattr(self._options, 'executor'):
+            self._options.executor = opts_executor
+
         return aer_job
 
     def configuration(self):
@@ -358,16 +368,6 @@ class AerBackend(Backend, ABC):
             delattr(qobj.config, 'executor')
 
         return qobj
-
-    def _get_executor(self, **run_options):
-        """Get the executor"""
-        if 'executor' in run_options:
-            return run_options['executor']
-        else:
-            _executor = getattr(self._options, 'executor', None)
-            if _executor:
-                delattr(self._options, 'executor')
-            return _executor
 
     @abstractmethod
     def _execute(self, qobj):

--- a/releasenotes/notes/fix-dask-fe5813daeec259ce.yaml
+++ b/releasenotes/notes/fix-dask-fe5813daeec259ce.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes issue where using a Dask Client executor would cause an error at
+    job submission due to the executor Client not being pickleable.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
FIx issue #1364 

### Details and comments
DASK can pickle the object stored in a only local variable. If the dask executor is passed to qobj or class variables, dask occurs a serialization error when the first `run()` is called. So we need to store the executor variable to `self._executor` after `submit()` function. 

