### PR TITLE
Use terra from release in Python 3.6 job

### DIFF
--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -45,7 +45,7 @@ jobs:
     needs: ["lint"]
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         platform: [
           { os: "ubuntu-latest", python-architecture: "x64" },
         ]
@@ -110,7 +110,10 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version}}-pip-
             ${{ runner.os }}-${{ matrix.python-version}}-
       - name: Install Deps
-        run: python -m pip install -U -c constraints.txt -r requirements-dev.txt wheel git+https://github.com/Qiskit/qiskit-terra
+        run: python -m pip install -U -c constraints.txt -r requirements-dev.txt wheel
+      - name: Install terra from source
+        run: python -m pip install -U -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
+        if: matrix.python-version != '3.6'
       - name: Install openblas
         run: |
           set -e


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Terra's main branch which is currently developing the 0.20.0 release has
dropped support for running with Python 3.6 as the recently released
0.19.x is the last release series with 3.6 support. For the upcoming Aer
0.10.0 release we still want to support 3.6 and release artifacts. We
already relaxed our testing of 3.6 to just be linux to reduce our CI
time recently, but those jobs are failing now. This commit addresses
this by installing terra from release instead of main in the 3.6 jobs.
Arguably we should be doing this everywhere as we release aer against
terra on pypi, not it's development branch. But that's something we can
discuss in a future change. For right now this just makes the adjustment
on the 3.6 test job.


### Details and comments


