### PR TITLE
Format results and store save type metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ test/.asv
 docs/_build/
 docs/stubs/
 docs/api/
+
+# Ignore DASK temporary files
+dask-worker-space/*

--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -390,8 +390,8 @@ class AerSimulator(AerBackend):
             'quantum_channel', 'qerror_loc', 'roerror', 'snapshot',
             'save_expval', 'save_expval_var',
             'save_probabilities', 'save_probabilities_dict',
-            'save_amplitudes_sq', 'save_state', 'save_stabilizer',
-            'set_stabilizer'
+            'save_amplitudes_sq', 'save_state', 'save_clifford',
+            'save_stabilizer', 'set_stabilizer'
         ]),
         'extended_stabilizer': sorted([
             'quantum_channel', 'qerror_loc', 'roerror', 'snapshot', 'save_statevector'

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -33,6 +33,7 @@ from qiskit.utils import deprecate_arguments
 from ..aererror import AerError
 from ..jobs import AerJob, AerJobSet, split_qobj
 from ..noise.noise_model import NoiseModel, QuantumErrorLocation
+from .backend_utils import format_save_type
 
 # Logger
 logger = logging.getLogger(__name__)
@@ -279,7 +280,7 @@ class AerBackend(Backend, ABC):
             pending_jobs=0,
             status_msg='')
 
-    def _run(self, qobj, job_id=''):
+    def _run(self, qobj, job_id='', format_result=True):
         """Run a job"""
         # Start timer
         start = time.time()
@@ -310,7 +311,21 @@ class AerBackend(Backend, ABC):
             if "status" in output:
                 msg += f" and returned the following error message:\n{output['status']}"
             logger.warning(msg)
+        if format_result:
+            return self._format_results(output)
+        return output
 
+    @staticmethod
+    def _format_results(output):
+        """Format C++ simulator output for constructing Result"""
+        for result in output["results"]:
+            data = result.get("data", {})
+            metadata = result.get("metadata", {})
+            save_types = metadata.get("result_types", {})
+            save_subtypes = metadata.get("result_subtypes", {})
+            for key, val in data.items():
+                if key in save_types:
+                    data[key] = format_save_type(val, save_types[key], save_subtypes[key])
         return Result.from_dict(output)
 
     def _assemble(self, circuits, parameter_binds=None, **run_options):

--- a/qiskit/providers/aer/backends/backend_utils.py
+++ b/qiskit/providers/aer/backends/backend_utils.py
@@ -20,6 +20,10 @@ from qiskit.utils import local_hardware_info
 from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import assemble
 from qiskit.qobj import QasmQobjInstruction
+from qiskit.result import ProbDistribution
+from qiskit.quantum_info import (
+    Statevector, DensityMatrix, Operator, Clifford, SuperOp)
+
 
 # Available system memory
 SYSTEM_MEMORY_GB = local_hardware_info()['memory']
@@ -172,3 +176,32 @@ def map_legacy_method_options(qobj):
     if method in LEGACY_METHOD_MAP:
         qobj.config.method, qobj.config.device = LEGACY_METHOD_MAP[method]
     return qobj
+
+
+def format_save_type(data, save_type, save_subtype):
+    """Format raw simulator result data based on save type."""
+    init_fns = {
+        "save_statevector": Statevector,
+        "save_density_matrix": DensityMatrix,
+        "save_unitary": Operator,
+        "save_superop": SuperOp,
+        "save_stabilizer": Clifford.from_dict,
+        "save_probabilities_dict": ProbDistribution,
+    }
+
+    # Non-handled cases return raw data
+    if save_type not in init_fns:
+        return data
+
+    if save_subtype in ["list", "c_list"]:
+        def func(data):
+            init_fn = init_fns[save_type]
+            return [init_fn(i) for i in data]
+    else:
+        func = init_fns[save_type]
+
+    # Conditional save
+    if save_subtype[:2] == "c_":
+        return {key: func(val) for key, val in data.items()}
+
+    return func(data)

--- a/qiskit/providers/aer/backends/backend_utils.py
+++ b/qiskit/providers/aer/backends/backend_utils.py
@@ -22,7 +22,7 @@ from qiskit.compiler import assemble
 from qiskit.qobj import QasmQobjInstruction
 from qiskit.result import ProbDistribution
 from qiskit.quantum_info import (
-    Statevector, DensityMatrix, Operator, Clifford, SuperOp)
+    Statevector, DensityMatrix, StabilizerState, Operator, Clifford, SuperOp)
 
 
 # Available system memory
@@ -185,7 +185,8 @@ def format_save_type(data, save_type, save_subtype):
         "save_density_matrix": DensityMatrix,
         "save_unitary": Operator,
         "save_superop": SuperOp,
-        "save_stabilizer": Clifford.from_dict,
+        "save_stabilizer": (lambda data: StabilizerState(Clifford.from_dict(data))),
+        "save_clifford": Clifford.from_dict,
         "save_probabilities_dict": ProbDistribution,
     }
 

--- a/qiskit/providers/aer/backends/backend_utils.py
+++ b/qiskit/providers/aer/backends/backend_utils.py
@@ -21,8 +21,9 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import assemble
 from qiskit.qobj import QasmQobjInstruction
 from qiskit.result import ProbDistribution
-from qiskit.quantum_info import (
-    Statevector, DensityMatrix, StabilizerState, Operator, Clifford, SuperOp)
+from qiskit.quantum_info import Clifford
+from .compatibility import (
+    Statevector, DensityMatrix, StabilizerState, Operator, SuperOp)
 
 
 # Available system memory

--- a/qiskit/providers/aer/backends/compatibility.py
+++ b/qiskit/providers/aer/backends/compatibility.py
@@ -26,6 +26,7 @@ import qiskit.quantum_info as qi
 
 
 class Statevector(qi.Statevector):
+    """Aer result backwards compatibility wrapper for qiskit Statevector."""
 
     def __getattr__(self, attr):
         if hasattr(self.data, attr):
@@ -41,13 +42,14 @@ class Statevector(qi.Statevector):
 
     def __eq__(self, other):
         return (
-            isinstance(self, type(self))
-            and self._op_shape == other._op_shape
-            and np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
+            isinstance(self, type(self)) and
+            self._op_shape == other._op_shape and
+            np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
         )
 
 
 class DensityMatrix(qi.DensityMatrix):
+    """Aer result backwards compatibility wrapper for qiskit DensityMatrix."""
 
     def __getattr__(self, attr):
         if hasattr(self.data, attr):
@@ -63,13 +65,14 @@ class DensityMatrix(qi.DensityMatrix):
 
     def __eq__(self, other):
         return (
-            isinstance(self, type(self))
-            and self._op_shape == other._op_shape
-            and np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
+            isinstance(self, type(self)) and
+            self._op_shape == other._op_shape and
+            np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
         )
 
 
 class Operator(qi.Operator):
+    """Aer result backwards compatibility wrapper for qiskit Operator."""
 
     def __getattr__(self, attr):
         if hasattr(self.data, attr):
@@ -85,13 +88,14 @@ class Operator(qi.Operator):
 
     def __eq__(self, other):
         return (
-            isinstance(self, type(self))
-            and self._op_shape == other._op_shape
-            and np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
+            isinstance(self, type(self)) and
+            self._op_shape == other._op_shape and
+            np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
         )
 
 
 class SuperOp(qi.SuperOp):
+    """Aer result backwards compatibility wrapper for qiskit SuperOp."""
 
     def __getattr__(self, attr):
         if hasattr(self.data, attr):
@@ -107,13 +111,14 @@ class SuperOp(qi.SuperOp):
 
     def __eq__(self, other):
         return (
-            isinstance(self, type(self))
-            and self._op_shape == other._op_shape
-            and np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
+            isinstance(self, type(self)) and
+            self._op_shape == other._op_shape and
+            np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
         )
 
 
 class StabilizerState(qi.StabilizerState):
+    """Aer result backwards compatibility wrapper for qiskit StabilizerState."""
 
     def __getattr__(self, attr):
         if hasattr(dict, attr):

--- a/qiskit/providers/aer/backends/compatibility.py
+++ b/qiskit/providers/aer/backends/compatibility.py
@@ -44,7 +44,7 @@ class Statevector(qi.Statevector):
                 " and will result in an error in a future release. Use the `.data`"
                 " property to access the the stored ndarray for the Statevector.",
                 DeprecationWarning, stacklevel=2)
-            return getattr(self.data, attr)
+            return getattr(self._data, attr)
         return getattr(super(), attr)
 
     def __eq__(self, other):
@@ -67,7 +67,7 @@ class DensityMatrix(qi.DensityMatrix):
                 " and will result in an error in a future release. Use the `.data`"
                 " property to access the the stored ndarray for the DensityMatrix.",
                 DeprecationWarning, stacklevel=2)
-            return getattr(self.data, attr)
+            return getattr(self._data, attr)
         return getattr(super(), attr)
 
     def __eq__(self, other):
@@ -90,7 +90,7 @@ class Operator(qi.Operator):
                 " and will result in an error in a future release. Use the `.data`"
                 " property to access the the stored ndarray for the Operator.",
                 DeprecationWarning, stacklevel=2)
-            return getattr(self.data, attr)
+            return getattr(self._data, attr)
         return getattr(super(), attr)
 
     def __eq__(self, other):
@@ -113,7 +113,7 @@ class SuperOp(qi.SuperOp):
                 " and will result in an error in a future release. Use the `.data`"
                 " property to access the the stored ndarray for the SuperOp.",
                 DeprecationWarning, stacklevel=2)
-            return getattr(self.data, attr)
+            return getattr(self._data, attr)
         return getattr(super(), attr)
 
     def __eq__(self, other):

--- a/qiskit/providers/aer/backends/compatibility.py
+++ b/qiskit/providers/aer/backends/compatibility.py
@@ -1,0 +1,140 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Compatibility classes for changes to save instruction return types.
+
+These subclasses include a `__getattr__` method that allows existing
+code which used numpy.ndarray attributes to continue functioning with
+a deprecation warning.
+
+Numpy functions that consumed these classes should already work due to
+them having an `__array__` method for implicit array conversion.
+"""
+
+import warnings
+import numpy as np
+import qiskit.quantum_info as qi
+
+
+class Statevector(qi.Statevector):
+
+    def __getattr__(self, attr):
+        if hasattr(self.data, attr):
+            warnings.warn(
+                "The return type of saved statevectors has been changed from"
+                " a `numpy.ndarray` to a `qiskit.quantum_info.Statevector` as"
+                "of qiskit-aer 0.10. Accessing numpy array attributes is deprecated"
+                " and will result in an error in a future release. Use the `.data`"
+                " property to access the the stored ndarray for the Statevector.",
+                DeprecationWarning, stacklevel=2)
+            return getattr(self.data, attr)
+        return super().__getattribute__(attr)
+
+    def __eq__(self, other):
+        return (
+            isinstance(self, type(self))
+            and self._op_shape == other._op_shape
+            and np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
+        )
+
+
+class DensityMatrix(qi.DensityMatrix):
+
+    def __getattr__(self, attr):
+        if hasattr(self.data, attr):
+            warnings.warn(
+                "The return type of saved density matrices has been changed from"
+                " a `numpy.ndarray` to a `qiskit.quantum_info.DensityMatrix` as"
+                "of qiskit-aer 0.10. Accessing numpy array attributes is deprecated"
+                " and will result in an error in a future release. Use the `.data`"
+                " property to access the the stored ndarray for the DensityMatrix.",
+                DeprecationWarning, stacklevel=2)
+            return getattr(self.data, attr)
+        return super().__getattribute__(attr)
+
+    def __eq__(self, other):
+        return (
+            isinstance(self, type(self))
+            and self._op_shape == other._op_shape
+            and np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
+        )
+
+
+class Operator(qi.Operator):
+
+    def __getattr__(self, attr):
+        if hasattr(self.data, attr):
+            warnings.warn(
+                "The return type of saved unitaries has been changed from"
+                " a `numpy.ndarray` to a `qiskit.quantum_info.Operator` as"
+                "of qiskit-aer 0.10. Accessing numpy array attributes is deprecated"
+                " and will result in an error in a future release. Use the `.data`"
+                " property to access the the stored ndarray for the Operator.",
+                DeprecationWarning, stacklevel=2)
+            return getattr(self.data, attr)
+        return super().__getattribute__(attr)
+
+    def __eq__(self, other):
+        return (
+            isinstance(self, type(self))
+            and self._op_shape == other._op_shape
+            and np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
+        )
+
+
+class SuperOp(qi.SuperOp):
+
+    def __getattr__(self, attr):
+        if hasattr(self.data, attr):
+            warnings.warn(
+                "The return type of saved superoperators has been changed from"
+                " a `numpy.ndarray` to a `qiskit.quantum_info.SuperOp` as"
+                "of qiskit-aer 0.10. Accessing numpy array attributes is deprecated"
+                " and will result in an error in a future release. Use the `.data`"
+                " property to access the the stored ndarray for the SuperOp.",
+                DeprecationWarning, stacklevel=2)
+            return getattr(self.data, attr)
+        return super().__getattribute__(attr)
+
+    def __eq__(self, other):
+        return (
+            isinstance(self, type(self))
+            and self._op_shape == other._op_shape
+            and np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
+        )
+
+
+class StabilizerState(qi.StabilizerState):
+
+    def __getattr__(self, attr):
+        if hasattr(dict, attr):
+            warnings.warn(
+                "The return type of saved stabilizers has been changed from"
+                " a `dict` to a `qiskit.quantum_info.StabilizerState` as of qiskit-aer 0.10."
+                " Accessing dict attributes is deprecated and will result in an"
+                " error in a future release. Use the `.clifford.to_dict()` methods to access "
+                " the stored Clifford operator and convert to a dictionary.",
+                DeprecationWarning, stacklevel=2)
+            return getattr(self.clifford.to_dict(), attr)
+        return super().__getattribute__(attr)
+
+    def __getitem__(self, item):
+        if item in ["stabilizer", "destabilizer"]:
+            warnings.warn(
+                "The return type of saved stabilizers has been changed from"
+                " a `dict` to a `qiskit.quantum_info.StabilizerState` as of qiskit-aer 0.10."
+                " Accessing dict items is deprecated and will result in an"
+                " error in a future release. Use the `.clifford.to_dict()` methods to access "
+                " the stored Clifford operator and convert to a dictionary.",
+                DeprecationWarning, stacklevel=2)
+            return self.clifford.to_dict()[item]
+        raise TypeError("'StabilizerState object is not subscriptable'")

--- a/qiskit/providers/aer/backends/compatibility.py
+++ b/qiskit/providers/aer/backends/compatibility.py
@@ -42,7 +42,7 @@ class Statevector(qi.Statevector):
 
     def __eq__(self, other):
         return (
-            isinstance(self, type(self)) and
+            isinstance(self, type(other)) and
             self._op_shape == other._op_shape and
             np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
         )
@@ -65,7 +65,7 @@ class DensityMatrix(qi.DensityMatrix):
 
     def __eq__(self, other):
         return (
-            isinstance(self, type(self)) and
+            isinstance(self, type(other)) and
             self._op_shape == other._op_shape and
             np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
         )
@@ -84,11 +84,11 @@ class Operator(qi.Operator):
                 " property to access the the stored ndarray for the Operator.",
                 DeprecationWarning, stacklevel=2)
             return getattr(self.data, attr)
-        return super().__getattribute__(attr)
+        return getattr(super(), attr)
 
     def __eq__(self, other):
         return (
-            isinstance(self, type(self)) and
+            isinstance(self, type(other)) and
             self._op_shape == other._op_shape and
             np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
         )
@@ -107,11 +107,11 @@ class SuperOp(qi.SuperOp):
                 " property to access the the stored ndarray for the SuperOp.",
                 DeprecationWarning, stacklevel=2)
             return getattr(self.data, attr)
-        return super().__getattribute__(attr)
+        return getattr(super(), attr)
 
     def __eq__(self, other):
         return (
-            isinstance(self, type(self)) and
+            isinstance(self, type(other)) and
             self._op_shape == other._op_shape and
             np.allclose(self.data, other.data, rtol=self.rtol, atol=self.atol)
         )
@@ -130,7 +130,7 @@ class StabilizerState(qi.StabilizerState):
                 " the stored Clifford operator and convert to a dictionary.",
                 DeprecationWarning, stacklevel=2)
             return getattr(self.clifford.to_dict(), attr)
-        return super().__getattribute__(attr)
+        return getattr(super(), attr)
 
     def __getitem__(self, item):
         if item in ["stabilizer", "destabilizer"]:

--- a/qiskit/providers/aer/backends/compatibility.py
+++ b/qiskit/providers/aer/backends/compatibility.py
@@ -25,11 +25,18 @@ import numpy as np
 import qiskit.quantum_info as qi
 
 
+def _forward_attr(attr):
+    """Return True if attribute should be passed to legacy class"""
+    if attr[:2] == '__' or attr in ['_data', '_op_shape']:
+        return False
+    return True
+
+
 class Statevector(qi.Statevector):
     """Aer result backwards compatibility wrapper for qiskit Statevector."""
 
     def __getattr__(self, attr):
-        if hasattr(self.data, attr):
+        if _forward_attr(attr) and hasattr(self._data, attr):
             warnings.warn(
                 "The return type of saved statevectors has been changed from"
                 " a `numpy.ndarray` to a `qiskit.quantum_info.Statevector` as"
@@ -52,7 +59,7 @@ class DensityMatrix(qi.DensityMatrix):
     """Aer result backwards compatibility wrapper for qiskit DensityMatrix."""
 
     def __getattr__(self, attr):
-        if hasattr(self.data, attr):
+        if _forward_attr(attr) and hasattr(self._data, attr):
             warnings.warn(
                 "The return type of saved density matrices has been changed from"
                 " a `numpy.ndarray` to a `qiskit.quantum_info.DensityMatrix` as"
@@ -75,7 +82,7 @@ class Operator(qi.Operator):
     """Aer result backwards compatibility wrapper for qiskit Operator."""
 
     def __getattr__(self, attr):
-        if hasattr(self.data, attr):
+        if _forward_attr(attr) and hasattr(self._data, attr):
             warnings.warn(
                 "The return type of saved unitaries has been changed from"
                 " a `numpy.ndarray` to a `qiskit.quantum_info.Operator` as"
@@ -98,7 +105,7 @@ class SuperOp(qi.SuperOp):
     """Aer result backwards compatibility wrapper for qiskit SuperOp."""
 
     def __getattr__(self, attr):
-        if hasattr(self.data, attr):
+        if _forward_attr(attr) and hasattr(self._data, attr):
             warnings.warn(
                 "The return type of saved superoperators has been changed from"
                 " a `numpy.ndarray` to a `qiskit.quantum_info.SuperOp` as"
@@ -121,7 +128,7 @@ class StabilizerState(qi.StabilizerState):
     """Aer result backwards compatibility wrapper for qiskit StabilizerState."""
 
     def __getattr__(self, attr):
-        if hasattr(dict, attr):
+        if _forward_attr(attr) and hasattr(dict, attr):
             warnings.warn(
                 "The return type of saved stabilizers has been changed from"
                 " a `dict` to a `qiskit.quantum_info.StabilizerState` as of qiskit-aer 0.10."
@@ -129,7 +136,7 @@ class StabilizerState(qi.StabilizerState):
                 " error in a future release. Use the `.clifford.to_dict()` methods to access "
                 " the stored Clifford operator and convert to a dictionary.",
                 DeprecationWarning, stacklevel=2)
-            return getattr(self.clifford.to_dict(), attr)
+            return getattr(self._data.to_dict(), attr)
         return getattr(super(), attr)
 
     def __getitem__(self, item):
@@ -141,7 +148,7 @@ class StabilizerState(qi.StabilizerState):
                 " error in a future release. Use the `.clifford.to_dict()` methods to access "
                 " the stored Clifford operator and convert to a dictionary.",
                 DeprecationWarning, stacklevel=2)
-            return self.clifford.to_dict()[item]
+            return self._data.to_dict()[item]
         raise TypeError("'StabilizerState object is not subscriptable'")
 
     def _add(self, other):

--- a/qiskit/providers/aer/backends/compatibility.py
+++ b/qiskit/providers/aer/backends/compatibility.py
@@ -38,7 +38,7 @@ class Statevector(qi.Statevector):
                 " property to access the the stored ndarray for the Statevector.",
                 DeprecationWarning, stacklevel=2)
             return getattr(self.data, attr)
-        return super().__getattribute__(attr)
+        return getattr(super(), attr)
 
     def __eq__(self, other):
         return (
@@ -61,7 +61,7 @@ class DensityMatrix(qi.DensityMatrix):
                 " property to access the the stored ndarray for the DensityMatrix.",
                 DeprecationWarning, stacklevel=2)
             return getattr(self.data, attr)
-        return super().__getattribute__(attr)
+        return getattr(super(), attr)
 
     def __eq__(self, other):
         return (

--- a/qiskit/providers/aer/backends/compatibility.py
+++ b/qiskit/providers/aer/backends/compatibility.py
@@ -143,3 +143,9 @@ class StabilizerState(qi.StabilizerState):
                 DeprecationWarning, stacklevel=2)
             return self.clifford.to_dict()[item]
         raise TypeError("'StabilizerState object is not subscriptable'")
+
+    def _add(self, other):
+        raise NotImplementedError(f"{type(self)} does not support addition")
+
+    def _multiply(self, other):
+        raise NotImplementedError(f"{type(self)} does not support scalar multiplication")

--- a/qiskit/providers/aer/library/instructions_table.csv
+++ b/qiskit/providers/aer/library/instructions_table.csv
@@ -1,6 +1,7 @@
 ﻿Instruction,Automatic,Statevector,Density Matrix,MPS,Stabilizer,Ext. Stabilizer,Unitary,SuperOp
 :class:`SaveAmplitudes`,✔,✔,✘,✔,✘,✘,✘,✘
 :class:`SaveAmplitudesSquared`,✔,✔,✔,✔,✔,✘,✘,✘
+:class:`SaveClifford`,✔,✘,✘,✘,✔,✘,✘,✘
 :class:`SaveDensityMatrix`,✔,✔,✔,✔,✘,✘,✘,✘
 :class:`SaveExpectationValue`,✔,✔,✔,✔,✔,✘,✘,✘
 :class:`SaveExpectationValueVariance`,✔,✔,✔,✔,✔,✘,✘,✘

--- a/qiskit/providers/aer/library/save_instructions/__init__.py
+++ b/qiskit/providers/aer/library/save_instructions/__init__.py
@@ -25,6 +25,7 @@ from .save_density_matrix import SaveDensityMatrix, save_density_matrix
 from .save_amplitudes import (SaveAmplitudes, save_amplitudes,
                               SaveAmplitudesSquared, save_amplitudes_squared)
 from .save_stabilizer import (SaveStabilizer, save_stabilizer)
+from .save_clifford import (SaveClifford, save_clifford)
 from .save_unitary import (SaveUnitary, save_unitary)
 from .save_matrix_product_state import (
     SaveMatrixProductState, save_matrix_product_state)

--- a/qiskit/providers/aer/library/save_instructions/save_clifford.py
+++ b/qiskit/providers/aer/library/save_instructions/save_clifford.py
@@ -18,20 +18,17 @@ from .save_data import SaveSingleData
 from ..default_qubits import default_qubits
 
 
-class SaveStabilizer(SaveSingleData):
-    """Save Stabilizer instruction"""
-    def __init__(self, num_qubits, label="stabilizer",
-                 pershot=False, conditional=False):
-        """Create new instruction to save the stabilizer simulator state as a StabilizerState.
+class SaveClifford(SaveSingleData):
+    """Save Clifford instruction"""
+    def __init__(self, num_qubits, label="clifford", pershot=False):
+        """Create new instruction to save the stabilizer simulator state as a Clifford.
 
         Args:
             num_qubits (int): the number of qubits of the
             label (str): the key for retrieving saved data from results.
-            pershot (bool): if True save a list of StabilizerStates for each
+            pershot (bool): if True save a list of Cliffords for each
                             shot of the simulation rather than a single
                             statevector [Default: False].
-            conditional (bool): if True save data conditional on the current
-                                classical register values [Default: False].
 
         .. note::
 
@@ -39,21 +36,16 @@ class SaveStabilizer(SaveSingleData):
             qubits in a circuit, otherwise an exception will be raised during
             simulation.
         """
-        super().__init__('save_stabilizer', num_qubits, label,
-                         pershot=pershot,
-                         conditional=conditional)
+        super().__init__('save_clifford', num_qubits, label, pershot=pershot)
 
 
-def save_stabilizer(self, label="stabilizer", pershot=False, conditional=False):
-    """Save the current stabilizer simulator quantum state as a StabilizerState.
+def save_clifford(self, label="clifford", pershot=False):
+    """Save the current stabilizer simulator quantum state as a Clifford.
 
     Args:
         label (str): the key for retrieving saved data from results.
-        pershot (bool): if True save a list of StabilizerStates for each
+        pershot (bool): if True save a list of Cliffords for each
                         shot of the simulation [Default: False].
-        conditional (bool): if True save pershot data conditional on the
-                            current classical register values
-                            [Default: False].
 
     Returns:
         QuantumCircuit: with attached instruction.
@@ -63,11 +55,8 @@ def save_stabilizer(self, label="stabilizer", pershot=False, conditional=False):
         This instruction is always defined across all qubits in a circuit.
     """
     qubits = default_qubits(self)
-    instr = SaveStabilizer(len(qubits),
-                           label=label,
-                           pershot=pershot,
-                           conditional=conditional)
+    instr = SaveClifford(len(qubits), label=label, pershot=pershot)
     return self.append(instr, qubits)
 
 
-QuantumCircuit.save_stabilizer = save_stabilizer
+QuantumCircuit.save_clifford = save_clifford

--- a/qiskit/providers/aer/library/set_instructions/set_stabilizer.py
+++ b/qiskit/providers/aer/library/set_instructions/set_stabilizer.py
@@ -10,12 +10,12 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """
-Instruction to set the state simulator state to a matrix.
+Instruction to set the simulator state to a stabilizer state.
 """
 
 from qiskit.circuit import QuantumCircuit, Instruction
 from qiskit.extensions.exceptions import ExtensionError
-from qiskit.quantum_info import Clifford
+from qiskit.quantum_info import StabilizerState, Clifford
 from ..default_qubits import default_qubits
 
 
@@ -28,7 +28,7 @@ class SetStabilizer(Instruction):
         """Create new instruction to set the Clifford stabilizer state of the simulator.
 
         Args:
-            state (Clifford): A clifford operator.
+            state (StabilizerState or Clifford): A clifford operator.
 
         .. note::
 
@@ -36,7 +36,9 @@ class SetStabilizer(Instruction):
             qubits in a circuit, otherwise an exception will be raised during
             simulation.
         """
-        if not isinstance(state, Clifford):
+        if isinstance(state, StabilizerState):
+            state = state.clifford
+        elif not isinstance(state, Clifford):
             state = Clifford(state)
         super().__init__('set_stabilizer', state.num_qubits, 0, [state.to_dict()])
 
@@ -59,6 +61,8 @@ def set_stabilizer(self, state):
         This instruction is always defined across all qubits in a circuit.
     """
     qubits = default_qubits(self)
+    if isinstance(state, StabilizerState):
+        state = state.clifford
     if not isinstance(state, Clifford):
         state = Clifford(state)
     if state.num_qubits != len(qubits):

--- a/releasenotes/notes/result-types-2bdbcccb94d43cfa.yaml
+++ b/releasenotes/notes/result-types-2bdbcccb94d43cfa.yaml
@@ -1,0 +1,24 @@
+---
+features:
+  - |
+    Adds a :class:`~qiskit.providers.aer.library.SaveClifford` instruction for
+    saving the state of the stabilizer simulation method as a
+    :class:`~qiskit.quantum_info.Clifford` object.
+
+    Note that this instruction is essentially equivalent to the
+    :class:`~qiskit.providers.aer.library.SaveStabilizer` instruction, however
+    that instruction will return the saved state as a
+    :class:`~qiskit.quantum_info.StabilizerState` object instead of a
+    :class:`~qiskit.quantum_info.Clifford` object.
+upgrade:
+  - |
+    The return type of several save instructions have been changed to be the
+    corresponding `qiskit-terra` classes rather than raw numpy arrays or
+    dictionaries. The types that have changed are
+
+    * ``save_statvector`` now returns as a :class:`qiskit.quantum_info.Statevector`
+    * ``save_density_matrix`` now returns as a :class:`qiskit.quantum_info.DensityMatrix`
+    * ``save_stabilizer`` now returns as :class:`qiskit.quantum_info.StabilizerState`
+    * ``save_unitary`` now returns as :class:`qiskit.quantum_info.Operator`
+    * ``save_superop`` now returns as :class:`qiskit.quantum_info.SuperOp`
+    * ``save_probabilities_dict`` now returns as a :class:`qiskit.result.ProbDistribution`

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -356,6 +356,7 @@ void Circuit::set_params(bool truncation) {
         case OpType::save_amps:
         case OpType::save_amps_sq:
         case OpType::save_stabilizer:
+        case OpType::save_clifford:
         case OpType::save_unitary:
         case OpType::save_mps:
         case OpType::save_superop: 
@@ -471,6 +472,7 @@ bool Circuit::check_result_ancestor(const Op& op, std::unordered_set<uint_t>& an
     case OpType::save_amps:
     case OpType::save_amps_sq:
     case OpType::save_stabilizer:
+    case OpType::save_clifford:
     case OpType::save_unitary:
     case OpType::save_mps:
     case OpType::save_superop: {

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -181,6 +181,39 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
 }
 
 
+inline std::ostream& operator<<(std::ostream& stream, const DataSubType& subtype) {
+  switch (subtype) {
+    case DataSubType::single:
+      stream << "single";
+      break;
+    case DataSubType::c_single:
+      stream << "c_single";
+      break;
+    case DataSubType::list:
+      stream << "list";
+      break;
+    case DataSubType::c_list:
+      stream << "c_list";
+      break;
+    case DataSubType::accum:
+      stream << "accum";
+      break;
+    case DataSubType::c_accum:
+      stream << "c_accum";
+      break;
+    case DataSubType::average:
+      stream << "average";
+      break;
+    case DataSubType::c_average:
+      stream << "c_average";
+      break;
+    default:
+      stream << "unknown";
+  }
+  return stream;
+}
+
+
 //------------------------------------------------------------------------------
 // Op Class
 //------------------------------------------------------------------------------
@@ -493,6 +526,8 @@ inline void from_json(const json_t &js, Op &op) {op = input_to_op(js);}
 
 inline void to_json(json_t &js, const Op &op) { js = op_to_json(op);}
 
+void to_json(json_t &js, const DataSubType& type);
+
 // Standard operations
 template<typename inputdata_t>
 Op input_to_op_gate(const inputdata_t& input);
@@ -680,6 +715,20 @@ json_t op_to_json(const Op &op) {
   if (!op.mats.empty())
     ret["mats"] = op.mats;
   return ret;
+}
+
+
+void to_json(json_t &js, const OpType& type) {
+  std::stringstream ss;
+  ss << type;
+  js = ss.str();
+}
+
+
+void to_json(json_t &js, const DataSubType& subtype) {
+  std::stringstream ss;
+  ss << subtype;
+  js = ss.str();
 }
 
 

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -44,7 +44,7 @@ enum class OpType {
   // Save instructions
   save_state, save_expval, save_expval_var, save_statevec, save_statevec_dict,
   save_densmat, save_probs, save_probs_ket, save_amps, save_amps_sq,
-  save_stabilizer, save_unitary, save_mps, save_superop,
+  save_stabilizer, save_clifford, save_unitary, save_mps, save_superop,
   // Set instructions
   set_statevec, set_densmat, set_unitary, set_superop,
     set_stabilizer, set_mps
@@ -113,6 +113,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     break;
   case OpType::save_stabilizer:
     stream << "save_stabilizer";
+    break;
+  case OpType::save_clifford:
+    stream << "save_clifford";
     break;
   case OpType::save_unitary:
     stream << "save_unitary";
@@ -642,6 +645,8 @@ Op input_to_op(const inputdata_t& input) {
     return input_to_op_save_default(input, OpType::save_statevec_dict);
   if (name == "save_stabilizer")
     return input_to_op_save_default(input, OpType::save_stabilizer);
+  if (name == "save_clifford")
+    return input_to_op_save_default(input, OpType::save_clifford);
   if (name == "save_unitary")
     return input_to_op_save_default(input, OpType::save_unitary);
   if (name == "save_superop")

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -59,6 +59,7 @@ static const std::unordered_set<OpType> SAVE_TYPES = {
   OpType::save_statevec, OpType::save_statevec_dict,
   OpType::save_densmat, OpType::save_probs, OpType::save_probs_ket,
   OpType::save_amps, OpType::save_amps_sq, OpType::save_stabilizer,
+  OpType::save_clifford,
   OpType::save_unitary, OpType::save_mps, OpType::save_superop
 };
 

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -777,17 +777,16 @@ void State<densmat_t>::apply_save_probs(const int_t iChunk, const Operations::Op
   if (op.type == OpType::save_probs_ket) {
     BaseState::save_data_average(iChunk, result, op.string_params[0],
                                  Utils::vec2ket(probs, json_chop_threshold_, 16),
-                                 op.save_type);
+                                 op.type, op.save_type);
   } else {
     BaseState::save_data_average(iChunk, result, op.string_params[0],
-                                 std::move(probs), op.save_type);
+                                 std::move(probs), op.type, op.save_type);
   }
 }
 
 template <class densmat_t>
 void State<densmat_t>::apply_save_amplitudes_sq(const int_t iChunkIn, const Operations::Op &op,
-                                                ExperimentResult &result) 
-{
+                                                ExperimentResult &result) {
   if (op.int_params.empty()) {
     throw std::invalid_argument("Invalid save_amplitudes_sq instructions (empty params).");
   }
@@ -826,13 +825,12 @@ void State<densmat_t>::apply_save_amplitudes_sq(const int_t iChunkIn, const Oper
     }
   }
   BaseState::save_data_average(iChunkIn, result, op.string_params[0],
-                               std::move(amps_sq), op.save_type);
+                               std::move(amps_sq), op.type, op.save_type);
 }
 
 template <class densmat_t>
 double State<densmat_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
-                                      const std::string& pauli) 
-{
+                                      const std::string& pauli)  {
   if(!BaseState::multi_chunk_distribution_)
     return BaseState::qregs_[iChunk].expval_pauli(qubits, pauli);
 
@@ -922,11 +920,10 @@ double State<densmat_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
 template <class densmat_t>
 void State<densmat_t>::apply_save_density_matrix(const int_t iChunk, const Operations::Op &op,
                                                  ExperimentResult &result,
-                                                 bool last_op) 
-{
+                                                 bool last_op) {
   BaseState::save_data_average(iChunk, result, op.string_params[0],
                                reduced_density_matrix(iChunk, op.qubits, last_op),
-                               op.save_type);
+                               op.type, op.save_type);
 }
 
 template <class densmat_t>
@@ -957,13 +954,11 @@ void State<densmat_t>::apply_save_state(const int_t iChunk, const Operations::Op
                       ? "density_matrix"
                       : op.string_params[0];
   if (last_op) {
-    BaseState::save_data_average(iChunk, result, key,
-                                 move_to_matrix(iChunk),
-                                 save_type);
+    BaseState::save_data_average(iChunk, result, key, move_to_matrix(iChunk),
+                                 OpType::save_densmat, save_type);
   } else {
-    BaseState::save_data_average(iChunk, result, key,
-                                 copy_to_matrix(iChunk),
-                                 save_type);
+    BaseState::save_data_average(iChunk, result, key, copy_to_matrix(iChunk),
+                                 OpType::save_densmat, save_type);
   }
 }
 

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -829,7 +829,7 @@ void State::apply_save_statevector(const Operations::Op &op,
   BaseState::save_data_pershot(
     result, op.string_params[0],
     std::move(statevec),
-    op.save_type);
+    op.type, op.save_type);
 }
 
 void State::apply_save_expval(const Operations::Op &op,
@@ -858,9 +858,9 @@ void State::apply_save_expval(const Operations::Op &op,
     std::vector<double> expval_var(2);
     expval_var[0] = expval;  // mean
     expval_var[1] = sq_expval - expval * expval;  // variance
-    save_data_average(result, op.string_params[0], expval_var, op.save_type);
+    save_data_average(result, op.string_params[0], expval_var, op.type, op.save_type);
   } else {
-    save_data_average(result, op.string_params[0], expval, op.save_type);
+    save_data_average(result, op.string_params[0], expval, op.type, op.save_type);
   }
 }
 

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -625,10 +625,10 @@ void State::apply_save_mps(const Operations::Op &op,
                       : op.string_params[0];
   if (last_op) {
     BaseState::save_data_pershot(result, key, qreg_.move_to_mps_container(),
-				                         op.save_type);
+				                         OpType::save_mps, op.save_type);
   } else {
     BaseState::save_data_pershot(result, key, qreg_.copy_to_mps_container(),
-                                 op.save_type);
+                                 OpType::save_mps, op.save_type);
   }
 }
 
@@ -639,10 +639,10 @@ void State::apply_save_probs(const Operations::Op &op,
   if (op.type == OpType::save_probs_ket) {
     BaseState::save_data_average(result, op.string_params[0],
                                  Utils::vec2ket(probs, MPS::get_json_chop_threshold(), 16),
-                                 op.save_type);
+                                 op.type, op.save_type);
   } else {
     BaseState::save_data_average(result, op.string_params[0],
-                                 std::move(probs), op.save_type);
+                                 std::move(probs), op.type, op.save_type);
   }
 }
 
@@ -658,10 +658,10 @@ void State::apply_save_amplitudes(const Operations::Op &op,
     std::transform(amps.data(), amps.data() + amps.size(), amps_sq.begin(),
       [](complex_t val) -> double { return pow(abs(val), 2); });
     BaseState::save_data_average(result, op.string_params[0],
-                                 std::move(amps_sq), op.save_type);
+                                 std::move(amps_sq), op.type, op.save_type);
   } else {
     BaseState::save_data_pershot(result, op.string_params[0],
-                                 std::move(amps), op.save_type);
+                                 std::move(amps), op.type, op.save_type);
   }
 }
 
@@ -678,7 +678,7 @@ void State::apply_save_statevector(const Operations::Op &op,
         " Only the full statevector can be saved.");
   }
   BaseState::save_data_pershot(result, op.string_params[0],
-                               qreg_.full_statevector(), op.save_type);
+                               qreg_.full_statevector(), op.type, op.save_type);
 }
 
 
@@ -693,7 +693,7 @@ void State::apply_save_density_matrix(const Operations::Op &op,
   }
 
   BaseState::save_data_average(result, op.string_params[0],
-                               std::move(reduced_state), op.save_type);
+                               std::move(reduced_state), op.type, op.save_type);
 }
 
 //=========================================================================

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -539,7 +539,7 @@ void State::apply_save_stabilizer(const Operations::Op &op,
   std::string key = (op.string_params[0] == "_method_") ? "stabilizer" : op.string_params[0];
   json_t clifford = BaseState::qreg_;
   BaseState::save_data_pershot(result, key,
-                               std::move(clifford), op.save_type);
+                               std::move(clifford), OpType::save_stabilizer, op.save_type);
 }
 
 void State::apply_save_probs(const Operations::Op &op,
@@ -563,13 +563,13 @@ void State::apply_save_probs(const Operations::Op &op,
     get_probabilities_auxiliary(
         op.qubits, std::string(op.qubits.size(), 'X'), 1, probs);
     BaseState::save_data_average(result, op.string_params[0],
-                                 std::move(probs), op.save_type);
+                                 std::move(probs), op.type, op.save_type);
   } else {
     std::vector<double> probs(1ULL << op.qubits.size(), 0.);
     get_probabilities_auxiliary(
       op.qubits, std::string(op.qubits.size(), 'X'), 1, probs); 
     BaseState::save_data_average(result, op.string_params[0],
-                                 std::move(probs), op.save_type);
+                                 std::move(probs), op.type, op.save_type);
   }
 }
 
@@ -587,7 +587,7 @@ void State::apply_save_amplitudes_sq(const Operations::Op &op,
     amps_sq[i] = get_probability(op.qubits, Utils::int2bin(op.int_params[i], num_qubits));
   }
   BaseState::save_data_average(result, op.string_params[0],
-                               std::move(amps_sq), op.save_type);
+                               std::move(amps_sq), op.type, op.save_type);
 }
 
 double State::expval_pauli(const reg_t &qubits,

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -538,11 +538,26 @@ void State::apply_set_stabilizer(const Clifford::Clifford &clifford) {
 void State::apply_save_stabilizer(const Operations::Op &op,
                                 ExperimentResult &result) {
   std::string key = op.string_params[0];
-  if (key == "_method_") {
-    key = (op.type == OpType::save_clifford) ? "clifford" : "stabilizer";
+  OpType op_type = op.type;
+  switch (op_type) {
+    case OpType::save_clifford: {
+      if (key == "_method_") {
+        key = "clifford";
+      }
+      break;
+    }
+    case OpType::save_stabilizer:
+    case OpType::save_state: {
+      if (key == "_method_") {
+        key = "stabilizer";
+      }
+      op_type = OpType::save_stabilizer;
+      break;
+    }
+    default:
+      // We shouldn't ever reach here...
+      throw std::invalid_argument("Invalid save state instruction for stabilizer");
   }
-  OpType op_type = (op.type == OpType::save_clifford) ? OpType::save_clifford
-                                                      : OpType::save_stabilizer;
   json_t clifford = BaseState::qreg_;
   BaseState::save_data_pershot(result, key, std::move(clifford), op_type, op.save_type);
 }

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -37,8 +37,8 @@ const Operations::OpSet StateOpSet(
     OpType::roerror, OpType::save_expval,
     OpType::save_expval_var, OpType::save_probs,
     OpType::save_probs_ket, OpType::save_amps_sq,
-    OpType::save_stabilizer, OpType::save_state,
-    OpType::set_stabilizer},
+    OpType::save_stabilizer, OpType::save_clifford,
+    OpType::save_state, OpType::set_stabilizer},
   // Gates
   {"CX", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s", "sdg",
    "sx", "sxdg", "delay", "pauli"},
@@ -358,6 +358,7 @@ void State::apply_op(const Operations::Op &op,
         break;
       case OpType::save_state:
       case OpType::save_stabilizer:
+      case OpType::save_clifford:
         apply_save_stabilizer(op, result);
         break;
       default:
@@ -536,10 +537,14 @@ void State::apply_set_stabilizer(const Clifford::Clifford &clifford) {
 
 void State::apply_save_stabilizer(const Operations::Op &op,
                                 ExperimentResult &result) {
-  std::string key = (op.string_params[0] == "_method_") ? "stabilizer" : op.string_params[0];
+  std::string key = op.string_params[0];
+  if (key == "_method_") {
+    key = (op.type == OpType::save_clifford) ? "clifford" : "stabilizer";
+  }
+  OpType op_type = (op.type == OpType::save_clifford) ? OpType::save_clifford
+                                                      : OpType::save_stabilizer;
   json_t clifford = BaseState::qreg_;
-  BaseState::save_data_pershot(result, key,
-                               std::move(clifford), OpType::save_stabilizer, op.save_type);
+  BaseState::save_data_pershot(result, key, std::move(clifford), op_type, op.save_type);
 }
 
 void State::apply_save_probs(const Operations::Op &op,

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -849,10 +849,10 @@ void State<statevec_t>::apply_save_probs(const int_t iChunk, const Operations::O
     // Convert to ket dict
     BaseState::save_data_average(iChunk, result, op.string_params[0],
                                  Utils::vec2ket(probs, json_chop_threshold_, 16),
-                                 op.save_type);
+                                 op.type, op.save_type);
   } else {
     BaseState::save_data_average(iChunk, result, op.string_params[0],
-                                 std::move(probs), op.save_type);
+                                 std::move(probs), op.type, op.save_type);
   }
 }
 
@@ -985,9 +985,11 @@ void State<statevec_t>::apply_save_statevector(const int_t iChunk, const Operati
                       : op.string_params[0];
 
   if (last_op) {
-    BaseState::save_data_pershot(iChunk, result, key, move_to_vector(iChunk), op.save_type);
+    BaseState::save_data_pershot(iChunk, result, key, move_to_vector(iChunk),
+                                 OpType::save_statevec, op.save_type);
   } else {
-    BaseState::save_data_pershot(iChunk, result, key, copy_to_vector(iChunk), op.save_type);
+    BaseState::save_data_pershot(iChunk, result, key, copy_to_vector(iChunk),
+                                 OpType::save_statevec, op.save_type);
   }
 }
 
@@ -1010,7 +1012,7 @@ void State<statevec_t>::apply_save_statevector_dict(const int_t iChunk, const Op
       }
     }
     BaseState::save_data_pershot(iChunk, result, op.string_params[0],
-                                 std::move(result_state_ket), op.save_type);
+                                 std::move(result_state_ket), op.type, op.save_type);
   }
   else{
     auto state_ket = BaseState::qregs_[iChunk].vector_ket(json_chop_threshold_);
@@ -1019,7 +1021,7 @@ void State<statevec_t>::apply_save_statevector_dict(const int_t iChunk, const Op
       result_state_ket[it.first] = it.second;
     }
     BaseState::save_data_pershot(iChunk, result, op.string_params[0],
-                                 std::move(result_state_ket), op.save_type);
+                                 std::move(result_state_ket), op.type, op.save_type);
   }
 }
 
@@ -1052,7 +1054,7 @@ void State<statevec_t>::apply_save_density_matrix(const int_t iChunk, const Oper
   }
 
   BaseState::save_data_average(iChunk, result, op.string_params[0],
-                               std::move(reduced_state), op.save_type);
+                               std::move(reduced_state), op.type, op.save_type);
 }
 
 template <class statevec_t>
@@ -1086,7 +1088,7 @@ void State<statevec_t>::apply_save_amplitudes(const int_t iChunkIn, const Operat
       }
     }
     BaseState::save_data_pershot(iChunkIn, result, op.string_params[0],
-                                 std::move(amps), op.save_type);
+                                 std::move(amps), op.type, op.save_type);
   }
   else{
     rvector_t amps_sq(size,0);
@@ -1108,7 +1110,7 @@ void State<statevec_t>::apply_save_amplitudes(const int_t iChunkIn, const Operat
 #endif
     }
     BaseState::save_data_average(iChunkIn, result, op.string_params[0],
-                                 std::move(amps_sq), op.save_type);
+                                 std::move(amps_sq), op.type, op.save_type);
   }
 }
 

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -558,10 +558,12 @@ void State<statevec_t>::apply_save_state(const Operations::Op &op,
   if (last_op) {
     BaseState::save_data_pershot(result, key,
                                  BaseState::qreg_.move_to_matrix(),
+                                 Operations::OpType::save_superop,
                                  op.save_type);
   } else {
     BaseState::save_data_pershot(result, key,
                                  BaseState::qreg_.copy_to_matrix(),
+                                 Operations::OpType::save_superop,
                                  op.save_type);
   }
 }

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -754,12 +754,12 @@ void State<unitary_matrix_t>::apply_save_unitary(const int_t iChunk, const Opera
   std::string key = (op.string_params[0] == "_method_") ? "unitary" : op.string_params[0];
 
   if (last_op) {
-    BaseState::save_data_pershot(iChunk, result, key,
-                                 move_to_matrix(iChunk),
+    BaseState::save_data_pershot(iChunk, result, key, move_to_matrix(iChunk),
+                                 Operations::OpType::save_unitary,
                                  op.save_type);
   } else {
-    BaseState::save_data_pershot(iChunk, result, key,
-                                 copy_to_matrix(iChunk),
+    BaseState::save_data_pershot(iChunk, result, key, copy_to_matrix(iChunk),
+                                 Operations::OpType::save_unitary,
                                  op.save_type);
   }
 }

--- a/test/terra/backends/aer_simulator/test_pauli_gate.py
+++ b/test/terra/backends/aer_simulator/test_pauli_gate.py
@@ -42,7 +42,7 @@ class TestPauliGate(SimulatorTestCase):
             circuit.save_density_matrix(label=label)
             fidelity_fn = qi.state_fidelity
         elif method == 'stabilizer':
-            target = qi.Clifford(circuit)
+            target = qi.StabilizerState(qi.Clifford(circuit))
             circuit.save_stabilizer(label=label)
             fidelity_fn = qi.process_fidelity
         elif method == 'unitary':

--- a/test/terra/backends/aer_simulator/test_pauli_gate.py
+++ b/test/terra/backends/aer_simulator/test_pauli_gate.py
@@ -40,27 +40,22 @@ class TestPauliGate(SimulatorTestCase):
         if method == 'density_matrix':
             target = qi.DensityMatrix(circuit)
             circuit.save_density_matrix(label=label)
-            state_fn = qi.DensityMatrix
             fidelity_fn = qi.state_fidelity
         elif method == 'stabilizer':
             target = qi.Clifford(circuit)
             circuit.save_stabilizer(label=label)
-            state_fn = qi.Clifford.from_dict
             fidelity_fn = qi.process_fidelity
         elif method == 'unitary':
             target = qi.Operator(circuit)
             circuit.save_unitary(label=label)
-            state_fn = qi.Operator
             fidelity_fn = qi.process_fidelity
         elif method == 'superop':
             target = qi.SuperOp(circuit)
             circuit.save_superop(label=label)
-            state_fn = qi.SuperOp
             fidelity_fn = qi.process_fidelity
         else:
             target = qi.Statevector(circuit)
             circuit.save_statevector(label=label)
-            state_fn = qi.Statevector
             fidelity_fn = qi.state_fidelity
 
         result = backend.run(transpile(
@@ -71,8 +66,7 @@ class TestPauliGate(SimulatorTestCase):
         self.assertTrue(success, msg="Simulation unexpectedly failed")
         data = result.data(0)
         self.assertIn(label, data)
-        value = state_fn(data[label])
-        fidelity = fidelity_fn(target, value)
+        fidelity = fidelity_fn(target, data[label])
 
         threshold = 0.9999
         self.assertGreater(

--- a/test/terra/backends/aer_simulator/test_save_density_matrix.py
+++ b/test/terra/backends/aer_simulator/test_save_density_matrix.py
@@ -50,7 +50,7 @@ class QasmSaveDensityMatrixTests(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.DensityMatrix(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)
 
     @supported_methods(['automatic', 'statevector', 'density_matrix',
@@ -168,5 +168,5 @@ class QasmSaveDensityMatrixTests(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.DensityMatrix(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)

--- a/test/terra/backends/aer_simulator/test_save_state.py
+++ b/test/terra/backends/aer_simulator/test_save_state.py
@@ -74,7 +74,7 @@ class TestSaveState(SimulatorTestCase):
             for val, targ in zip(value[1], target[1]):
                 self.assertTrue(np.allclose(val, targ))
         else:
-            self.assertTrue(np.all(value == target))
+            self.assertEqual(value, target)
 
     @supported_methods(['statevector', 'density_matrix'])
     def test_save_state_cache_blocking(self, method, device):
@@ -107,4 +107,4 @@ class TestSaveState(SimulatorTestCase):
         self.assertIn('target', simdata)
         value = simdata[method]
         target = simdata['target']
-        self.assertTrue(np.all(value == target))
+        self.assertEqual(value, target)

--- a/test/terra/backends/aer_simulator/test_save_statevector.py
+++ b/test/terra/backends/aer_simulator/test_save_statevector.py
@@ -50,7 +50,7 @@ class TestSaveStatevector(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.Statevector(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)
 
     @supported_methods(['automatic', 'statevector', 'matrix_product_state',
@@ -82,7 +82,7 @@ class TestSaveStatevector(SimulatorTestCase):
         self.assertIn(label, simdata)
         for key, vec in simdata[label].items():
             self.assertIn(key, target)
-            self.assertEqual(qi.Statevector(vec), target[key])
+            self.assertEqual(vec, target[key])
 
     @supported_methods(['automatic', 'statevector', 'matrix_product_state',
                         'extended_stabilizer'])
@@ -114,7 +114,7 @@ class TestSaveStatevector(SimulatorTestCase):
         value = simdata[label]
         self.assertEqual(len(value), shots)
         for vec in value:
-            self.assertEqual(qi.Statevector(vec), target)
+            self.assertEqual(vec, target)
 
     @supported_methods(['automatic', 'statevector', 'matrix_product_state',
                         'extended_stabilizer'])
@@ -149,7 +149,7 @@ class TestSaveStatevector(SimulatorTestCase):
         self.assertIn('0x0', value)
         self.assertEqual(len(value['0x0']), shots)
         for vec in value['0x0']:
-            self.assertEqual(qi.Statevector(vec), target)
+            self.assertEqual(vec, target)
 
     @supported_methods(['statevector'])
     def test_save_statevector_cache_blocking(self, method, device):
@@ -177,5 +177,5 @@ class TestSaveStatevector(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.Statevector(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)

--- a/test/terra/backends/aer_simulator/test_save_superop.py
+++ b/test/terra/backends/aer_simulator/test_save_superop.py
@@ -46,5 +46,5 @@ class TestSaveSuperOp(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.SuperOp(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)

--- a/test/terra/backends/aer_simulator/test_save_unitary.py
+++ b/test/terra/backends/aer_simulator/test_save_unitary.py
@@ -46,5 +46,5 @@ class TestSaveUnitary(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.Operator(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)

--- a/test/terra/backends/aer_simulator/test_set_state.py
+++ b/test/terra/backends/aer_simulator/test_set_state.py
@@ -24,15 +24,15 @@ from test.terra.backends.simulator_test_case import (
 @ddt
 class TestSetState(SimulatorTestCase):
     """Test for set state instructions"""
-    @supported_methods(['automatic', 'stabilizer'], [1, 2, 3, 4])
-    def test_set_stabilizer(self, method, device, num_qubits):
+    @supported_methods(['automatic', 'stabilizer'], [1, 2, 3])
+    def test_set_stabilizer_stabilizer_state(self, method, device, num_qubits):
         """Test SetStabilizer instruction"""
         backend = self.backend(method=method, device=device)
 
         seed = 100
         label = 'state'
 
-        target = qi.random_clifford(num_qubits, seed=seed)
+        target = qi.StabilizerState(qi.random_clifford(num_qubits, seed=seed))
 
         circ = QuantumCircuit(num_qubits)
         circ.set_stabilizer(target)
@@ -47,7 +47,30 @@ class TestSetState(SimulatorTestCase):
         value = simdata[label]
         self.assertEqual(value, target)
 
-    @supported_methods(['automatic', 'statevector'], [1, 2, 3, 4, 5])
+    @supported_methods(['automatic', 'stabilizer'], [1, 2, 3])
+    def test_set_stabilizer_clifford(self, method, device, num_qubits):
+        """Test SetStabilizer instruction"""
+        backend = self.backend(method=method, device=device)
+
+        seed = 100
+        label = 'state'
+
+        target = qi.random_clifford(num_qubits, seed=seed)
+
+        circ = QuantumCircuit(num_qubits)
+        circ.set_stabilizer(target)
+        circ.save_clifford(label=label)
+
+        # Run
+        result = backend.run(transpile(circ, backend, optimization_level=0),
+                             shots=1).result()
+        self.assertTrue(result.success)
+        simdata = result.data(0)
+        self.assertIn(label, simdata)
+        value = simdata[label]
+        self.assertEqual(value, target)
+
+    @supported_methods(['automatic', 'statevector'], [1, 2, 3])
     def test_set_statevector(self, method, device, num_qubits):
         """Test SetStatevector for instruction"""
         backend = self.backend(method=method, device=device)

--- a/test/terra/backends/aer_simulator/test_set_state.py
+++ b/test/terra/backends/aer_simulator/test_set_state.py
@@ -44,7 +44,7 @@ class TestSetState(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.Clifford.from_dict(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)
 
     @supported_methods(['automatic', 'statevector'], [1, 2, 3, 4, 5])
@@ -67,7 +67,7 @@ class TestSetState(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.Statevector(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)
 
     @supported_methods(['automatic', 'density_matrix'], [1, 2, 3])
@@ -90,7 +90,7 @@ class TestSetState(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.DensityMatrix(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)
 
     @supported_methods(['automatic', 'unitary'], [1, 2, 3])
@@ -113,7 +113,7 @@ class TestSetState(SimulatorTestCase):
         self.assertTrue(result.success)
         simdata = result.data(0)
         self.assertIn(label, simdata)
-        value = qi.Operator(simdata[label])
+        value = simdata[label]
         self.assertEqual(value, target)
 
     @supported_methods(['automatic', 'superop'], [1, 2])

--- a/test/terra/backends/aer_simulator/test_standard_gates.py
+++ b/test/terra/backends/aer_simulator/test_standard_gates.py
@@ -121,27 +121,22 @@ class TestGates(SimulatorTestCase):
             if method == 'density_matrix':
                 target = qi.DensityMatrix(circuit)
                 circuit.save_density_matrix(label=label)
-                state_fn = qi.DensityMatrix
                 fidelity_fn = qi.state_fidelity
             elif method == 'stabilizer':
                 target = qi.Clifford(circuit)
                 circuit.save_stabilizer(label=label)
-                state_fn = qi.Clifford.from_dict
                 fidelity_fn = qi.process_fidelity
             elif method == 'unitary':
                 target = qi.Operator(circuit)
                 circuit.save_unitary(label=label)
-                state_fn = qi.Operator
                 fidelity_fn = qi.process_fidelity
             elif method == 'superop':
                 target = qi.SuperOp(circuit)
                 circuit.save_superop(label=label)
-                state_fn = qi.SuperOp
                 fidelity_fn = qi.process_fidelity
             else:
                 target = qi.Statevector(circuit)
                 circuit.save_statevector(label=label)
-                state_fn = qi.Statevector
                 fidelity_fn = qi.state_fidelity
 
             result = backend.run(transpile(
@@ -152,7 +147,7 @@ class TestGates(SimulatorTestCase):
             self.assertTrue(success)
             data = result.data(0)
             self.assertIn(label, data)
-            value = state_fn(data[label])
+            value = data[label]
             fidelity = fidelity_fn(target, value)
             self.assertGreater(fidelity, 0.9999)
 

--- a/test/terra/backends/aer_simulator/test_standard_gates.py
+++ b/test/terra/backends/aer_simulator/test_standard_gates.py
@@ -123,7 +123,7 @@ class TestGates(SimulatorTestCase):
                 circuit.save_density_matrix(label=label)
                 fidelity_fn = qi.state_fidelity
             elif method == 'stabilizer':
-                target = qi.Clifford(circuit)
+                target = qi.StabilizerState(qi.Clifford(circuit))
                 circuit.save_stabilizer(label=label)
                 fidelity_fn = qi.process_fidelity
             elif method == 'unitary':

--- a/test/terra/backends/test_compatibility.py
+++ b/test/terra/backends/test_compatibility.py
@@ -1,0 +1,101 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Tests if quantum info result compatibility classes.
+These can be removed when this deprecation period is finished.
+"""
+
+from test.terra.common import QiskitAerTestCase
+
+import numpy as np
+import qiskit.quantum_info as qi
+import qiskit.providers.aer.backends.compatibility as cqi
+
+
+class TestResultCompatibility(QiskitAerTestCase):
+    """Result compatiblity class tests."""
+
+    def test_statevector_eq(self):
+        orig = qi.random_statevector(4, seed=10)
+        compat = cqi.Statevector(orig.data)
+        self.assertEqual(compat, orig)
+        self.assertEqual(orig, compat)
+
+    def test_statevector_getattr(self):
+        compat = cqi.Statevector([1, 1e-10])
+        with self.assertWarns(DeprecationWarning):
+            value = compat.round(5)
+        self.assertEqual(type(value), np.ndarray)
+        self.assertTrue(np.all(value == np.array([1, 0])))
+
+    def test_density_matrix_eq(self):
+        orig = qi.random_density_matrix(4, seed=10)
+        compat = cqi.DensityMatrix(orig.data)
+        self.assertEqual(compat, orig)
+        self.assertEqual(orig, compat)
+
+    def test_density_matrix_getattr(self):
+        compat = cqi.DensityMatrix([[1, 0], [0, 1e-10]])
+        with self.assertWarns(DeprecationWarning):
+            value = compat.round(5)
+        self.assertEqual(type(value), np.ndarray)
+        self.assertTrue(np.all(value == np.array([[1, 0], [0, 0]])))
+
+    def test_operator_eq(self):
+        orig = qi.random_unitary(4, seed=10)
+        compat = cqi.Operator(orig.data)
+        self.assertEqual(compat, orig)
+        self.assertEqual(orig, compat)
+
+    def test_operator_getattr(self):
+        compat = cqi.Operator([[1, 0], [1e-10, 1]])
+        with self.assertWarns(DeprecationWarning):
+            value = compat.round(5)
+        self.assertEqual(type(value), np.ndarray)
+        self.assertTrue(np.all(value == np.eye(2)))
+
+    def test_superop_eq(self):
+        orig = qi.SuperOp(qi.random_quantum_channel(4, seed=10))
+        compat = cqi.SuperOp(orig.data)
+        self.assertEqual(compat, orig)
+        self.assertEqual(orig, compat)
+
+    def test_superop_getattr(self):
+        compat = cqi.SuperOp(np.eye(4))
+        with self.assertWarns(DeprecationWarning):
+            value = compat.round(5)
+        self.assertEqual(type(value), np.ndarray)
+        self.assertTrue(np.all(value == np.eye(4)))
+
+    def test_stabilizer_eq(self):
+        orig = qi.StabilizerState(qi.random_clifford(4, seed=10))
+        compat = cqi.StabilizerState(orig.clifford)
+        self.assertEqual(compat, orig)
+        self.assertEqual(orig, compat)
+
+    def test_stabilizer_getattr(self):
+        clifford = qi.random_clifford(4, seed=10)
+        compat = cqi.StabilizerState(clifford)
+        with self.assertWarns(DeprecationWarning):
+            value = compat.keys()
+        self.assertEqual(value, clifford.to_dict().keys())
+
+    def test_stabilizer_getitem(self):
+        clifford = qi.random_clifford(4, seed=10)
+        cliff_dict = clifford.to_dict()
+        compat = cqi.StabilizerState(clifford)
+        with self.assertWarns(DeprecationWarning):
+            stabs = compat['stabilizer']
+        self.assertEqual(stabs, cliff_dict['stabilizer'])
+        with self.assertWarns(DeprecationWarning):
+            destabs = compat['destabilizer']
+        self.assertEqual(destabs, cliff_dict['destabilizer'])

--- a/test/terra/backends/test_compatibility.py
+++ b/test/terra/backends/test_compatibility.py
@@ -14,6 +14,7 @@ Tests if quantum info result compatibility classes.
 These can be removed when this deprecation period is finished.
 """
 
+import copy
 from test.terra.common import QiskitAerTestCase
 
 import numpy as np
@@ -37,6 +38,17 @@ class TestResultCompatibility(QiskitAerTestCase):
         self.assertEqual(type(value), np.ndarray)
         self.assertTrue(np.all(value == np.array([1, 0])))
 
+    def test_statevector_copy(self):
+        compat = cqi.Statevector([1, 1e-10])
+        cpy = copy.copy(compat)
+        self.assertEqual(cpy, compat)
+
+    def test_statevector_linop(self):
+        orig = qi.random_statevector(4, seed=10)
+        compat = cqi.Statevector(orig.data)
+        self.assertEqual(2 * compat - orig, orig)
+        self.assertEqual(2 * orig - compat, orig)
+
     def test_density_matrix_eq(self):
         orig = qi.random_density_matrix(4, seed=10)
         compat = cqi.DensityMatrix(orig.data)
@@ -50,18 +62,40 @@ class TestResultCompatibility(QiskitAerTestCase):
         self.assertEqual(type(value), np.ndarray)
         self.assertTrue(np.all(value == np.array([[1, 0], [0, 0]])))
 
-    def test_operator_eq(self):
+    def test_density_matrix_copy(self):
+        compat = cqi.DensityMatrix([[1, 0], [0, 1e-10]])
+        cpy = copy.copy(compat)
+        self.assertEqual(cpy, compat)
+
+    def test_density_matrix_linop(self):
+        orig = qi.random_density_matrix(4, seed=10)
+        compat = cqi.DensityMatrix(orig.data)
+        self.assertEqual(2 * compat - orig, orig)
+        self.assertEqual(2 * orig - compat, orig)
+
+    def test_unitary_eq(self):
         orig = qi.random_unitary(4, seed=10)
         compat = cqi.Operator(orig.data)
         self.assertEqual(compat, orig)
         self.assertEqual(orig, compat)
 
-    def test_operator_getattr(self):
+    def test_unitary_getattr(self):
         compat = cqi.Operator([[1, 0], [1e-10, 1]])
         with self.assertWarns(DeprecationWarning):
             value = compat.round(5)
         self.assertEqual(type(value), np.ndarray)
         self.assertTrue(np.all(value == np.eye(2)))
+
+    def test_unitary_copy(self):
+        compat = cqi.Operator([[1, 0], [1e-10, 1]])
+        cpy = copy.copy(compat)
+        self.assertEqual(cpy, compat)
+
+    def test_unitary_linop(self):
+        orig = qi.random_unitary(4, seed=10)
+        compat = cqi.Operator(orig.data)
+        self.assertEqual(2 * compat - orig, orig)
+        self.assertEqual(2 * orig - compat, orig)
 
     def test_superop_eq(self):
         orig = qi.SuperOp(qi.random_quantum_channel(4, seed=10))
@@ -75,6 +109,17 @@ class TestResultCompatibility(QiskitAerTestCase):
             value = compat.round(5)
         self.assertEqual(type(value), np.ndarray)
         self.assertTrue(np.all(value == np.eye(4)))
+
+    def test_superop_copy(self):
+        compat = cqi.SuperOp(np.eye(4))
+        cpy = copy.copy(compat)
+        self.assertEqual(cpy, compat)
+
+    def test_superop_linop(self):
+        orig = qi.SuperOp(qi.random_quantum_channel(4, seed=10))
+        compat = cqi.SuperOp(orig.data)
+        self.assertEqual(2 * compat - orig, orig)
+        self.assertEqual(2 * orig - compat, orig)
 
     def test_stabilizer_eq(self):
         orig = qi.StabilizerState(qi.random_clifford(4, seed=10))
@@ -99,3 +144,9 @@ class TestResultCompatibility(QiskitAerTestCase):
         with self.assertWarns(DeprecationWarning):
             destabs = compat['destabilizer']
         self.assertEqual(destabs, cliff_dict['destabilizer'])
+
+    def test_stabilizer_copy(self):
+        clifford = qi.random_clifford(4, seed=10)
+        compat = cqi.StabilizerState(clifford)
+        cpy = copy.copy(compat)
+        self.assertEqual(cpy, compat)

--- a/test/terra/backends/test_compatibility.py
+++ b/test/terra/backends/test_compatibility.py
@@ -49,6 +49,23 @@ class TestResultCompatibility(QiskitAerTestCase):
         self.assertEqual(2 * compat - orig, orig)
         self.assertEqual(2 * orig - compat, orig)
 
+    def test_statevector_tensor(self):
+        orig = qi.random_statevector(2, seed=10)
+        compat = cqi.Statevector(orig.data)
+        target = orig.tensor(orig)
+        self.assertEqual(compat.tensor(orig), target)
+        self.assertEqual(orig.tensor(compat), target)
+
+    def test_statevector_evolve(self):
+        orig = qi.random_statevector(2, seed=10)
+        compat = cqi.Statevector(orig.data)
+        orig_op = qi.random_unitary(2, seed=10)
+        compat_op = cqi.Operator(orig_op.data)
+        target = orig.evolve(orig_op)
+        self.assertEqual(orig.evolve(compat_op), target)
+        self.assertEqual(compat.evolve(orig_op), target)
+        self.assertEqual(compat.evolve(compat_op), target)
+
     def test_density_matrix_eq(self):
         orig = qi.random_density_matrix(4, seed=10)
         compat = cqi.DensityMatrix(orig.data)
@@ -73,6 +90,23 @@ class TestResultCompatibility(QiskitAerTestCase):
         self.assertEqual(2 * compat - orig, orig)
         self.assertEqual(2 * orig - compat, orig)
 
+    def test_density_matrix_tensor(self):
+        orig = qi.random_density_matrix(2, seed=10)
+        compat = cqi.DensityMatrix(orig.data)
+        target = orig.tensor(orig)
+        self.assertEqual(compat.tensor(orig), target)
+        self.assertEqual(orig.tensor(compat), target)
+
+    def test_density_matrix_evolve(self):
+        orig = qi.random_density_matrix(2, seed=10)
+        compat = cqi.DensityMatrix(orig.data)
+        orig_op = qi.random_unitary(2, seed=10)
+        compat_op = cqi.Operator(orig_op.data)
+        target = orig.evolve(orig_op)
+        self.assertEqual(orig.evolve(compat_op), target)
+        self.assertEqual(compat.evolve(orig_op), target)
+        self.assertEqual(compat.evolve(compat_op), target)
+
     def test_unitary_eq(self):
         orig = qi.random_unitary(4, seed=10)
         compat = cqi.Operator(orig.data)
@@ -96,6 +130,27 @@ class TestResultCompatibility(QiskitAerTestCase):
         compat = cqi.Operator(orig.data)
         self.assertEqual(2 * compat - orig, orig)
         self.assertEqual(2 * orig - compat, orig)
+
+    def test_unitary_tensor(self):
+        orig = qi.random_unitary(2, seed=10)
+        compat = cqi.Operator(orig.data)
+        target = orig.tensor(orig)
+        self.assertEqual(compat.tensor(orig), target)
+        self.assertEqual(orig.tensor(compat), target)
+
+    def test_unitary_compose(self):
+        orig = qi.random_unitary(2, seed=10)
+        compat = cqi.Operator(orig.data)
+        target = orig.compose(orig)
+        self.assertEqual(compat.compose(orig), target)
+        self.assertEqual(orig.compose(compat), target)
+
+    def test_unitary_evolve(self):
+        orig = qi.random_unitary(2, seed=10)
+        compat = cqi.Operator(orig.data)
+        state = qi.random_statevector(2, seed=10)
+        target = state.evolve(orig)
+        self.assertEqual(state.evolve(compat), target)
 
     def test_superop_eq(self):
         orig = qi.SuperOp(qi.random_quantum_channel(4, seed=10))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This updates the returned result to store metadata for the type and subtype of all save instructions.
This metadata is used to convert the raw results into the appropriate qiskit-terra class objects.

Note this depends on https://github.com/Qiskit/qiskit-terra/pull/7277 for several tests to pass.

### Details and comments

The types that have changed are
      * ``save_statvector`` now returns as a :class:`qiskit.quantum_info.Statevector`
      * ``save_density_matrix`` now returns as a :class:`qiskit.quantum_info.DensityMatrix`
      * ``save_stabilizer`` now returns as :class:`qiskit.quantum_info.StabilizerState`
      * ``save_unitary`` now returns as :class:`qiskit.quantum_info.Operator`
      * ``save_superop`` now returns as :class:`qiskit.quantum_info.SuperOp`
      * ``save_probabilities_dict`` now returns as a :class:`qiskit.result.ProbDistribution`