### PR TITLE
Reduce dependency to ClassicalRegister from AER::QV::QubitVector

### DIFF
--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -944,7 +944,7 @@ void StateChunk<state_t>::apply_ops_multi_shots(InputIterator first, InputIterat
 
     //collect measured bits and copy memory
     for(i=0;i<n_shots;i++){
-      qregs_[i].get_creg(cregs_[global_chunk_index_ + i_begin + i]);
+      qregs_[i].read_measured_data(cregs_[global_chunk_index_ + i_begin + i]);
     }
 
     i_begin += n_shots;

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -31,9 +31,12 @@
 #include "simulators/statevector/indexes.hpp"
 #include "simulators/statevector/transformer.hpp"
 #include "simulators/statevector/transformer_avx2.hpp"
+#include "framework/operations.hpp"
+#include "framework/rng.hpp"
 #include "framework/avx2_detect.hpp"
 #include "framework/json.hpp"
 #include "framework/utils.hpp"
+#include "framework/linalg/matrix_utils/vmatrix_defs.hpp"
 #include "framework/linalg/vector.hpp"
 
 namespace AER {
@@ -312,7 +315,8 @@ public:
   virtual void apply_batched_reset(const reg_t& qubits,std::vector<RngEngine>& rng){}
 
   //copy classical register stored on qreg 
-  void get_creg(ClassicalRegister& creg){}
+  template <typename storage_t>
+  void read_measured_data(storage_t& creg){}
 
   virtual int_t set_batched_system_conditional(int_t src_reg, reg_t& mask){return -1;}
 

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -347,7 +347,7 @@ public:
   virtual void store_cmemory(uint_t qubit,int val);
 
   //copy classical register stored on qreg 
-  void get_creg(ClassicalRegister& creg);
+  void read_measured_data(ClassicalRegister& creg);
 
   //apply Pauli ops to multiple-shots (apply sampled Pauli noises)
   virtual void apply_batched_pauli_ops(const std::vector<std::vector<Operations::Op>> &ops);
@@ -2405,7 +2405,7 @@ int QubitVectorThrust<data_t>::measured_cmemory(uint_t qubit)
 }
 
 template <typename data_t>
-void QubitVectorThrust<data_t>::get_creg(ClassicalRegister& creg)
+void QubitVectorThrust<data_t>::read_measured_data(ClassicalRegister& creg)
 {
   uint_t i;
   reg_t pos(1);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Reduce dependency to `ClassicalRegister` to construct `AER::QV::QubitVector` objects.

### Details and comments

`qubitvector.hpp` is not self-sufficient. This PR adds some include-statements for some header files to the file.
Additionally, `ClassicalRegister` becomes not referred. This odd dependency is added for batch-execution on GPU noise optimization and it is not necessary in `AER::QV::QubitVector`. This PR reduces this dependency by templating the class.

With this change, the following code will be compiled successfully.

```
#include <iostream>
#include "simulators/statevector/qubitvector.hpp"

int main() {
    AER::QV::QubitVector<double> qv(21);
    qv.initialize();
    std::cout << qv[0] << std::endl;
    return 1;
}
```

