### PR TITLE
Pin windows CI image to Windows Server 2019

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macOS-latest", "ubuntu-latest", "windows-2019"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
@@ -121,7 +121,7 @@ jobs:
     needs: ["standalone"]
     strategy:
       matrix:
-        os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macOS-latest", "ubuntu-latest", "windows-2019"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python Python 3.8

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build qiskit-aer wheels
     strategy:
       matrix:
-        os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macOS-latest", "ubuntu-latest", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lint:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         python-version: [3.8]
@@ -47,8 +47,8 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         platform: [
-          { os: "windows-latest",   python-architecture: "x64"},
-          { os: "windows-latest",   python-architecture: "x86"},
+          { os: "windows-2019",   python-architecture: "x64"},
+          { os: "windows-2019",   python-architecture: "x86"},
         ]
     steps:
       - uses: actions/checkout@v2
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        os: ["windows-latest"]
+        os: ["windows-2019"]
     env:
       AER_THRUST_BACKEND: OMP
       QISKIT_TEST_CAPTURE_STREAMS: 1
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        os: ["windows-latest"]
+        os: ["windows-2019"]
     env:
       AER_THRUST_BACKEND: OMP
       QISKIT_TEST_CAPTURE_STREAMS: 1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Github actions recently changed the image used for the windows-latest
image tag from windows server 2019 to windows server 2022. Unfortunately
it looks like upstream C++ projects we're leveraging via conan do not
have precompiled versions available on the conan center with the msvc
version bundled in the new windows image. The fallback to building them
from source is not functioning either. Until we can resolve this issue
this commit just pins the windows ci jobs to explicitly use the windows
server 2019 image that worked before. Once we solve the issues building
aer in the new windows version we can revert this and go back to
following the latest release.

### Details and comments