### PR TITLE
stop installing qiskit-terra from source in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ setenv =
   LC_ALL=en_US.utf-8
 deps =
   -r requirements-dev.txt
-  qiskit-terra
 commands =
     python setup.py bdist_wheel -- -- -j4
     pip install --find-links={toxinidir}/dist qiskit_aer
@@ -31,7 +30,6 @@ commands =
 deps =
   pycodestyle
   pylint
-  qiskit-terra
 commands =
   pycodestyle --ignore=E402,W504 --max-line-length=100 qiskit/providers/aer
   pylint -j 2 -rn qiskit/providers/aer
@@ -39,7 +37,6 @@ commands =
 [testenv:docs]
 deps =
   -r requirements-dev.txt
-  qiskit-terra
   qiskit-ibmq-provider
 commands =
   python setup.py bdist_wheel -- -- -j4

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
   LC_ALL=en_US.utf-8
 deps =
   -r requirements-dev.txt
-  git+https://github.com/Qiskit/qiskit-terra.git
+  qiskit-terra
 commands =
     python setup.py bdist_wheel -- -- -j4
     pip install --find-links={toxinidir}/dist qiskit_aer
@@ -31,7 +31,7 @@ commands =
 deps =
   pycodestyle
   pylint
-  git+https://github.com/Qiskit/qiskit-terra.git
+  qiskit-terra
 commands =
   pycodestyle --ignore=E402,W504 --max-line-length=100 qiskit/providers/aer
   pylint -j 2 -rn qiskit/providers/aer
@@ -39,7 +39,7 @@ commands =
 [testenv:docs]
 deps =
   -r requirements-dev.txt
-  git+https://github.com/Qiskit/qiskit-terra.git
+  qiskit-terra
   qiskit-ibmq-provider
 commands =
   python setup.py bdist_wheel -- -- -j4


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

stop installing qiskit-terra from source in tox

### Details and comments

This changes installation of qiskit-terra in tox.
Recent commit of #1448  changed installation of qiskit-terra to use pypi in most CI workflow, but not tox.

