### PR TITLE
Only install terra from binary for wheel jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ test-command = "python {project}/tools/verify_wheels.py"
 # tendency to crash if they're installed from source by `pip install`, and since
 # Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
 # restricting any dependencies that Numpy and Scipy might have.
-before-test = "pip install --only-binary=numpy,scipy numpy scipy"
+before-test = "pip install --only-binary=numpy,scipy,qiskit-terra numpy scipy qiskit-terra"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y openblas-devel"

--- a/test/terra/noise/test_standard_errors.py
+++ b/test/terra/noise/test_standard_errors.py
@@ -520,7 +520,7 @@ class TestNoiseOldInterface(QiskitAerTestCase):
         for i in range(actual.size):
             circ, prob = actual.error_term(i)
             expected_circ, expected_prob = expected.error_term(i)
-            self.assertEqual(circ, expected_circ)
+            self.assertTrue(qi.Operator(circ).equiv(qi.Operator(expected_circ)))
             self.assertAlmostEqual(prob, expected_prob)
 
     def test_pauli_error_2q_gate_from_pauli(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the recently released terra 0.20.0 release the minimum python
packaging spec supported is manylinux2014 now. On the main branch we
bumped the manylinux base image we use for wheel jobs to manylinux2014
in #1498. However, on the stable 0.10.x branch we don't want to do that
since we probably should not drop support for older environments on a
stable release. This commit updates the wheel job config to instead
install terra from a compatible binary wheel instead of using the latest
release. This should hopefully avoid the CI failure but still enable us
to run without building terra from source or dropping support for
manylinux2010.

### Details and comments