### PR TITLE
Fix automatic method selection when some circuits have invalid instructions

### DIFF
--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -1732,8 +1732,11 @@ Controller::simulation_methods(std::vector<Circuit> &circuits,
         method = automatic_simulation_method(circ, noise_model);
 
       }
+      // If setting a method for this circuit raised an exception fallback to
+      // a default of statevector. The execution will fail but we will get
+      // partial result generation and generate a user facing error message
       catch (std::exception &e) {
-        continue;
+        method = Method::statevector;
       }
       sim_methods.push_back(method);
       if (!superop_enabled && (method == Method::density_matrix || method == Method::superop)) {

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -1727,7 +1727,14 @@ Controller::simulation_methods(std::vector<Circuit> &circuits,
     bool superop_enabled = false;
     bool kraus_enabled = false;
     for (const auto& circ: circuits) {
-      auto method = automatic_simulation_method(circ, noise_model);
+      Controller::Method method;
+      try {
+        method = automatic_simulation_method(circ, noise_model);
+
+      }
+      catch (std::exception &e) {
+        continue;
+      }
       sim_methods.push_back(method);
       if (!superop_enabled && (method == Method::density_matrix || method == Method::superop)) {
         noise_model.enable_superop_method(max_parallel_threads_);
@@ -1738,7 +1745,9 @@ Controller::simulation_methods(std::vector<Circuit> &circuits,
         kraus_enabled = true;
       }
     }
-    return sim_methods;
+    if (!sim_methods.empty()) {
+        return sim_methods;
+    }
   }
 
   // Use non-automatic default method for all circuits

--- a/test/terra/backends/aer_simulator/test_auto_method.py
+++ b/test/terra/backends/aer_simulator/test_auto_method.py
@@ -224,14 +224,13 @@ class TestSimulationMethod(SimulatorTestCase):
         qc.h(0)
         qc.cx(0, 1)
         qc.measure_all()
-        circuits.append(qc)
         qc_2 = QuantumVolume(5)
         qc_2.measure_all()
         circuits.append(qc_2)
+        circuits.append(qc)
         backend = self.backend()
         shots = 100
         result = backend.run(circuits, shots=shots).result()
         self.assertEqual(result.status, 'PARTIAL COMPLETED')
-
-        self.assertTrue(hasattr(result.results[0].data, 'counts'))
-        self.assertFalse(hasattr(result.results[1].data, 'counts'))
+        self.assertTrue(hasattr(result.results[1].data, 'counts'))
+        self.assertFalse(hasattr(result.results[0].data, 'counts'))

--- a/test/terra/backends/aer_simulator/test_auto_method.py
+++ b/test/terra/backends/aer_simulator/test_auto_method.py
@@ -17,6 +17,8 @@ from ddt import ddt, data
 
 from test.terra.reference import ref_2q_clifford
 from test.terra.reference import ref_non_clifford
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import QuantumVolume
 from qiskit.providers.aer import QasmSimulator
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors import QuantumError
@@ -215,3 +217,21 @@ class TestSimulationMethod(SimulatorTestCase):
         success = getattr(result, 'success', False)
         self.compare_result_metadata(result, circuits, 'method', "density_matrix")
 
+    def test_auto_method_partial_result_a_single_invalid_circuit(self):
+        """Test a partial result is returned with a job with a valid and invalid circuit."""
+        circuits = []
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure_all()
+        circuits.append(qc)
+        qc_2 = QuantumVolume(5)
+        qc_2.measure_all()
+        circuits.append(qc_2)
+        backend = self.backend()
+        shots = 100
+        result = backend.run(circuits, shots=shots).result()
+        self.assertEqual(result.status, 'PARTIAL COMPLETED')
+
+        self.assertTrue(hasattr(result.results[0].data, 'counts'))
+        self.assertFalse(hasattr(result.results[1].data, 'counts'))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When the automatic method detection loop was moved to occur once ahead
of time in #1312 the loop over all circuits there was not tolerant of
any circuits in a job with multiple circuits being invalid for all
simulation methods. This was an unexpected change from the previous
behavior where we would return a partial result and only the circuits
with no matching methods would error and the other results would be
returned. This commit fixes the behavior and restores the partial result
generation and only errors for the jobs where the circuit is not
runnable.

### Details and comments

Fixes #1370
