### PR TITLE
Only install terra from binary for wheel jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ test-command = "python {project}/tools/verify_wheels.py"
 # tendency to crash if they're installed from source by `pip install`, and since
 # Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
 # restricting any dependencies that Numpy and Scipy might have.
-before-test = "pip install --only-binary=numpy,scipy numpy scipy"
+before-test = "pip install --only-binary=numpy,scipy,qiskit-terra numpy scipy qiskit-terra"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y openblas-devel"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Only install terra from binary for wheel jobs

### Details and comments

In the recently released terra 0.20.0 release the minimum python
packaging spec supported is manylinux2014 now.  This commit updates
the wheel job config to instead install terra from a compatible binary wheel
instead of using the latest release. This will avoid compilation fails of terra in terra.

This commit will be necessary until main starts using only manylinux2014 in #1498.