### PR TITLE
Fix performance regression from QuantumError.to_dict

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -24,7 +24,6 @@ from qiskit.circuit import QuantumCircuit, Instruction, QuantumRegister
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.library.generalized_gates import PauliGate
 from qiskit.circuit.library.standard_gates import IGate
-from qiskit.compiler import assemble
 from qiskit.exceptions import QiskitError
 from qiskit.extensions import UnitaryGate
 from qiskit.quantum_info.operators.base_operator import BaseOperator
@@ -453,13 +452,12 @@ class QuantumError(BaseOperator, TolerancesMixin):
 
     def to_dict(self):
         """Return the current error as a dictionary."""
-        qobj = assemble(self.circuits)
-        instructions = [exp.to_dict()['instructions'] for exp in qobj.experiments]
         error = {
             "type": "qerror",
             "id": self.id,
             "operations": [],
-            "instructions": instructions,
+            "instructions": [[op[0].assemble().to_dict() for op in circ.data]
+                             for circ in self._circs],
             "probabilities": list(self.probabilities)
         }
         return error

--- a/releasenotes/notes/fix-qerror-assemble-9919a93b210ca776.yaml
+++ b/releasenotes/notes/fix-qerror-assemble-9919a93b210ca776.yaml
@@ -2,6 +2,7 @@
 fixes:
   - |
     Fix performance regression in noisy simulations due to large increase in
-    serialization overhead for loading noise models from Python into C++.
-    See `issue 1407 <https://github.com/Qiskit/qiskit-aer/issues/1407>`_ for
-    details.
+    serialization overhead for loading noise models from Python into C++
+    resulting from unintended nested Python multiprocessing calls.
+    See `issue 1407 <https://github.com/Qiskit/qiskit-aer/issues/1407>`__
+    for details.

--- a/releasenotes/notes/fix-qerror-assemble-9919a93b210ca776.yaml
+++ b/releasenotes/notes/fix-qerror-assemble-9919a93b210ca776.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix performance regression in noisy simulations due to large increase in
+    serialization overhead for loading noise models from Python into C++.
+    See `issue 1407 <https://github.com/Qiskit/qiskit-aer/issues/1407>`_ for
+    details.

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -332,8 +332,6 @@ protected:
     }
     return max_memory_mb_;
   }
-  // Truncate and remap input qubits
-  bool enable_truncation_ = true;
 
   // The maximum number of threads to use for various levels of parallelization
   int max_parallel_threads_;
