### PR TITLE
[WIP] temporally disable avx for diagonal matrix multiplication on windows

### DIFF
--- a/src/simulators/statevector/qv_avx2.cpp
+++ b/src/simulators/statevector/qv_avx2.cpp
@@ -1163,6 +1163,11 @@ Avx apply_diagonal_matrix_avx<double>(double* qv_data_,
                                       const double* vec_,
                                       const size_t omp_threads) {
 
+#if defined(_WIN64) || defined(_WIN32)
+  //temporally disable windows
+  return Avx::NotApplied;
+#else
+
   auto qv_data = _to_complex(qv_data_);
   const auto input_vec = _to_complex(vec_);
 
@@ -1208,6 +1213,7 @@ Avx apply_diagonal_matrix_avx<double>(double* qv_data_,
   free(double_tmp);
 
   return Avx::Applied;
+#endif
 }
 
 template <>
@@ -1218,6 +1224,10 @@ Avx apply_diagonal_matrix_avx<float>(float* qv_data_,
                                      const float* vec_,
                                      const size_t omp_threads) {
 
+#if defined(_WIN64) || defined(_WIN32)
+  //temporally disable windows
+  return Avx::NotApplied;
+#else
   if (data_size < (1UL << 2))
     return Avx::NotApplied;
 
@@ -1270,6 +1280,7 @@ Avx apply_diagonal_matrix_avx<float>(float* qv_data_,
   free(float_tmp);
 
   return Avx::Applied;
+#endif
 }
 
 } /* End namespace QV */


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR disables use of AVX in diagonal matrix multiplication only on Windows.

### Details and comments

CI fails only on Windows and the last commit is related AVX in diagonal matrix multiplication.
This PR temporally disable AVX only on Windows for debug this issue.
