### PR TITLE
Only install numpy and scipy from wheels in build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,13 +134,6 @@ jobs:
       - name: Install deps
         run: python -m pip install -U cibuildwheel==2.1.2
       - name: Build Wheels
-        env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
-          CIBW_SKIP: "pp*"
-          CIBW_BEFORE_TEST: "pip install --only-binary=numpy,scipy numpy scipy"
-          CIBW_TEST_SKIP: "cp310-win32 cp310-manylinux_i686"
-          CIBW_TEST_COMMAND: "python {project}/tools/verify_wheels.py"
-          CIBW_ENVIRONMENT_WINDOWS: "CMAKE_GENERATOR='Visual Studio 16 2019'"
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
         with:
@@ -160,7 +153,6 @@ jobs:
         run: python -m pip install -U cibuildwheel==2.1.2
       - name: Build Wheels
         env:
-          CIBW_SKIP: "pp*"
           CIBW_ARCHS_MACOS: arm64
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.2
         if: runner.os == 'Windows'
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.1.2
+        run: python -m pip install -U cibuildwheel==2.2.2
       - name: Build Wheels
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
@@ -150,7 +150,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.1.2
+        run: python -m pip install -U cibuildwheel==2.2.2
       - name: Build Wheels
         env:
           CIBW_ARCHS_MACOS: arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
           CIBW_SKIP: "pp*"
+          CIBW_BEFORE_TEST: "pip install --only-binary=numpy,scipy numpy scipy"
           CIBW_TEST_SKIP: "cp310-win32 cp310-manylinux_i686"
           CIBW_TEST_COMMAND: "python {project}/tools/verify_wheels.py"
           CIBW_ENVIRONMENT_WINDOWS: "CMAKE_GENERATOR='Visual Studio 16 2019'"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,15 +20,7 @@ jobs:
         run: |
           python -m pip install cibuildwheel==2.1.2
       - name: Build wheels
-        env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
-          CIBW_BEFORE_TEST: "pip install --only-binary=numpy,scipy numpy scipy"
-          CIBW_SKIP: "pp*"
-          CIBW_TEST_SKIP: "cp310-win32 cp310-manylinux_i686"
-          CIBW_TEST_COMMAND: "python {project}/tools/verify_wheels.py"
-          CIBW_ENVIRONMENT_WINDOWS: "CMAKE_GENERATOR='Visual Studio 16 2019'"
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -67,9 +59,6 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y https://dl.fedoraproject.org/pub/epel/7/aarch64/Packages/e/epel-release-7-12.noarch.rpm && yum install -y openblas-devel"
-          CIBW_SKIP: "pp*"
-          CIBW_BEFORE_TEST: "pip install --only-binary=numpy,scipy numpy scipy"
-          CIBW_TEST_COMMAND: "python {project}/tools/verify_wheels.py"
           CIBW_ARCHS_LINUX: aarch64
       - uses: actions/upload-artifact@v2
         with:
@@ -95,7 +84,6 @@ jobs:
         run: python -m pip install -U cibuildwheel==2.1.2 twine
       - name: Build Wheels
         env:
-          CIBW_SKIP: "pp*"
           CIBW_ARCHS_MACOS: arm64
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
@@ -148,9 +136,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 openblas-devel"
           CIBW_SKIP: "*-manylinux_i686 pp*"
-          CIBW_BEFORE_TEST: "pip install --only-binary=numpy,scipy numpy scipy"
           CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu AER_THRUST_BACKEND=CUDA CUDACXX=/usr/local/cuda/bin/nvcc
-          CIBW_TEST_COMMAND: "python {project}/tools/verify_wheels.py"
         run: |
           python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.7'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2
+          python -m pip install cibuildwheel==2.2.2
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
@@ -53,7 +53,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2 twine
+          python -m pip install cibuildwheel==2.2.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.1.2 twine
+        run: python -m pip install -U cibuildwheel==2.2.2 twine
       - name: Build Wheels
         env:
           CIBW_ARCHS_MACOS: arm64
