### PR TITLE
Fix import path for deprecated Pauli

### DIFF
--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -21,9 +21,8 @@ from qiskit.circuit import QuantumCircuit, Reset
 from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
 from qiskit.exceptions import QiskitError
 from qiskit.extensions import UnitaryGate
-from qiskit.quantum_info.operators import Operator
+from qiskit.quantum_info.operators import Operator, Pauli
 from qiskit.quantum_info.operators.channel import Choi, Kraus
-from qiskit.quantum_info.operators.pauli import Pauli
 from qiskit.quantum_info.operators.predicates import is_identity_matrix
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Same with https://github.com/Qiskit/qiskit-aer/pull/1295

### Details and comments


