### PR TITLE
Fixes to from_backend for V2

### DIFF
--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -15,7 +15,6 @@ Qiskit Aer qasm simulator backend.
 
 import copy
 import logging
-import warnings
 from qiskit.providers.options import Options
 from qiskit.providers.models import QasmBackendConfiguration
 from qiskit.providers.backend import BackendV2
@@ -569,7 +568,7 @@ class AerSimulator(AerBackend):
         """Initialize simulator from backend."""
         if isinstance(backend, BackendV2):
             raise AerError(
-                "AerSimulator.from_backend is not yet supported for V2 Backends."
+                "AerSimulator.from_backend does not currently support V2 Backends."
             )
         # Get configuration and properties from backend
         configuration = copy.copy(backend.configuration())

--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -15,8 +15,10 @@ Qiskit Aer qasm simulator backend.
 
 import copy
 import logging
+import warnings
 from qiskit.providers.options import Options
 from qiskit.providers.models import QasmBackendConfiguration
+from qiskit.providers.backend import BackendV2
 
 from ..version import __version__
 from .aerbackend import AerBackend, AerError
@@ -565,6 +567,10 @@ class AerSimulator(AerBackend):
     @classmethod
     def from_backend(cls, backend, **options):
         """Initialize simulator from backend."""
+        if isinstance(backend, BackendV2):
+            raise AerError(
+                "AerSimulator.from_backend is not yet supported for V2 Backends."
+            )
         # Get configuration and properties from backend
         configuration = copy.copy(backend.configuration())
         properties = copy.copy(backend.properties())

--- a/qiskit/providers/aer/backends/pulse_simulator.py
+++ b/qiskit/providers/aer/backends/pulse_simulator.py
@@ -23,6 +23,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import schedule
 from qiskit.providers.options import Options
 from qiskit.providers.models import BackendConfiguration, PulseDefaults
+from qiskit.providers.backend import BackendV2
 from qiskit.utils import deprecate_arguments
 
 from ..version import __version__
@@ -247,6 +248,10 @@ class PulseSimulator(AerBackend):
     @classmethod
     def from_backend(cls, backend, **options):
         """Initialize simulator from backend."""
+        if isinstance(backend, BackendV2):
+            raise AerError(
+                "PulseSimulator.from_backend does not currently support V2 Backends."
+            )
         configuration = copy.copy(backend.configuration())
         defaults = copy.copy(backend.defaults())
         properties = copy.copy(backend.properties())

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -18,6 +18,7 @@ import logging
 from warnings import warn
 from qiskit.providers.options import Options
 from qiskit.providers.models import QasmBackendConfiguration
+from qiskit.providers.backend import BackendV2
 
 from ..version import __version__
 from ..aererror import AerError
@@ -452,6 +453,10 @@ class QasmSimulator(AerBackend):
     @classmethod
     def from_backend(cls, backend, **options):
         """Initialize simulator from backend."""
+        if isinstance(backend, BackendV2):
+            raise AerError(
+                "QasmSimulator.from_backend does not currently support V2 Backends."
+            )
         # pylint: disable=import-outside-toplevel
         # Avoid cyclic import
         from ..noise.noise_model import NoiseModel

--- a/qiskit/providers/aer/noise/__init__.py
+++ b/qiskit/providers/aer/noise/__init__.py
@@ -157,6 +157,19 @@ The following functions can be used to generate many common types of
     kraus_error
 
 
+Noise Transpiler Passes
+=======================
+
+These transpiler passes can be used to build noise models that can be applied
+to circuits via transpilation.
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    LocalNoisePass
+    RelaxationNoisePass
+
+
 Device Noise Parameters
 =======================
 
@@ -191,6 +204,10 @@ from .errors import thermal_relaxation_error
 from .errors import phase_amplitude_damping_error
 from .errors import amplitude_damping_error
 from .errors import phase_damping_error
+
+# Transpiler Passes
+from .passes import LocalNoisePass
+from .passes import RelaxationNoisePass
 
 # Submodules
 from . import errors

--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -304,7 +304,7 @@ class NoiseModel:
         """
         if isinstance(backend, BackendV2):
             raise NoiseError(
-                "V2 Backends are not yet supported by `NoiseModel.from_backend`")
+                "NoiseModel.from_backend does not currently support V2 Backends.")
         if isinstance(backend, (BaseBackend, BackendV1)):
             properties = backend.properties()
             configuration = backend.configuration()

--- a/test/terra/noise/passes/test_local_noise_pass.py
+++ b/test/terra/noise/passes/test_local_noise_pass.py
@@ -13,8 +13,7 @@
 LocalNoisePass class tests
 """
 
-from qiskit.providers.aer.noise.errors import ReadoutError
-from qiskit.providers.aer.noise.passes import LocalNoisePass
+from qiskit.providers.aer.noise import ReadoutError, LocalNoisePass
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import SXGate, HGate

--- a/test/terra/noise/passes/test_relaxation_noise_pass.py
+++ b/test/terra/noise/passes/test_relaxation_noise_pass.py
@@ -13,8 +13,7 @@
 RelaxationNoisePass class tests
 """
 
-from qiskit.providers.aer.noise.errors import thermal_relaxation_error
-from qiskit.providers.aer.noise.passes import RelaxationNoisePass
+from qiskit.providers.aer.noise import thermal_relaxation_error, RelaxationNoisePass
 
 import qiskit.quantum_info as qi
 from qiskit.circuit import QuantumCircuit, Delay


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `*Simulator.from_backend` and `NoiseModel.from_backend` assume the input backend is a V1 backend.
This changes these functions to raise an exception if a V2 backend is passed until we can work out how to make them support V2 backends.

### Details and comments

This also reworks some of the functionality added in #1391 to be more robust when looking for required backend attributes (like dt, t1, t2)
