### PR TITLE
Remove duplicate build of aer from tutorials job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,6 @@ jobs:
           pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
           pip install -c constraints.txt .
           pip install -U "qiskit-ibmq-provider" "z3-solver" "qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" jupyter pylatexenc nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
-          python setup.py build_ext --inplace
           sudo apt install -y graphviz pandoc libopenblas-dev
           pip check
         shell: bash


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the recent release of pip 21.3 the method of how in-repo builds was
changed to be done in place. This change caused a conflict with how the
tutorial jobs were setup where they were building aer twice
inadvertently, once to build the package and a second time to build the
binaries in place in the source for when the notebooks are executed.
This second step wasn't necessary originally and was masking the real
issue (the conflict with qiskit/ in the working dir and the python env).
However, now that we're building binaries in place this is coming to a
head. This commit attempts to fix the issue by removing the second build
since it's not necessary, if we still have issues after this change we
can just run the tutorial from a different working directory and it
should use the prior build.

### Details and comments


