### PR TITLE
Fix LocalNoisePass for circuit returns from noise func

### DIFF
--- a/qiskit/providers/aer/noise/passes/local_noise_pass.py
+++ b/qiskit/providers/aer/noise/passes/local_noise_pass.py
@@ -136,11 +136,6 @@ class LocalNoisePass(TransformationPass):
                     f"Number of qubits of generated op {new_op.num_qubits} != "
                     f"{len(node.qargs)} that of a reference op {node.name}"
                 )
-            if new_op.num_clbits != len(node.cargs):
-                raise TranspilerError(
-                    f"Number of clbits of generated op {new_op.num_clbits} != "
-                    f"{len(node.cargs)} that of a reference op {node.name}"
-                )
 
             # Add the noise op returned by the function
             if isinstance(new_op, QuantumCircuit):

--- a/qiskit/providers/aer/noise/passes/local_noise_pass.py
+++ b/qiskit/providers/aer/noise/passes/local_noise_pass.py
@@ -130,7 +130,7 @@ class LocalNoisePass(TransformationPass):
                         "Function must return an object implementing 'to_instruction' method."
                     ) from att_err
 
-            # Valide the instruciton matches the number of qubits and clbits of the node
+            # Validate the instruction matches the number of qubits and clbits of the node
             if new_op.num_qubits != len(node.qargs):
                 raise TranspilerError(
                     f"Number of qubits of generated op {new_op.num_qubits} != "

--- a/releasenotes/notes/fix-local-noise-pass-f94546869a169103.yaml
+++ b/releasenotes/notes/fix-local-noise-pass-f94546869a169103.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixes an issue with :class:`.LocalNoisePass` for noise functions that
+    return a :class:`.QuantumCircuit` for the noise op. These were appended
+    to the DAG as an opaque circuit instruction that must be unrolled to be
+    simulated. This fix composes them so that the cirucit instructions are
+    added to the new DAG and can be simulated without additional unrolling
+    if all circuit instructions are supported by the simulator.
+
+    See `#1447 <https://github.com/Qiskit/qiskit-aer/issues/1447>`__
+    for details.

--- a/test/terra/noise/passes/test_local_noise_pass.py
+++ b/test/terra/noise/passes/test_local_noise_pass.py
@@ -16,7 +16,7 @@ LocalNoisePass class tests
 from qiskit.providers.aer.noise import ReadoutError, LocalNoisePass
 
 from qiskit.circuit import QuantumCircuit
-from qiskit.circuit.library.standard_gates import SXGate, HGate
+from qiskit.circuit.library.standard_gates import SXGate, HGate, CXGate
 from qiskit.transpiler import TranspilerError
 from test.terra.common import QiskitAerTestCase
 
@@ -94,3 +94,19 @@ class TestLocalNoisePass(QiskitAerTestCase):
         noise_pass = LocalNoisePass(func=out_readout_error, op_types=HGate)
         with self.assertRaises(TranspilerError):
             noise_pass(qc)
+
+    def test_append_circuit(self):
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1)
+
+        def composite_error(op, qubits):
+            circ = QuantumCircuit(2)
+            for q in qubits:
+                circ.x(q)
+            return circ
+
+        noise_pass = LocalNoisePass(func=composite_error, op_types=CXGate)
+        noise_qc = noise_pass(qc)
+        self.assertEqual(len(noise_qc.data), 3)
+        self.assertEqual(noise_qc.data[1][0].name, "x")
+        self.assertEqual(noise_qc.data[2][0].name, "x")

--- a/test/terra/noise/passes/test_local_noise_pass.py
+++ b/test/terra/noise/passes/test_local_noise_pass.py
@@ -107,6 +107,10 @@ class TestLocalNoisePass(QiskitAerTestCase):
 
         noise_pass = LocalNoisePass(func=composite_error, op_types=CXGate)
         noise_qc = noise_pass(qc)
-        self.assertEqual(len(noise_qc.data), 3)
-        self.assertEqual(noise_qc.data[1][0].name, "x")
-        self.assertEqual(noise_qc.data[2][0].name, "x")
+
+        expected = QuantumCircuit(2)
+        expected.cx(0, 1)
+        expected.x(0)
+        expected.x(1)
+
+        self.assertEqual(expected, noise_qc)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1447 

IF the local noise pass function returns a QuantumCircuit instead of an instruction or operator this composes the circuit into the DAG so that it is unrolled, rather than added as an opaque circuit instruction.

### Details and comments


