### PR TITLE
Pin jinja2 in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -7,3 +7,8 @@ scipy>=1.0
 # with modern importlib-metadata (4.8.1). importlib-metadata is only needed on
 # Python <3.8.
 importlib-metadata==4.6.4
+
+# Jinja2 3.1.0 is incompatible with sphinx and/or jupyter until they are updated
+# to work with the new jinja version (the jinja maintainers aren't going to
+# fix things) pin to the previous working version.
+jinja2==3.0.3


### PR DESCRIPTION
### Summary

The 3.1 release of Jinja breaks some part of the Sphinx/nbsphinx
pipeline, causing tutorial jobs to fail.  The jinja2 developers consider
this a Sphinx bug, so we need to pin Jinja until a new version of Sphinx
or the nbsphinx extension is released to fix the issue.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

See also Qiskit/qiskit-terra#7815