@@ -131,11 +131,11 @@ jobs:
         if: runner.os == 'Windows'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2
+          python -m pip install cibuildwheel==2.2.2
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 openblas-devel"
-          CIBW_SKIP: "*-manylinux_i686 pp*"
+          CIBW_SKIP: "*-manylinux_i686 pp* *musllinux*"
           CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu AER_THRUST_BACKEND=CUDA CUDACXX=/usr/local/cuda/bin/nvcc
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
+          CIBW_BEFORE_TEST: "pip install --only-binary=numpy,scipy numpy scipy"
           CIBW_SKIP: "pp*"
           CIBW_TEST_SKIP: "cp310-win32 cp310-manylinux_i686"
           CIBW_TEST_COMMAND: "python {project}/tools/verify_wheels.py"
@@ -67,6 +68,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL_LINUX: "yum install -y https://dl.fedoraproject.org/pub/epel/7/aarch64/Packages/e/epel-release-7-12.noarch.rpm && yum install -y openblas-devel"
           CIBW_SKIP: "pp*"
+          CIBW_BEFORE_TEST: "pip install --only-binary=numpy,scipy numpy scipy"
           CIBW_TEST_COMMAND: "python {project}/tools/verify_wheels.py"
           CIBW_ARCHS_LINUX: aarch64
       - uses: actions/upload-artifact@v2
@@ -146,6 +148,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 openblas-devel"
           CIBW_SKIP: "*-manylinux_i686 pp*"
+          CIBW_BEFORE_TEST: "pip install --only-binary=numpy,scipy numpy scipy"
           CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu AER_THRUST_BACKEND=CUDA CUDACXX=/usr/local/cuda/bin/nvcc
           CIBW_TEST_COMMAND: "python {project}/tools/verify_wheels.py"
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
+manylinux-i686-image = "manylinux2010"
 skip = "pp* *musllinux*"
 test-skip = "cp310-win32 cp310-manylinux_i686"
 test-command = "python {project}/tools/verify_wheels.py"
@@ -34,4 +34,3 @@ environment = "CMAKE_GENERATOR='Visual Studio 16 2019'"
 [[tool.cibuildwheel.overrides]]
 select = "cp3{6,7,8,9}-manylinux*"
 manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ before-test = "pip install --only-binary=numpy,scipy numpy scipy"
 [tool.cibuildwheel.linux]
 before-all = "yum install -y openblas-devel"
 
-[tool.cibuildwheel.environment]
+[tool.cibuildwheel.windows]
 environment = "CMAKE_GENERATOR='Visual Studio 16 2019'"
 
 # For older Pythons we maintain our manylinux2010 support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,27 @@ requires = [
   "numpy==1.16.3; python_version<='3.7' and platform_machine!='aarch64' or platform_python_implementation=='PyPy'",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+skip = "pp* *musllinux*"
+test-skip = "cp310-win32 cp310-manylinux_i686"
+test-command = "python {project}/tools/verify_wheels.py"
+# We need to use pre-built versions of Numpy and Scipy in the tests; they have a
+# tendency to crash if they're installed from source by `pip install`, and since
+# Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
+# restricting any dependencies that Numpy and Scipy might have.
+before-test = "pip install --only-binary=numpy,scipy numpy scipy"
+
+[tool.cibuildwheel.linux]
+before-all = "yum install -y openblas-devel"
+
+[tool.cibuildwheel.environment]
+environment = "CMAKE_GENERATOR='Visual Studio 16 2019'"
+
+# For older Pythons we maintain our manylinux2010 support.
+[[tool.cibuildwheel.overrides]]
+select = "cp3{6,7,8,9}-manylinux*"
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With recent changes to the upstream numpy and scipy packaging our CI
build jobs are spending most of their time build numpy and/or scipy from
source to test the built wheels function correctly. This is unecessary
as there are compatible wheels available on pypi. To correct this issue
this commit updates the cibuildwheel config used in the wheel build jobs
(both for ci and release artifacts) to only use binary wheels for numpy
and scipy before testing.

### Details and comments