### PR TITLE
Fix for the latest cuStateVec APIs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -645,7 +645,7 @@ Few notes on GPU builds:
 
 Qiskit Aer now supports cuQuantum optimized Quantum computing APIs from NVIDIA®.
 cuStateVec APIs can be exploited to accelerate statevector, density_matrix and unitary methods.
-Because cuQuantum is beta version currently, some of the operations are not accelerated by cuStateVec.
+Supported version of cuQuantum is 0.40 or higher and required version of CUDA toolkit is 11.2 or higher.
 
 To build Qiskit Aer with cuStateVec support, please set the path to cuQuantum root directory to CUSTATEVEC_ROOT as following.
 

--- a/releasenotes/notes/support_for_cuQuantum0.40-566391cc42be2341.yaml
+++ b/releasenotes/notes/support_for_cuQuantum0.40-566391cc42be2341.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    This is the fix for cuStateVec support, fix for build error
+    because of specification change of some APIs of cuStateVec
+    from cuQuantum version 0.40.
+    

--- a/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
@@ -204,8 +204,7 @@ reg_t cuStateVecChunkContainer<data_t>::sample_measure(uint_t iChunk,const std::
     AERDeviceVector<unsigned char> extBuf;
     void* pExtBuf = nullptr;
     if(extSize > 0){
-      extBuf.resize(extSize);
-      pExtBuf = thrust::raw_pointer_cast(extBuf.data());
+      cudaMalloc(&pExtBuf, extSize);
     }
 
     err = custatevecSamplerPreprocess(custatevec_handle_,sampler,pExtBuf,extSize);
@@ -233,9 +232,8 @@ reg_t cuStateVecChunkContainer<data_t>::sample_measure(uint_t iChunk,const std::
       samples[i] = bitStr[i];
     }
 
-    if(extSize > 0){
-      extBuf.clear();
-      extBuf.shrink_to_fit();
+    if(pExtBuf){
+      cudaFree(pExtBuf);
     }
 
     custatevecSamplerDestroy(sampler);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is the fix to support the latest cuQuantum (ver. 0.40).


### Details and comments
Compilation failed with cuStateVec support because some cuStateVec APIs' name and parameters are changed from the previous version. This PR follows the latest cuStateVec.

Also cuQuantum 0.40 newly supports memory pool mechanism to allocate work space inside cuStateVec APIs.
Qiskit Aer now use memory pool instead of allocating static work buffer if the version of CUDA installed on the system supports it.
