### PR TITLE
Fix diagonal fusion in parallel transpilations

### DIFF
--- a/releasenotes/notes/fix_parallel_diag_fusion-a7f914b3a9f491f7.yaml
+++ b/releasenotes/notes/fix_parallel_diag_fusion-a7f914b3a9f491f7.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Multi-threaded transpilations to generate diagonal gates will now work correctly if
+    the number of gates of a circuit exceeds ``fusion_parallelization_threshold``.
+    Previously, different threads would occasionally fuse the same element into multiple blocks,
+    causing incorrect results.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

fusion to generate a diagonal matrix has a bug when transpilation is in parallel

### Details and comments

If a number of gates exceeds `fusion_parallelization_threshold`, fusion transpiler divides the sequence of gates into sub-sequences and multiple threads run transpilation for each sub-sequence. A thread can fuse gates only in a sub-sequence. However, current diagonal-fusion searches gates across sub-sequences and can produce wrong results. This PR prevent from a thread not to fuse gates across sub-sequences.