### PR TITLE
Stop using deprecated BaseBackend class

### DIFF
--- a/qiskit/providers/aer/noise/noise_model.py
+++ b/qiskit/providers/aer/noise/noise_model.py
@@ -21,7 +21,6 @@ from warnings import warn, catch_warnings, filterwarnings
 from numpy import ndarray
 
 from qiskit.circuit import Instruction, Delay
-from qiskit.providers import BaseBackend, BackendV1, BackendV2
 from qiskit.providers.exceptions import BackendPropertyError
 from qiskit.providers.models import BackendProperties
 from qiskit.transpiler import PassManager
@@ -303,10 +302,14 @@ class NoiseModel:
         Raises:
             NoiseError: If the input backend is not valid.
         """
-        if isinstance(backend, BackendV2):
+        backend_interface_version = getattr(backend, "version", None)
+        if not isinstance(backend_interface_version, int):
+            backend_interface_version = 0
+
+        if backend_interface_version == 2:
             raise NoiseError(
                 "NoiseModel.from_backend does not currently support V2 Backends.")
-        if isinstance(backend, (BaseBackend, BackendV1)):
+        if backend_interface_version <= 1:
             properties = backend.properties()
             configuration = backend.configuration()
             basis_gates = configuration.basis_gates

--- a/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
+++ b/qiskit/providers/aer/pulse/system_models/pulse_system_model.py
@@ -17,7 +17,7 @@
 
 from warnings import warn
 from collections import OrderedDict
-from qiskit.providers import BaseBackend, Backend
+from qiskit.providers import Backend
 from ...aererror import AerError
 from .hamiltonian_model import HamiltonianModel
 
@@ -94,7 +94,7 @@ class PulseSystemModel():
             AerError: If channel or u_channel_lo are invalid.
         """
 
-        if not isinstance(backend, (BaseBackend, Backend)):
+        if not isinstance(backend, Backend):
             raise AerError("{} is not a Qiskit backend".format(backend))
 
         # get relevant information from backend


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The BaseBackend class in qiskit-terra (along with the rest of the legacy
provider interface) is deprecated and being removed soon in
Qiskit/qiskit-terra#7886. To avoid potential compatibility issues or
deprecation warnings we shouldn't be using this class anymore. This
commit removes the last 2 uses of these legacy classes to avoid issues
moving forward.

### Details and comments