### PR TITLE
Fix deprecated qiskit.util imports

### DIFF
--- a/qiskit/providers/aer/backends/backend_utils.py
+++ b/qiskit/providers/aer/backends/backend_utils.py
@@ -16,7 +16,7 @@ Qiskit Aer simulator backend utils
 """
 import os
 from math import log2
-from qiskit.util import local_hardware_info
+from qiskit.utils import local_hardware_info
 from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import assemble
 from qiskit.qobj import QasmQobjInstruction

--- a/qiskit/providers/aer/backends/statevector_simulator.py
+++ b/qiskit/providers/aer/backends/statevector_simulator.py
@@ -16,7 +16,7 @@ Qiskit Aer statevector simulator backend.
 import copy
 import logging
 from warnings import warn
-from qiskit.util import local_hardware_info
+from qiskit.utils import local_hardware_info
 from qiskit.providers.options import Options
 from qiskit.providers.models import QasmBackendConfiguration
 

--- a/qiskit/providers/aer/backends/unitary_simulator.py
+++ b/qiskit/providers/aer/backends/unitary_simulator.py
@@ -17,7 +17,7 @@ Qiskit Aer Unitary Simulator Backend.
 import copy
 import logging
 from warnings import warn
-from qiskit.util import local_hardware_info
+from qiskit.utils import local_hardware_info
 from qiskit.providers.options import Options
 from qiskit.providers.models import QasmBackendConfiguration
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The proper name is `qiskit.utils`, but Terra hasn't been issuing very strong deprecation warnings yet.

### Details and comments

See also Qiskit/qiskit-terra#7208

