### PR TITLE
fix wrong memory free in avx2

### DIFF
--- a/src/simulators/statevector/qv_avx2.cpp
+++ b/src/simulators/statevector/qv_avx2.cpp
@@ -1207,10 +1207,8 @@ Avx apply_diagonal_matrix_avx<double>(double* qv_data_,
 
   avx_apply_lambda(data_size >> (batch + 1), 1, lambda, omp_threads, input_vec);
 
-#pragma omp parallel for if (omp_threads > 1) num_threads(omp_threads)
-  for (int i = 0; i < omp_threads; ++i) {
-    free(double_tls);
-  }
+#pragma omp parallel if (omp_threads > 1) num_threads(omp_threads)
+  free(double_tls);
 
   return Avx::Applied;
 }
@@ -1267,10 +1265,8 @@ Avx apply_diagonal_matrix_avx<float>(float* qv_data_,
 
   avx_apply_lambda(data_size >> (batch + 2), 1, lambda, omp_threads, input_vec);
 
-#pragma omp parallel for if (omp_threads > 1) num_threads(omp_threads)
-  for (int i = 0; i < omp_threads; ++i) {
-    free(float_tls);
-  }
+#pragma omp parallel if (omp_threads > 1) num_threads(omp_threads)
+  free(float_tls);
 
   return Avx::Applied;
 }

--- a/src/simulators/statevector/qv_avx2.cpp
+++ b/src/simulators/statevector/qv_avx2.cpp
@@ -1174,7 +1174,6 @@ Avx apply_diagonal_matrix_avx<double>(double* qv_data_,
 
 #pragma omp parallel if (omp_threads > 1) num_threads(omp_threads)
   {
-    double_tls = reinterpret_cast<std::complex<double>*>(malloc(sizeof(std::complex<double>*)));
 #if !defined(_WIN64) && !defined(_WIN32)
     void* data = nullptr;
     posix_memalign(&data, 64, sizeof(std::complex<double>) * 2);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes wrong memory free in avx2 for diagonal matrix multiplication if a number of shots is less than of cores.

### Details and comments

Memory free does not work correctly in avx2. Especially, the following code fails if a number of cores is less than 10, which is a configured `shots`.

```
from qiskit import Aer, transpile
from qiskit.providers.aer import AerSimulator
from qiskit.circuit.library import QuantumVolume
from qiskit.providers.aer.noise import NoiseModel
from qiskit.providers.aer.noise import depolarizing_error

noise_model = NoiseModel()
noise_model.add_all_qubit_quantum_error(depolarizing_error(0.05, 1), ['u'])
qbackend = AerSimulator(noise_model=noise_model, method="statevector")

circ_list = []
circ = transpile(QuantumVolume(num_qubits=15, depth=1), basis_gates=['u','cx'])
circ.measure_all()

result = qbackend.run(circ, shots=10).result()
```

This PR will fix this issue.