### PR TITLE
Fix: cache blocking transpiler for density_matrix with noises

### DIFF
--- a/releasenotes/notes/density-multi-chunk-fix-e9effc67d0365418.yaml
+++ b/releasenotes/notes/density-multi-chunk-fix-e9effc67d0365418.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix cache blocking transpiler to recognize superop to be cache blocked.
+    This is fix for
+    `issue 1479 <https://github.com/Qiskit/qiskit-aer/issues/1479>`
+    now density_matrix with noise models can be parallelized.
+

--- a/releasenotes/notes/density-multi-chunk-fix-e9effc67d0365418.yaml
+++ b/releasenotes/notes/density-multi-chunk-fix-e9effc67d0365418.yaml
@@ -5,4 +5,9 @@ fixes:
     This is fix for
     `issue 1479 <https://github.com/Qiskit/qiskit-aer/issues/1479>`
     now density_matrix with noise models can be parallelized.
-
+    New test, test_noise.TestNoise.test_kraus_gate_noise_on_QFT_cache_blocking
+    is added to verify this issue.
+    Also this fix include fix for
+    `issue 1483 <https://github.com/Qiskit/qiskit-aer/issues/1483>`
+    discovered by adding new test case.
+    This fixes measure over chunks for statevector.

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -415,7 +415,7 @@ public:
   // Get the sample_measure index size
   int get_sample_measure_index_size() {return sample_measure_index_size_;}
 
-  virtual bool enable_batch(bool flg)
+  virtual bool enable_batch(bool flg) const
   {
     return false;
   }

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -320,7 +320,7 @@ public:
 #endif
   }
 
-  bool enable_batch(bool flg);
+  bool enable_batch(bool flg) const;
 
   virtual void apply_bfunc(const Operations::Op &op);
   virtual void set_conditional(int_t reg);
@@ -463,7 +463,7 @@ protected:
   uint_t chunk_index_;
   bool multi_chunk_distribution_;
   bool multi_shots_;
-  bool enable_batch_;
+  mutable bool enable_batch_;
   bool cuStateVec_enable_ = false;
 
   bool register_blocking_;
@@ -1114,7 +1114,7 @@ void QubitVectorThrust<data_t>::set_conditional(int_t reg)
 }
 
 template <typename data_t>
