### PR TITLE
Update garrison's name in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -26,6 +26,8 @@ Hiroshi Horii <horii@jp.ibm.com> <hhorii@users.noreply.github.com>
 Hitomi Takahashi <hitomi@jp.ibm.com> <hitomi@jp.ibm.com>
 Hitomi Takahashi <hitomi@jp.ibm.com> <hitomi@hitominbookpuro.dhcp.hakozaki.ibm.com>
 Ikko Hamamura <ikkoham@users.noreply.github.com>
+James R. Garrison <garrison@ibm.com>
+James R. Garrison <garrison@ibm.com> <jim@garrison.cc>
 Jay M. Gambetta <jay.gambetta@us.ibm.com>
 Joe Latone <jlatone@us.ibm.com>
 John A. Gunnels <john.a.gunnels@gmail.com>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This change is to avoid my name appearing in two different forms in `Qiskit.bib` upon the next Aer release, now that #1424 has been merged.

### Details and comments


