### PR TITLE
Reduce unnecessary circuit iteration

### DIFF
--- a/qiskit/providers/aer/backends/aer_compiler.py
+++ b/qiskit/providers/aer/backends/aer_compiler.py
@@ -76,8 +76,8 @@ class AerCompiler:
         )
 
         # Check via optypes
-        if isinstance(optype, set) and optype.intersection(controlflow_types):
-            return True
+        if isinstance(optype, set):
+            return bool(optype.intersection(controlflow_types))
 
         # Check via iteration
         for inst, _, _ in circuit.data:

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -21,7 +21,7 @@ import uuid
 import warnings
 from abc import ABC, abstractmethod
 
-from qiskit.circuit import QuantumCircuit, ParameterExpression
+from qiskit.circuit import QuantumCircuit, ParameterExpression, Delay
 from qiskit.compiler import assemble
 from qiskit.providers import BackendV1 as Backend
 from qiskit.providers.models import BackendStatus
@@ -32,6 +32,7 @@ from qiskit.utils import deprecate_arguments
 from ..aererror import AerError
 from ..jobs import AerJob, AerJobSet, split_qobj
 from ..noise.noise_model import NoiseModel, QuantumErrorLocation
+from ..noise.errors.quantum_error import QuantumChannelInstruction
 from .aer_compiler import compile_circuit
 from .backend_utils import format_save_type
 
@@ -330,11 +331,21 @@ class AerBackend(Backend, ABC):
                     data[key] = format_save_type(val, save_types[key], save_subtypes[key])
         return Result.from_dict(output)
 
+    @staticmethod
+    def _circuit_optypes(circuit):
+        """Retur set of all operation names in a circuit"""
+        if not isinstance(circuit, QuantumCircuit):
+            return set()
+        optypes = set()
+        for instr, _, _ in circuit._data:
+            optypes.add(type(instr))
+        return optypes
+
     def _assemble(self, circuits, parameter_binds=None, **run_options):
         """Assemble one or more Qobj for running on the simulator"""
         # Remove quantum error instructions from circuits and add to
         # run option noise model
-        circuits, run_options = self._assemble_noise_model(circuits, **run_options)
+        circuits, optypes, run_options = self._assemble_noise_model(circuits, **run_options)
 
         # This conditional check can be removed when we remove passing
         # qobj to run
@@ -346,12 +357,27 @@ class AerBackend(Backend, ABC):
             assemble_binds = []
             assemble_binds.append({param: 1 for bind in parameter_binds for param in bind})
 
-            qobj = assemble(compile_circuit(circuits, self.configuration().basis_gates),
-                            self,
-                            parameter_binds=assemble_binds,
-                            parameterizations=parameterizations)
+            qobj = assemble(
+                compile_circuit(
+                    circuits,
+                    basis_gates=self.configuration().basis_gates,
+                    optypes=optypes),
+                self,
+                parameter_binds=assemble_binds,
+                parameterizations=parameterizations)
         else:
-            qobj = assemble(compile_circuit(circuits, self.configuration().basis_gates), self)
+            qobj = assemble(
+                compile_circuit(
+                    circuits,
+                    basis_gates=self.configuration().basis_gates,
+                    optypes=optypes),
+                self)
+
+        # Add optypes to qobj
+        # We convert to strings to avoid pybinding of types
+        qobj.config.optypes = [
+            [i.__name__ for i in optype] if optype else [] for optype in optypes
+        ]
 
         # Add options
         for key, val in self.options.__dict__.items():
@@ -367,10 +393,17 @@ class AerBackend(Backend, ABC):
     def _assemble_noise_model(self, circuits, **run_options):
         """Move quantum error instructions from circuits to noise model"""
         if isinstance(circuits, (QasmQobj, PulseQobj)):
-            return circuits, run_options
+            optypes = [set() for _ in range(len(circuits.experiments))]
+            return circuits, optypes, run_options
 
         if isinstance(circuits, (QuantumCircuit, Schedule, ScheduleBlock)):
-            circuits = [circuits]
+            run_circuits = [circuits]
+        else:
+            # Make a shallow copy so we can modify list elements if required
+            run_circuits = copy.copy(circuits)
+
+        # Generate opsets of instructions
+        optypes = [self._circuit_optypes(circ) for circ in run_circuits]
 
         # Flag for if we need to make a deep copy of the noise model
         # This avoids unnecessarily copying the noise model for circuits
@@ -379,24 +412,35 @@ class AerBackend(Backend, ABC):
         noise_model = run_options.get(
             'noise_model', getattr(self.options, 'noise_model', None))
 