-bool QubitVectorThrust<data_t>::enable_batch(bool flg)
+bool QubitVectorThrust<data_t>::enable_batch(bool flg) const
 {
   bool prev = enable_batch_;
 
@@ -1329,6 +1329,8 @@ void QubitVectorThrust<data_t>::apply_function_sum(double* pSum,Function func,bo
   if(func.batch_enable() && ((multi_chunk_distribution_ && chunk_.device() >= 0 && num_qubits_ == num_qubits()) || (enable_batch_))){
     if(chunk_.pos() != 0){
       //only first chunk on device calculates all the chunks
+      if(pSum)
+        *pSum = 0.0;
       return;
     }
     count = chunk_.container()->num_chunks();
@@ -1354,6 +1356,10 @@ void QubitVectorThrust<data_t>::apply_function_sum2(double* pSum,Function func,b
   if(func.batch_enable() && ((multi_chunk_distribution_ && chunk_.device() >= 0 && num_qubits_ == num_qubits()) || (enable_batch_))){
     if(chunk_.pos() != 0){
       //only first chunk on device calculates all the chunks
+      if(pSum){
+        pSum[0] = 0.0;
+        pSum[1] = 0.0;
+      }
       return;
     }
     count = chunk_.container()->num_chunks();
@@ -1818,7 +1824,7 @@ double QubitVectorThrust<data_t>::norm() const
   uint_t count = 1;
 
 #ifdef AER_THRUST_CUDA
-  if((multi_chunk_distribution_ && chunk_.device() >= 0) || enable_batch_){
+  if(enable_batch_ && ((multi_chunk_distribution_ && chunk_.device() >= 0) || !multi_chunk_distribution_)){
     if(chunk_.pos() != 0)
       return 0.0;   //first chunk execute all in batch
     count = chunk_.container()->num_chunks();

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -1963,12 +1963,18 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
     //calculate per chunk sum
     if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) 
-      for(i=0;i<BaseState::qregs_.size();i++)
+      for(i=0;i<BaseState::qregs_.size();i++){
+        bool batched = BaseState::qregs_[i].enable_batch(true);   //return sum of all chunks in group
         chunkSum[i] = BaseState::qregs_[i].norm();
+        BaseState::qregs_[i].enable_batch(batched);
+      }
     }
     else{
-      for(i=0;i<BaseState::qregs_.size();i++)
+      for(i=0;i<BaseState::qregs_.size();i++){
+        bool batched = BaseState::qregs_[i].enable_batch(true);   //return sum of all chunks in group
         chunkSum[i] = BaseState::qregs_[i].norm();
+        BaseState::qregs_[i].enable_batch(batched);
+      }
     }
 
     localSum = 0.0;

--- a/src/transpile/cacheblocking.hpp
+++ b/src/transpile/cacheblocking.hpp
@@ -1,7 +1,7 @@
 /**
  * This code is part of Qiskit.
  *
- * (C) Copyright IBM 2018, 2019.
+ * (C) Copyright IBM 2018, 2019, 2022.
  *
  * This code is licensed under the Apache License, Version 2.0. You may
  * obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -345,13 +345,9 @@ bool CacheBlocking::can_reorder(Operations::Op& op,std::vector<Operations::Op>& 
   //check if the operation can be reordered in front of waiting queue
   uint_t j,iq,jq;
 
-  //only gate and matrix can be reordered
-  if(op.type != Operations::OpType::gate && op.type != Operations::OpType::matrix && op.type != Operations::OpType::diagonal_matrix){
-    //except for reset for density matrix
-    if(!density_matrix_ || op.type != Operations::OpType::reset){
-      return false;
-    }
-  }
+  //only blockable ops can be reordered
+  if(!is_blockable_operation(op))
+    return false;
 
   for(j=0;j<waiting_ops.size();j++){
     if(is_blockable_operation(waiting_ops[j])){
@@ -518,266 +514,187 @@ uint_t CacheBlocking::add_ops(std::vector<Operations::Op>& ops,std::vector<Opera
   pos_begin = out.size();
   num_gates_added = 0;
 
-//  if(doSwap){
-    //find qubits to be blocked
-    if(first && doSwap){
-      //use lower bits for initialization
-      for(i=0;i<block_bits_;i++){
-        blockedQubits.push_back(i);
-      }
+  //find qubits to be blocked
+  if(first && doSwap){
+    //use lower bits for initialization
+    for(i=0;i<block_bits_;i++){
+      blockedQubits.push_back(i);
+    }
+  }
+  else{
+    if(crossQubitOnly){
+      //add multi-qubits gate at first
+      define_blocked_qubits(ops,blockedQubits,true);
+
+      //not enough qubits are blocked, then add one qubit gate
+      if(blockedQubits.size() < block_bits_)
+        define_blocked_qubits(ops,blockedQubits,false);
     }
     else{
-      if(crossQubitOnly){
-        //add multi-qubits gate at first
-        define_blocked_qubits(ops,blockedQubits,true);
+      define_blocked_qubits(ops,blockedQubits,false);
+    }
+  }
 
-        //not enough qubits are blocked, then add one qubit gate
-        if(blockedQubits.size() < block_bits_)
-          define_blocked_qubits(ops,blockedQubits,false);
-      }
-      else{
-        define_blocked_qubits(ops,blockedQubits,false);
+  pos_begin = out.size();
+  num_gates_added = 0;
+
+  if(doSwap){
+    //insert swap gates to block operations
+    reg_t swap(block_bits_);
+    std::vector<bool> mapped(block_bits_,false);
+    nq = blockedQubits.size();
+    for(i=0;i<nq;i++){
+      swap[i] = qubits_;  //not defined
+      for(j=0;j<block_bits_;j++){
+        if(blockedQubits[i] == qubitSwapped_[j]){
+          swap[i] = j;
+          mapped[j] = true;
+          break;
+        }
       }
     }
-
-    pos_begin = out.size();
-    num_gates_added = 0;
-
-    if(doSwap){
-      //insert swap gates to block operations
-      reg_t swap(block_bits_);
-      std::vector<bool> mapped(block_bits_,false);
-      nq = blockedQubits.size();
-      for(i=0;i<nq;i++){
-        swap[i] = qubits_;  //not defined
+    for(i=0;i<nq;i++){
+      if(swap[i] == qubits_){
         for(j=0;j<block_bits_;j++){
-          if(blockedQubits[i] == qubitSwapped_[j]){
+          if(!mapped[j]){
             swap[i] = j;
             mapped[j] = true;
             break;
           }
         }
       }
-      for(i=0;i<nq;i++){
-        if(swap[i] == qubits_){
-          for(j=0;j<block_bits_;j++){
-            if(!mapped[j]){
-              swap[i] = j;
-              mapped[j] = true;
-              break;
+    }
+    for(i=0;i<nq;i++){
+      if(qubitSwapped_[swap[i]] != blockedQubits[i]){ //need swap gate
+        if(!first){   //swap gate is not required for initial state
+          insert_swap(out,swap[i],qubitMap_[blockedQubits[i]],true);
+        }
+
+        //swap map
+        j = qubitMap_[blockedQubits[i]];
+        qubitMap_[qubitSwapped_[swap[i]]] = j;
+        qubitMap_[blockedQubits[i]] = swap[i];
+
+        qubitSwapped_[j] = qubitSwapped_[swap[i]];
+        qubitSwapped_[swap[i]] = blockedQubits[i];
+      }
+    }
+  }
+
+  if(doSwap)
+    insert_sim_op(out,"begin_blocking",blockedQubits);
+  else
+    insert_sim_op(out,"begin_memory_blocking",blockedQubits);
+  end_block_inserted = false;
+
+  //gather blocked gates
+  for(i=0;i<ops.size();i++){
+    if(is_blockable_operation(ops[i])){
+      if(!end_block_inserted){
+        if(is_diagonal_op(ops[i]) || can_block(ops[i],blockedQubits)){
+          if(can_reorder(ops[i],queue)){
+            //mapping swapped qubits
+            for(iq=0;iq<ops[i].qubits.size();iq++){
+              ops[i].qubits[iq] = qubitMap_[ops[i].qubits[iq]];
             }
+            out.push_back(ops[i]);
+            num_gates_added++;
+            continue;
           }
         }
-      }
-      for(i=0;i<nq;i++){
-        if(qubitSwapped_[swap[i]] != blockedQubits[i]){ //need swap gate
-          if(!first){   //swap gate is not required for initial state
-            insert_swap(out,swap[i],qubitMap_[blockedQubits[i]],true);
+        else if(ops[i].name == "pauli"){
+          if(can_reorder(ops[i],queue)){
+            if(split_pauli(ops[i],blockedQubits,out,queue))
+              num_gates_added++;
+            continue;
           }
-
-          //swap map
-          j = qubitMap_[blockedQubits[i]];
-          qubitMap_[qubitSwapped_[swap[i]]] = j;
-          qubitMap_[blockedQubits[i]] = swap[i];
-
-          qubitSwapped_[j] = qubitSwapped_[swap[i]];
-          qubitSwapped_[swap[i]] = blockedQubits[i];
+        }
+        else if(ops[i].type == Operations::OpType::reset){    //reset for density matrix can be cache blocked
+          if(can_reorder(ops[i],queue)){
+            if(split_op(ops[i],blockedQubits,out,queue))
+              num_gates_added++;
+            continue;
+          }
         }
       }
     }
-
-    if(doSwap)
-      insert_sim_op(out,"begin_blocking",blockedQubits);
-    else
-      insert_sim_op(out,"begin_memory_blocking",blockedQubits);
-    end_block_inserted = false;
-
-    //gather blocked gates
-    for(i=0;i<ops.size();i++){
-      if(is_blockable_operation(ops[i])){
-        if(!end_block_inserted){
-          if(is_diagonal_op(ops[i]) || can_block(ops[i],blockedQubits)){
-            if(can_reorder(ops[i],queue)){
-              //mapping swapped qubits
-              for(iq=0;iq<ops[i].qubits.size();iq++){
-                ops[i].qubits[iq] = qubitMap_[ops[i].qubits[iq]];
-              }
-              out.push_back(ops[i]);
-              num_gates_added++;
-              continue;
-            }
+    else{
+      if(queue.size() == 0){          //if queue is empty, apply op here
+        bool restore_qubits = false;
+        if(ops[i].type == Operations::OpType::kraus){
+          if(ops[i].qubits.size() > block_bits_){
+            throw std::runtime_error("CacheBlocking : Kraus operator, number of qubits should be smaller than chunk qubit size");
+            break;
           }
-          else if(ops[i].name == "pauli"){
-            if(can_reorder(ops[i],queue)){
-              if(split_pauli(ops[i],blockedQubits,out,queue))
-                num_gates_added++;
-              continue;
-            }
-          }
-          else if(ops[i].type == Operations::OpType::reset){    //reset for density matrix can be cache blocked
-            if(can_reorder(ops[i],queue)){
-              if(split_op(ops[i],blockedQubits,out,queue))
-                num_gates_added++;
-              continue;
-            }
+          if(!can_block(ops[i],blockedQubits)){  //if some qubits are out of chunk, queued for next step
+            queue.push_back(ops[i]);
+            continue;
           }
         }
-      }
-      else{
-        if(queue.size() == 0){          //if queue is empty, apply op here
-          bool restore_qubits = false;
-          if(ops[i].type == Operations::OpType::kraus){
-            if(ops[i].qubits.size() > block_bits_){
-              throw std::runtime_error("CacheBlocking : Kraus operator, number of qubits should be smaller than chunk qubit size");
-              break;
-            }
+        else if(ops[i].type == Operations::OpType::initialize){
+          if(ops[i].qubits.size() <= block_bits_){
             if(!can_block(ops[i],blockedQubits)){  //if some qubits are out of chunk, queued for next step
               queue.push_back(ops[i]);
               continue;
             }
           }
-          else if(ops[i].type == Operations::OpType::initialize){
-            if(ops[i].qubits.size() <= block_bits_){
-              if(!can_block(ops[i],blockedQubits)){  //if some qubits are out of chunk, queued for next step
-                queue.push_back(ops[i]);
-                continue;
-              }
-            }
-            //otherwise StateChunk have to parallelize initialize operation
-          }
-          else if(sample_measure_ && ops[i].type == Operations::OpType::measure){
-            //currently sampling should be done with original qubit mapping (TO DO : sampling without inserting swaps)
+          //otherwise StateChunk have to parallelize initialize operation
+        }
+        else if(sample_measure_ && ops[i].type == Operations::OpType::measure){
+          //currently sampling should be done with original qubit mapping (TO DO : sampling without inserting swaps)
+          restore_qubits = true;
+        }
+        else if(ops[i].type != Operations::OpType::measure && ops[i].type != Operations::OpType::reset && 
+                ops[i].type != Operations::OpType::save_amps && ops[i].type != Operations::OpType::save_amps_sq &&
+                ops[i].type != Operations::OpType::save_densmat){
+          if(!(ops[i].type == Operations::OpType::snapshot && ops[i].name == "density_matrix")){
             restore_qubits = true;
           }
-          else if(ops[i].type != Operations::OpType::measure && ops[i].type != Operations::OpType::reset && 
-                  ops[i].type != Operations::OpType::save_amps && ops[i].type != Operations::OpType::save_amps_sq &&
-                  ops[i].type != Operations::OpType::save_densmat){
-            if(!(ops[i].type == Operations::OpType::snapshot && ops[i].name == "density_matrix")){
-              restore_qubits = true;
-            }
-          }
-
-          if(num_gates_added > 0 && !end_block_inserted){  //insert end of block to synchronize chunks
-            if(doSwap)
-              insert_sim_op(out,"end_blocking",blockedQubits);
-            else
-              insert_sim_op(out,"end_memory_blocking",blockedQubits);
-          }
-          else if(!end_block_inserted){
-            out.pop_back();
-          }
-          if(restore_qubits && doSwap)
-            restore_qubits_order(out);
-
-          //mapping swapped qubits
-          if(doSwap){
-            for(iq=0;iq<ops[i].qubits.size();iq++){
-              ops[i].qubits[iq] = qubitMap_[ops[i].qubits[iq]];
-            }
-          }
-
-          out.push_back(ops[i]);
-          num_gates_added++;
-
-          end_block_inserted = true;
-          continue;
         }
-      }
-      queue.push_back(ops[i]);
-    }
 
-    if(!end_block_inserted){
-      if(num_gates_added > 0){
-        if(doSwap)
-          insert_sim_op(out,"end_blocking",blockedQubits);
-        else
-          insert_sim_op(out,"end_memory_blocking",blockedQubits);
-      }
-      else{
-        //pop unnecessary operations
-        while(out.size() > pos_begin){
+        if(num_gates_added > 0 && !end_block_inserted){  //insert end of block to synchronize chunks
+          if(doSwap)
+            insert_sim_op(out,"end_blocking",blockedQubits);
+          else
+            insert_sim_op(out,"end_memory_blocking",blockedQubits);
+        }
+        else if(!end_block_inserted){
           out.pop_back();
         }
-      }
-    }
-/*  }
-  else{
-    i = 0;
-    //add chunk swap and block ops (if blocking is enabled)
-    if(blocking_enabled_){
-      while(i <ops.size()){
-        if(ops[i].type == Operations::OpType::sim_op){
-          out.push_back(ops[i]);
-        }
-        else if(ops[i].type == Operations::OpType::gate && ops[i].name == "swap_chunk"){
-          out.push_back(ops[i]);
-        }
-        else{
-          break;
-        }
-        i++;
-      }
-    }
+        if(restore_qubits && doSwap)
+          restore_qubits_order(out);
 
-    insert_sim_op(out,"begin_register_blocking",blockedQubits);
-    //gather blocked gates
-    while(i < ops.size()){
-      if(ops[i].type == Operations::OpType::gate || ops[i].type == Operations::OpType::matrix){
-        if((ops[i].qubits.size() > 1 && ops[i].type == Operations::OpType::matrix) || ops[i].name == "pauli"){
-          queue.push_back(ops[i]);
-        }
-        else{
-          if(can_reorder(ops[i],queue)){
-            if(is_diagonal_op(ops[i])){
-              //diagonal gate can be applied
-              out.push_back(ops[i]);
-              num_gates_added++;
-            }
-            else{
-              exist = false;
-              iq = ops[i].qubits[ops[i].qubits.size()-1]; //block target bit
-              nq = blockedQubits.size();
-              for(j=0;j<nq;j++){
-                if(iq == blockedQubits[j]){
-                  exist = true;
-                  break;
-                }
-              }
-              if(exist){
-                out.push_back(ops[i]);
-                num_gates_added++;
-              }
-              else{
-                if(nq == memory_blocking_bits_){
-                  queue.push_back(ops[i]);
-                }
-                else{
-                  blockedQubits.push_back(iq);
-                  out.push_back(ops[i]);
-                  num_gates_added++;
-                }
-              }
-            }
-          }
-          else{
-            queue.push_back(ops[i]);
+        //mapping swapped qubits
+        if(doSwap){
+          for(iq=0;iq<ops[i].qubits.size();iq++){
+            ops[i].qubits[iq] = qubitMap_[ops[i].qubits[iq]];
           }
         }
-      }
-      else{
-        queue.push_back(ops[i]);
-      }
-      i++;
-    }
 
-    if(out.size() > pos_begin + 1){
-      out[pos_begin].qubits = blockedQubits;  //store qubits to be blocked in the sim_op::begin_register_blocking
-      insert_sim_op(out,"end_register_blocking",blockedQubits);
+        out.push_back(ops[i]);
+        num_gates_added++;
+
+        end_block_inserted = true;
+        continue;
+      }
+    }
+    queue.push_back(ops[i]);
+  }
+
+  if(!end_block_inserted){
+    if(num_gates_added > 0){
+      if(doSwap)
+        insert_sim_op(out,"end_blocking",blockedQubits);
+      else
+        insert_sim_op(out,"end_memory_blocking",blockedQubits);
     }
     else{
-      out.pop_back();
+      //pop unnecessary operations
+      while(out.size() > pos_begin){
+        out.pop_back();
+      }
     }
-  }*/
+  }
 
   return num_gates_added;
 }

--- a/test/terra/backends/aer_simulator/test_chunk.py
+++ b/test/terra/backends/aer_simulator/test_chunk.py
@@ -89,6 +89,35 @@ class TestChunkSimulators(SimulatorTestCase):
         self.assertEqual(counts_no_chunk, counts)
 
     @supported_methods(['statevector', 'density_matrix'])
+    def test_chunk_QFT(self, method, device):
+        """Test multi-chunk with QFT"""
+        opts_no_chunk = {
+            "fusion_enable": False,
+            "fusion_threshold": 10,
+        } 
+        opts_chunk = copy.copy(opts_no_chunk)
+        opts_chunk["blocking_enable"] = True
+        opts_chunk["blocking_qubits"] = 2
+
+        backend = self.backend(
+            method=method, device=device, **opts_chunk)
+        backend_no_chunk = self.backend(
+            method=method, device=device, **opts_no_chunk)
+
+        shots = 100
+        num_qubits = 3
+        circuit = transpile(QFT(num_qubits), backend=backend,
+                            optimization_level=0)
+        circuit.measure_all()
+        
+        result = backend.run(circuit, shots=shots, memory=True).result()
+        counts = result.get_counts(circuit)
+        result_no_chunk = backend_no_chunk.run(circuit, shots=shots, memory=True).result()
+        counts_no_chunk = result_no_chunk.get_counts(circuit)
+
+        self.assertEqual(counts_no_chunk, counts)
+
+    @supported_methods(['statevector', 'density_matrix'])
     def test_chunk_QFTWithFusion(self, method, device):
         """Test multi-chunk with fused QFT (testing multi-chunk diagonal matrix)"""
         opts_no_chunk = {

--- a/test/terra/backends/aer_simulator/test_noise.py
+++ b/test/terra/backends/aer_simulator/test_noise.py
@@ -153,10 +153,7 @@ class TestNoise(SimulatorTestCase):
             self.assertSuccess(result)
             self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
 
-    @supported_methods([
-        'automatic', 'statevector', 'density_matrix', 'matrix_product_state'])
-    def test_kraus_gate_noise_on_QFT(self, method, device):
-        """Test Kraus noise on a QFT circuit"""
+    def _test_kraus_gate_noise_on_QFT(self, **options):
         shots = 10000
 
         # Build noise model
@@ -166,8 +163,7 @@ class TestNoise(SimulatorTestCase):
         noise_model.add_all_qubit_quantum_error(error1, ['h'])
         noise_model.add_all_qubit_quantum_error(error2, ['cp', 'swap'])
 
-        backend = self.backend(
-            method=method, device=device, noise_model=noise_model)
+        backend = self.backend(**options, noise_model=noise_model)
         ideal_circuit = transpile(QFT(3), backend)
 
         # manaully build noise circuit
@@ -187,6 +183,20 @@ class TestNoise(SimulatorTestCase):
         result = backend.run(ideal_circuit, shots=shots).result()
         self.assertSuccess(result)
         self.compare_counts(result, [ideal_circuit], [ref_target], hex_counts=False, delta=0.1 * shots)
+
+    @supported_methods([
+        'automatic', 'statevector', 'density_matrix', 'matrix_product_state'])
+    def test_kraus_gate_noise_on_QFT(self, method, device):
+        """Test Kraus noise on a QFT circuit"""
+        self._test_kraus_gate_noise_on_QFT(
+            method=method, device=device)
+
+    @supported_methods([
+        'statevector', 'density_matrix'])
+    def test_kraus_gate_noise_on_QFT_cache_blocking(self, method, device):
+        """Test Kraus noise on a QFT circuit with caceh blocking"""
+        self._test_kraus_gate_noise_on_QFT(
+            method=method, device=device, blocking_qubits=2)
 
     @supported_methods(ALL_METHODS)
     def test_clifford_circuit_noise(self, method, device):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is fix for issue #1479 

A test case to test Kraus noise on QFT with cache blocking (in` test_noise.py`)
Also this PR fixes issue #1483 that was found when adding the test case. 

### Details and comments
superop was missing in `CacheBlocking::can_reorder` function so recognize it by calling `CacheBlocking::is_blockable_operation`

I could not make separate PR for issue #1483 because `test_noise.test_kraus_gate_noise_on_QFT_cache_blocking` fails if we separate PR.

For issue #1483,
` QubitVectorThrust<data_t>::norm()` originally returns sum of norm for all chunks. 
This causes incorrect measurement result when qubit is out of chunk qubits.
I changed ` QubitVectorThrust<data_t>::norm()` returns norm for one chunk if ` QubitVectorThrust<data_t>::enable_batch_` is not set. ` sample_measure` only uses batched sum of norm at this time.
