### PR TITLE
Addressing default branch name change

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 <!-- Copyright Contributors to the Qiskit project. -->
 
 # Code of Conduct
-All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md)
 
 ----
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 <!-- Copyright Contributors to the Qiskit project. -->
 
 # Code of Conduct
-All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md)
+All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
 ----
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ it has been tagged::
 At release time, ``reno report`` is used to generate the release notes for the
 release and the output will be submitted as a pull request to the documentation
 repository's [release notes file](
-https://github.com/Qiskit/qiskit/blob/master/docs/release_notes.rst)
+https://github.com/Qiskit/qiskit/blob/main/docs/release_notes.rst)
 
 #### Building release notes locally
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install qiskit
 
 Pip will handle all dependencies automatically for us and you will always install the latest (and well-tested) version.
 
-To install from source, follow the instructions in the [contribution guidelines](https://github.com/Qiskit/qiskit-aer/blob/master/CONTRIBUTING.md).
+To install from source, follow the instructions in the [contribution guidelines](CONTRIBUTING.md).
 
 ## Installing GPU support
 
@@ -35,7 +35,7 @@ ability to run the GPU supported simulators: statevector, density matrix, and un
 
 **Note**: This package is only available on x86_64 Linux. For other platforms
 that have CUDA support you will have to build from source. You can refer to
-the [contributing guide](https://github.com/Qiskit/qiskit-aer/blob/master/CONTRIBUTING.md#building-with-gpu-support)
+the [contributing guide](CONTRIBUTING.md#building-with-gpu-support)
 for instructions on doing this.
 
 ## Simulating your first quantum program with Qiskit Aer
@@ -84,7 +84,7 @@ print('Counts(noise):', counts_noise)
 ## Contribution Guidelines
 
 If you'd like to contribute to Qiskit, please take a look at our
-[contribution guidelines](https://github.com/Qiskit/qiskit-aer/blob/master/CONTRIBUTING.md). This project adheres to Qiskit's [code of conduct](https://github.com/Qiskit/qiskit-aer/blob/master/CODE_OF_CONDUCT.md). By participating, you are expect to uphold to this code.
+[contribution guidelines](CONTRIBUTING.md). This project adheres to Qiskit's [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expect to uphold to this code.
 
 We use [GitHub issues](https://github.com/Qiskit/qiskit-aer/issues) for tracking requests and bugs. Please use our [slack](https://qiskit.slack.com) for discussion and simple questions. To join our Slack community use the [link](https://qiskit.slack.com/join/shared_invite/zt-fybmq791-hYRopcSH6YetxycNPXgv~A#/). For questions that are more suited for a forum we use the Qiskit tag in the [Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/qiskit).
 

--- a/releasenotes/notes/0.8/0.8-release-179e83619783737f.yaml
+++ b/releasenotes/notes/0.8/0.8-release-179e83619783737f.yaml
@@ -12,12 +12,12 @@ features:
   - |
     This release includes support for building qiskit-aer with MPI support to
     run large simulations on a distributed computing environment. See the
-    `contributing guide <https://github.com/Qiskit/qiskit-aer/blob/master/CONTRIBUTING.md#building-with-mpi-support>`__
+    `contributing guide <https://github.com/Qiskit/qiskit-aer/blob/main/CONTRIBUTING.md#building-with-mpi-support>`__
     for instructions on building and running in an MPI environment.
   - |
     It is now possible to build qiskit-aer with CUDA enabled in Windows.
     See the
-    `contributing guide <https://github.com/Qiskit/qiskit-aer/blob/master/CONTRIBUTING.md#building-with-gpu-support>`__
+    `contributing guide <https://github.com/Qiskit/qiskit-aer/blob/main/CONTRIBUTING.md#building-with-gpu-support>`__
     for instructions on building from source with GPU support.
   - |
     When building the qiskit-aer Python extension from source several build

--- a/src/misc/clang_omp_symbols.hpp
+++ b/src/misc/clang_omp_symbols.hpp
@@ -19,7 +19,7 @@
  * This is some sort of "black magic" to solve a problem we have with OpenMP libraries on Mac.
  * The problem is actually in the library itself, but it's out of our control, so we had to
  * fix it this way.
- * Symbol signatures are taken from: https://github.com/llvm/llvm-project/blob/master/openmp/runtime/src/kmp.h
+ * Symbol signatures are taken from: https://github.com/llvm/llvm-project/blob/main/openmp/runtime/src/kmp.h
  */
 
 #include <dlfcn.h>


### PR DESCRIPTION
### Summary

Addresses change in default branch naming from master to main while also taking advantage of relative links.

### Details and comments

Fixes issue #1509  by addressing default project branch changes from master to main in non-root directory, while leveraging relative links in root directory files such as README.md and CODE_OF_CONDUCT.md where appropriate.
