### PR TITLE
Ensure error results include empry results field

### DIFF
--- a/src/framework/results/result.hpp
+++ b/src/framework/results/result.hpp
@@ -73,8 +73,12 @@ json_t Result::to_json() {
   js["backend_version"] = backend_version;
   js["date"] = date;
   js["job_id"] = job_id;
-  for (auto& res : results) {
-    js["results"].push_back(res.to_json());
+  if (results.empty()) {
+    js["results"] = json_t::array({});
+  } else {
+      for (auto& res : results) {
+        js["results"].push_back(res.to_json());
+      }
   }
   if (header.empty() == false)
     js["header"] = header;


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The IBM Quantum API results schema says that the results field is
required [1]. However, when aer standalone returned an error response
this field was missing. Since we want aer standalone to be compliant with
the IBM Quantum API schemas this field should be included in the
response even if there are no results. This commit updates the results
json generation to include an empty json array when the results vector
is empty so it'll be in the output json.

### Details and comments

Related to #1370

[1] https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/result_schema.json#L107
