### PR TITLE
Generate seeds deterministically based on seed of the first circuit in multi-circuit simulation if seed_simulator is not set

### DIFF
--- a/releasenotes/notes/make_random_seed_reproducible-a7abdfc09ec67bd8.yaml
+++ b/releasenotes/notes/make_random_seed_reproducible-a7abdfc09ec67bd8.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Because a seed was randomly assigned to each circuit if seed_simulator is not set,
+    multi-circuit simulation was not reproducible with another multi-circuit simulation.
+    Users needed to run multiple single-circuit simulation with the seed_simulator which
+    is randomly assigned in the multi-circuit simulation. This fix allows users to reproduce
+    multi-circuit simulation with another multi-circuit simulation by setting seed_simulator
+    of the first circuit in the first multi-circuit simulation. This fix also resolve an
+    issue reported in https://github.com/Qiskit/qiskit-aer/issues/1511, where simulation
+    with parameter-binds returns identical results for each circuit instance.

--- a/src/framework/qobj.hpp
+++ b/src/framework/qobj.hpp
@@ -174,11 +174,12 @@ Qobj::Qobj(const inputdata_t &input) {
   // Override random seed with fixed seed if set
   // We shift the seed for each successive experiment
   // So that results aren't correlated between experiments
-  if (has_simulator_seed) {
-    for (auto& circuit : circuits) {
-      circuit.seed = seed + seed_shift;
-      seed_shift += 2113;  // Shift the seed
-    }
+  if (!has_simulator_seed) {
+    seed = circuits[0].seed;
+  }
+  for (auto& circuit : circuits) {
+    circuit.seed = seed + seed_shift;
+    seed_shift += 2113;  // Shift the seed
   }
 }
 

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -328,6 +328,23 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         for i in range(3):
             self.assertEqual(result.data(i)['sv'], result_without_parameters.data(i)['sv'])
 
+    def test_different_seed(self):
+        """Test parameterized circuits have different seeds"""
+        shots = 1000
+        backend = AerSimulator()
+        circuit = QuantumCircuit(2)
+        theta = Parameter('theta')
+        circuit.rx(theta, 0)
+        circuit.cx(0, 1)
+        circuit.measure_all()
+        parameter_binds = [{theta: [0, pi, 2 * pi]}]
+        res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
+        seed_simulator_list = [ result.seed_simulator for result in res.results ]
+        self.assertEqual(len(seed_simulator_list), len(np.unique(seed_simulator_list)))
+
+        res2 = backend.run(circuit, shots=shots, parameter_binds=parameter_binds, seed_simulator=seed_simulator_list[0]).result()
+        self.assertEqual(seed_simulator_list, [ result.seed_simulator for result in res2.results ])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #1511 and a potential issue without `seed_simulator`

### Details and comments

Currently, a circuit is copied for each parameter set, including `seed_simulator` (if `seed_simulator` is specified as a run option, different seeds are set to circuits). Also, if `backend.run()` simulates multiple circuits without `seed_simulator`, a seed of each circuit is randomly generated and make users to reproduce simulation difficult.

This PR sets seeds deterministically based on the seed of the first circuit in multi-circuit simulation. For example, `res1` and `res2` are identical:
```
res1 = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
res2 = backend.run(circuit, shots=shots, parameter_binds=parameter_binds, seed_simulator=res1.results[0].seed_simulator).result()
```