### PR TITLE
Apply multiplexer to statevector even if no control qubit exists

### DIFF
--- a/releasenotes/notes/allow_multiplexer_without_control_qubits-f5cb8bdbe6302e55.yaml
+++ b/releasenotes/notes/allow_multiplexer_without_control_qubits-f5cb8bdbe6302e55.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Handles a multiplexer gate as a unitary gate if it has no control qubits.
+    Previously, if a multiplexer gate does not have control qubits, quantum state
+    was not updated.

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -491,6 +491,9 @@ inline Op make_multiplexer(const reg_t &qubits,
   if (1ULL << num_controls != num_mats) {
     throw std::invalid_argument("invalid number of multiplexer matrices.");
   }
+  if (num_controls == 0) { // mats.size() must be 1
+    return make_unitary(qubits, mats[0]);
+  }
   // Check number of targets and controls matches qubits
   if (num_controls + num_targets != qubits.size()) {
     throw std::invalid_argument("multiplexer qubits don't match parameters.");

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -1636,7 +1636,8 @@ void State<statevec_t>::apply_multiplexer(const int_t iChunk, const reg_t &contr
                                           const reg_t &target_qubits,
                                           const cmatrix_t &mat) 
 {
-  if (target_qubits.empty() == false && mat.size() > 0) {
+  if (control_qubits.empty() == false && target_qubits.empty() == false &&
+      mat.size() > 0) {
     cvector_t vmat = Utils::vectorize_matrix(mat);
     BaseState::qregs_[iChunk].apply_multiplexer(control_qubits, target_qubits, vmat);
   }

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -1636,8 +1636,7 @@ void State<statevec_t>::apply_multiplexer(const int_t iChunk, const reg_t &contr
                                           const reg_t &target_qubits,
                                           const cmatrix_t &mat) 
 {
-  if (control_qubits.empty() == false && target_qubits.empty() == false &&
-      mat.size() > 0) {
+  if (target_qubits.empty() == false && mat.size() > 0) {
     cvector_t vmat = Utils::vectorize_matrix(mat);
     BaseState::qregs_[iChunk].apply_multiplexer(control_qubits, target_qubits, vmat);
   }

--- a/test/terra/reference/ref_multiplexer.py
+++ b/test/terra/reference/ref_multiplexer.py
@@ -13,8 +13,8 @@
 """
 Test circuits and reference outputs for multiplexer gates.
 """
-
-from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+import numpy as np
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, transpile
 from test.terra.utils.multiplexer import multiplexer_multi_controlled_x
 from test.terra.reference.ref_2q_clifford import (cx_gate_counts_nondeterministic,
                                                   cx_gate_counts_deterministic)
@@ -283,3 +283,14 @@ def multiplexer_ccx_gate_counts_deterministic(shots, hex_counts=True):
 def multiplexer_ccx_gate_counts_nondeterministic(shots, hex_counts=True):
     """ The counts are exactly the same as the ccx gate """
     return ccx_gate_counts_nondeterministic(shots, hex_counts)
+
+def multiplexer_no_control_qubits(final_measure=True):
+    qc = QuantumCircuit(1,1)
+    vector = [0.2, 0.1]
+    vector_circuit = QuantumCircuit(1)
+    vector_circuit.isometry(vector / np.linalg.norm(vector), [0], None)
+    vector_circuit = vector_circuit.inverse()
+    qc.append(vector_circuit, [0])
+    if final_measure:
+      qc.measure(0,0)
+    return [transpile(qc, basis_gates=['multiplexer', 'measure'])]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Apply multiplexer to statevector even if no control qubit exists.

### Details and comments

Currently, multiplexer needs control qubits to apply matrices to target qubits.
However, as reported in #1503, control-qubits may not exist.
This fix allows multiplexer to apply updates without control qubits.
