### PR TITLE
Fix unit handling in RelaxationNoisePass

### DIFF
--- a/releasenotes/notes/delay-pass-units-a31341568057fdb3.yaml
+++ b/releasenotes/notes/delay-pass-units-a31341568057fdb3.yaml
@@ -5,3 +5,6 @@ fixes:
     were always assumed to be in *dt* time units, regardless of the actual
     unit of the isntruction. Now unit conversion is correctly handled for
     all instruction duration units.
+
+    See `#1453 <https://github.com/Qiskit/qiskit-aer/issues/1453>`__
+    for details.

--- a/releasenotes/notes/delay-pass-units-a31341568057fdb3.yaml
+++ b/releasenotes/notes/delay-pass-units-a31341568057fdb3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes a bug in :class:`.RelaxationNoisePass` where instruction durations
+    were always assumed to be in *dt* time units, regardless of the actual
+    unit of the isntruction. Now unit conversion is correctly handled for
+    all instruction duration units.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1453

RelaxationNoisePass assumes all instructions have dt unit durations. This fix changes it to check the specified unit for each op and convert non-dt units to seconds correctly.

### Details and comments

