### PR TITLE
Fix device=Thrust was very slow for small number of qubits

### DIFF
--- a/releasenotes/notes/fix-thrust-cpu-threads-67db86b2edcf06b3.yaml
+++ b/releasenotes/notes/fix-thrust-cpu-threads-67db86b2edcf06b3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    device=Thrust was very slow for small number of qubits because OpenMP
+    threading was always applied. This fix applies OpenMP threads as same
+    as device=CPU by using statevector_parallel_threshold.

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -991,7 +991,7 @@ Result Controller::execute(std::vector<Circuit> &circuits,
     const int NUM_RESULTS = result.results.size();
     //following looks very similar but we have to separate them to avoid omp nested loops that causes performance degradation
     //(DO NOT use if statement in #pragma omp)
-    if (parallel_experiments_ == 1 || sim_device_ == Device::ThrustCPU) {
+    if (parallel_experiments_ == 1) {
       for (int j = 0; j < NUM_RESULTS; ++j) {
         set_parallelization_circuit(circuits[j], noise_model, methods[j]);
         run_circuit(circuits[j], noise_model,methods[j],

--- a/src/simulators/statevector/chunk/device_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/device_chunk_container.hpp
@@ -653,7 +653,10 @@ void DeviceChunkContainer<data_t>::Zero(uint_t iChunk,uint_t count)
 #ifdef AER_THRUST_CUDA
   thrust::fill_n(thrust::cuda::par.on(stream_),data_.begin() + (iChunk << this->chunk_bits_),count,0.0);
 #else
-  thrust::fill_n(thrust::device,data_.begin() + (iChunk << this->chunk_bits_),count,0.0);
+  if(this->omp_threads_ > 1)
+    thrust::fill_n(thrust::device,data_.begin() + (iChunk << this->chunk_bits_),count,0.0);
+  else
+    thrust::fill_n(thrust::seq,data_.begin() + (iChunk << this->chunk_bits_),count,0.0);
 #endif
 }
 
@@ -700,12 +703,22 @@ reg_t DeviceChunkContainer<data_t>::sample_measure(uint_t iChunk,const std::vect
   cudaStreamSynchronize(stream_);
 
 #else
-  if(dot)
-    thrust::transform_inclusive_scan(thrust::device,iter.begin(),iter.end(),iter.begin(),complex_dot_scan<data_t>(),thrust::plus<thrust::complex<data_t>>());
-  else
-    thrust::inclusive_scan(thrust::device,iter.begin(),iter.end(),iter.begin(),thrust::plus<thrust::complex<data_t>>());
+  if(this->omp_threads_ > 1){
+    if(dot)
+      thrust::transform_inclusive_scan(thrust::device,iter.begin(),iter.end(),iter.begin(),complex_dot_scan<data_t>(),thrust::plus<thrust::complex<data_t>>());
+    else
+      thrust::inclusive_scan(thrust::device,iter.begin(),iter.end(),iter.begin(),thrust::plus<thrust::complex<data_t>>());
 
-  thrust::lower_bound(thrust::device, iter.begin(), iter.end(), rnds.begin(), rnds.begin() + SHOTS, samples.begin() ,complex_less<data_t>());
+    thrust::lower_bound(thrust::device, iter.begin(), iter.end(), rnds.begin(), rnds.begin() + SHOTS, samples.begin() ,complex_less<data_t>());
+  }
+  else{
+    if(dot)
+      thrust::transform_inclusive_scan(thrust::seq,iter.begin(),iter.end(),iter.begin(),complex_dot_scan<data_t>(),thrust::plus<thrust::complex<data_t>>());
+    else
+      thrust::inclusive_scan(thrust::seq,iter.begin(),iter.end(),iter.begin(),thrust::plus<thrust::complex<data_t>>());
+
+    thrust::lower_bound(thrust::seq, iter.begin(), iter.end(), rnds.begin(), rnds.begin() + SHOTS, samples.begin() ,complex_less<data_t>());
+  }
 #endif
 
   return samples;

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -34,6 +34,11 @@
 
 #include "simulators/statevector/chunk/chunk_manager.hpp"
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+
 namespace AER {
 namespace QV {
 
@@ -483,7 +488,7 @@ protected:
   // Config settings
   //----------------------------------------------------------------------- 
   uint_t omp_threads_ = 1;     // Disable multithreading by default
-  uint_t omp_threshold_ = 1;  // Qubit threshold for multithreading when enabled
+  uint_t omp_threshold_ = 14;  // Qubit threshold for multithreading when enabled
   int sample_measure_index_size_ = 1; // Sample measure indexing qubit size
   double json_chop_threshold_ = 0;  // Threshold for choping small values
                                     // in JSON serialization
@@ -900,6 +905,10 @@ void QubitVectorThrust<data_t>::set_num_qubits(size_t num_qubits)
   chunk_.set_num_qubits(num_qubits);
 
   register_blocking_ = false;
+
+  //set OpenMP threads for ThrustCPU
+  if(num_qubits_ > omp_threshold_ && omp_threads_ > 1)
+    chunk_.container()->set_omp_threads(omp_threads_);
 
 #ifdef AER_DEBUG
   if(chunk_.pos() == 0){
@@ -1391,9 +1400,16 @@ void QubitVectorThrust<data_t>::apply_function_sum2(double* pSum,Function func,b
  ******************************************************************************/
 
 template <typename data_t>
-void QubitVectorThrust<data_t>::set_omp_threads(int n) {
+void QubitVectorThrust<data_t>::set_omp_threads(int n) 
+{
   if (n > 0)
     omp_threads_ = n;
+
+#ifdef _OPENMP
+  //disable nested parallel for ThrustCPU
+  if(omp_get_num_threads() > 1)
+    omp_threads_ = 1;
+#endif
 }
 
 template <typename data_t>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is a fix for device=Thrust, Thrust running on CPU was very slow for small number of qubits.

### Details and comments
This was because Thrust CPU always applied OpenMP for threading kernel programs without referring to the number of qubits.
This fix applies OpenMP referring to statevector_parallel_threshold parameter as same as device=CPU.