-        # Add custom pass noise only to QuantumCircuit objects
-        if noise_model and all(isinstance(circ, QuantumCircuit) for circ in circuits):
+        # Add custom pass noise only to QuantumCircuit objects that contain delay
+        # instructions since this is the only instruction handled by the noise pass
+        # at present
+        if noise_model and all(isinstance(circ, QuantumCircuit) for circ in run_circuits):
             npm = noise_model._pass_manager()
             if npm is not None:
-                circuits = npm.run(circuits)
-                if isinstance(circuits, QuantumCircuit):
-                    circuits = [circuits]
+                # Get indicies of circuits that need noise transpiling
+                transpile_idxs = [
+                    idx for idx, opset in enumerate(optypes) if Delay in opset
+                ]
+
+                # Transpile only the required circuits
+                transpiled_circuits = npm.run([run_circuits[i] for i in transpile_idxs])
+                if isinstance(transpiled_circuits, QuantumCircuit):
+                    transpiled_circuits = [transpiled_circuits]
+
+                # Update the circuits with transpiled ones
+                for idx, circ in zip(transpile_idxs, transpiled_circuits):
+                    run_circuits[idx] = circ
+                    optypes[idx] = self._circuit_optypes(circ)
 
         # Check if circuits contain quantum error instructions
-        run_circuits = []
-        for circ in circuits:
-            if isinstance(circ, (Schedule, ScheduleBlock)):
-                run_circuits.append(circ)
-            else:
+        for idx, circ in enumerate(run_circuits):
+            if QuantumChannelInstruction in optypes[idx] and not isinstance(
+                    circ, (Schedule, ScheduleBlock)):
                 updated_circ = False
                 new_data = []
                 for inst, qargs, cargs in circ.data:
-                    if inst.name == "quantum_channel":
+                    if isinstance(inst, QuantumChannelInstruction):
                         updated_circ = True
                         if not updated_noise:
                             # Deep copy noise model on first update
@@ -407,7 +451,9 @@ class AerBackend(Backend, ABC):
                             updated_noise = True
                         # Extract error and replace with place holder
                         qerror = inst._quantum_error
-                        new_data.append((QuantumErrorLocation(qerror), qargs, cargs))
+                        qerror_loc = QuantumErrorLocation(qerror)
+                        new_data.append((qerror_loc, qargs, cargs))
+                        optypes[idx].add(QuantumErrorLocation)
                         # Add error to noise model
                         if qerror.id not in noise_model._default_quantum_errors:
                             noise_model.add_all_qubit_quantum_error(qerror, qerror.id)
@@ -416,16 +462,16 @@ class AerBackend(Backend, ABC):
                 if updated_circ:
                     new_circ = circ.copy()
                     new_circ.data = new_data
-                    run_circuits.append(new_circ)
-                else:
-                    run_circuits.append(circ)
+                    run_circuits[idx] = new_circ
+                    if QuantumChannelInstruction in optypes[idx]:
+                        optypes[idx].remove(QuantumChannelInstruction)
 
         # If we modified the existing noise model, add it to the run options
         if updated_noise:
             run_options['noise_model'] = noise_model
 
         # Return the possibly updated circuits and noise model
-        return run_circuits, run_options
+        return run_circuits, optypes, run_options
 
     def _get_executor(self, **run_options):
         """Get the executor"""

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -338,7 +338,7 @@ class AerBackend(Backend, ABC):
         else:
             # Generate optypes for circuit
             # Generate opsets of instructions
-            if not isinstance(circuits, list):
+            if isinstance(circuits, (QuantumCircuit, Schedule, ScheduleBlock)):
                 circuits = [circuits]
             optypes = [circuit_optypes(circ) for circ in circuits]
 
@@ -369,7 +369,7 @@ class AerBackend(Backend, ABC):
             # Add optypes to qobj
             # We convert to strings to avoid pybinding of types
             qobj.config.optypes = [
-                [i.__name__ for i in optype] if optype else []
+                set(i.__name__ for i in optype) if optype else set()
                 for optype in optypes]
 
         # Add options

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -338,7 +338,7 @@ class AerBackend(Backend, ABC):
         else:
             # Generate optypes for circuit
             # Generate opsets of instructions
-            if not isinstance(circuits,list):
+            if not isinstance(circuits, list):
                 circuits = [circuits]
             optypes = [circuit_optypes(circ) for circ in circuits]
 

--- a/qiskit/providers/aer/backends/backend_utils.py
+++ b/qiskit/providers/aer/backends/backend_utils.py
@@ -207,3 +207,14 @@ def format_save_type(data, save_type, save_subtype):
         return {key: func(val) for key, val in data.items()}
 
     return func(data)
+
+
+def circuit_optypes(circuit):
+    """Return set of all operation names in a circuit"""
+    if not isinstance(circuit, QuantumCircuit):
+        return set()
+    optypes = set()
+    for inst, _, _ in circuit._data:
+        optypes.update(type(inst).mro())
+    optypes.discard(object)
+    return optypes

