### PR TITLE
Split out gpu Python 3.10 wheel build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,8 +134,40 @@ jobs:
           python -m pip install cibuildwheel==2.2.2
       - name: Build wheels
         env:
-          CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 openblas-devel"
-          CIBW_SKIP: "*-manylinux_i686 pp* cp36* *musllinux*"
+          CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget -q https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 openblas-devel"
+          CIBW_SKIP: "*-manylinux_i686 cp310* pp* cp36* *musllinux*"
+          CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu AER_THRUST_BACKEND=CUDA CUDACXX=/usr/local/cuda/bin/nvcc
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+      - name: Publish Wheels
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: qiskit
+        run : |
+          pip install -U twine
+          twine upload wheelhouse/*
+  gpu-build-310:
+    name: Build qiskit-aer-gpu wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
+        if: runner.os == 'Windows'
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2.2.2
+      - name: Build wheels
+        env:
+          CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget -q https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel7-10-1-local-10.1.105-418.39-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel7-10-1-local-10.1.105-418.39-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 openblas-devel"
+          CIBW_BUILD: "cp310-manylinux_x86_64"
           CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu AER_THRUST_BACKEND=CUDA CUDACXX=/usr/local/cuda/bin/nvcc
         run: |
           python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The aer gpu package wheel job for python 3.10 builds in the manylinux2014
container image, while for the older Python versions it uses the
manylinux2010 image. The manylinux2014 image is based on Centos 7 while
the manylinux2010 image is based on Centos 6. During the qiskit-aer
0.10.3 release the gpu wheel job failed because when running the py3.10
build we installed the cuda package for centos 6 in the manylinux2014
centos 7 based image. This caused the job to fail when nvcc was called
because it was not installed properly. To fix this issue the Python 3.10
build is split out into a separate job. This separate job will install
the same cuda version but for centos 7 which is appropriate for the
manylinux2014 image.

### Details and comments