### PR TITLE
Include pyproject.toml in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include MANIFEST.in
 include README.md
+include pyproject.toml
 recursive-include qiskit *pyx
 recursive-include qiskit *pxd
 recursive-include qiskit *.pxi


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since qiskit-aer uses scikit-build instead of setuptools directly we
have not been including our pyproject.toml file in the sdist. This has
the undesired effect of causing pip to not find the setup/build
requirements until it's processing the sdist (and sees the
setup_requires list). While in theory this should be sufficient it's not
because setuptools relies on easy_install instead of pip to install the
packages in the setup_requires list. easy_install doesn't respect the
same options as pip and in environments with custom mirrors (like
piwheels for raspberry pi users) this can cause build dependencies to
needlessly be built from source or not install correctly as easy_install
will unconditionally go to PyPI and try to install everything in the
setup_requires list. Having a pyproject.toml fixes this because pip
respects PEP517 and will look in the pyproject.toml first and install the
build-system requirements prior to running the setup.py. When a setup.py
uses setuptools instead of scikit-build the pyproject.toml is always
included in the sdist if present without any manual intervention needed.
However, with scikit-build it includes the pyproject.toml by default by
bundling it in the generated MANIFEST file, unless there is a MANIFEST.in
present (like we have in aer) which overrides the default MANIFEST
generated. This commit fixes this issue by explicitly adding the
pyproject.toml to the MANIFEST.in file ensuring it gets included in the
scikit-build generated MANIFEST which means it will get included in the
output sdist.

### Details and comments