--- a/qiskit/providers/aer/backends/backend_utils.py
+++ b/qiskit/providers/aer/backends/backend_utils.py
@@ -210,7 +210,7 @@ def format_save_type(data, save_type, save_subtype):
 
 
 def circuit_optypes(circuit):
-    """Return set of all operation names in a circuit"""
+    """Return set of all operation types and parent types in a circuit."""
     if not isinstance(circuit, QuantumCircuit):
         return set()
     optypes = set()

--- a/qiskit/providers/aer/jobs/utils.py
+++ b/qiskit/providers/aer/jobs/utils.py
@@ -162,9 +162,17 @@ def split_qobj(qobj, max_size=None, max_shot_size=None, qobj_id=None):
     Returns:
         List: A list of qobjs.
     """
+    optypes = getattr(qobj.config, 'optypes', None)
     split_qobj_list = []
     if (max_shot_size is not None and max_shot_size > 0):
-        if _check_custom_instruction(qobj.experiments):
+        contains_saves = False
+        if optypes is None:
+            contains_saves = _check_custom_instruction(qobj.experiments)
+        else:
+            contains_saves = any(
+                "save" in name for optype in optypes for name in optype
+            )
+        if contains_saves:
             raise JobError("`max_shot_size` option cannot"
                            "be used with circuits containing save instructions.")
 

--- a/qiskit/providers/aer/jobs/utils.py
+++ b/qiskit/providers/aer/jobs/utils.py
@@ -121,23 +121,19 @@ def _split_qobj(qobj, max_size, qobj_id, seed):
 
 
 def _check_custom_instruction(experiments, optypes=None):
-
-    def _check_not_allowed(inst_name):
-        for not_allowed in ["Save", "Snapshot"]:
-            if not_allowed in inst_name:
-                return True
-        return False
-
+    """Return True if circuits contain instructions that cant be split"""
     # Check via optype list if available
     if optypes is not None:
+        # Optypes store class names as strings
         return any(
-            _check_not_allowed(name)
-            for optype in optypes for name in optype)
-
+            "Save"  in name or "Snapshot" in name
+            for optype in optypes for name in optype
+        )
     # Otherwise iterate over instructions
     return any(
-        _check_not_allowed(inst.name)
-        for exp in experiments for inst in exp.instructions)
+        "save"  in inst.name or "snapshot" in inst.name
+        for exp in experiments for inst in exp.instructions
+    )
 
 
 def _set_seed(qobj_list, seed):

--- a/qiskit/providers/aer/jobs/utils.py
+++ b/qiskit/providers/aer/jobs/utils.py
@@ -125,7 +125,7 @@ def _check_custom_instruction(experiments):
     # check if save instruction exist
     for exp in experiments:
         for inst in exp.instructions:
-            if "save" in inst.name:
+            if "Save" in inst.name or "Snapshot" in inst.name:
                 return True
     return False
 

--- a/qiskit/providers/aer/jobs/utils.py
+++ b/qiskit/providers/aer/jobs/utils.py
@@ -126,12 +126,13 @@ def _check_custom_instruction(experiments, optypes=None):
     if optypes is not None:
         # Optypes store class names as strings
         return any(
-            "Save" in name or "Snapshot" in name
-            for optype in optypes for name in optype
+            {"SaveData", "Snapshot"}.intersection(optype)
+            for optype in optypes
         )
-    # Otherwise iterate over instructions
+
+    # Otherwise iterate over instruction names
     return any(
-        "save" in inst.name or "snapshot" in inst.name
+        "save_" in inst.name or "snapshot" in inst.name
         for exp in experiments for inst in exp.instructions
     )
 

--- a/qiskit/providers/aer/jobs/utils.py
+++ b/qiskit/providers/aer/jobs/utils.py
@@ -126,12 +126,12 @@ def _check_custom_instruction(experiments, optypes=None):
     if optypes is not None:
         # Optypes store class names as strings
         return any(
-            "Save"  in name or "Snapshot" in name
+            "Save" in name or "Snapshot" in name
             for optype in optypes for name in optype
         )
     # Otherwise iterate over instructions
     return any(
-        "save"  in inst.name or "snapshot" in inst.name
+        "save" in inst.name or "snapshot" in inst.name
         for exp in experiments for inst in exp.instructions
     )
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR complements #1408 to reduce some other possible, but less serious, regressions from Aer 0.10.

### Details and comments

This adds checks to avoid transpiling or iterating over circuits for noise model transpilation, quanutm error replacement, qasm3 compiling, and qobj splitting if the required instructions are not in the circuits. This is done by collecting sets of all instructions in each circuit in advance, and using that set for checks before running the other transpilation/compilation steps.
