### PR TITLE
Add mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,22 +1,6 @@
-queue_reules:
+queue_rules:
   - name: automerge
-    conditions:
-      - check-success=lint
-      - check-success=sdist
-      - check-success=tests_linux
-      - check-success=tests_macos
-      - check-success=tests_windows
-      - check-success=tests-json-input
-      - check-success=standalone
-      - check-success=mpi_standalone
-      - check-success=wheel-arm64
-      - check-success=wheel
-      - check-success=docs
-      - check-success=tutorials
-      - or:
-        - check-success=license/cla
-        - check-neutral=license/cla
-        - check-skipped=license/cla
+    conditions: []  # No additional rules, because branch-protection does them.
 
 pull_request_rules:
   - name: automatic merge on CI success and review
@@ -25,22 +9,14 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - label=automerge
       - label!=on hold
-      - check-success=lint
-      - check-success=sdist
-      - check-success=tests_linux
-      - check-success=tests_macos
-      - check-success=tests_windows
-      - check-success=tests-json-input
-      - check-success=standalone
-      - check-success=mpi_standalone
-      - check-success=wheel-arm64
-      - check-success=wheel
-      - check-success=docs
-      - check-success=tutorials
+      # GitHub branch-protection rules are automatically applied by mergify, so
+      # the queue can't actually merge things unless _all_ statuses are passed.
+      # This section is just a sanity check before the PR can enter the main
+      # queue.
       - or:
-        - check-success=license/cla
-        - check-neutral=license/cla
-        - check-skipped=license/cla
+        - check-success=tests_linux (3.10, ubuntu-latest)
+        - check-neutral=tests_linux (3.10, ubuntu-latest)
+        - check-skipped=tests_linux (3.10, ubuntu-latest)
     actions:
       queue:
         name: automerge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,47 @@
+queue_reules:
+  - name: automerge
+    conditions:
+      - check-success=lint
+      - check-success=sdist
+      - check-success=tests_linux
+      - check-success=tests_macos
+      - check-success=tests_windows
+      - check-success=tests-json-input
+      - check-success=standalone
+      - check-success=mpi_standalone
+      - check-success=wheel-arm64
+      - check-success=wheel
+      - check-success=docs
+      - check-success=tutorials
+      - or:
+        - check-success=license/cla
+        - check-neutral=license/cla
+        - check-skipped=license/cla
+
+pull_request_rules:
+  - name: automatic merge on CI success and review
+    conditions:
+      - base=main
+      - "#approved-reviews-by>=1"
+      - label=automerge
+      - label!=on hold
+      - check-success=lint
+      - check-success=sdist
+      - check-success=tests_linux
+      - check-success=tests_macos
+      - check-success=tests_windows
+      - check-success=tests-json-input
+      - check-success=standalone
+      - check-success=mpi_standalone
+      - check-success=wheel-arm64
+      - check-success=wheel
+      - check-success=docs
+      - check-success=tutorials
+      - or:
+        - check-success=license/cla
+        - check-neutral=license/cla
+        - check-skipped=license/cla
+    actions:
+      queue:
+        name: automerge
+        method: squash


### PR DESCRIPTION
### Summary

This adds a configuration similar to what already exists on Terra that
causes the mergify bot to handle merging automatically on our behalf, if
a PR passes all its status checks and has the `automerge` label applied.
Procedure on Aer has usually been to group stable backports rather than
doing them one at a time, so this configuration does not add a backport
rule (unlike Terra's version).

GitHub Actions (what Aer uses for CI) tests appear as separate status
check entries, so we have to manually specify all of these to get the
desired behaviour.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments


