### PR TITLE
MPS: Normalize lambda after every svd

### DIFF
--- a/releasenotes/notes/mps_normalize_lambda-9d931abbfb6d4d2c.yaml
+++ b/releasenotes/notes/mps_normalize_lambda-9d931abbfb6d4d2c.yaml
@@ -1,0 +1,10 @@
+---
+
+fixes:
+  - |
+    Slight errors in the computation of lambda may give a norm slightly off 1,
+    even without truncation. During measurement these errors may build up when
+    many qubits are involved, eventually leading to a segmentation fault.
+    Therefore always check its norm, and normalize if needed.
+
+

--- a/releasenotes/notes/mps_normalize_lambda-9d931abbfb6d4d2c.yaml
+++ b/releasenotes/notes/mps_normalize_lambda-9d931abbfb6d4d2c.yaml
@@ -2,9 +2,6 @@
 
 fixes:
   - |
-    Slight errors in the computation of lambda may give a norm slightly off 1,
-    even without truncation. During measurement these errors may build up when
-    many qubits are involved, eventually leading to a segmentation fault.
-    Therefore always check its norm, and normalize if needed.
-
-
+    Fixed an issue with the `matrix_product_state` simulation method where
+    the accumulation of small rounding errors during measurement of many
+    quits could sometimes cause a segmentation fault.

--- a/src/simulators/matrix_product_state/svd.cpp
+++ b/src/simulators/matrix_product_state/svd.cpp
@@ -127,14 +127,15 @@ double reduce_zeros(cmatrix_t &U, rvector_t &S, cmatrix_t &V,
     for (uint_t i=new_SV_num; i<SV_num; i++) {
       discarded_value += std::norm(S[i]);
     }
-    // After approximation, we may need to re-normalize the values of S
-    double new_sum_squares = 0;
-    for (uint_t i=0; i<S.size(); i++) 
-      new_sum_squares +=std::norm(S[i]);
-    
-    double sqrt_sum = std::sqrt(new_sum_squares);
-    for (uint_t i=0; i<S.size(); i++)
-      S[i] /= sqrt_sum;
+  }
+  // Check if we need to re-normalize the values of S
+  double new_sum_squares = 0;
+  for (uint_t i=0; i<S.size(); i++) 
+    new_sum_squares +=std::norm(S[i]);
+  if (!Linalg::almost_equal(new_sum_squares, 1.0, THRESHOLD)) {
+	double sqrt_sum = std::sqrt(new_sum_squares);
+	for (uint_t i=0; i<S.size(); i++)
+	  S[i] /= sqrt_sum;
   }
   return discarded_value;
 }

--- a/src/simulators/matrix_product_state/svd.cpp
+++ b/src/simulators/matrix_product_state/svd.cpp
@@ -132,7 +132,7 @@ double reduce_zeros(cmatrix_t &U, rvector_t &S, cmatrix_t &V,
   double new_sum_squares = 0;
   for (uint_t i=0; i<S.size(); i++) 
     new_sum_squares +=std::norm(S[i]);
-  if (!Linalg::almost_equal(new_sum_squares, 1.0, THRESHOLD)) {
+  if (!Linalg::almost_equal(1.0 - new_sum_squares, 0., THRESHOLD)) {
 	double sqrt_sum = std::sqrt(new_sum_squares);
 	for (uint_t i=0; i<S.size(); i++)
 	  S[i] /= sqrt_sum;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The norm of lambda after svd may be slightly off 1 even without truncation. Therefore  always check its norm, and normalize if needed.


### Details and comments
Slight errors in the computation of lambda during measurement may build up when many qubits are involved, eventually leading to a segmentation fault.