@@ -390,8 +388,6 @@ protected:
 //-------------------------------------------------------------------------
 
 void Controller::set_config(const json_t &config) {
-  // Load validation threshold
-  JSON::get_value(enable_truncation_, "enable_truncation", config);
 
   // Load validation threshold
   JSON::get_value(validation_threshold_, "validation_threshold", config);
@@ -847,7 +843,7 @@ Result Controller::execute(const inputdata_t &input_qobj) {
     auto timer_start = myclock_t::now();
 
     // Initialize QOBJ
-    Qobj qobj(input_qobj, enable_truncation_);
+    Qobj qobj(input_qobj);
     auto qobj_time_taken =
         std::chrono::duration<double>(myclock_t::now() - timer_start).count();
 

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -846,37 +846,31 @@ Result Controller::execute(const inputdata_t &input_qobj) {
     // Start QOBJ timer
     auto timer_start = myclock_t::now();
 
-    Noise::NoiseModel noise_model;
-    json_t config;
+    // Initialize QOBJ
+    Qobj qobj(input_qobj, enable_truncation_);
+    auto qobj_time_taken =
+        std::chrono::duration<double>(myclock_t::now() - timer_start).count();
 
-    // Check for config
-    if (Parser<inputdata_t>::get_value(config, "config", input_qobj)) {
-      // Set config
-      set_config(config);
-      // Load noise model
-      Parser<json_t>::get_value(noise_model, "noise_model", config);
-    }
+    // Set config
+    set_config(qobj.config);
 
-    // Initialize qobj
-    Qobj qobj;
-    if (noise_model.has_nonlocal_quantum_errors()) {
-       // Non-local noise does not work with optimized initialization
-       qobj = Qobj(input_qobj, false);
-    } else {
-      qobj = Qobj(input_qobj, enable_truncation_);
-    }
+    // Run qobj circuits
+    auto result = execute(qobj.circuits, qobj.noise_model, qobj.config);
 
-    auto result = execute(qobj.circuits, noise_model, config);
+    // Add QOBJ loading time
+    result.metadata.add(qobj_time_taken, "time_taken_load_qobj");
+
     // Get QOBJ id and pass through header to result
     result.qobj_id = qobj.id;
     if (!qobj.header.empty()) {
       result.header = qobj.header;
     }
+
     // Stop the timer and add total timing data including qobj parsing
-    auto timer_stop = myclock_t::now();
     auto time_taken =
-        std::chrono::duration<double>(timer_stop - timer_start).count();
+        std::chrono::duration<double>(myclock_t::now() - timer_start).count();
     result.metadata.add(time_taken, "time_taken");
+    
     return result;
   } catch (std::exception &e) {
     // qobj was invalid, return valid output containing error message
@@ -1007,7 +1001,7 @@ Result Controller::execute(std::vector<Circuit> &circuits,
     auto timer_stop = myclock_t::now();
     auto time_taken =
         std::chrono::duration<double>(timer_stop - timer_start).count();
-    result.metadata.add(time_taken, "time_taken");
+    result.metadata.add(time_taken, "time_taken_execute");
   }
   // If execution failed return valid output reporting error
   catch (std::exception &e) {

--- a/test/terra/backends/aer_simulator/test_truncate.py
+++ b/test/terra/backends/aer_simulator/test_truncate.py
@@ -40,7 +40,7 @@ class TestTruncateQubits(SimulatorTestCase):
         circuit.measure(1, 1)
         return circuit
 
-    def deveice_backend(self):
+    def device_backend(self):
         return mock.FakeQuito()
 
     def test_truncate_ideal_sparse_circuit(self):
@@ -65,7 +65,7 @@ class TestTruncateQubits(SimulatorTestCase):
             [0, 1], [1, 2], [2, 3], [3, 4], [4, 5],
             [5, 6], [6, 7], [7, 8], [8, 9], [9, 0]
         ]
-        noise_model = NoiseModel.from_backend(self.deveice_backend())
+        noise_model = NoiseModel.from_backend(self.device_backend())
         backend = self.backend(noise_model=noise_model)
         circuit = transpile(
             self.create_circuit_for_truncate(),
@@ -78,7 +78,7 @@ class TestTruncateQubits(SimulatorTestCase):
 
     def test_truncate_non_measured_qubits(self):
         """Test truncation of non-measured uncoupled qubits."""
-        noise_model = NoiseModel.from_backend(self.deveice_backend())
+        noise_model = NoiseModel.from_backend(self.device_backend())
         backend = self.backend(noise_model=noise_model)
         circuit = transpile(
             self.create_circuit_for_truncate(),
@@ -95,7 +95,7 @@ class TestTruncateQubits(SimulatorTestCase):
             [0, 1], [1, 2], [2, 3], [3, 4], [4, 5],
             [5, 6], [6, 7], [7, 8], [8, 9], [9, 0]
         ]
-        noise_model = NoiseModel.from_backend(self.deveice_backend())
+        noise_model = NoiseModel.from_backend(self.device_backend())
         backend = self.backend(noise_model=noise_model, enable_truncation=False)
         circuit = transpile(
             self.create_circuit_for_truncate(),

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -283,8 +283,9 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         )
 
     @staticmethod
-    def aslist(qargs):
-        return [q.index for q in qargs]
+    def qubits_list(circ, qargs):
+        qubit_map = {qubit: i for i, qubit in enumerate(circ.qubits)}
+        return [qubit_map[q] for q in qargs]
 
     @ddt.data(
         ('id', np.eye(2)),
@@ -384,7 +385,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
             instr, _ = error.error_term(j)
             self.assertEqual(len(instr), 1)
             self.assertIn(instr[0][0].name, ['x', 'y', 'z', 'id'])
-            self.assertEqual(self.aslist(instr[0][1]), [0])
+            self.assertEqual(self.qubits_list(instr, instr[0][1]), [0])
         target = SuperOp(kraus)
         self.assertEqual(target, SuperOp(error))
 
@@ -398,7 +399,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         circ, prob = error.error_term(0)
         self.assertEqual(prob, 1)
         self.assertEqual(circ[0][0].name, 'kraus')
-        self.assertEqual(self.aslist(circ.qubits), [0, 1])
+        self.assertEqual(self.qubits_list(circ, circ.qubits), [0, 1])
         self.assertEqual(target, SuperOp(error), msg="Incorrect tensor kraus")
 
     def test_tensor_both_unitary_standard_gates(self):
@@ -417,7 +418,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
             self.assertEqual(len(circ), 2)
             for instr, qargs, _ in circ:
                 self.assertIn(instr.name, ['s', 'x', 'y', 'z'])
-                self.assertIn(self.aslist(qargs), [[0], [1]])
+                self.assertIn(self.qubits_list(circ, qargs), [[0], [1]])
         self.assertEqual(SuperOp(error), target)
 
     def test_tensor_kraus_and_unitary(self):
@@ -428,7 +429,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         target = SuperOp(kraus).tensor(kraus_unitaries)
 
         circ, prob = error.error_term(0)
-        self.assertEqual(self.aslist(circ.qubits), [0, 1])
+        self.assertEqual(self.qubits_list(circ, circ.qubits), [0, 1])
         self.assertEqual(target, SuperOp(error))
 
     def test_tensor_unitary_and_kraus(self):
@@ -439,7 +440,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         target = SuperOp(kraus_unitaries).tensor(kraus)
 
         circ, prob = error.error_term(0)
-        self.assertEqual(self.aslist(circ.qubits), [0, 1])
+        self.assertEqual(self.qubits_list(circ, circ.qubits), [0, 1])
         self.assertEqual(target, SuperOp(error))
 
     def test_expand_both_kraus(self):
@@ -453,8 +454,8 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         self.assertEqual(prob, 1)
         self.assertEqual(circ[0][0].name, 'kraus')
         self.assertEqual(circ[1][0].name, 'kraus')
-        self.assertEqual(self.aslist(circ[0][1]), [0])
-        self.assertEqual(self.aslist(circ[1][1]), [1])
+        self.assertEqual(self.qubits_list(circ, circ[0][1]), [0])
+        self.assertEqual(self.qubits_list(circ, circ[1][1]), [1])
         self.assertEqual(target, SuperOp(error))
 
     def test_expand_both_unitary_standard_gates(self):
@@ -473,7 +474,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
             self.assertEqual(len(circ), 2)
             for instr, qargs, _ in circ:
                 self.assertIn(instr.name, ['s', 'x', 'y', 'z'])
-                self.assertIn(self.aslist(qargs), [[0], [1]])
+                self.assertIn(self.qubits_list(circ, qargs), [[0], [1]])
         self.assertEqual(SuperOp(error), target)
 
     def test_expand_kraus_and_unitary(self):
@@ -486,7 +487,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         circ, prob = error.error_term(0)
         # self.assertEqual(prob, 1)
         self.assertEqual(circ[0][0].name, 'kraus')
-        self.assertEqual(self.aslist(circ.qubits), [0, 1])
+        self.assertEqual(self.qubits_list(circ, circ.qubits), [0, 1])
         self.assertEqual(target, SuperOp(error))
 
     def test_expand_unitary_and_kraus(self):
@@ -497,7 +498,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         target = SuperOp(kraus_unitaries).expand(kraus)
 
         circ, prob = error.error_term(0)
-        self.assertEqual(self.aslist(circ.qubits), [0, 1])
+        self.assertEqual(self.qubits_list(circ, circ.qubits), [0, 1])
         self.assertEqual(target, SuperOp(error))
 
     def test_compose_both_kraus(self):
@@ -510,7 +511,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         kraus, prob = error.error_term(0)
         self.assertEqual(prob, 1)
         self.assertEqual(kraus[0][0].name, 'kraus')
-        self.assertEqual(self.aslist(kraus[0][1]), [0])
+        self.assertEqual(self.qubits_list(kraus, kraus[0][1]), [0])
         self.assertEqual(target, SuperOp(error), msg="Incorrect tensor kraus")
 
     def test_compose_both_unitary_standard_gates(self):
@@ -527,7 +528,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         for j in range(4):
             circ, _ = error.error_term(j)
             self.assertIn(circ[0][0].name, ['s', 'x', 'y', 'z'])
-            self.assertEqual(self.aslist(circ[0][1]), [0])
+            self.assertEqual(self.qubits_list(circ, circ[0][1]), [0])
         self.assertEqual(SuperOp(error), target)
 
     def test_compose_kraus_and_unitary(self):
@@ -540,7 +541,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         circ, prob = error.error_term(0)
         # self.assertEqual(prob, 1)
         self.assertEqual(circ[0][0].name, 'kraus')
-        self.assertEqual(self.aslist(circ[0][1]), [0])
+        self.assertEqual(self.qubits_list(circ, circ[0][1]), [0])
         self.assertEqual(target, SuperOp(error))
 
     def test_compose_unitary_and_kraus(self):
@@ -551,7 +552,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         target = SuperOp(kraus_unitaries).compose(kraus)
 
         circ, prob = error.error_term(0)
-        self.assertEqual(self.aslist(circ[0][1]), [0])
+        self.assertEqual(self.qubits_list(circ, circ[0][1]), [0])
         self.assertEqual(target, SuperOp(error))
 
     def test_dot_both_kraus(self):
@@ -564,7 +565,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         kraus, prob = error.error_term(0)
         self.assertEqual(prob, 1)
         self.assertEqual(kraus[0][0].name, 'kraus')
-        self.assertEqual(self.aslist(kraus[0][1]), [0])
+        self.assertEqual(self.qubits_list(kraus, kraus[0][1]), [0])
         self.assertEqual(target, SuperOp(error), msg="Incorrect dot kraus")
 
     def test_dot_both_unitary_standard_gates(self):
@@ -581,7 +582,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         for j in range(4):
             circ, _ = error.error_term(j)
             self.assertIn(circ[0][0].name, ['s', 'x', 'y', 'z'])
-            self.assertEqual(self.aslist(circ[0][1]), [0])
+            self.assertEqual(self.qubits_list(circ, circ[0][1]), [0])
         self.assertEqual(SuperOp(error), target)
 
     def test_dot_kraus_and_unitary(self):
@@ -592,7 +593,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         target = SuperOp(kraus).dot(kraus_unitaries)
 
         circ, prob = error.error_term(0)
-        self.assertEqual(self.aslist(circ[0][1]), [0])
+        self.assertEqual(self.qubits_list(circ, circ[0][1]), [0])
         self.assertEqual(target, SuperOp(error))
 
     def test_dot_unitary_and_kraus(self):
@@ -605,7 +606,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
         circ, prob = error.error_term(0)
         # self.assertEqual(prob, 1)
         self.assertEqual(circ[0][0].name, 'kraus')
-        self.assertEqual(self.aslist(circ[0][1]), [0])
+        self.assertEqual(self.qubits_list(circ, circ[0][1]), [0])
         self.assertEqual(target, SuperOp(error))
 
     def test_to_quantumchannel_kraus(self):

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -284,8 +284,7 @@ class TestQuantumErrorOldInterface(QiskitAerTestCase):
 
     @staticmethod
     def qubits_list(circ, qargs):
-        qubit_map = {qubit: i for i, qubit in enumerate(circ.qubits)}
-        return [qubit_map[q] for q in qargs]
+        return [circ.find_bit(q).index for q in qargs]
 
     @ddt.data(
         ('id', np.eye(2)),

--- a/test/terra/reference/ref_kraus_noise.py
+++ b/test/terra/reference/ref_kraus_noise.py
@@ -60,15 +60,6 @@ def kraus_gate_error_noise_models():
 
     return noise_models
 
-def kraus_gate_error_noise_models_full():
-    """Kraus gate error noise models on many gate types"""
-
-    # Amplitude damping error on "u1", "u2", "u3", "cx"
-    error = amplitude_damping_error(0.2)
-    noise_model = NoiseModel()
-    noise_model.add_all_qubit_quantum_error(error, ['h'])
-    noise_model.add_all_qubit_quantum_error(error.tensor(error), ['cp', 'swap'])
-    return noise_model
 
 def kraus_gate_error_counts(shots, hex_counts=True):
     """Kraus gate error circuits reference counts"""
@@ -80,13 +71,3 @@ def kraus_gate_error_counts(shots, hex_counts=True):
 
     # Convert to counts dict
     return [list2dict(i, hex_counts) for i in counts_lists]
-
-def kraus_gate_error_counts_on_QFT(shots, hex_counts=False):
-    """Kraus gate error QFT circuits reference counts"""
-
-    # Kraus error on all kinds of gates - the results are highly dependent on the
-    # specific circuit and therefore are hardcoded
-    counts = {'0x0':370*shots/1000, '0x1':175*shots/1000, '0x2':170*shots/1000,
-              '0x3':75*shots/1000,  '0x4':100*shots/1000,  '0x5':45*shots/1000,
-              '0x6':45*shots/1000,  '0x7':20*shots/1000}
-    return counts


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1407 #1398 

Fixes issue with QuantumError.to_dict causing a huge performance regression in noisy simulations from its calling of `qiskit.assemble` inside Pybind11 code.

### Details and comments

This also fixed an inefficiency in the C++ controller `execute` function where the qobj config was deserialized/parsed twice (which doubled the performance regression in #1407)