### PR TITLE
Support `pauli` instructions in `NoiseModel.from_dict()`

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -292,6 +292,9 @@ class QuantumError(BaseOperator, TolerancesMixin):
                     elif dic['name'] == 'unitary':
                         circ.append(UnitaryGate(data=dic['params'][0]),
                                     qargs=dic['qubits'])
+                    elif dic['name'] == 'pauli':
+                        circ.append(PauliGate(dic['params'][0]),
+                                    qargs=dic['qubits'])
                     else:
                         with warnings.catch_warnings():
                             warnings.filterwarnings(

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -20,6 +20,7 @@ import numpy as np
 from qiskit.providers.aer.backends import AerSimulator
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.device.models import _excited_population
+from qiskit.providers.aer.noise.errors import QuantumError
 from qiskit.providers.aer.noise.errors.standard_errors import amplitude_damping_error
 from qiskit.providers.aer.noise.errors.standard_errors import kraus_error
 from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
@@ -28,6 +29,8 @@ from qiskit.providers.aer.noise.errors.standard_errors import thermal_relaxation
 from qiskit.providers.aer.utils.noise_transformation import transform_noise_model
 
 from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.circuit.library.generalized_gates import PauliGate
+from qiskit.circuit.library.standard_gates import IGate, XGate
 from qiskit.compiler import transpile
 from qiskit.test import mock
 from test.terra.common import QiskitAerTestCase
@@ -335,6 +338,22 @@ class TestNoiseModel(QiskitAerTestCase):
         result = AerSimulator().run(qc, noise_model=noise_model).result()
         self.assertTrue(result.success)
 
+    def test_from_dict(self):
+        noise_ops_1q = [((IGate(), [0]), 0.9),
+                     ((XGate(), [0]), 0.1)]
+
+        noise_ops_2q = [((PauliGate('II'), [0, 1]), 0.9),
+                     ((PauliGate('IX'), [0, 1]), 0.045),
+                     ((PauliGate('XI'), [0, 1]), 0.045),
+                     ((PauliGate('XX'), [0, 1]), 0.01)]
+
+        noise_model = NoiseModel()
+        with self.assertWarns(DeprecationWarning):
+            noise_model.add_quantum_error(QuantumError(noise_ops_1q, 1), 'h', [0])
+            noise_model.add_quantum_error(QuantumError(noise_ops_1q, 1), 'h', [1])
+            noise_model.add_quantum_error(QuantumError(noise_ops_2q, 2), 'cx', [0, 1])
+            noise_model.add_quantum_error(QuantumError(noise_ops_2q, 2), 'cx', [1, 0])
+            noise_model.from_dict(noise_model.to_dict())
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -353,7 +353,9 @@ class TestNoiseModel(QiskitAerTestCase):
             noise_model.add_quantum_error(QuantumError(noise_ops_1q, 1), 'h', [1])
             noise_model.add_quantum_error(QuantumError(noise_ops_2q, 2), 'cx', [0, 1])
             noise_model.add_quantum_error(QuantumError(noise_ops_2q, 2), 'cx', [1, 0])
-            noise_model.from_dict(noise_model.to_dict())
+            deserialized = NoiseModel.from_dict(noise_model.to_dict())
+            self.assertEqual(noise_model, deserialized)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently, a `pauli` instruction can not be deserialized from `dict` in `NoiseMode.from_dict()`. This PR adds its support.

### Details and comments

Resolve #1505.
Note that this PR fixes issues in deprecated function from 0.11.
