### PR TITLE
Replace string qubits with tuple of integers in NoiseModel

### DIFF
--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -540,15 +540,16 @@ class NoiseModel:
         Additional Information:
             If the error object is ideal it will not be added to the model.
         """
-        if not isinstance(qubits, (list, tuple)):
-            raise NoiseError("Qubits must be a list of integers.")
-        qubits = tuple(qubits)
         # Error checking
         if not isinstance(error, QuantumError):
             try:
                 error = QuantumError(error)
             except NoiseError:
                 raise NoiseError("Input is not a valid quantum error.")
+        try:
+            qubits = tuple(qubits)
+        except TypeError as ex:
+            raise NoiseError("Qubits must be convertible to a tuple of integers") from ex
         # Check if error is ideal and if so don't add to the noise model
         if error.ideal():
             return
@@ -635,18 +636,17 @@ class NoiseModel:
              ' a circuit you should write a custom qiskit transpiler pass.',
              DeprecationWarning)
 
-        if not isinstance(noise_qubits, (list, tuple)):
-            raise NoiseError("Noise qubits must be a list of integers.")
         # Error checking
         if not isinstance(error, QuantumError):
             try:
                 error = QuantumError(error)
             except NoiseError:
                 raise NoiseError("Input is not a valid quantum error.")
-        if not isinstance(qubits, (list, tuple)):
-            raise NoiseError("Qubits must be a list of integers.")
-        noise_qubits = tuple(noise_qubits)
-        qubits = tuple(qubits)
+        try:
+            qubits = tuple(qubits)
+            noise_qubits = tuple(noise_qubits)
+        except TypeError as ex:
+            raise NoiseError("Qubits must be convertible to a tuple of integers") from ex
         # Check if error is ideal and if so don't add to the noise model
         if error.ideal():
             return
@@ -753,9 +753,10 @@ class NoiseModel:
                 error = ReadoutError(error)
             except NoiseError:
                 raise NoiseError("Input is not a valid readout error.")
-        if not isinstance(qubits, (list, tuple)):
-            raise NoiseError("Qubits must be a list of integers.")
-        qubits = tuple(qubits)
+        try:
+            qubits = tuple(qubits)
+        except TypeError as ex:
+            raise NoiseError("Qubits must be convertible to a tuple of integers") from ex
 
         # Check if error is ideal and if so don't add to the noise model
         if error.ideal():

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -530,7 +530,7 @@ class NoiseModel:
             instructions (str or list[str] or
                           Instruction or
                           list[Instruction]): the instructions error applies to.
-            qubits (list[int] or tuple[int]): qubits instruction error applies to.
+            qubits (Sequence[int]): qubits instruction error applies to.
             warnings (bool): Display warning if appending to an instruction that
                              already has an error (Default: True).
 
@@ -616,8 +616,8 @@ class NoiseModel:
             instructions (str or list[str] or
                           Instruction or
                           list[Instruction]): the instructions error applies to.
-            qubits (list[int] or tuple[int]): qubits instruction error applies to.
-            noise_qubits (list[int] or tuple[int]): Specify the exact qubits the error
+            qubits (Sequence[int]): qubits instruction error applies to.
+            noise_qubits (Sequence[int]): Specify the exact qubits the error
                                       should be applied to if different
                                       to the instruction qubits.
             warnings (bool): Display warning if appending to an instruction that

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -812,7 +812,7 @@ class NoiseModel:
             for qubits, error in qubit_dict.items():
                 error_dict = error.to_dict()
                 error_dict["operations"] = [name]
-                error_dict["gate_qubits"] = [list(qubits)]
+                error_dict["gate_qubits"] = [qubits]
                 error_list.append(error_dict)
 
         # Add non-local errors
@@ -821,8 +821,8 @@ class NoiseModel:
                 for noise_qubits, error in noise_qubit_dict.items():
                     error_dict = error.to_dict()
                     error_dict["operations"] = [name]
-                    error_dict["gate_qubits"] = [list(qubits)]
-                    error_dict["noise_qubits"] = [list(noise_qubits)]
+                    error_dict["gate_qubits"] = [qubits]
+                    error_dict["noise_qubits"] = [noise_qubits]
                     error_list.append(error_dict)
 
         # Add default readout error
@@ -833,7 +833,7 @@ class NoiseModel:
         # Add local readout error
         for qubits, error in self._local_readout_errors.items():
             error_dict = error.to_dict()
-            error_dict["gate_qubits"] = [list(qubits)]
+            error_dict["gate_qubits"] = [qubits]
             error_list.append(error_dict)
 
         ret = {"errors": error_list}

--- a/qiskit/providers/aer/utils/noise_model_inserter.py
+++ b/qiskit/providers/aer/utils/noise_model_inserter.py
@@ -56,8 +56,7 @@ def insert_noise(circuits, noise_model, transpile=False):
             # Priority for error model used:
             # nonlocal error > local error > default error
             if inst.name in nonlocal_errors and qubits in nonlocal_errors[inst.name]:
-                for noise_qubits in nonlocal_errors[inst.name][qubits].keys():
-                    error = nonlocal_errors[inst.name][qubits][noise_qubits]
+                for noise_qubits, error in nonlocal_errors[inst.name][qubits].items():
                     result_circuit.append(error.to_instruction(), noise_qubits)
             elif inst.name in local_errors and qubits in local_errors[inst.name]:
                 error = local_errors[inst.name][qubits]

--- a/qiskit/providers/aer/utils/noise_model_inserter.py
+++ b/qiskit/providers/aer/utils/noise_model_inserter.py
@@ -48,20 +48,19 @@ def insert_noise(circuits, noise_model, transpile=False):
         else:
             transpiled_circuit = circuit
         qubit_indices = {bit: index for index, bit in enumerate(transpiled_circuit.qubits)}
-        result_circuit = circuit.copy(name=transpiled_circuit.name + '_with_noise')
+        result_circuit = transpiled_circuit.copy(name=transpiled_circuit.name + '_with_noise')
         result_circuit.data = []
         for inst, qargs, cargs in transpiled_circuit.data:
             result_circuit.data.append((inst, qargs, cargs))
-            qubits_string = ",".join([str(qubit_indices[q]) for q in qargs])
+            qubits = tuple(qubit_indices[q] for q in qargs)
             # Priority for error model used:
             # nonlocal error > local error > default error
-            if inst.name in nonlocal_errors and qubits_string in nonlocal_errors[inst.name]:
-                for noise_qubits in nonlocal_errors[inst.name][qubits_string].keys():
-                    error = nonlocal_errors[inst.name][qubits_string][noise_qubits]
-                    noise_qargs = noise_model._str2qubits(noise_qubits)
-                    result_circuit.append(error.to_instruction(), noise_qargs)
-            elif inst.name in local_errors and qubits_string in local_errors[inst.name]:
-                error = local_errors[inst.name][qubits_string]
+            if inst.name in nonlocal_errors and qubits in nonlocal_errors[inst.name]:
+                for noise_qubits in nonlocal_errors[inst.name][qubits].keys():
+                    error = nonlocal_errors[inst.name][qubits][noise_qubits]
+                    result_circuit.append(error.to_instruction(), noise_qubits)
+            elif inst.name in local_errors and qubits in local_errors[inst.name]:
+                error = local_errors[inst.name][qubits]
                 result_circuit.append(error.to_instruction(), qargs)
             elif inst.name in default_errors.keys():
                 error = default_errors[inst.name]

--- a/qiskit/providers/aer/utils/noise_remapper.py
+++ b/qiskit/providers/aer/utils/noise_remapper.py
@@ -95,13 +95,13 @@ def remap_noise_model(noise_model, remapping, discard_qubits=False, warnings=Tru
     def in_target(qubits):  # check if qubits are to be remapped or not
         if not discard_qubits:
             return True
-        for q in noise_model._str2qubits(qubits):
+        for q in qubits:
             if q in discarded_qubits:
                 return False
         return True
 
     def remapped(qubits):
-        return tuple(inv_map[q] for q in noise_model._str2qubits(qubits))
+        return tuple(inv_map[q] for q in qubits)
 
     # Copy from original noise model
     new_model = NoiseModel()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Replacing string keys representing qubits used internally in NoiseModel with tuple of integers so to avoid many conversions using `_str2qubits` and `_qubits2str`.


