### PR TITLE
Fixed a compile error when enabling cuStateVec

### DIFF
--- a/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
@@ -120,7 +120,7 @@ uint_t cuStateVecChunkContainer<data_t>::Allocate(int idev,int chunk_bits,int nu
     throw std::runtime_error(str.str());
   }
 
-  err = custatevecSetStream(custatevec_handle_,BaseContainer::stream_[0]);
+  err = custatevecSetStream(custatevec_handle_,BaseContainer::stream_);
   if(err != CUSTATEVEC_STATUS_SUCCESS){
     std::stringstream str;
     str << "cuStateVecChunkContainer::allocate::custatevecSetStream : " << custatevecGetErrorString(err);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`BaseContainer::stream_` is of type `cudaStream_t` (opaque pointer), cannot be used as an array.

This caused a compile error when enabling cuStateVec.

### Details and comments

This is potentially a fallout from this commit https://github.com/Qiskit/qiskit-aer/commit/ce6c733bd8da4a4a3d7d6126cc6cedbe098a350e where `BaseContainer::stream_` was refactored from a vector to a value.

