### PR TITLE
Initial input of AerState

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,50 +392,52 @@ else() # Standalone build
 	# This will add the linter as part of the compiling build target
 	#add_linter(qasm_simulator)
 
-	set(AER_RUNTIME_SOURCES "${PROJECT_SOURCE_DIR}/contrib/runtime/aer_runtime.cpp")
-	if(CUDA_FOUND AND AER_THRUST_BACKEND STREQUAL "CUDA")
-		set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES LANGUAGE CUDA)
-		set_source_files_properties(${AER_RUNTIME_SOURCES} PROPERTIES LANGUAGE CUDA)
-		set_source_files_properties(${AER_RUNTIME_SOURCES} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS}")
-		if(DEFINED SIMD_FLAGS_LIST)
-			nvcc_add_compiler_options_list("${SIMD_FLAGS_LIST}" SIMD_FLAGS)
-			set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS} ${SIMD_FLAGS}")
-		endif()
-		add_executable(aer ${AER_RUNTIME_SOURCES} ${SIMD_SOURCE_FILE})
-		target_link_libraries(aer ${AER_LIBRARIES})
-		string(STRIP ${AER_COMPILER_FLAGS} AER_COMPILER_FLAGS_STRIPPED)
-		nvcc_add_compiler_options(${AER_COMPILER_FLAGS_STRIPPED} AER_COMPILER_FLAGS_OUT)
+	if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
+		set(AER_RUNTIME_SOURCES "${PROJECT_SOURCE_DIR}/contrib/runtime/aer_runtime.cpp")
+		if(CUDA_FOUND AND AER_THRUST_BACKEND STREQUAL "CUDA")
+			set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES LANGUAGE CUDA)
+			set_source_files_properties(${AER_RUNTIME_SOURCES} PROPERTIES LANGUAGE CUDA)
+			set_source_files_properties(${AER_RUNTIME_SOURCES} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS}")
+			if(DEFINED SIMD_FLAGS_LIST)
+				nvcc_add_compiler_options_list("${SIMD_FLAGS_LIST}" SIMD_FLAGS)
+				set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS} ${SIMD_FLAGS}")
+			endif()
+			add_executable(aer ${AER_RUNTIME_SOURCES} ${SIMD_SOURCE_FILE})
+			target_link_libraries(aer ${AER_LIBRARIES})
+			string(STRIP ${AER_COMPILER_FLAGS} AER_COMPILER_FLAGS_STRIPPED)
+			nvcc_add_compiler_options(${AER_COMPILER_FLAGS_STRIPPED} AER_COMPILER_FLAGS_OUT)
 
-		set_target_properties(aer PROPERTIES
-			LINKER_LANGUAGE CXX
-			CXX_STANDARD 14
-			COMPILE_FLAGS ${AER_COMPILER_FLAGS_OUT}
-			LINK_FLAGS ${AER_LINKER_FLAGS}
-			RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
-			RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
-	else()
+			set_target_properties(aer PROPERTIES
+				LINKER_LANGUAGE CXX
+				CXX_STANDARD 14
+				COMPILE_FLAGS ${AER_COMPILER_FLAGS_OUT}
+				LINK_FLAGS ${AER_LINKER_FLAGS}
+				RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
+				RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
+		else()
 			string(REPLACE ";" " " SIMD_FLAGS "${SIMD_FLAGS_LIST}")
-		set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${SIMD_FLAGS}")
-		add_library(aer SHARED ${AER_RUNTIME_SOURCES} ${SIMD_SOURCE_FILE})
-		target_link_libraries(aer PRIVATE ${AER_LIBRARIES})
-		set_target_properties(aer PROPERTIES
-			LINKER_LANGUAGE CXX
-			CXX_STANDARD 14
-			COMPILE_FLAGS ${AER_COMPILER_FLAGS}
-			LINK_FLAGS ${AER_LINKER_FLAGS}
-			RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
-			RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
-	endif()
-	target_include_directories(aer
-		PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR}
-		PRIVATE ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
-	target_compile_definitions(aer
-		PRIVATE ${AER_COMPILER_DEFINITIONS})
-	if(WIN32 AND NOT AER_BLAS_LIB_PATH)
-		add_custom_command(TARGET aer POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
-				${BACKEND_REDIST_DEPS}
-				$<TARGET_FILE_DIR:aer>)
-		install(FILES ${BACKEND_REDIST_DEPS} DESTINATION bin)
+			set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${SIMD_FLAGS}")
+			add_library(aer SHARED ${AER_RUNTIME_SOURCES} ${SIMD_SOURCE_FILE})
+			target_link_libraries(aer PRIVATE ${AER_LIBRARIES})
+			set_target_properties(aer PROPERTIES
+				LINKER_LANGUAGE CXX
+				CXX_STANDARD 14
+				COMPILE_FLAGS ${AER_COMPILER_FLAGS}
+				LINK_FLAGS ${AER_LINKER_FLAGS}
+				RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
+				RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
+		endif()
+		target_include_directories(aer
+			PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR}
+			PRIVATE ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
+		target_compile_definitions(aer
+			PRIVATE ${AER_COMPILER_DEFINITIONS})
+		if(WIN32 AND NOT AER_BLAS_LIB_PATH)
+			add_custom_command(TARGET aer POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
+					${BACKEND_REDIST_DEPS}
+					$<TARGET_FILE_DIR:aer>)
+			install(FILES ${BACKEND_REDIST_DEPS} DESTINATION bin)
+		endif()
 	endif()
 
 	install(TARGETS aer DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,116 +331,105 @@ if(SKBUILD) # Terra Addon build
 	add_subdirectory(src/open_pulse)
 else() # Standalone build
 
-	if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
-		if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
-			# We build SIMD filed separately, because they will be reached only if the
-			# machine running the code has SIMD support
-			set(SIMD_SOURCE_FILE "${PROJECT_SOURCE_DIR}/src/simulators/statevector/qv_avx2.cpp")
+	function(build_cuda target src_file is_exec)
+		if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
+			if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+				# We build SIMD filed separately, because they will be reached only if the
+				# machine running the code has SIMD support
+				set(SIMD_SOURCE_FILE "${PROJECT_SOURCE_DIR}/src/simulators/statevector/qv_avx2.cpp")
+			endif()
 		endif()
-	endif()
-
-	set(AER_SIMULATOR_SOURCES "${PROJECT_SOURCE_DIR}/contrib/standalone/qasm_simulator.cpp")
-	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-	if(CUDA_FOUND AND AER_THRUST_BACKEND STREQUAL "CUDA")
 		set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES LANGUAGE CUDA)
-		set_source_files_properties(${AER_SIMULATOR_SOURCES} PROPERTIES LANGUAGE CUDA)
-		set_source_files_properties(${AER_SIMULATOR_SOURCES} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS}")
+		set_source_files_properties(${src_file} PROPERTIES LANGUAGE CUDA)
+		set_source_files_properties(${src_file} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS}")
 		if(DEFINED SIMD_FLAGS_LIST)
 			nvcc_add_compiler_options_list("${SIMD_FLAGS_LIST}" SIMD_FLAGS)
 			set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS} ${SIMD_FLAGS}")
 		endif()
-		add_executable(qasm_simulator ${AER_SIMULATOR_SOURCES} ${SIMD_SOURCE_FILE})
-		target_link_libraries(qasm_simulator ${AER_LIBRARIES})
+		if(${is_exec})
+			add_executable(${target} ${src_file} ${SIMD_SOURCE_FILE})
+		else()
+			add_library(${target} ${src_file} ${SIMD_SOURCE_FILE})
+		endif()
+		target_link_libraries(${target} ${AER_LIBRARIES})
 		string(STRIP ${AER_COMPILER_FLAGS} AER_COMPILER_FLAGS_STRIPPED)
 		nvcc_add_compiler_options(${AER_COMPILER_FLAGS_STRIPPED} AER_COMPILER_FLAGS_OUT)
 
-		set_target_properties(qasm_simulator PROPERTIES
+		set_target_properties(${target} PROPERTIES
 			LINKER_LANGUAGE CXX
 			CXX_STANDARD 14
 			COMPILE_FLAGS ${AER_COMPILER_FLAGS_OUT}
 			LINK_FLAGS ${AER_LINKER_FLAGS}
 			RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
 			RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
-	else()
+
+
+	endfunction()
+
+	function(build_cpu target src_file is_exec)
+		if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
+			if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+				# We build SIMD filed separately, because they will be reached only if the
+				# machine running the code has SIMD support
+				set(SIMD_SOURCE_FILE "${PROJECT_SOURCE_DIR}/src/simulators/statevector/qv_avx2.cpp")
+			endif()
+		endif()
 		string(REPLACE ";" " " SIMD_FLAGS "${SIMD_FLAGS_LIST}")
 		set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${SIMD_FLAGS}")
-		add_executable(qasm_simulator ${AER_SIMULATOR_SOURCES} ${SIMD_SOURCE_FILE})
-		target_link_libraries(qasm_simulator PRIVATE ${AER_LIBRARIES})
-		set_target_properties(qasm_simulator PROPERTIES
+		if(${is_exec})
+			add_executable(${target} ${src_file} ${SIMD_SOURCE_FILE})
+		else()
+			add_library(${target} SHARED ${src_file} ${SIMD_SOURCE_FILE})
+		endif()
+		target_link_libraries(${target} PRIVATE ${AER_LIBRARIES})
+		set_target_properties(${target} PROPERTIES
 			LINKER_LANGUAGE CXX
 			CXX_STANDARD 14
 			COMPILE_FLAGS ${AER_COMPILER_FLAGS}
 			LINK_FLAGS ${AER_LINKER_FLAGS}
 			RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
 			RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
-	endif()
-	target_include_directories(qasm_simulator
-		PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR}
-		PRIVATE ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
-	target_compile_definitions(qasm_simulator
-		PRIVATE ${AER_COMPILER_DEFINITIONS})
-	if(WIN32 AND NOT AER_BLAS_LIB_PATH)
-		add_custom_command(TARGET qasm_simulator POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
-				${BACKEND_REDIST_DEPS}
-				$<TARGET_FILE_DIR:qasm_simulator>)
-		install(FILES ${BACKEND_REDIST_DEPS} DESTINATION bin)
+
+		target_include_directories(${target}
+			PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR}
+			PRIVATE ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
+		target_compile_definitions(${target}
+			PRIVATE ${AER_COMPILER_DEFINITIONS})
+		if(WIN32 AND NOT AER_BLAS_LIB_PATH)
+			add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
+					${BACKEND_REDIST_DEPS}
+					$<TARGET_FILE_DIR:${target}>)
+			install(FILES ${BACKEND_REDIST_DEPS} DESTINATION bin)
+		endif()
+	endfunction()
+
+	# build qasm_simulator
+	set(AER_SIMULATOR_SOURCE "${PROJECT_SOURCE_DIR}/contrib/standalone/qasm_simulator.cpp")
+	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+	if(CUDA_FOUND AND AER_THRUST_BACKEND STREQUAL "CUDA")
+		build_cuda(qasm_simulator ${AER_SIMULATOR_SOURCE} TRUE)
+	else()
+		build_cpu(qasm_simulator ${AER_SIMULATOR_SOURCE} TRUE)
 	endif()
 
 	install(TARGETS qasm_simulator DESTINATION bin)
 
-	# Linter
-	# This will add the linter as part of the compiling build target
-	#add_linter(qasm_simulator)
-
-	if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
-		set(AER_RUNTIME_SOURCES "${PROJECT_SOURCE_DIR}/contrib/runtime/aer_runtime.cpp")
+	# build libaer.so (currently, Linux on x86 is supportted)
+	if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+		set(AER_RUNTIME_SOURCE "${PROJECT_SOURCE_DIR}/contrib/runtime/aer_runtime.cpp")
 		if(CUDA_FOUND AND AER_THRUST_BACKEND STREQUAL "CUDA")
-			set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES LANGUAGE CUDA)
-			set_source_files_properties(${AER_RUNTIME_SOURCES} PROPERTIES LANGUAGE CUDA)
-			set_source_files_properties(${AER_RUNTIME_SOURCES} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS}")
-			if(DEFINED SIMD_FLAGS_LIST)
-				nvcc_add_compiler_options_list("${SIMD_FLAGS_LIST}" SIMD_FLAGS)
-				set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS} ${SIMD_FLAGS}")
-			endif()
-			add_executable(aer ${AER_RUNTIME_SOURCES} ${SIMD_SOURCE_FILE})
-			target_link_libraries(aer ${AER_LIBRARIES})
-			string(STRIP ${AER_COMPILER_FLAGS} AER_COMPILER_FLAGS_STRIPPED)
-			nvcc_add_compiler_options(${AER_COMPILER_FLAGS_STRIPPED} AER_COMPILER_FLAGS_OUT)
-
-			set_target_properties(aer PROPERTIES
-				LINKER_LANGUAGE CXX
-				CXX_STANDARD 14
-				COMPILE_FLAGS ${AER_COMPILER_FLAGS_OUT}
-				LINK_FLAGS ${AER_LINKER_FLAGS}
-				RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
-				RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
+			build_cuda(aer ${AER_RUNTIME_SOURCE} FALSE)
 		else()
-			string(REPLACE ";" " " SIMD_FLAGS "${SIMD_FLAGS_LIST}")
-			set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${SIMD_FLAGS}")
-			add_library(aer SHARED ${AER_RUNTIME_SOURCES} ${SIMD_SOURCE_FILE})
-			target_link_libraries(aer PRIVATE ${AER_LIBRARIES})
-			set_target_properties(aer PROPERTIES
-				LINKER_LANGUAGE CXX
-				CXX_STANDARD 14
-				COMPILE_FLAGS ${AER_COMPILER_FLAGS}
-				LINK_FLAGS ${AER_LINKER_FLAGS}
-				RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
-				RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
+			build_cpu(aer ${AER_RUNTIME_SOURCE} FALSE)
 		endif()
-		target_include_directories(aer
-			PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR}
-			PRIVATE ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
-		target_compile_definitions(aer
-			PRIVATE ${AER_COMPILER_DEFINITIONS})
-		if(WIN32 AND NOT AER_BLAS_LIB_PATH)
-			add_custom_command(TARGET aer POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
-					${BACKEND_REDIST_DEPS}
-					$<TARGET_FILE_DIR:aer>)
-			install(FILES ${BACKEND_REDIST_DEPS} DESTINATION bin)
-		endif()
+		install(TARGETS aer)
+		# run test
+		add_executable(runtime_test "${PROJECT_SOURCE_DIR}/test/runtime/runtime_sample.c")
+		target_include_directories(runtime_test PUBLIC "${PROJECT_SOURCE_DIR}/contrib/runtime/")
+		target_link_libraries(runtime_test PRIVATE ${AER_LIBRARIES})
+		target_link_libraries(runtime_test PRIVATE aer)
+		add_test(aer_runtime_test runtime_test)
 	endif()
-
-	install(TARGETS aer DESTINATION bin)
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,14 +26,14 @@ if(NOT DEFINED AER_THRUST_BACKEND AND DEFINED ENV{AER_THRUST_BACKEND})
 endif()
 
 if(AER_THRUST_BACKEND STREQUAL "CUDA")
-  include(nvcc_add_compiler_options)
-  set(CUDA_FOUND TRUE)
-  #include(FindCUDA) # for cuda_select_nvcc_arch_flags, CUDA_FOUND
-  include(FindCUDA/select_compute_arch)
-  enable_language(CUDA)
+	include(nvcc_add_compiler_options)
+	set(CUDA_FOUND TRUE)
+	#include(FindCUDA) # for cuda_select_nvcc_arch_flags, CUDA_FOUND
+	include(FindCUDA/select_compute_arch)
+	enable_language(CUDA)
 else()
-  # idiosyncrasy of CMake that it still creates a reference to this
-  set(CMAKE_CUDA_COMPILE_WHOLE_COMPILATION "")
+	# idiosyncrasy of CMake that it still creates a reference to this
+	set(CMAKE_CUDA_COMPILE_WHOLE_COMPILATION "")
 endif()
 
 
@@ -60,7 +60,7 @@ include(dependency_utils)
 # Get version information
 get_version(${VERSION_NUM})
 configure_file("${PROJECT_SOURCE_DIR}/contrib/standalone/version.hpp.in"
-               "${PROJECT_SOURCE_DIR}/contrib/standalone/version.hpp")
+							 "${PROJECT_SOURCE_DIR}/contrib/standalone/version.hpp")
 
 set(AER_SIMULATOR_CPP_SRC_DIR "${PROJECT_SOURCE_DIR}/src")
 set(AER_SIMULATOR_CPP_EXTERNAL_LIBS
@@ -99,13 +99,13 @@ if(STATIC_LINKING)
 		message(WARNING "Clang on MacOS doesn't support some -static-* flags. Switching to dyn compilation...")
 		unset(STATIC_LINKING)
 	else()
-	    # MacOS compilers don't support -static flag either
-	    if(NOT APPLE)
-	        enable_cxx_compiler_flag_if_supported("-static")
-	    endif()
-	    # This is enough to build a semi-static executable on Mac
-	    enable_cxx_compiler_flag_if_supported("-static-libgcc")
-	    enable_cxx_compiler_flag_if_supported("-static-libstdc++")
+			# MacOS compilers don't support -static flag either
+			if(NOT APPLE)
+				enable_cxx_compiler_flag_if_supported("-static")
+			endif()
+			# This is enough to build a semi-static executable on Mac
+			enable_cxx_compiler_flag_if_supported("-static-libgcc")
+			enable_cxx_compiler_flag_if_supported("-static-libstdc++")
 	endif()
 endif()
 
@@ -132,10 +132,10 @@ else("Windows general compiler flags")
 endif()
 
 if(STATIC_LINKING)
-    SET(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
-    if(WIN32)
-        SET(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
-    endif()
+	SET(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+	if(WIN32)
+		SET(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
+	endif()
 endif()
 
 #
@@ -148,7 +148,7 @@ setup_dependencies()
 set(AER_LINKER_FLAGS " ")
 set(AER_COMPILER_FLAGS " ")
 if(MSVC)
-  set(AER_COMPILER_FLAGS " /bigobj")
+	set(AER_COMPILER_FLAGS " /bigobj")
 endif ()
 
 if(NOT OPENMP_FOUND) # Could already be setup for macos with conan
@@ -226,11 +226,11 @@ endif()
 message(STATUS "BLAS library found: ${BLAS_LIBRARIES}")
 
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
-    if(APPLE OR UNIX)
-        if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
-            set(SIMD_FLAGS_LIST "-mfma;-mavx2")
-	        enable_cxx_compiler_flag_if_supported("-mpopcnt")
-        endif()
+	if(APPLE OR UNIX)
+		if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+			set(SIMD_FLAGS_LIST "-mfma;-mavx2")
+			enable_cxx_compiler_flag_if_supported("-mpopcnt")
+		endif()
 	elseif(MSVC)
 		set(SIMD_FLAGS_LIST "/arch:AVX2")
 	endif()
@@ -259,7 +259,7 @@ if(AER_THRUST_SUPPORTED)
 		if(CUSTATEVEC_ROOT)
 			set(AER_COMPILER_DEFINITIONS ${AER_COMPILER_DEFINITIONS} AER_CUSTATEVEC)
 			set(AER_COMPILER_FLAGS "${AER_COMPILER_FLAGS} -I${CUSTATEVEC_ROOT}/include")
-            if(CUSTATEVEC_STATIC)
+			if(CUSTATEVEC_STATIC)
 				set(THRUST_DEPENDANT_LIBS "-L${CUSTATEVEC_ROOT}/lib -L${CUSTATEVEC_ROOT}/lib64 -lcustatevec_static -L${CUDA_TOOLKIT_ROOT_DIR}/lib64 -lcublas")
 			else()
 				set(THRUST_DEPENDANT_LIBS "-L${CUSTATEVEC_ROOT}/lib -L${CUSTATEVEC_ROOT}/lib64 -lcustatevec")
@@ -307,7 +307,7 @@ if(AER_MPI)
 	set(AER_SIMULATOR_CPP_EXTERNAL_LIBS ${AER_SIMULATOR_CPP_EXTERNAL_LIBS} ${MPI_CXX_INCLUDE_PATH})
 	set(MPI_DEPENDANT_LIBS ${MPI_CXX_LIBRARIES})
 	if(AER_DISABLE_GDR)
-	  set(AER_COMPILER_DEFINITIONS ${AER_COMPILER_DEFINITIONS} AER_DISABLE_GDR)
+		set(AER_COMPILER_DEFINITIONS ${AER_COMPILER_DEFINITIONS} AER_DISABLE_GDR)
 	endif()
 else()
 	set(MPI_DEPENDANT_LIBS "")
@@ -331,13 +331,13 @@ if(SKBUILD) # Terra Addon build
 	add_subdirectory(src/open_pulse)
 else() # Standalone build
 
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
-      if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
-          # We build SIMD filed separately, because they will be reached only if the
-          # machine running the code has SIMD support
-          set(SIMD_SOURCE_FILE "${PROJECT_SOURCE_DIR}/src/simulators/statevector/qv_avx2.cpp")
-      endif()
-  endif()
+	if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+		if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+			# We build SIMD filed separately, because they will be reached only if the
+			# machine running the code has SIMD support
+			set(SIMD_SOURCE_FILE "${PROJECT_SOURCE_DIR}/src/simulators/statevector/qv_avx2.cpp")
+		endif()
+	endif()
 
 	set(AER_SIMULATOR_SOURCES "${PROJECT_SOURCE_DIR}/contrib/standalone/qasm_simulator.cpp")
 	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
@@ -352,7 +352,7 @@ else() # Standalone build
 		add_executable(qasm_simulator ${AER_SIMULATOR_SOURCES} ${SIMD_SOURCE_FILE})
 		target_link_libraries(qasm_simulator ${AER_LIBRARIES})
 		string(STRIP ${AER_COMPILER_FLAGS} AER_COMPILER_FLAGS_STRIPPED)
-                nvcc_add_compiler_options(${AER_COMPILER_FLAGS_STRIPPED} AER_COMPILER_FLAGS_OUT)
+		nvcc_add_compiler_options(${AER_COMPILER_FLAGS_STRIPPED} AER_COMPILER_FLAGS_OUT)
 
 		set_target_properties(qasm_simulator PROPERTIES
 			LINKER_LANGUAGE CXX
@@ -362,7 +362,7 @@ else() # Standalone build
 			RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
 			RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
 	else()
-  		string(REPLACE ";" " " SIMD_FLAGS "${SIMD_FLAGS_LIST}")
+		string(REPLACE ";" " " SIMD_FLAGS "${SIMD_FLAGS_LIST}")
 		set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${SIMD_FLAGS}")
 		add_executable(qasm_simulator ${AER_SIMULATOR_SOURCES} ${SIMD_SOURCE_FILE})
 		target_link_libraries(qasm_simulator PRIVATE ${AER_LIBRARIES})
@@ -391,6 +391,55 @@ else() # Standalone build
 	# Linter
 	# This will add the linter as part of the compiling build target
 	#add_linter(qasm_simulator)
+
+	set(AER_RUNTIME_SOURCES "${PROJECT_SOURCE_DIR}/contrib/runtime/aer_runtime.cpp")
+	if(CUDA_FOUND AND AER_THRUST_BACKEND STREQUAL "CUDA")
+		set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES LANGUAGE CUDA)
+		set_source_files_properties(${AER_RUNTIME_SOURCES} PROPERTIES LANGUAGE CUDA)
+		set_source_files_properties(${AER_RUNTIME_SOURCES} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS}")
+		if(DEFINED SIMD_FLAGS_LIST)
+			nvcc_add_compiler_options_list("${SIMD_FLAGS_LIST}" SIMD_FLAGS)
+			set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${CUDA_NVCC_FLAGS} ${SIMD_FLAGS}")
+		endif()
+		add_executable(aer ${AER_RUNTIME_SOURCES} ${SIMD_SOURCE_FILE})
+		target_link_libraries(aer ${AER_LIBRARIES})
+		string(STRIP ${AER_COMPILER_FLAGS} AER_COMPILER_FLAGS_STRIPPED)
+		nvcc_add_compiler_options(${AER_COMPILER_FLAGS_STRIPPED} AER_COMPILER_FLAGS_OUT)
+
+		set_target_properties(aer PROPERTIES
+			LINKER_LANGUAGE CXX
+			CXX_STANDARD 14
+			COMPILE_FLAGS ${AER_COMPILER_FLAGS_OUT}
+			LINK_FLAGS ${AER_LINKER_FLAGS}
+			RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
+			RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
+	else()
+			string(REPLACE ";" " " SIMD_FLAGS "${SIMD_FLAGS_LIST}")
+		set_source_files_properties(${SIMD_SOURCE_FILE} PROPERTIES COMPILE_FLAGS "${SIMD_FLAGS}")
+		add_library(aer SHARED ${AER_RUNTIME_SOURCES} ${SIMD_SOURCE_FILE})
+		target_link_libraries(aer PRIVATE ${AER_LIBRARIES})
+		set_target_properties(aer PROPERTIES
+			LINKER_LANGUAGE CXX
+			CXX_STANDARD 14
+			COMPILE_FLAGS ${AER_COMPILER_FLAGS}
+			LINK_FLAGS ${AER_LINKER_FLAGS}
+			RUNTIME_OUTPUT_DIRECTORY_DEBUG Debug
+			RUNTIME_OUTPUT_DIRECTORY_RELEASE Release)
+	endif()
+	target_include_directories(aer
+		PRIVATE ${AER_SIMULATOR_CPP_SRC_DIR}
+		PRIVATE ${AER_SIMULATOR_CPP_EXTERNAL_LIBS})
+	target_compile_definitions(aer
+		PRIVATE ${AER_COMPILER_DEFINITIONS})
+	if(WIN32 AND NOT AER_BLAS_LIB_PATH)
+		add_custom_command(TARGET aer POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				${BACKEND_REDIST_DEPS}
+				$<TARGET_FILE_DIR:aer>)
+		install(FILES ${BACKEND_REDIST_DEPS} DESTINATION bin)
+	endif()
+
+	install(TARGETS aer DESTINATION bin)
+
 endif()
 
 # Tests

--- a/contrib/runtime/aer_runtime.cpp
+++ b/contrib/runtime/aer_runtime.cpp
@@ -5,8 +5,7 @@
 extern "C" {
 
 void* aer_state_initialize() {
-  int seed = 0;
-  AER::AerState* handler = new AER::AerState(seed);
+  AER::AerState* handler = new AER::AerState();
   return handler;
 };
 
@@ -54,7 +53,7 @@ complex_t aer_amplitude(void* handler, uint_t outcome) {
 // returned pointer must be freed in the caller
 complex_t* aer_release_statevector(void* handler) {
   AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
-  AER::Vector<complex_t> sv = state->release_statevector();
+  AER::Vector<complex_t> sv = state->move_to_vector();
   return sv.move_to_buffer();
 };
 

--- a/contrib/runtime/aer_runtime.cpp
+++ b/contrib/runtime/aer_runtime.cpp
@@ -4,8 +4,14 @@
 // initialize and return state
 extern "C" {
 
-void* aer_state_initialize() {
+void* aer_state() {
   AER::AerState* handler = new AER::AerState();
+  return handler;
+};
+
+void* aer_state_initialize(void* handler) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->initialize();
   return handler;
 };
 

--- a/contrib/runtime/aer_runtime.cpp
+++ b/contrib/runtime/aer_runtime.cpp
@@ -1,0 +1,211 @@
+#include <cmath>
+#include "controllers/state_controller.hpp"
+
+// initialize and return state
+extern "C" {
+
+void* aer_state_initialize() {
+  int seed = 0;
+  AER::AerState* handler = new AER::AerState(seed);
+  return handler;
+};
+
+// finalize state
+void aer_state_finalize(void* handler) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  delete(state);
+};
+
+// configure state
+void aer_state_configure(void* handler, char* key, char* value) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->configure(key, value);
+};
+
+// allocate qubits and return the first qubit index.
+// following qubits are indexed with incremented indices.
+uint_t aer_allocate_qubits(void* handler, uint_t num_qubits) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  auto qubit_ids = state->allocate_qubits(num_qubits);
+  return qubit_ids[0];
+};
+
+// measure qubits
+uint_t aer_apply_measure(void* handler, uint_t* qubits_, size_t num_qubits) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  std::vector<uint_t> qubits;
+  qubits.insert(qubits.end(), &(qubits_[0]), &(qubits[num_qubits - 1]));
+  return state->apply_measure(qubits);
+};
+
+// return probability of a specific bitstring
+double aer_probability(void* handler, uint_t outcome) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  return state->probability(outcome);
+};
+
+// return probability amplitude of a specific bitstring
+complex_t aer_amplitude(void* handler, uint_t outcome) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  return state->amplitude(outcome);
+};
+
+// return probability amplitudes
+// returned pointer must be freed in the caller
+complex_t* aer_release_statevector(void* handler) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  AER::Vector<complex_t> sv = state->release_statevector();
+  return sv.move_to_buffer();
+};
+
+// phase gate
+void aer_apply_p(void* handler, uint_t qubit, double lambda) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcphase({qubit}, lambda);
+};
+
+// Pauli gate: bit-flip or NOT gate
+void aer_apply_x(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcx({qubit});
+};
+
+// Pauli gate: bit and phase flip
+void aer_apply_y(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcy({qubit});
+};
+
+// Pauli gate: phase flip
+void aer_apply_z(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcz({qubit});
+};
+
+// Clifford gate: Hadamard
+void aer_apply_h(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcu({qubit}, M_PI / 2.0, 0, M_PI);
+};
+
+// Clifford gate: sqrt(Z) or S gate
+void aer_apply_s(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcu({qubit}, 0, 0, M_PI / 2.0);
+};
+
+// Clifford gate: inverse of sqrt(Z)
+void aer_apply_sdg(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcu({qubit}, 0, 0, - M_PI / 2.0);
+};
+
+// // sqrt(S) or T gate
+void aer_apply_t(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcu({qubit}, 0, 0, M_PI / 4.0);
+};
+
+// inverse of sqrt(S)
+void aer_apply_tdg(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcu({qubit}, 0, 0, - M_PI / 4.0);
+};
+
+// sqrt(NOT) gate
+void aer_apply_sx(void* handler, uint_t qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcrx({qubit}, - M_PI / 4.0);
+};
+
+// Rotation around X-axis
+void aer_apply_rx(void* handler, uint_t qubit, double theta) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcrx({qubit}, theta);
+};
+
+// rotation around Y-axis
+void aer_apply_ry(void* handler, uint_t qubit, double theta) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcry({qubit}, theta);
+};
+
+// rotation around Z axis
+void aer_apply_rz(void* handler, uint_t qubit, double theta) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcrz({qubit}, theta);
+};
+
+// controlled-NOT
+void aer_apply_cx(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcx({ctrl_qubit, tgt_qubit});
+};
+
+// controlled-Y
+void aer_apply_cy(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcy({ctrl_qubit, tgt_qubit});
+};
+
+// controlled-Z
+void aer_apply_cz(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcz({ctrl_qubit, tgt_qubit});
+};
+
+// controlled-phase
+void aer_apply_cp(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit, double lambda) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcphase({ctrl_qubit, tgt_qubit}, lambda);
+};
+
+// controlled-rx
+void aer_apply_crx(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit, double theta) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcrx({ctrl_qubit, tgt_qubit}, theta);
+};
+
+// controlled-ry
+void aer_apply_cry(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit, double theta) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcry({ctrl_qubit, tgt_qubit}, theta);
+};
+
+// controlled-rz
+void aer_apply_crz(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit, double theta) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcrz({ctrl_qubit, tgt_qubit}, theta);
+};
+
+// controlled-H
+void aer_apply_ch(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcu({ctrl_qubit, tgt_qubit}, M_PI / 2.0, 0, M_PI);
+};
+
+// swap
+void aer_apply_swap(void* handler, uint_t qubit0, uint_t qubit1) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcswap({qubit0, qubit1});
+};
+
+// Toffoli
+void aer_apply_ccx(void* handler, uint_t qubit0, uint_t qubit1, uint_t qubit2) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcx({qubit0, qubit1, qubit2});
+};
+
+// // controlled-swap
+void aer_apply_cswap(void* handler, uint_t ctrl_qubit, uint_t qubit0, uint_t qubit1) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcswap({ctrl_qubit, qubit0, qubit1});
+};
+
+// four parameter controlled-U gate with relative phase γ
+void aer_apply_cu(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit, double theta, double phi, double lambda, double gamma) {
+  AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
+  state->apply_mcphase({ctrl_qubit}, gamma);
+  state->apply_mcu({ctrl_qubit, tgt_qubit}, theta, phi, lambda);
+};
+}

--- a/contrib/runtime/aer_runtime_api.h
+++ b/contrib/runtime/aer_runtime_api.h
@@ -3,7 +3,10 @@
 
 typedef uint_fast64_t uint_t; 
 
-// initialize and return state
+// construct an aer state
+void* aer_state();
+
+// initialize aer state
 void* aer_state_initialize();
 
 // finalize state

--- a/contrib/runtime/aer_runtime_api.h
+++ b/contrib/runtime/aer_runtime_api.h
@@ -1,0 +1,90 @@
+#include <complex.h>
+#include <stdint.h>
+
+typedef uint_fast64_t uint_t; 
+
+// initialize and return state
+void* aer_state_initialize();
+
+// finalize state
+void aer_state_finalize(void* state);
+
+// configure state
+void aer_state_configure(void* state, char* key, char* value);
+
+// allocate qubits and return the first qubit index.
+// following qubits are indexed with incremented indices.
+uint_t aer_allocate_qubits(void* state, uint_t num_qubits);
+
+// measure qubits
+uint_t aer_apply_measure(void* state, uint_t* qubits, size_t num_qubits);
+
+// return probability of a specific bitstring
+double aer_probability(void* state, uint_t outcome);
+
+// return probability amplitude of a specific bitstring
+double complex aer_amplitude(void* state, uint_t outcome);
+
+// return probability amplitudes
+// returned pointer must be freed in the caller
+double complex* aer_release_statevector(void* state);
+
+// phase gate
+void aer_apply_p(void* state, uint_t qubit, double lambda);
+
+// Pauli gate: bit-flip or NOT gate
+void aer_apply_x(void* state, uint_t qubit);
+// Pauli gate: bit and phase flip
+void aer_apply_y(void* state, uint_t qubit);
+// Pauli gate: phase flip
+void aer_apply_z(void* state, uint_t qubit);
+
+// Clifford gate: Hadamard
+void aer_apply_h(void* state, uint_t qubit);
+// Clifford gate: sqrt(Z) or S gate
+void aer_apply_s(void* state, uint_t qubit);
+// Clifford gate: inverse of sqrt(Z)
+void aer_apply_sdg(void* state, uint_t qubit);
+
+// sqrt(S) or T gate
+void aer_apply_t(void* state, uint_t qubit);
+// inverse of sqrt(S)
+void aer_apply_tdg(void* state, uint_t qubit);
+
+// sqrt(NOT) gate
+void aer_apply_sx(void* state, uint_t qubit);
+
+// Rotation around X-axis
+void aer_apply_rx(void* state, uint_t qubit, double theta);
+// rotation around Y-axis
+void aer_apply_ry(void* state, uint_t qubit, double theta);
+// rotation around Z axis
+void aer_apply_rz(void* state, uint_t qubit, double theta);
+
+// controlled-NOT
+void aer_apply_cx(void* state, uint_t ctrl_qubit, uint_t tgt_qubit);
+// controlled-Y
+void aer_apply_cy(void* state, uint_t ctrl_qubit, uint_t tgt_qubit);
+// controlled-Z
+void aer_apply_cz(void* state, uint_t ctrl_qubit, uint_t tgt_qubit);
+// controlled-phase
+void aer_apply_cp(void* state, uint_t ctrl_qubit, uint_t tgt_qubit, double lambda);
+// controlled-rx
+void aer_apply_crx(void* state, uint_t ctrl_qubit, uint_t tgt_qubit, double theta);
+// controlled-ry
+void aer_apply_cry(void* state, uint_t ctrl_qubit, uint_t tgt_qubit, double theta);
+// controlled-rz
+void aer_apply_crz(void* state, uint_t ctrl_qubit, uint_t tgt_qubit, double theta);
+// controlled-H
+void aer_apply_ch(void* state, uint_t ctrl_qubit, uint_t tgt_qubit);
+
+// swap
+void aer_apply_swap(void* state, uint_t qubit0, uint_t qubit1);
+
+// Toffoli
+void aer_apply_ccx(void* state, uint_t qubit0, uint_t qubit1, uint_t qubit2);
+// controlled-swap
+void aer_apply_cswap(void* state, uint_t ctrl_qubit, uint_t qubit0, uint_t qubit1);
+
+// four parameter controlled-U gate with relative phase γ
+void aer_apply_cu(void* state, uint_t ctrl_qubit, uint_t tgt_qubit, double theta, double phi, double lambda, double gamma);

--- a/docs/apidocs/parallel.rst
+++ b/docs/apidocs/parallel.rst
@@ -51,14 +51,14 @@ Example: Threadpool execution
     circ.h(0)
     circ.cx(0, 1)
     circ.cx(1, 2)
-    circ.u1(pi/2,2)
+    circ.p(pi/2, 2)
     circ.measure([0, 1, 2], [0, 1 ,2])
 
     circ2 = qiskit.QuantumCircuit(15, 15)
     circ2.h(0)
     circ2.cx(0, 1)
     circ2.cx(1, 2)
-    circ2.u1(pi/2,2)
+    circ2.p(pi/2, 2)
     circ2.measure([0, 1, 2], [0, 1 ,2])
     circ_list = [circ, circ2]
 
@@ -87,14 +87,14 @@ guard it by an ``if __name__ == "__main__":`` block.
         circ.h(0)
         circ.cx(0, 1)
         circ.cx(1, 2)
-        circ.u1(pi/2,2)
+        circ.p(pi/2, 2)
         circ.measure([0, 1, 2], [0, 1 ,2])
 
         circ2 = qiskit.QuantumCircuit(15, 15)
         circ2.h(0)
         circ2.cx(0, 1)
         circ2.cx(1, 2)
-        circ2.u1(pi/2,2)
+        circ2.p(pi/2, 2)
         circ2.measure([0, 1, 2], [0, 1 ,2])
 
         circ_list = [circ, circ2]

--- a/qiskit/providers/aer/backends/wrappers/bindings.cc
+++ b/qiskit/providers/aer/backends/wrappers/bindings.cc
@@ -72,11 +72,12 @@ PYBIND11_MODULE(controller_wrappers, m) {
     aer_state.def("initialize",  &AER::AerState::initialize);
     aer_state.def("initialize_statevector", [aer_state](AER::AerState &state,
                                                         int num_of_qubits,
-                                                        py::array_t<std::complex<double>> &values) {
+                                                        py::array_t<std::complex<double>> &values,
+                                                        bool copy) {
       std::complex<double>* data_ptr = reinterpret_cast<std::complex<double>*>(values.mutable_data(0));
       if (AerToPy::is_python_owned(data_ptr)) {
         state.configure("method", "statevector");
-        state.initialize_statevector(num_of_qubits, data_ptr);
+        state.initialize_statevector(num_of_qubits, data_ptr, copy);
         return true;
       } else {
         return false;

--- a/qiskit/providers/aer/backends/wrappers/bindings.cc
+++ b/qiskit/providers/aer/backends/wrappers/bindings.cc
@@ -99,6 +99,13 @@ PYBIND11_MODULE(controller_wrappers, m) {
       return ret;
     });
 
+    aer_state.def("flush",  &AER::AerState::flush_ops);
+
+    aer_state.def("last_result",  [aer_state](AER::AerState &state) {
+      return AerToPy::to_python(state.last_result().to_json());
+    });
+
+
     aer_state.def("apply_initialize",  &AER::AerState::apply_initialize);
     aer_state.def("apply_unitary", [aer_state](AER::AerState &state,
                                                    const reg_t &qubits,

--- a/qiskit/providers/aer/quantum_info/states/__init__.py
+++ b/qiskit/providers/aer/quantum_info/states/__init__.py
@@ -1,0 +1,19 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+=============================================
+State (:mod:`qiskit.providers.aer.quantum_info.state`)
+=============================================
+"""
+
+from .aer_statevector import AerStatevector

--- a/qiskit/providers/aer/quantum_info/states/aer_state.py
+++ b/qiskit/providers/aer/quantum_info/states/aer_state.py
@@ -88,20 +88,20 @@ class AerState:
             value = str(value)
         self._state.configure(key, value)
 
-    def initialize(self, data=None):
+    def initialize(self, data=None, copy=False):
         """Initialize state"""
         self._assert_created_state()
 
         if data is None:
             self._state.initialize()
         elif isinstance(data, np.ndarray):
-            self._initialize_with_ndarray(data)
+            self._initialize_with_ndarray(data, copy)
         else:
             raise AerError('unsupported init data.')
 
         self._shift_to_initialized_state()
 
-    def _initialize_with_ndarray(self, data):
+    def _initialize_with_ndarray(self, data, copy):
         if AerState._is_in_use(data):
             raise AerError('another AerState owns this data')
 
@@ -113,9 +113,10 @@ class AerState:
         initialized = False
         if(isinstance(data, np.ndarray) and
            self._method == 'statevector' and
-           self._state.initialize_statevector(num_of_qubits, data)):
-            self._init_data = data
-            AerState._in_use(data)
+           self._state.initialize_statevector(num_of_qubits, data, copy)):
+            if not copy:
+                self._init_data = data
+                AerState._in_use(data)
             initialized = True
 
         if not initialized:

--- a/qiskit/providers/aer/quantum_info/states/aer_state.py
+++ b/qiskit/providers/aer/quantum_info/states/aer_state.py
@@ -111,7 +111,7 @@ class AerState:
         qubits = [qubit for qubit in range(num_of_qubits)]
 
         initialized = False
-        if(isinstance(data, np.ndarray) and
+        if (isinstance(data, np.ndarray) and
            self._method == 'statevector' and
            self._state.initialize_statevector(num_of_qubits, data, copy)):
             if not copy:

--- a/qiskit/providers/aer/quantum_info/states/aer_state.py
+++ b/qiskit/providers/aer/quantum_info/states/aer_state.py
@@ -160,6 +160,13 @@ class AerState:
         elif qubit < 0 or qubit > self._last_qubit:
             raise AerError('invalid qubit: index={}'.format(qubit))
 
+    def flush(self):
+        self._assert_initialized_state()
+        return self._state.flush()
+
+    def last_result(self):
+        return self._state.last_result()
+
     def apply_unitary(self, qubits, data):
         self._assert_initialized_state()
         self._assert_in_allocated_qubits(qubits)

--- a/qiskit/providers/aer/quantum_info/states/aer_state.py
+++ b/qiskit/providers/aer/quantum_info/states/aer_state.py
@@ -16,6 +16,7 @@ import numpy as np
 from qiskit.providers.aer.backends.controller_wrappers import AerStateWrapper
 from ...backends.aerbackend import AerError
 
+
 class AerState:
 
     _data_in_use = {}
@@ -27,7 +28,7 @@ class AerState:
     @staticmethod
     def _not_in_use(data):
         del AerState._data_in_use[id(data)]
-  
+
     @staticmethod
     def _is_in_use(data):
         return id(data) in AerState._data_in_use
@@ -281,5 +282,3 @@ class AerState:
 
         # retrieve probability
         return self._state.probabilities(qubits)
-
-  

--- a/qiskit/providers/aer/quantum_info/states/aer_state.py
+++ b/qiskit/providers/aer/quantum_info/states/aer_state.py
@@ -1,0 +1,285 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019, 2020, 2021, 2022
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+State class that handles internal C++ state safely
+"""
+import numpy as np
+from qiskit.providers.aer.backends.controller_wrappers import AerStateWrapper
+from ...backends.aerbackend import AerError
+
+class AerState:
+
+    _data_in_use = {}
+
+    @staticmethod
+    def _in_use(data):
+        AerState._data_in_use[id(data)] = data
+
+    @staticmethod
+    def _not_in_use(data):
+        del AerState._data_in_use[id(data)]
+  
+    @staticmethod
+    def _is_in_use(data):
+        return id(data) in AerState._data_in_use
+
+    def __init__(self):
+        """State that handles cpp quantum state safely"""
+        self._shift_to_created_state()
+        self._state = AerStateWrapper()
+        self._method = 'statevector'
+        self._init_data = None
+        self._last_qubit = -1
+
+    def _is_created_state(self):
+        return (not self._initialized) and (not self._closed)
+
+    def _is_initialized_state(self):
+        return self._initialized and (not self._closed)
+
+    def _is_closed_state(self):
+        return self._initialized and self._closed
+
+    def _shift_to_created_state(self):
+        self._initialized = False
+        self._closed = False
+
+    def _assert_created_state(self):
+        if self._is_initialized_state():
+            raise AerError('AerState was already initialized.')
+        if self._is_closed_state():
+            raise AerError('AerState has already been closed.')
+
+    def _shift_to_initialized_state(self):
+        if not self._is_created_state():
+            raise AerError('unexpected state transition')
+        self._initialized = True
+        self._closed = False
+
+    def _assert_initialized_state(self):
+        if not self._is_initialized_state():
+            raise AerError('AerState has not been initialized yet.')
+        if self._is_closed_state():
+            raise AerError('AerState has already been closed.')
+
+    def _shift_to_closed_state(self):
+        if (not self._is_initialized_state()) and (not self._is_created_state()):
+            raise AerError('unexpected state transition')
+        self._initialized = True
+        self._closed = True
+
+    def configure(self, key, value):
+        """configure AerState"""
+        self._assert_created_state()
+
+        if not isinstance(key, str):
+            raise AerError('AerState is configured with a str key')
+        if not isinstance(value, str):
+            value = str(value)
+        self._state.configure(key, value)
+
+    def initialize(self, data=None):
+        """Initialize state"""
+        self._assert_created_state()
+
+        if data is None:
+            self._state.initialize()
+        elif isinstance(data, np.ndarray):
+            self._initialize_with_ndarray(data)
+        else:
+            raise AerError('unsupported init data.')
+
+        self._shift_to_initialized_state()
+
+    def _initialize_with_ndarray(self, data):
+        if AerState._is_in_use(data):
+            raise AerError('another AerState owns this data')
+
+        num_of_qubits = int(np.log2(len(data)))
+        if len(data) != np.power(2, num_of_qubits):
+            raise AerError('length of init data must be power of two')
+        qubits = [qubit for qubit in range(num_of_qubits)]
+
+        initialized = False
+        if(isinstance(data, np.ndarray) and
+           self._method == 'statevector' and
+           self._state.initialize_statevector(num_of_qubits, data)):
+            self._init_data = data
+            AerState._in_use(data)
+            initialized = True
+
+        if not initialized:
+            self._state.reallocate_qubits(num_of_qubits)
+            self._state.initialize()
+            self._state.apply_initialize(qubits, data)
+
+    def close(self):
+        """Safely release all releated memory"""
+        self._unbind_data()
+        self._shift_to_closed_state()
+
+    def _unbind_data(self):
+        if self._init_data is not None:
+            # intentional memory leak
+            # memory of self._state will be freed when self._init_data is collected
+            self._state.move_to_buffer()
+            AerState._not_in_use(self._init_data)
+            self._init_data = None
+        else:
+            self._state.clear()
+
+    def move_to_ndarray(self):
+        if self._init_data is not None:
+            ret = self._init_data
+            self._unbind_data()
+        else:
+            ret = self._state.move_to_ndarray()
+        return ret
+
+    def allocate_qubits(self, num_of_qubits):
+        self._assert_created_state()
+        if num_of_qubits <= 0:
+            raise AerError('invalid number of qubits: {}'.format(num_of_qubits))
+        allocated = self._state.allocate_qubits(num_of_qubits)
+        self._last_qubit = allocated[len(allocated) - 1]
+
+    def _assert_in_allocated_qubits(self, qubit):
+        if isinstance(qubit, list):
+            for q in qubit:
+                self._assert_in_allocated_qubits(q)
+        elif qubit < 0 or qubit > self._last_qubit:
+            raise AerError('invalid qubit: index={}'.format(qubit))
+
+    def apply_unitary(self, qubits, data):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(qubits)
+        # Convert to numpy array in case not already an array
+        data = np.array(data, dtype=complex)
+        # Check input is N-qubit matrix
+        input_dim, output_dim = data.shape
+        num_qubits = int(np.log2(input_dim))
+        if input_dim != output_dim or 2**num_qubits != input_dim:
+            raise AerError("Input matrix is not an N-qubit operator.")
+        if len(qubits) != num_qubits:
+            raise AerError("Input matrix and qubits are insonsistent.")
+        # update state
+        self._state.apply_unitary(qubits, data)
+
+    def apply_multiplexer(self, control_qubits, target_qubits, mats):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(control_qubits)
+        self._assert_in_allocated_qubits(target_qubits)
+        if not isinstance(mats, list):
+            raise AerError("Input must be a list of ndarray.")
+        if len(mats) != (2 ** len(control_qubits)):
+            raise AerError("Input length must be 2 ** number of control gates.")
+        # Convert to np array in case not already an array
+        mats = [np.array(mat, dtype=complex) for mat in mats]
+        # Check input is N-qubit matrix
+        input_dim, output_dim = mats[0].shape
+        num_target_qubits = int(np.log2(input_dim))
+        if input_dim != output_dim or 2**num_target_qubits != input_dim:
+            raise AerError("Input matrix is not an N-qubit operator.")
+        for mat in mats[1:]:
+            if mat.shape != mats[0].shape:
+                raise AerError("Input matrix is not an N-qubit operator.")
+        if len(target_qubits) != num_target_qubits:
+            raise AerError("Input matrix and qubits are insonsistent.")
+        # update state
+        self._state.apply_multiplexer(control_qubits, target_qubits, mats)
+
+    def apply_diagonal(self, qubits, diag):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(qubits)
+        # Convert to numpy array in case not already an array
+        diag = np.array(diag, dtype=complex)
+        # Check input is N-qubit vector
+        input_dim = diag.shape[0]
+        num_qubits = int(np.log2(input_dim))
+        if 2**num_qubits != input_dim:
+            raise AerError("Input vector is not an N-qubit operator.")
+        if len(qubits) != num_qubits:
+            raise AerError("Input vector and qubits are insonsistent.")
+        # update state
+        self._state.apply_diagonal(qubits, diag)
+
+    def apply_mcx(self, control_qubits, target_qubit):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(control_qubits)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._state.apply_mcx(control_qubits + [target_qubit])
+
+    def apply_mcy(self, control_qubits, target_qubit):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(control_qubits)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._state.apply_mcy(control_qubits + [target_qubit])
+
+    def apply_mcz(self, control_qubits, target_qubit):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(control_qubits)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._state.apply_mcz(control_qubits + [target_qubit])
+
+    def apply_mcphase(self, control_qubits, target_qubit, phase):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(control_qubits)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._state.apply_mcphase(control_qubits + [target_qubit], phase)
+
+    def apply_mcu(self, control_qubits, target_qubit, theta, phi, lamb):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(control_qubits)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._state.apply_mcu(control_qubits + [target_qubit], theta, phi, lamb)
+
+    def apply_mcswap(self, control_qubits, qubit0, qubit1):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(control_qubits)
+        self._assert_in_allocated_qubits(qubit0)
+        self._assert_in_allocated_qubits(qubit1)
+        # update state
+        self._state.apply_mcswap(control_qubits + [qubit0, qubit1], theta, phi, lamb)
+
+    def apply_measure(self, qubits):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(qubits)
+        # measure and update state
+        return self._state.apply_measure(qubits)
+
+    def apply_reset(self, qubits):
+        self._assert_initialized_state()
+        self._assert_in_allocated_qubits(qubits)
+        # update state
+        return self._state.apply_reset(qubits)
+
+    def probability(self, outcome):
+        self._assert_initialized_state()
+        # retrieve probability
+        return self._state.probability(outcome)
+
+    def probabilities(self, qubits=None):
+        self._assert_initialized_state()
+        if qubits is None:
+            qubits = [q for q in range(self._last_qubit + 1)]
+        else:
+            self._assert_in_allocated_qubits(qubits)
+
+        # retrieve probability
+        return self._state.probabilities(qubits)
+
+  

--- a/qiskit/providers/aer/quantum_info/states/aer_state.py
+++ b/qiskit/providers/aer/quantum_info/states/aer_state.py
@@ -161,6 +161,11 @@ class AerState:
         elif qubit < 0 or qubit > self._last_qubit:
             raise AerError('invalid qubit: index={}'.format(qubit))
 
+    @property
+    def num_qubits(self):
+        self._assert_initialized_state()
+        return self._last_qubit + 1
+
     def flush(self):
         self._assert_initialized_state()
         return self._state.flush()

--- a/qiskit/providers/aer/quantum_info/states/aer_statevector.py
+++ b/qiskit/providers/aer/quantum_info/states/aer_statevector.py
@@ -17,6 +17,7 @@ from qiskit.quantum_info.states import Statevector
 from qiskit.circuit import QuantumCircuit, Instruction
 from qiskit.providers.aer.quantum_info.states.aer_state import AerState
 
+
 class AerStatevector(Statevector):
     """AerStatevector class"""
 
@@ -41,7 +42,7 @@ class AerStatevector(Statevector):
         super().__init__(data)
 
     @classmethod
-    def from_instruction(cls, instruction):
+    def from_instruction(cls, inst):
         """Return the output statevector of an instruction.
 
         The statevector is initialized in the state :math:`|{0,\\ldots,0}\\rangle` of the
@@ -49,7 +50,7 @@ class AerStatevector(Statevector):
         by the input instruction, and the output statevector returned.
 
         Args:
-            instruction (qiskit.circuit.Instruction or QuantumCircuit): instruction or circuit
+            inst (qiskit.circuit.Instruction or QuantumCircuit): instruction or circuit
 
         Returns:
             Statevector: The final statevector.
@@ -59,22 +60,24 @@ class AerStatevector(Statevector):
                          the statevector simulation.
         """
         aer_state = AerState()
-        if isinstance(instruction, QuantumCircuit):
-            circuit = instruction
+        if isinstance(inst, QuantumCircuit):
+            circuit = inst
             aer_state.allocate_qubits(circuit.num_qubits)
             aer_state.initialize()
             AerStatevector._evolve_circuit(aer_state, circuit, range(circuit.num_qubits))
         else:
-            aer_state.allocate_qubits(instruction.num_qubits)
-            AerStatevector._evolve_instruction(aer_state, instruction, range(instruction.num_qubits))
+            aer_state.allocate_qubits(inst.num_qubits)
+            AerStatevector._evolve_instruction(aer_state, inst, range(inst.num_qubits))
 
         return aer_state.move_to_ndarray()
 
     @classmethod
     def _evolve_circuit(cls, aer_state, circuit, qubits):
         """Apply circuit into aer_state"""
-        for inst, qargs, cargs in circuit.data:
-            AerStatevector._evolve_instruction(aer_state, inst, [qubits[circuit.find_bit(qarg).index] for qarg in qargs])
+        for inst, qargs, _ in circuit.data:
+            AerStatevector._evolve_instruction(aer_state, inst,
+                                               [qubits[circuit.find_bit(qarg).index]
+                                                for qarg in qargs])
 
     @classmethod
     def _evolve_instruction(cls, aer_state, inst, qubits):
@@ -97,5 +100,3 @@ class AerStatevector(Statevector):
             if definition is inst:
                 raise AerError('cannot decompose ' + inst.name)
             AerStatevector._evolve_circuit(aer_state, definition, qubits)
-
-

--- a/qiskit/providers/aer/quantum_info/states/aer_statevector.py
+++ b/qiskit/providers/aer/quantum_info/states/aer_statevector.py
@@ -1,0 +1,101 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019, 2020, 2021, 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Statevector quantum state class.
+"""
+from qiskit.quantum_info.states import Statevector
+from qiskit.circuit import QuantumCircuit, Instruction
+from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+class AerStatevector(Statevector):
+    """AerStatevector class"""
+
+    def __init__(self, data):
+        """Initialize a statevector object.
+
+        Args:
+            data (np.array or list or Statevector or Operator or QuantumCircuit or
+                  qiskit.circuit.Instruction):
+                Data from which the statevector can be constructed. This can be either a complex
+                vector, another statevector, a ``Operator`` with only one column or a
+                ``QuantumCircuit`` or ``Instruction``.  If the data is a circuit or instruction,
+                the statevector is constructed by assuming that all qubits are initialized to the
+                zero state.
+
+        Raises:
+            QiskitError: if input data is not valid.
+
+        """
+        if isinstance(data, (QuantumCircuit, Instruction)):
+            data = AerStatevector.from_instruction(data)
+        super().__init__(data)
+
+    @classmethod
+    def from_instruction(cls, instruction):
+        """Return the output statevector of an instruction.
+
+        The statevector is initialized in the state :math:`|{0,\\ldots,0}\\rangle` of the
+        same number of qubits as the input instruction or circuit, evolved
+        by the input instruction, and the output statevector returned.
+
+        Args:
+            instruction (qiskit.circuit.Instruction or QuantumCircuit): instruction or circuit
+
+        Returns:
+            Statevector: The final statevector.
+
+        Raises:
+            QiskitError: if the instruction contains invalid instructions for
+                         the statevector simulation.
+        """
+        aer_state = AerState()
+        if isinstance(instruction, QuantumCircuit):
+            circuit = instruction
+            aer_state.allocate_qubits(circuit.num_qubits)
+            aer_state.initialize()
+            AerStatevector._evolve_circuit(aer_state, circuit, range(circuit.num_qubits))
+        else:
+            aer_state.allocate_qubits(instruction.num_qubits)
+            AerStatevector._evolve_instruction(aer_state, instruction, range(instruction.num_qubits))
+
+        return aer_state.move_to_ndarray()
+
+    @classmethod
+    def _evolve_circuit(cls, aer_state, circuit, qubits):
+        """Apply circuit into aer_state"""
+        for inst, qargs, cargs in circuit.data:
+            AerStatevector._evolve_instruction(aer_state, inst, [qubits[circuit.find_bit(qarg).index] for qarg in qargs])
+
+    @classmethod
+    def _evolve_instruction(cls, aer_state, inst, qubits):
+        """Apply instruction into aer_state"""
+        params = inst.params
+        if inst.name == 'u':
+            aer_state.apply_mcu(qubits, params[0], params[1], params[2])
+        elif inst.name in ['x', 'cx', 'ccx']:
+            aer_state.apply_mcx(qubits)
+        elif inst.name in ['y', 'cy']:
+            aer_state.apply_mcy(qubits)
+        elif inst.name in ['z', 'cz']:
+            aer_state.apply_mcz(qubits)
+        elif inst.name == 'unitary':
+            aer_state.apply_unitary(qubits, inst.params[0])
+        elif inst.name == 'diagonal':
+            aer_state.apply_diagonal(qubits, inst.params[0])
+        else:
+            definition = inst.definition
+            if definition is inst:
+                raise AerError('cannot decompose ' + inst.name)
+            AerStatevector._evolve_circuit(aer_state, definition, qubits)
+
+

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -1381,7 +1381,7 @@ void Controller::run_single_shot(const Circuit &circ, State_t &state,
   state.initialize_qreg(circ.num_qubits);
   state.initialize_creg(circ.num_memory, circ.num_registers);
   state.apply_ops(circ.ops.cbegin(), circ.ops.cend(), result, rng, true);
-  result.save_count_data(state.creg(), save_creg_memory_);
+  result.save_count_data(state.cregs(), save_creg_memory_);
 }
 
 template <class State_t>
@@ -1512,7 +1512,7 @@ void Controller::run_circuit_without_sampled_noise(Circuit &circ,
 
       state.apply_ops_multi_shots(circ.ops.cbegin(), circ.ops.cend(), noise, result, circ.seed, true);
 
-      result.save_count_data(state.creg(), save_creg_memory_);
+      result.save_count_data(state.cregs(), save_creg_memory_);
 
       // Add batched multi-shots optimizaiton metadata
       result.metadata.add(true, "batched_shots_optimization");
@@ -1681,7 +1681,7 @@ void Controller::measure_sampler(
   // Check if meas_circ is empty, and if so return initial creg
   if (first_meas == last_meas) {
     while (shots-- > 0) {
-      result.save_count_data(state.creg(), save_creg_memory_);
+      result.save_count_data(state.cregs(), save_creg_memory_);
     }
     return;
   }

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -229,10 +229,6 @@ protected:
   bool check_measure_sampling_opt(const Circuit &circ,
                                   const Method method) const;
 
-  // Save count data
-  void save_count_data(ExperimentResult &result,
-                       const ClassicalRegister &creg) const;
-
   //-------------------------------------------------------------------------
   // State validation
   //-------------------------------------------------------------------------
@@ -1026,17 +1022,6 @@ Result Controller::execute(std::vector<Circuit> &circuits,
   return result;
 }
 
-void Controller::save_count_data(ExperimentResult &result,
-                                 const ClassicalRegister &creg) const {
-  if (creg.memory_size() > 0) {
-    std::string memory_hex = creg.memory_hex();
-    result.data.add_accum(static_cast<uint_t>(1ULL), "counts", memory_hex);
-    if (save_creg_memory_) {
-      result.data.add_list(std::move(memory_hex), "memory");
-    }
-  }
-}
-
 //-------------------------------------------------------------------------
 // Base class override
 //-------------------------------------------------------------------------
@@ -1393,7 +1378,7 @@ void Controller::run_single_shot(const Circuit &circ, State_t &state,
   state.initialize_qreg(circ.num_qubits);
   state.initialize_creg(circ.num_memory, circ.num_registers);
   state.apply_ops(circ.ops.cbegin(), circ.ops.cend(), result, rng, true);
-  save_count_data(result, state.creg());
+  result.save_count_data(state.creg(), save_creg_memory_);
 }
 
 template <class State_t>
@@ -1517,7 +1502,7 @@ void Controller::run_circuit_without_sampled_noise(Circuit &circ,
 
       state.apply_ops_multi_shots(circ.ops.cbegin(), circ.ops.cend(), noise, result, circ.seed, true);
 
-      state.save_count_data(result,save_creg_memory_);
+      result.save_count_data(state.creg(), save_creg_memory_);
 
       // Add batched multi-shots optimizaiton metadata
       result.metadata.add(true, "batched_shots_optimization");
@@ -1673,7 +1658,7 @@ void Controller::measure_sampler(
   // Check if meas_circ is empty, and if so return initial creg
   if (first_meas == last_meas) {
     while (shots-- > 0) {
-      save_count_data(result, state.creg());
+      result.save_count_data(state.creg(), save_creg_memory_);
     }
     return;
   }
@@ -1755,7 +1740,7 @@ void Controller::measure_sampler(
     }
 
     // Save count data
-    save_count_data(result, creg);
+      result.save_count_data(creg, save_creg_memory_);
 
     // pop off processed sample
     all_samples.pop_back();

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -164,7 +164,7 @@ public:
   // Allocate qubits with inputted complex array
   // method must be statevector and the length of the array must be 2^{num_qubits}
   // given data will not be freed in this class
-  virtual reg_t initialize_statevector(uint_t num_qubits, complex_t* data);
+  virtual reg_t initialize_statevector(uint_t num_qubits, complex_t* data, bool copy);
 
   // Release internal statevector
   // The caller must free the returned pointer
@@ -611,7 +611,7 @@ reg_t AerState::reallocate_qubits(uint_t num_qubits) {
   return allocate_qubits(num_qubits);
 };
 
-reg_t AerState::initialize_statevector(uint_t num_of_qubits, complex_t* data) {
+reg_t AerState::initialize_statevector(uint_t num_of_qubits, complex_t* data, bool copy) {
   assert_not_initialized();
   if (device_ != Device::CPU)
     throw std::runtime_error("only CPU device supports initialize_statevector()");
@@ -622,7 +622,7 @@ reg_t AerState::initialize_statevector(uint_t num_of_qubits, complex_t* data) {
   state->set_config(configs_);
   state->set_distribution(1);
   state->set_max_matrix_qubits(max_gate_qubits_);
-  state->initialize_qreg(num_of_qubits_, QV::QubitVector<double>(num_of_qubits_, data));
+  state->initialize_qreg(num_of_qubits_, QV::QubitVector<double>(num_of_qubits_, data, copy));
   state->initialize_creg(num_of_qubits_, num_of_qubits_);
   state_ = state;
   rng_.set_seed(seed_);

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -1,0 +1,658 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_state_hpp_
+#define _aer_state_hpp_
+
+#include <cstdint>
+#include <complex>
+#include <string>
+#include <vector>
+
+#include "framework/rng.hpp"
+#include "misc/warnings.hpp"
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#ifdef AER_MPI
+#include <mpi.h>
+#endif
+
+DISABLE_WARNING_PUSH
+#include <nlohmann/json.hpp>
+DISABLE_WARNING_POP
+
+#include "framework/creg.hpp"
+#include "framework/qobj.hpp"
+#include "framework/results/experiment_result.hpp"
+#include "framework/results/result.hpp"
+#include "framework/rng.hpp"
+#include "framework/linalg/vector.hpp"
+
+#include "noise/noise_model.hpp"
+
+#include "transpile/cacheblocking.hpp"
+#include "transpile/fusion.hpp"
+
+#include "simulators/density_matrix/densitymatrix_state.hpp"
+#include "simulators/extended_stabilizer/extended_stabilizer_state.hpp"
+#include "simulators/matrix_product_state/matrix_product_state.hpp"
+#include "simulators/stabilizer/stabilizer_state.hpp"
+#include "simulators/statevector/qubitvector.hpp"
+#include "simulators/statevector/qubitvector.hpp"
+#include "simulators/statevector/statevector_state.hpp"
+#include "simulators/superoperator/superoperator_state.hpp"
+#include "simulators/unitary/unitary_state.hpp"
+
+using int_t = int_fast64_t;
+using uint_t = uint_fast64_t; 
+using complex_t = std::complex<double>;
+using complexf_t = std::complex<float>;
+using cvector_t = std::vector<complex_t>;
+using cvectorf_t = std::vector<complexf_t>;
+using cmatrix_t = matrix<complex_t>;
+using cmatrixf_t = matrix<complexf_t>;
+using reg_t = std::vector<uint_t>;
+using json_t = nlohmann::json;
+
+namespace AER {
+
+class AerState {
+public:
+  //-----------------------------------------------------------------------
+  // Constructors
+  //-----------------------------------------------------------------------
+  AerState(int seed = 0) : seed_(seed){ rng_.set_seed(seed); }
+
+  virtual ~AerState() { };
+
+  //-----------------------------------------------------------------------
+  // Configuration
+  //-----------------------------------------------------------------------
+  
+  // Set configuration. All of the configuration must be done before calling
+  // any gate operations.
+  virtual void configure(const std::string& key, const std::string& value);
+
+  // Return true if gate operations have been performed and no configuration
+  // is permitted.
+  virtual bool is_initialized() const { return initialized_; };
+
+  // Allocate qubits and return a list of qubit identifiers, which start
+  // `0` with incrementation `+1`.
+  virtual reg_t allocate_qubits(uint_t num_qubits);
+
+  // Return a number of qubits.
+  virtual uint_t num_of_qubits() const { return num_of_qubits_; };
+
+  // Allocate qubits with inputted complex array
+  // method must be statevector and the length of the array must be 2^{num_qubits}
+  virtual reg_t initialize_statevector(uint_t num_qubits, complex_t* data);
+
+  // Allocate qubits with qubit vector
+  virtual reg_t initialize_statevector(uint_t num_of_qubits, QV::QubitVector<double> qv);
+
+  // Clear qubits
+  virtual void clear();
+
+  // Release internal statevector
+  // The caller must free the returned pointer
+  virtual AER::Vector<complex_t> release_statevector();
+
+  //-----------------------------------------------------------------------
+  // Apply Matrices
+  //-----------------------------------------------------------------------
+
+  // Apply a N-qubit matrix to the state vector.
+  virtual void apply_unitary(const reg_t &qubits, const cmatrix_t &mat);
+
+  // Apply a stacked set of 2^control_count target_count--qubit matrix to the state vector.
+  virtual void apply_multiplexer(const reg_t &control_qubits, const reg_t &target_qubits, const std::vector<cmatrix_t> &mats);
+
+  // Apply a N-qubit diagonal matrix to the state vector.
+  virtual void apply_diagonal_matrix(const reg_t &qubits, const cvector_t &mat);
+
+  //-----------------------------------------------------------------------
+  // Apply Specialized Gates
+  //-----------------------------------------------------------------------
+
+  // Apply a general N-qubit multi-controlled X-gate
+  // If N=1 this implements an optimized X gate
+  // If N=2 this implements an optimized CX gate
+  // If N=3 this implements an optimized Toffoli gate
+  virtual void apply_mcx(const reg_t &qubits);
+
+  // Apply a general multi-controlled Y-gate
+  // If N=1 this implements an optimized Y gate
+  // If N=2 this implements an optimized CY gate
+  // If N=3 this implements an optimized CCY gate
+  virtual void apply_mcy(const reg_t &qubits);
+
+  // Apply a general multi-controlled Z-gate
+  // If N=1 this implements an optimized Z gate
+  // If N=2 this implements an optimized CZ gate
+  // If N=3 this implements an optimized CCZ gate
+  virtual void apply_mcz(const reg_t &qubits);
+
+  // Apply a general multi-controlled single-qubit phase gate
+  // with diagonal [1, ..., 1, std::exp(complex_t(0, 1) * phase]
+  // If N=1 this implements an optimized single-qubit phase gate
+  // If N=2 this implements an optimized CPhase gate
+  // If N=3 this implements an optimized CCPhase gate
+  virtual void apply_mcphase(const reg_t &qubits, const std::complex<double> phase);
+
+  // Apply a general multi-controlled single-qubit unitary gate
+  // If N=1 this implements an optimized single-qubit U gate
+  // If N=2 this implements an optimized CU gate
+  // If N=3 this implements an optimized CCU gate
+  virtual void apply_mcu(const reg_t &qubits, const double theta, const double phi, const double lambda);
+
+  // Apply a general multi-controlled SWAP gate
+  // If N=2 this implements an optimized SWAP  gate
+  // If N=3 this implements an optimized Fredkin gate
+  virtual void apply_mcswap(const reg_t &qubits);
+
+  // Apply a general N-qubit multi-controlled RX-gate
+  // If N=1 this implements an optimized RX gate
+  // If N=2 this implements an optimized CRX gate
+  // If N=3 this implements an optimized CCRX gate
+  virtual void apply_mcrx(const reg_t &qubits, const double theta);
+
+  // Apply a general N-qubit multi-controlled RY-gate
+  // If N=1 this implements an optimized RY gate
+  // If N=2 this implements an optimized CRY gate
+  // If N=3 this implements an optimized CCRY gate
+  virtual void apply_mcry(const reg_t &qubits, const double theta);
+
+  // Apply a general N-qubit multi-controlled RZ-gate
+  // If N=1 this implements an optimized RZ gate
+  // If N=2 this implements an optimized CRZ gate
+  // If N=3 this implements an optimized CCRZ gate
+  virtual void apply_mcrz(const reg_t &qubits, const double theta);
+
+  //-----------------------------------------------------------------------
+  // Apply Non-Unitary Gates
+  //-----------------------------------------------------------------------
+
+  // Measure qubits and return a list of outcomes [q0, q1, ...]
+  // If a state subclass supports this function it then "measure"
+  // should be contained in the set returned by the 'allowed_ops'
+  // method.
+  virtual uint_t apply_measure(const reg_t &qubits);
+
+  // Reset the specified qubits to the |0> state by simulating
+  // a measurement, applying a conditional x-gate if the outcome is 1, and
+  // then discarding the outcome.
+  void apply_reset(const reg_t &qubits);
+
+  //-----------------------------------------------------------------------
+  // Z-measurement outcome probabilities
+  //-----------------------------------------------------------------------
+
+  // Return the Z-basis measurement outcome probability P(outcome) for
+  // outcome in [0, 2^num_qubits - 1]
+  virtual double probability(const uint_t outcome);
+
+  // Return the probability amplitude for outcome in [0, 2^num_qubits - 1]
+  virtual complex_t amplitude(const uint_t outcome);
+
+  // // Return the probabilities for all measurement outcomes in the current vector
+  // // This is equivalent to returning a new vector with  new[i]=|orig[i]|^2.
+  // // Eg. For 2-qubits this is [P(00), P(01), P(010), P(11)]
+  virtual std::vector<double> probabilities();
+
+  // // Return the Z-basis measurement outcome probabilities [P(0), ..., P(2^N-1)]
+  // // for measurement of N-qubits.
+  virtual std::vector<double> probabilities(const reg_t &qubits);
+
+  // // Return M sampled outcomes for Z-basis measurement of all qubits
+  // // The input is a length M list of random reals between [0, 1) used for
+  // // generating samples.
+  virtual std::unordered_map<uint_t, uint_t> sample_measure(uint_t shots);
+
+private:
+  void assert_initialized() const;
+  void assert_not_initialized() const;
+  void initialize_if_necessary();
+
+private:
+  bool initialized_ = false;
+  uint_t num_of_qubits_ = 0;
+  RngEngine rng_;
+  const int seed_;
+  std::shared_ptr<Base::StateBase> state_;
+  json_t configs_;
+};
+
+void AerState::configure(const std::string& key, const std::string& value) {
+  configs_[key] = value;
+};
+
+void AerState::assert_initialized() const {
+  if (!initialized_) {
+    std::stringstream msg;
+    msg << "this AerState has not initialized." << std::endl;
+    throw std::runtime_error(msg.str());
+  }
+};
+
+void AerState::assert_not_initialized() const {
+  if (initialized_) {
+    std::stringstream msg;
+    msg << "this AerState has already initialized." << std::endl;
+    throw std::runtime_error(msg.str());
+  }
+};
+
+void AerState::initialize_if_necessary() {
+  if (initialized_) return;
+  state_ = std::make_shared<Statevector::State<QV::QubitVector<double>>>();
+  state_->initialize_qreg(num_of_qubits_);
+  state_->initialize_creg(num_of_qubits_, num_of_qubits_);
+  state_->set_config(configs_);
+  rng_.set_seed(seed_);
+  initialized_ = true;
+};
+
+reg_t AerState::allocate_qubits(uint_t num_qubits) {
+  assert_not_initialized();
+  reg_t ret;
+  for (auto i = 0; i < num_qubits; ++i)
+      ret.push_back(num_of_qubits_++);
+  return ret;
+};
+
+reg_t AerState::initialize_statevector(uint_t num_of_qubits, complex_t* data) {
+  num_of_qubits_ = num_of_qubits;
+  auto qv = QV::QubitVector<double>(num_of_qubits_, data);
+  auto state = std::make_shared<Statevector::State<QV::QubitVector<double>>>();
+  state->initialize_qreg(num_of_qubits_, qv);
+  state->initialize_creg(num_of_qubits_, num_of_qubits_);
+  state->set_config(configs_);
+  state_ = state;
+  rng_.set_seed(seed_);
+  initialized_ = true;
+  reg_t ret;
+  ret.reserve(num_of_qubits);
+  for (auto i = 0; i < num_of_qubits; ++i)
+    ret.push_back(i);
+  return ret;
+};
+
+reg_t AerState::initialize_statevector(uint_t num_of_qubits, QV::QubitVector<double> qv) {
+  num_of_qubits_ = num_of_qubits;
+  auto state = std::make_shared<Statevector::State<QV::QubitVector<double>>>();
+  state->initialize_qreg(num_of_qubits_, qv);
+  state->initialize_creg(num_of_qubits_, num_of_qubits_);
+  state->set_config(configs_);
+  state_ = state;
+  rng_.set_seed(seed_);
+  initialized_ = true;
+  reg_t ret;
+  ret.reserve(num_of_qubits);
+  for (auto i = 0; i < num_of_qubits; ++i)
+    ret.push_back(i);
+  return ret;
+};
+
+void AerState::clear() {
+  if (initialized_) {
+    state_.reset();
+    initialized_ = false;
+  }
+  num_of_qubits_ = 0;
+};
+
+AER::Vector<complex_t> AerState::release_statevector() {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::save_statevec;
+  op.name = "save_statevec";
+  op.qubits.reserve(num_of_qubits_);
+  for (auto i = 0; i < num_of_qubits_; ++i)
+    op.qubits.push_back(i);
+  op.string_params.push_back("s");
+  op.save_type = Operations::DataSubType::list;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+
+  AER::Vector<complex_t> sv = std::move(std::move(((DataMap<ListData, Vector<complex_t>>)ret.data).value()["s"].value())[0]);
+
+  this->clear();
+
+  return std::move(sv);
+};
+
+
+//-----------------------------------------------------------------------
+// Apply Matrices
+//-----------------------------------------------------------------------
+
+void AerState::apply_unitary(const reg_t &qubits, const cmatrix_t &mat) {
+  initialize_if_necessary();
+  Operations::Op op;
+  op.type = Operations::OpType::matrix;
+  op.name = "unitary";
+  op.qubits = qubits;
+  op.mats.push_back(mat);
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_diagonal_matrix(const reg_t &qubits, const cvector_t &mat) {
+  initialize_if_necessary();
+  Operations::Op op;
+  op.type = Operations::OpType::diagonal_matrix;
+  op.name = "diagonal";
+  op.qubits = qubits;
+  op.params = mat;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_multiplexer(const reg_t &control_qubits, const reg_t &target_qubits, const std::vector<cmatrix_t> &mats) {
+  initialize_if_necessary();
+
+  if (mats.empty())
+    throw std::invalid_argument("no matrix input.");
+
+  // Check matrices are N-qubit
+  auto dim = mats[0].GetRows();
+  auto num_targets = static_cast<uint_t>(std::log2(dim));
+  if (1ULL << num_targets != dim || num_targets != target_qubits.size())
+    throw std::invalid_argument("invalid multiplexer matrix dimension.");
+
+  size_t num_mats = control_qubits.size();
+  auto num_controls = static_cast<uint_t>(std::log2(num_mats));
+  if (1ULL << num_controls != num_mats)
+    throw std::invalid_argument("invalid number of multiplexer matrices.");
+
+  if (num_controls == 0) // mats.size() must be 1
+    return this->apply_unitary(target_qubits, mats[0]);
+
+  // Get lists of controls and targets
+  reg_t qubits(num_controls + num_targets);
+  std::copy_n(control_qubits.begin(), num_controls, qubits.begin());
+  std::copy_n(target_qubits.begin(), num_targets, qubits.begin());
+
+  Operations::Op op;
+  op.type = Operations::OpType::multiplexer;
+  op.name = "multiplexer";
+  op.qubits = qubits;
+  op.regs = std::vector<reg_t>({control_qubits, target_qubits});
+  op.mats = mats;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+//-----------------------------------------------------------------------
+// Apply Specialized Gates
+//-----------------------------------------------------------------------
+
+void AerState::apply_mcx(const reg_t &qubits) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcx";
+  op.qubits = qubits;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_mcy(const reg_t &qubits) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcy";
+  op.qubits = qubits;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_mcz(const reg_t &qubits) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcz";
+  op.qubits = qubits;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_mcphase(const reg_t &qubits, const std::complex<double> phase) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcp";
+  op.qubits = qubits;
+  op.params.push_back(phase);
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_mcu(const reg_t &qubits, const double theta, const double phi, const double lambda) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcu";
+  op.qubits = qubits;
+  op.params = {theta, phi, lambda};
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_mcswap(const reg_t &qubits) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcswap";
+  op.qubits = qubits;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_mcrx(const reg_t &qubits, const double theta) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcrx";
+  op.qubits = qubits;
+  op.params = {theta};
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_mcry(const reg_t &qubits, const double theta) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcry";
+  op.qubits = qubits;
+  op.params = {theta};
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+void AerState::apply_mcrz(const reg_t &qubits, const double theta) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "mcrz";
+  op.qubits = qubits;
+  op.params = {theta};
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+//-----------------------------------------------------------------------
+// Apply Non-Unitary Gates
+//-----------------------------------------------------------------------
+
+uint_t AerState::apply_measure(const reg_t &qubits) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::measure;
+  op.name = "measure";
+  op.qubits = qubits;
+  op.memory = qubits;
+  op.registers = qubits;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+
+  uint_t bitstring = 0;
+  uint_t bit = 1;
+  for (const auto& qubit: qubits) {
+    if (state_->creg().creg_memory()[qubit] == '1')
+      bitstring |= bit;
+    bit <<= 1;
+  }
+  return bitstring;
+}
+
+void AerState::apply_reset(const reg_t &qubits) {
+  initialize_if_necessary();
+
+  Operations::Op op;
+  op.type = Operations::OpType::reset;
+  op.name = "reset";
+  op.qubits = qubits;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+}
+
+//-----------------------------------------------------------------------
+// Z-measurement outcome probabilities
+//-----------------------------------------------------------------------
+
+double AerState::probability(const uint_t outcome) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::save_amps_sq;
+  op.name = "save_amplitudes_sq";
+  op.string_params.push_back("s");
+  op.int_params.push_back(outcome);
+  op.save_type = Operations::DataSubType::list;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+
+  return ((DataMap<ListData, rvector_t>)ret.data).value()["s"].value()[0][0];
+}
+
+// Return the probability amplitude for outcome in [0, 2^num_qubits - 1]
+complex_t AerState::amplitude(const uint_t outcome) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::save_amps;
+  op.name = "save_amplitudes";
+  op.string_params.push_back("s");
+  op.int_params.push_back(outcome);
+  op.save_type = Operations::DataSubType::list;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+
+  return ((DataMap<ListData, Vector<complex_t>>)ret.data).value()["s"].value()[0][0];
+};
+
+std::vector<double> AerState::probabilities() {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::save_probs;
+  op.name = "save_probs";
+  op.string_params.push_back("s");
+  op.save_type = Operations::DataSubType::list;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+
+  return ((DataMap<ListData, rvector_t>)ret.data).value()["s"].value()[0];
+}
+
+std::vector<double> AerState::probabilities(const reg_t &qubits) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::save_probs;
+  op.name = "save_probs";
+  op.string_params.push_back("s");
+  op.qubits = qubits;
+  op.save_type = Operations::DataSubType::list;
+
+  ExperimentResult ret;
+  state_->apply_op(op, ret, rng_);
+
+  return ((DataMap<ListData, rvector_t>)ret.data).value()["s"].value()[0];
+}
+
+std::unordered_map<uint_t, uint_t> AerState::sample_measure(uint_t shots) {
+  assert_initialized();
+  reg_t qubits;
+  qubits.reserve(num_of_qubits_);
+  for (uint_t i = 0; i < num_of_qubits_; ++i)
+    qubits.push_back(i);
+  std::vector<reg_t> samples = state_->sample_measure(qubits, shots, rng_);
+  std::unordered_map<uint_t, uint_t> ret;
+  for(const auto sample: samples) {
+    uint_t sample_u = 0ULL;
+    uint_t mask = 1ULL;
+    for (const auto b: sample) {
+      if (b) sample_u |= mask;
+      mask <<= 1;
+    }
+    if (ret.find(sample_u) == ret.end())
+      ret[sample_u] = 1ULL;
+    else
+      ++ret[sample_u];
+  }
+  return ret;
+}
+
+//-------------------------------------------------------------------------
+} // end namespace AER
+//-------------------------------------------------------------------------
+#endif
+
+

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -379,7 +379,7 @@ void AerState::configure(const std::string& _key, const std::string& _value) {
   if ((key == "method" && !set_method(value))
       || (key == "device" && !set_device(value)) 
       || (key == "precision" && !set_precision(value))
-      || (key == "cuwtatevec_enable" && !set_custatevec("true" == value))
+      || (key == "custatevec_enable" && !set_custatevec("true" == value))
       || (key == "seed_simulator" && !set_seed_simulator(std::stoi(value)))
       || (key == "parallel_state_update" && !set_parallel_state_update(std::stoul(value)))
       ) {
@@ -399,11 +399,11 @@ bool AerState::set_method(const std::string& method_name) {
 
 bool AerState::set_device(const std::string& device_name) {
   assert_not_initialized();
-  if (device_name == "CPU")
+  if (device_name == "cpu")
     device_ = Device::CPU;
-  else if (device_name == "GPU" && is_gpu(true))
+  else if (device_name == "gpu" && is_gpu(true))
     device_ = Device::GPU;
-  else if (device_name == "ThrustCPU")
+  else if (device_name == "thrustcpu")
     device_ = Device::ThrustCPU;
   else
     return false;

--- a/src/framework/results/experiment_result.hpp
+++ b/src/framework/results/experiment_result.hpp
@@ -18,6 +18,8 @@
 #include "framework/results/legacy/snapshot_data.hpp"
 #include "framework/results/data/data.hpp"
 #include "framework/results/data/metadata.hpp"
+#include "framework/creg.hpp"
+#include "framework/opset.hpp"
 
 namespace AER {
 
@@ -26,6 +28,9 @@ namespace AER {
 //============================================================================
 
 struct ExperimentResult {
+  using OpType = Operations::OpType;
+  using DataSubType = Operations::DataSubType;
+
 public:
 
   // Status 
@@ -54,7 +59,46 @@ public:
 
   // Combine stored data
   ExperimentResult& combine(ExperimentResult &&other);
-};
+
+  //save creg as count data 
+  void save_count_data(const ClassicalRegister& creg, bool save_memory);
+
+  // Save data type which can be averaged over all shots.
+  // This supports DataSubTypes: list, c_list, accum, c_accum, average, c_average
+  template <class T>
+  void save_data_average(const ClassicalRegister& creg,
+                         const std::string &key, const T& datum, OpType type,
+                         DataSubType subtype = DataSubType::average);
+
+  template <class T>
+  void save_data_average(const ClassicalRegister& creg,
+                         const std::string &key, T&& datum, OpType type,
+                         DataSubType subtype = DataSubType::average);
+
+  // Save single shot data type. Typically this will be the value for the
+  // last shot of the simulation
+  template <class T>
+  void save_data_single(const ClassicalRegister& creg,
+                        const std::string &key, const T& datum, OpType type);
+
+  template <class T>
+  void save_data_single(const ClassicalRegister& creg,
+                        const std::string &key, T&& datum, OpType type);
+
+  // Save data type which is pershot and does not support accumulator or average
+  // This supports DataSubTypes: single, c_single, list, c_list
+  template <class T>
+  void save_data_pershot(const ClassicalRegister& creg,
+                         const std::string &key, const T& datum, OpType type,
+                         DataSubType subtype = DataSubType::list);
+
+  template <class T>
+  void save_data_pershot(const ClassicalRegister& creg,
+                         const std::string &key, T&& datum, OpType type,
+                         DataSubType subtype = DataSubType::list);
+
+
+ };
 
 //------------------------------------------------------------------------------
 // Implementation
@@ -98,6 +142,148 @@ json_t ExperimentResult::to_json() {
   result["metadata"] = metadata.to_json();
   return result;
 }
+
+void ExperimentResult::save_count_data(const ClassicalRegister& creg, bool save_memory) {
+  if (creg.memory_size() > 0) {
+    std::string memory_hex = creg.memory_hex();
+    data.add_accum(static_cast<uint_t>(1ULL), "counts", memory_hex);
+    if(save_memory) {
+      data.add_list(std::move(memory_hex), "memory");
+    }
+  }
+}
+
+template <class T>
+void ExperimentResult::save_data_average(const ClassicalRegister& creg,
+                                         const std::string &key,
+                                         const T& datum, OpType type,
+                                         DataSubType subtype) {
+  switch (subtype) {
+    case DataSubType::list:
+      data.add_list(datum, key);
+      break;
+    case DataSubType::c_list:
+      data.add_list(datum, key, creg.memory_hex());
+      break;
+    case DataSubType::accum:
+      data.add_accum(datum, key);
+      break;
+    case DataSubType::c_accum:
+      data.add_accum(datum, key, creg.memory_hex());
+      break;
+    case DataSubType::average:
+      data.add_average(datum, key);
+      break;
+    case DataSubType::c_average:
+      data.add_average(datum, key, creg.memory_hex());
+      break;
+    default:
+      throw std::runtime_error("Invalid average data subtype for data key: " + key);
+  }
+  metadata.add(type, "result_types", key);
+  metadata.add(subtype, "result_subtypes", key);
+}
+
+template <class T>
+void ExperimentResult::save_data_average(const ClassicalRegister& creg,
+                                         const std::string &key,
+                                         T&& datum, OpType type,
+                                         DataSubType subtype) {
+  switch (subtype) {
+    case DataSubType::list:
+      data.add_list(std::move(datum), key);
+      break;
+    case DataSubType::c_list:
+      data.add_list(std::move(datum), key, creg.memory_hex());
+      break;
+    case DataSubType::accum:
+      data.add_accum(std::move(datum), key);
+      break;
+    case DataSubType::c_accum:
+      data.add_accum(std::move(datum), key, creg.memory_hex());
+      break;
+    case DataSubType::average:
+      data.add_average(std::move(datum), key);
+      break;
+    case DataSubType::c_average:
+      data.add_average(std::move(datum), key, creg.memory_hex());
+      break;
+    default:
+      throw std::runtime_error("Invalid average data subtype for data key: " + key);
+  }
+  metadata.add(type, "result_types", key);
+  metadata.add(subtype, "result_subtypes", key);
+}
+
+template <class T>
+void ExperimentResult::save_data_pershot(const ClassicalRegister& creg,
+                                       const std::string &key,
+                                       const T& datum, OpType type,
+                                       DataSubType subtype) {
+  switch (subtype) {
+  case DataSubType::single:
+    data.add_single(datum, key);
+    break;
+  case DataSubType::c_single:
+    data.add_single(datum, key, creg.memory_hex());
+    break;
+  case DataSubType::list:
+    data.add_list(datum, key);
+    break;
+  case DataSubType::c_list:
+    data.add_list(datum, key, creg.memory_hex());
+    break;
+  default:
+    throw std::runtime_error("Invalid pershot data subtype for data key: " + key);
+  }
+  metadata.add(type, "result_types", key);
+  metadata.add(subtype, "result_subtypes", key);
+}
+
+template <class T>
+void ExperimentResult::save_data_pershot(const ClassicalRegister& creg, 
+                                         const std::string &key,
+                                         T&& datum, OpType type,
+                                         DataSubType subtype) {
+  switch (subtype) {
+    case DataSubType::single:
+      data.add_single(std::move(datum), key);
+      break;
+    case DataSubType::c_single:
+      data.add_single(std::move(datum), key, creg.memory_hex());
+      break;
+    case DataSubType::list:
+      data.add_list(std::move(datum), key);
+      break;
+    case DataSubType::c_list:
+      data.add_list(std::move(datum), key, creg.memory_hex());
+      break;
+    default:
+      throw std::runtime_error("Invalid pershot data subtype for data key: " + key);
+  }
+  metadata.add(type, "result_types", key);
+  metadata.add(subtype, "result_subtypes", key);
+}
+
+template <class T>
+void ExperimentResult::save_data_single(const ClassicalRegister& creg,
+                                        const std::string &key,
+                                        const T& datum, OpType type) {
+  data.add_single(datum, key);
+  metadata.add(type, "result_types", key);
+  metadata.add(DataSubType::single, "result_subtypes", key);
+}
+
+template <class T>
+void ExperimentResult::save_data_single(const ClassicalRegister& creg,
+                                        const std::string &key,
+                                        T&& datum, OpType type) {
+  data.add_single(std::move(datum), key);
+  metadata.add(type, "result_types", key);
+  metadata.add(DataSubType::single, "result_subtypes", key);
+}
+
+
 
 //------------------------------------------------------------------------------
 } // end namespace AER

--- a/src/framework/results/experiment_result.hpp
+++ b/src/framework/results/experiment_result.hpp
@@ -62,6 +62,7 @@ public:
 
   //save creg as count data 
   void save_count_data(const ClassicalRegister& creg, bool save_memory);
+  void save_count_data(const std::vector<ClassicalRegister>& cregs, bool save_memory);
 
   // Save data type which can be averaged over all shots.
   // This supports DataSubTypes: list, c_list, accum, c_accum, average, c_average
@@ -151,6 +152,11 @@ void ExperimentResult::save_count_data(const ClassicalRegister& creg, bool save_
       data.add_list(std::move(memory_hex), "memory");
     }
   }
+}
+
+void ExperimentResult::save_count_data(const std::vector<ClassicalRegister>& cregs, bool save_memory) {
+  for(int_t i=0;i<cregs.size();i++)
+    save_count_data(cregs[i], save_memory);
 }
 
 template <class T>

--- a/src/misc/common_macros.hpp
+++ b/src/misc/common_macros.hpp
@@ -15,7 +15,7 @@
 #ifndef QASM_SIMULATOR_COMMON_MACROS_HPP
 #define QASM_SIMULATOR_COMMON_MACROS_HPP
 
-#if defined(__GNUC__) && defined(__x86_64__)
+#if defined(__GNUC__) && defined(__x86_64__) && defined(__AVX2__)
  #define GNUC_AVX2
 #endif
 

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -866,13 +866,14 @@ void State<densmat_t>::apply_save_probs(const int_t iChunk, const Operations::Op
                                             ExperimentResult &result) 
 {
   auto probs = measure_probs(iChunk, op.qubits);
+  auto cr = this->creg(BaseState::get_global_shot_index(iChunk));
   if (op.type == OpType::save_probs_ket) {
-    BaseState::save_data_average(iChunk, result, op.string_params[0],
-                                 Utils::vec2ket(probs, json_chop_threshold_, 16),
-                                 op.type, op.save_type);
+    result.save_data_average(cr, op.string_params[0],
+                             Utils::vec2ket(probs, json_chop_threshold_, 16),
+                             op.type, op.save_type);
   } else {
-    BaseState::save_data_average(iChunk, result, op.string_params[0],
-                                 std::move(probs), op.type, op.save_type);
+    result.save_data_average(cr, op.string_params[0],
+                             std::move(probs), op.type, op.save_type);
   }
 }
 
@@ -916,8 +917,9 @@ void State<densmat_t>::apply_save_amplitudes_sq(const int_t iChunkIn, const Oper
       amps_sq[i] = BaseState::qregs_[iChunkIn].probability(op.int_params[i]);
     }
   }
-  BaseState::save_data_average(iChunkIn, result, op.string_params[0],
-                               std::move(amps_sq), op.type, op.save_type);
+  auto cr = this->creg(BaseState::get_global_shot_index(iChunkIn));
+  result.save_data_average(cr, op.string_params[0],
+                           std::move(amps_sq), op.type, op.save_type);
 }
 
 template <class densmat_t>
@@ -1010,9 +1012,10 @@ template <class densmat_t>
 void State<densmat_t>::apply_save_density_matrix(const int_t iChunk, const Operations::Op &op,
                                                  ExperimentResult &result,
                                                  bool last_op) {
-  BaseState::save_data_average(iChunk, result, op.string_params[0],
-                               reduced_density_matrix(iChunk, op.qubits, last_op),
-                               op.type, op.save_type);
+  auto cr = this->creg(BaseState::get_global_shot_index(iChunk));
+  result.save_data_average(cr, op.string_params[0],
+                           reduced_density_matrix(iChunk, op.qubits, last_op),
+                           op.type, op.save_type);
 }
 
 template <class densmat_t>
@@ -1042,12 +1045,13 @@ void State<densmat_t>::apply_save_state(const int_t iChunk, const Operations::Op
   std::string key = (op.string_params[0] == "_method_")
                       ? "density_matrix"
                       : op.string_params[0];
+  auto cr = this->creg(BaseState::get_global_shot_index(iChunk));
   if (last_op) {
-    BaseState::save_data_average(iChunk, result, key, move_to_matrix(iChunk),
-                                 OpType::save_densmat, save_type);
+    result.save_data_average(cr, key, move_to_matrix(iChunk),
+                             OpType::save_densmat, save_type);
   } else {
-    BaseState::save_data_average(iChunk, result, key, copy_to_matrix(iChunk),
-                                 OpType::save_densmat, save_type);
+    result.save_data_average(cr, key, copy_to_matrix(iChunk),
+                             OpType::save_densmat, save_type);
   }
 }
 

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -81,9 +81,9 @@ enum class Snapshots {
 //=========================================================================
 
 template <class densmat_t = QV::DensityMatrix<double>>
-class State : public Base::StateChunk<densmat_t> {
+class State : public QuantumState::StateChunk<densmat_t> {
 public:
-  using BaseState = Base::StateChunk<densmat_t>;
+  using BaseState = QuantumState::StateChunk<densmat_t>;
 
   State() : BaseState(StateOpSet) {}
   virtual ~State() = default;

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -66,10 +66,10 @@ enum class Snapshots {
   probs
 };
 
-class State: public Base::State<chstate_t>
+class State: public QuantumState::State<chstate_t>
 {
 public:
-  using BaseState = Base::State<chstate_t>;
+  using BaseState = QuantumState::State<chstate_t>;
   
   State() : BaseState(StateOpSet) {}
   virtual ~State() = default;
@@ -826,8 +826,8 @@ void State::apply_save_statevector(const Operations::Op &op,
   if (BaseState::has_global_phase_) {
     statevec *= BaseState::global_phase_;
   }
-  BaseState::save_data_pershot(
-    result, op.string_params[0],
+  result.save_data_pershot(
+    creg(), op.string_params[0],
     std::move(statevec),
     op.type, op.save_type);
 }
@@ -858,9 +858,9 @@ void State::apply_save_expval(const Operations::Op &op,
     std::vector<double> expval_var(2);
     expval_var[0] = expval;  // mean
     expval_var[1] = sq_expval - expval * expval;  // variance
-    save_data_average(result, op.string_params[0], expval_var, op.type, op.save_type);
+    result.save_data_average(creg(), op.string_params[0], expval_var, op.type, op.save_type);
   } else {
-    save_data_average(result, op.string_params[0], expval, op.type, op.save_type);
+    result.save_data_average(creg(), op.string_params[0], expval, op.type, op.save_type);
   }
 }
 

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -437,7 +437,7 @@ void State::apply_ops(InputIterator first, InputIterator last, ExperimentResult 
       for (auto it = it_nonstab_begin; it != last; it++)
       {
         const auto op = *it;
-        if(BaseState::creg_.check_conditional(op)) {
+        if(BaseState::creg().check_conditional(op)) {
           switch (op.type) {
             case Operations::OpType::gate:
               apply_gate(op, rng);
@@ -452,10 +452,10 @@ void State::apply_ops(InputIterator first, InputIterator last, ExperimentResult 
               apply_measure(op.qubits, op.memory, op.registers, rng);
               break;
             case Operations::OpType::roerror:
-              BaseState::creg_.apply_roerror(op, rng);
+              BaseState::creg().apply_roerror(op, rng);
               break;
             case Operations::OpType::bfunc:
-              BaseState::creg_.apply_bfunc(op);
+              BaseState::creg().apply_bfunc(op);
               break;
             case Operations::OpType::snapshot:
               apply_snapshot(op, result, rng);
@@ -575,7 +575,7 @@ void State::apply_stabilizer_circuit(InputIterator first, InputIterator last,
   for (auto it = first; it != last; ++it)
   {
     const Operations::Op op = *it;
-    if(BaseState::creg_.check_conditional(op)) {
+    if(BaseState::creg().check_conditional(op)) {
       switch (op.type)
       {
         case Operations::OpType::gate:
@@ -591,10 +591,10 @@ void State::apply_stabilizer_circuit(InputIterator first, InputIterator last,
           apply_measure(op.qubits, op.memory, op.registers, rng);
           break;
         case Operations::OpType::roerror:
-          BaseState::creg_.apply_roerror(op, rng);
+          BaseState::creg().apply_roerror(op, rng);
           break;
         case Operations::OpType::bfunc:
-          BaseState::creg_.apply_bfunc(op);
+          BaseState::creg().apply_bfunc(op);
           break;
         case Operations::OpType::snapshot:
           apply_snapshot(op, result, rng);
@@ -671,7 +671,7 @@ void State::apply_measure(const reg_t &qubits, const reg_t &cmemory, const reg_t
     }
   }
   // Convert the output string to a reg_t. and store
-  BaseState::creg_.store_measure(outcome, cmemory, cregister);
+  BaseState::creg().store_measure(outcome, cmemory, cregister);
 }
 
 void State::apply_reset(const reg_t &qubits, AER::RngEngine &rng)
@@ -1005,7 +1005,7 @@ void State::probabilities_snapshot(const Operations::Op &op, ExperimentResult &r
     }
   }
   result.legacy_data.add_average_snapshot("probabilities", op.string_params[0],
-                            BaseState::creg_.memory_hex(),
+                            BaseState::creg().memory_hex(),
                             Utils::vec2ket(probs, snapshot_chop_threshold_, 16),
                             false);
 }

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -528,7 +528,7 @@ void State::output_bond_dimensions(const Operations::Op &op) const {
 void State::apply_op(const Operations::Op &op,
                       ExperimentResult &result,
                       RngEngine &rng, bool final_op) {
-  if (BaseState::creg_.check_conditional(op)) {
+  if (BaseState::creg().check_conditional(op)) {
     switch (op.type) {
       case OpType::barrier:
       case OpType::qerror_loc:
@@ -543,10 +543,10 @@ void State::apply_op(const Operations::Op &op,
         apply_measure(op.qubits, op.memory, op.registers, rng);
         break;
       case OpType::bfunc:
-        BaseState::creg_.apply_bfunc(op);
+        BaseState::creg().apply_bfunc(op);
         break;
       case OpType::roerror:
-        BaseState::creg_.apply_roerror(op, rng);
+        BaseState::creg().apply_roerror(op, rng);
         break;
       case OpType::gate:
         apply_gate(op);
@@ -723,11 +723,11 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
   switch (type) {
     case SnapshotDataType::average:
       result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                                              BaseState::creg_.memory_hex(), expval, false);
+                                              BaseState::creg().memory_hex(), expval, false);
       break;
     case SnapshotDataType::average_var:
       result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                                              BaseState::creg_.memory_hex(), expval, true);
+                                              BaseState::creg().memory_hex(), expval, true);
       break;
     case SnapshotDataType::pershot:
       result.legacy_data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);
@@ -761,11 +761,11 @@ void State::snapshot_matrix_expval(const Operations::Op &op,
   switch (type) {
     case SnapshotDataType::average:
       result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                                              BaseState::creg_.memory_hex(), expval, false);
+                                              BaseState::creg().memory_hex(), expval, false);
       break;
     case SnapshotDataType::average_var:
       result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                                              BaseState::creg_.memory_hex(), expval, true);
+                                              BaseState::creg().memory_hex(), expval, true);
       break;
     case SnapshotDataType::pershot:
       result.legacy_data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);
@@ -788,7 +788,7 @@ void State::snapshot_probabilities(const Operations::Op &op,
 
   bool variance = type == SnapshotDataType::average_var;
   result.legacy_data.add_average_snapshot("probabilities", op.string_params[0], 
-  			                                  BaseState::creg_.memory_hex(), probs, variance);
+  			                                  BaseState::creg().memory_hex(), probs, variance);
 
 }
 
@@ -807,11 +807,11 @@ void State::snapshot_density_matrix(const Operations::Op &op,
   switch (type) {
     case SnapshotDataType::average:
       result.legacy_data.add_average_snapshot("density_matrix", op.string_params[0],
-                                              BaseState::creg_.memory_hex(), std::move(reduced_state), false);
+                                              BaseState::creg().memory_hex(), std::move(reduced_state), false);
       break;
     case SnapshotDataType::average_var:
       result.legacy_data.add_average_snapshot("density_matrix", op.string_params[0],
-                                              BaseState::creg_.memory_hex(), std::move(reduced_state), true);
+                                              BaseState::creg().memory_hex(), std::move(reduced_state), true);
       break;
     case SnapshotDataType::pershot:
       result.legacy_data.add_pershot_snapshot("density_matrix", op.string_params[0], std::move(reduced_state));
@@ -1005,7 +1005,7 @@ void State::apply_measure(const reg_t &qubits,
   for (int_t i = 0; i < qubits.size(); ++i)
     rands.push_back(rng.rand(0., 1.));
   reg_t outcome = qreg_.apply_measure(qubits, rands);
-  creg_.store_measure(outcome, cmemory, cregister);
+  creg().store_measure(outcome, cmemory, cregister);
 }
 
 rvector_t State::measure_probs(const reg_t &qubits) const {

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -67,10 +67,10 @@ enum class SnapshotDataType {average, average_var, pershot};
 // Stabilizer Table state class
 //============================================================================
 
-class State : public Base::State<Clifford::Clifford> {
+class State : public QuantumState::State<Clifford::Clifford> {
 
 public:
-  using BaseState = Base::State<Clifford::Clifford>;
+  using BaseState = QuantumState::State<Clifford::Clifford>;
 
   State() : BaseState(StateOpSet) {}
 
@@ -561,7 +561,7 @@ void State::apply_save_stabilizer(const Operations::Op &op,
       throw std::invalid_argument("Invalid save state instruction for stabilizer");
   }
   json_t clifford = BaseState::qreg_;
-  BaseState::save_data_pershot(result, key, std::move(clifford), op_type, op.save_type);
+  result.save_data_pershot(creg(), key, std::move(clifford), op_type, op.save_type);
 }
 
 void State::apply_save_probs(const Operations::Op &op,
@@ -584,14 +584,14 @@ void State::apply_save_probs(const Operations::Op &op,
     std::map<std::string, double> probs;
     get_probabilities_auxiliary(
         op.qubits, std::string(op.qubits.size(), 'X'), 1, probs);
-    BaseState::save_data_average(result, op.string_params[0],
-                                 std::move(probs), op.type, op.save_type);
+    result.save_data_average(creg(), op.string_params[0],
+                             std::move(probs), op.type, op.save_type);
   } else {
     std::vector<double> probs(1ULL << op.qubits.size(), 0.);
     get_probabilities_auxiliary(
       op.qubits, std::string(op.qubits.size(), 'X'), 1, probs); 
-    BaseState::save_data_average(result, op.string_params[0],
-                                 std::move(probs), op.type, op.save_type);
+    result.save_data_average(creg(), op.string_params[0],
+                             std::move(probs), op.type, op.save_type);
   }
 }
 
@@ -608,8 +608,8 @@ void State::apply_save_amplitudes_sq(const Operations::Op &op,
   for (size_t i = 0; i < op.int_params.size(); i++) {
     amps_sq[i] = get_probability(op.qubits, Utils::int2bin(op.int_params[i], num_qubits));
   }
-  BaseState::save_data_average(result, op.string_params[0],
-                               std::move(amps_sq), op.type, op.save_type);
+  result.save_data_average(creg(), op.string_params[0],
+                           std::move(amps_sq), op.type, op.save_type);
 }
 
 double State::expval_pauli(const reg_t &qubits,

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -321,7 +321,7 @@ void State::set_config(const json_t &config) {
 void State::apply_op(const Operations::Op &op,
                      ExperimentResult &result,
                      RngEngine &rng, bool final_op) {
-  if (BaseState::creg_.check_conditional(op)) {
+  if (BaseState::creg().check_conditional(op)) {
     switch (op.type) {
       case OpType::barrier:
       case OpType::qerror_loc:
@@ -333,10 +333,10 @@ void State::apply_op(const Operations::Op &op,
         apply_measure(op.qubits, op.memory, op.registers, rng);
         break;
       case OpType::bfunc:
-        BaseState::creg_.apply_bfunc(op);
+        BaseState::creg().apply_bfunc(op);
         break;
       case OpType::roerror:
-        BaseState::creg_.apply_roerror(op, rng);
+        BaseState::creg().apply_roerror(op, rng);
         break;
       case OpType::gate:
         apply_gate(op);
@@ -473,7 +473,7 @@ void State::apply_measure(const reg_t &qubits,
   // Apply measurement and get classical outcome
   reg_t outcome = apply_measure_and_update(qubits, rng);
   // Add measurement outcome to creg
-  BaseState::creg_.store_measure(outcome, cmemory, cregister);
+  BaseState::creg().store_measure(outcome, cmemory, cregister);
 }
 
 
@@ -865,7 +865,7 @@ void State::snapshot_probabilities(const Operations::Op &op,
 
   // Add snapshot to data
   result.legacy_data.add_average_snapshot("probabilities", op.string_params[0],
-                            BaseState::creg_.memory_hex(), probs, variance);
+                            BaseState::creg().memory_hex(), probs, variance);
 }
 
 
@@ -890,11 +890,11 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
   switch (type) {
     case SnapshotDataType::average:
       result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                            BaseState::creg_.memory_hex(), expval, false);
+                            BaseState::creg().memory_hex(), expval, false);
       break;
     case SnapshotDataType::average_var:
       result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                            BaseState::creg_.memory_hex(), expval, true);
+                            BaseState::creg().memory_hex(), expval, true);
       break;
     case SnapshotDataType::pershot:
       result.legacy_data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -60,7 +60,9 @@ public:
   // For snapshot ops allowed snapshots are specified by a set of string names,
   // For example this could include {"probabilities", "pauli_observable"}
 
-  Base(const Operations::OpSet &opset) : opset_(opset) {}
+  Base(const Operations::OpSet &opset) : opset_(opset) {
+    cregs_.resize(1);
+  }
 
   virtual ~Base() = default;
 
@@ -69,8 +71,10 @@ public:
   //-----------------------------------------------------------------------
 
   // Return the state creg object
-  ClassicalRegister &creg() { return creg_; }
-  const ClassicalRegister &creg() const { return creg_; }
+  auto &creg(uint_t idx=0) { return cregs_[idx]; }
+  const auto &creg(uint_t idx=0) const { return cregs_[idx]; }
+  std::vector<ClassicalRegister> &cregs() { return cregs_; }
+  const std::vector<ClassicalRegister> &cregs() const { return cregs_; }
 
   // Return the state opset object
   Operations::OpSet &opset() { return opset_; }
@@ -245,7 +249,7 @@ public:
 protected:
 
   // Classical register data
-  ClassicalRegister creg_;
+  std::vector<ClassicalRegister> cregs_;
 
   // Opset of instructions supported by the state
   Operations::OpSet opset_;
@@ -320,14 +324,14 @@ void Base::apply_ops(const OpItr first, const OpItr last,
 
 void Base::initialize_creg(uint_t num_memory, uint_t num_register) 
 {
-  creg_.initialize(num_memory, num_register);
+  creg().initialize(num_memory, num_register);
 }
 
 void Base::initialize_creg(uint_t num_memory,
                                 uint_t num_register,
                                 const std::string &memory_hex,
                                 const std::string &register_hex) {
-  creg_.initialize(num_memory, num_register, memory_hex, register_hex);
+  creg().initialize(num_memory, num_register, memory_hex, register_hex);
 }
 
 template <class state_t>
@@ -427,7 +431,7 @@ void Base::snapshot_creg_memory(const Operations::Op &op,
                                           std::string name) const {
   result.legacy_data.add_pershot_snapshot(name,
                                op.string_params[0],
-                               creg_.memory_hex());
+                               creg().memory_hex());
 }
 
 
@@ -436,7 +440,7 @@ void Base::snapshot_creg_register(const Operations::Op &op,
                                             std::string name) const {
   result.legacy_data.add_pershot_snapshot(name,
                                op.string_params[0],
-                               creg_.register_hex());
+                               creg().register_hex());
 }
 
 

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -31,8 +31,32 @@ namespace Base {
 // State interface base class for Qiskit-Aer
 //=========================================================================
 
+class StateBase {
+public:
+  StateBase() = default;
+  virtual ~StateBase() = default;
+
+  virtual void initialize_qreg(uint_t num_qubits) = 0;
+
+  virtual void initialize_creg(uint_t num_memory, uint_t num_register) = 0;
+
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine& rng,
+                        bool final_op = false) = 0;
+
+  virtual void set_config(const json_t &config) = 0;
+
+  virtual ClassicalRegister &creg() = 0;
+  virtual const ClassicalRegister &creg() const = 0;
+
+  virtual std::vector<reg_t> sample_measure(const reg_t &qubits,
+                                            uint_t shots,
+                                            RngEngine &rng) = 0;
+};
+
 template <class state_t>
-class State {
+class State: public StateBase {
 
 public:
   using ignore_argument = void;
@@ -79,8 +103,8 @@ public:
   const auto &qreg() const { return qreg_; }
 
   // Return the state creg object
-  auto &creg() { return creg_; }
-  const auto &creg() const { return creg_; }
+  ClassicalRegister &creg() { return creg_; }
+  const ClassicalRegister &creg() const { return creg_; }
 
   // Return the state opset object
   auto &opset() { return opset_; }

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -25,43 +25,18 @@
 
 namespace AER {
 
-namespace Base {
+namespace QuantumState {
 
 //=========================================================================
 // State interface base class for Qiskit-Aer
 //=========================================================================
 
-class StateBase {
-public:
-  StateBase() = default;
-  virtual ~StateBase() = default;
-
-  virtual void initialize_qreg(uint_t num_qubits) = 0;
-
-  virtual void initialize_creg(uint_t num_memory, uint_t num_register) = 0;
-
-  virtual void apply_op(const Operations::Op &op,
-                        ExperimentResult &result,
-                        RngEngine& rng,
-                        bool final_op = false) = 0;
-
-  virtual void set_config(const json_t &config) = 0;
-
-  virtual ClassicalRegister &creg() = 0;
-  virtual const ClassicalRegister &creg() const = 0;
-
-  virtual std::vector<reg_t> sample_measure(const reg_t &qubits,
-                                            uint_t shots,
-                                            RngEngine &rng) = 0;
-};
-
-template <class state_t>
-class State: public StateBase {
-
+class Base {
 public:
   using ignore_argument = void;
   using DataSubType = Operations::DataSubType;
   using OpType = Operations::OpType;
+  using OpItr = std::vector<Operations::Op>::const_iterator;
 
   //-----------------------------------------------------------------------
   // Constructors
@@ -85,30 +60,21 @@ public:
   // For snapshot ops allowed snapshots are specified by a set of string names,
   // For example this could include {"probabilities", "pauli_observable"}
 
-  State(const Operations::OpSet &opset) : opset_(opset) {}
+  Base(const Operations::OpSet &opset) : opset_(opset) {}
 
-  State(const Operations::OpSet::optypeset_t &optypes,
-        const stringset_t &gates,
-        const stringset_t &snapshots)
-    : State(Operations::OpSet(optypes, gates, snapshots)) {};
-
-  virtual ~State();
+  virtual ~Base() = default;
 
   //-----------------------------------------------------------------------
   // Data accessors
   //-----------------------------------------------------------------------
-
-  // Return the state qreg object
-  auto &qreg() { return qreg_; }
-  const auto &qreg() const { return qreg_; }
 
   // Return the state creg object
   ClassicalRegister &creg() { return creg_; }
   const ClassicalRegister &creg() const { return creg_; }
 
   // Return the state opset object
-  auto &opset() { return opset_; }
-  const auto &opset() const { return opset_; }
+  Operations::OpSet &opset() { return opset_; }
+  const Operations::OpSet &opset() const { return opset_; }
 
   //=======================================================================
   // Subclass Override Methods
@@ -128,13 +94,6 @@ public:
   // Return a string name for the State type
   virtual std::string name() const = 0;
 
-  // Initializes the State to the default state.
-  // Typically this is the n-qubit all |0> state
-  virtual void initialize_qreg(uint_t num_qubits) = 0;
-
-  // Initializes the State to a specific state.
-  virtual void initialize_qreg(uint_t num_qubits, const state_t &state) = 0;
-
   // Return an estimate of the required memory for implementing the
   // specified sequence of operations on a `num_qubit` sized State.
   virtual size_t required_memory_mb(uint_t num_qubits,
@@ -149,6 +108,58 @@ public:
   // raise an exception.
   virtual double expval_pauli(const reg_t &qubits,
                               const std::string& pauli) = 0;
+
+  // Initializes the State to the default state.
+  // Typically this is the n-qubit all |0> state
+  virtual void initialize_qreg(uint_t num_qubits) = 0;
+
+  //-----------------------------------------------------------------------
+  // ClassicalRegister methods
+  //-----------------------------------------------------------------------
+
+  // Initialize classical memory and register to default value (all-0)
+  virtual void initialize_creg(uint_t num_memory, uint_t num_register);
+
+  // Initialize classical memory and register to specific values
+  virtual void initialize_creg(uint_t num_memory,
+                               uint_t num_register,
+                               const std::string &memory_hex,
+                               const std::string &register_hex);
+
+  //-----------------------------------------------------------------------
+  // Apply circuits and ops
+  //-----------------------------------------------------------------------
+
+  // Apply a single operation
+  // The `final_op` flag indicates no more instructions will be applied
+  // to the state after this sequence, so the state can be modified at the
+  // end of the instructions.
+  virtual void apply_op(const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine& rng,
+                        bool final_op = false) = 0;
+
+  // Apply a sequence of operations to the current state of the State class.
+  // It is up to the State subclass to decide how this sequence should be
+  // executed (ie in sequence, or some other execution strategy.)
+  // If this sequence contains operations not in the supported opset
+  // an exeption will be thrown.
+  // The `final_ops` flag indicates no more instructions will be applied
+  // to the state after this sequence, so the state can be modified at the
+  // end of the instructions.
+  virtual void apply_ops(OpItr first, OpItr last,
+                         ExperimentResult &result, RngEngine &rng, bool final_ops = false);
+
+  //apply ops to multiple shots
+  //this function should be separately defined since apply_ops is called in quantum_error
+  void apply_ops_multi_shots(OpItr first, OpItr last,
+                             const Noise::NoiseModel &noise,
+                             ExperimentResult &result,
+                             uint_t rng_seed,
+                             bool final_ops = false)
+  {
+    throw std::invalid_argument("apply_ops_multi_shots is not supported in State " + name());
+  }
 
   //-----------------------------------------------------------------------
   // Optional: Load config settings
@@ -180,141 +191,6 @@ public:
                                             uint_t shots,
                                             RngEngine &rng);
 
-  //=======================================================================
-  // Standard non-virtual methods
-  //
-  // These methods should not be modified in any State subclasses
-  //=======================================================================
-
-  //-----------------------------------------------------------------------
-  // Apply circuits and ops
-  //-----------------------------------------------------------------------
-
-  // Apply a single operation
-  // The `final_op` flag indicates no more instructions will be applied
-  // to the state after this sequence, so the state can be modified at the
-  // end of the instructions.
-  virtual void apply_op(const Operations::Op &op,
-                        ExperimentResult &result,
-                        RngEngine& rng,
-                        bool final_op = false) = 0;
-
-
-  // Apply a sequence of operations to the current state of the State class.
-  // It is up to the State subclass to decide how this sequence should be
-  // executed (ie in sequence, or some other execution strategy.)
-  // If this sequence contains operations not in the supported opset
-  // an exeption will be thrown.
-  // The `final_ops` flag indicates no more instructions will be applied
-  // to the state after this sequence, so the state can be modified at the
-  // end of the instructions.
-  template <typename InputIterator>
-  void apply_ops(InputIterator first,
-                 InputIterator last,
-                 ExperimentResult &result,
-                 RngEngine &rng,
-                 bool final_ops = false);
-
-  //apply ops to multiple shots
-  //this function should be separately defined since apply_ops is called in quantum_error
-  template <typename InputIterator>
-  void apply_ops_multi_shots(InputIterator first,
-                 InputIterator last,
-                 const Noise::NoiseModel &noise,
-                 ExperimentResult &result,
-                 uint_t rng_seed,
-                 bool final_ops = false)
-  {
-    throw std::invalid_argument("apply_ops_multi_shots is not supported in State " + name());
-  }
-
-  //-----------------------------------------------------------------------
-  // ClassicalRegister methods
-  //-----------------------------------------------------------------------
-
-  // Initialize classical memory and register to default value (all-0)
-  virtual void initialize_creg(uint_t num_memory, uint_t num_register);
-
-  // Initialize classical memory and register to specific values
-  virtual void initialize_creg(uint_t num_memory,
-                       uint_t num_register,
-                       const std::string &memory_hex,
-                       const std::string &register_hex);
-
-  //-----------------------------------------------------------------------
-  // Save result data
-  //-----------------------------------------------------------------------
-
-  // Save current value of all classical registers to result
-  // This supports DataSubTypes: c_accum (counts), list (memory)
-  // TODO: Make classical data allow saving only subset of specified clbit values
-  void save_creg(ExperimentResult &result,
-                 const std::string &key,
-                 DataSubType subtype = DataSubType::c_accum) const;
-              
-  // Save single shot data type. Typically this will be the value for the
-  // last shot of the simulation
-  template <class T>
-  void save_data_single(ExperimentResult &result,
-                        const std::string &key, const T& datum, OpType type) const;
-
-  template <class T>
-  void save_data_single(ExperimentResult &result,
-                        const std::string &key, T&& datum, OpType type) const;
-
-  // Save data type which can be averaged over all shots.
-  // This supports DataSubTypes: list, c_list, accum, c_accum, average, c_average
-  template <class T>
-  void save_data_average(ExperimentResult &result,
-                         const std::string &key, const T& datum, OpType type,
-                         DataSubType subtype = DataSubType::average) const;
-
-  template <class T>
-  void save_data_average(ExperimentResult &result,
-                         const std::string &key, T&& datum, OpType type,
-                         DataSubType subtype = DataSubType::average) const;
-  
-  // Save data type which is pershot and does not support accumulator or average
-  // This supports DataSubTypes: single, c_single, list, c_list
-  template <class T>
-  void save_data_pershot(ExperimentResult &result,
-                         const std::string &key, const T& datum, OpType type,
-                         DataSubType subtype = DataSubType::list) const;
-
-  template <class T>
-  void save_data_pershot(ExperimentResult &result,
-                         const std::string &key, T&& datum, OpType type,
-                         DataSubType subtype = DataSubType::list) const;
-
-
-  //save creg as count data 
-  virtual void save_count_data(ExperimentResult& result,bool save_memory);
-
-  //-----------------------------------------------------------------------
-  // Common instructions
-  //-----------------------------------------------------------------------
- 
-  // Apply a save expectation value instruction
-  void apply_save_expval(const Operations::Op &op, ExperimentResult &result);
-
-  //-----------------------------------------------------------------------
-  // Standard snapshots
-  //-----------------------------------------------------------------------
-
-  // Snapshot the current statevector (single-shot)
-  // if type_label is the empty string the operation type will be used for the type
-  virtual void snapshot_state(const Operations::Op &op, ExperimentResult &result,
-                      std::string name = "") const;
-
-  // Snapshot the classical memory bits state (single-shot)
-  void snapshot_creg_memory(const Operations::Op &op, ExperimentResult &result,
-                            std::string name = "memory") const;
-
-  // Snapshot the classical register bits state (single-shot)
-  void snapshot_creg_register(const Operations::Op &op, ExperimentResult &result,
-                              std::string name = "register") const;
-
-
   //-----------------------------------------------------------------------
   // Config Settings
   //-----------------------------------------------------------------------
@@ -343,13 +219,30 @@ public:
 
   //Does this state support multi-chunk distribution?
   virtual bool multi_chunk_distribution_supported(void){return false;}
+
   //Does this state support multi-shot parallelization?
   virtual bool multi_shot_parallelization_supported(void){return false;}
 
-protected:
+  //-----------------------------------------------------------------------
+  // Common instructions
+  //-----------------------------------------------------------------------
+ 
+  // Apply a save expectation value instruction
+  void apply_save_expval(const Operations::Op &op, ExperimentResult &result);
 
-  // The quantum state data structure
-  state_t qreg_;
+  //-----------------------------------------------------------------------
+  // Standard snapshots
+  //-----------------------------------------------------------------------
+
+  // Snapshot the classical memory bits state (single-shot)
+  void snapshot_creg_memory(const Operations::Op &op, ExperimentResult &result,
+                            std::string name = "memory") const;
+
+  // Snapshot the classical register bits state (single-shot)
+  void snapshot_creg_register(const Operations::Op &op, ExperimentResult &result,
+                              std::string name = "register") const;
+
+protected:
 
   // Classical register data
   ClassicalRegister creg_;
@@ -370,51 +263,23 @@ protected:
   std::string sim_device_name_ = "CPU";
 };
 
-
-//=========================================================================
-// Implementations
-//=========================================================================
-
-template <class state_t>
-State<state_t>::~State(void)
-{
-}
-
-template <class state_t>
-void State<state_t>::set_config(const json_t &config) 
+void Base::set_config(const json_t &config) 
 {
   JSON::get_value(sim_device_name_, "device", config);
 }
 
-template <class state_t>
-void State<state_t>::set_global_phase(double theta) {
-  if (Linalg::almost_equal(theta, 0.0)) {
-    has_global_phase_ = false;
-    global_phase_ = 1;
-  }
-  else {
-    has_global_phase_ = true;
-    global_phase_ = std::exp(complex_t(0.0, theta));
-  }
+std::vector<reg_t> Base::sample_measure(const reg_t &qubits,
+                                             uint_t shots,
+                                             RngEngine &rng) {
+  (ignore_argument)qubits;
+  (ignore_argument)shots;
+  return std::vector<reg_t>();
 }
 
-template <class state_t>
-void State<state_t>::add_global_phase(double theta) {
-  if (Linalg::almost_equal(theta, 0.0)) 
-    return;
-  
-  has_global_phase_ = true;
-  global_phase_ *= std::exp(complex_t(0.0, theta));
-}
+void Base::apply_ops(const OpItr first, const OpItr last,
+                          ExperimentResult &result, RngEngine &rng, bool final_ops) {
 
-template <class state_t>
-template <typename InputIterator>
-void State<state_t>::apply_ops(InputIterator first, InputIterator last,
-                               ExperimentResult &result,
-                               RngEngine &rng,
-                               bool final_ops) {
-
-  std::unordered_map<std::string, InputIterator> marks;
+  std::unordered_map<std::string, OpItr> marks;
   // Simple loop over vector of input operations
   for (auto it = first; it != last; ++it) {
     switch (it->type) {
@@ -423,7 +288,7 @@ void State<state_t>::apply_ops(InputIterator first, InputIterator last,
       break;
     }
     case Operations::OpType::jump: {
-      if (creg_.check_conditional(*it)) {
+      if (creg().check_conditional(*it)) {
         const auto& mark_name = it->string_params[0];
         auto mark_it = marks.find(mark_name);
         if (mark_it != marks.end()) {
@@ -451,201 +316,113 @@ void State<state_t>::apply_ops(InputIterator first, InputIterator last,
     }
     }
   }
-}
+};
 
-template <class state_t>
-std::vector<reg_t> State<state_t>::sample_measure(const reg_t &qubits,
-                                                  uint_t shots,
-                                                  RngEngine &rng) {
-  (ignore_argument)qubits;
-  (ignore_argument)shots;
-  return std::vector<reg_t>();
-}
-
-
-template <class state_t>
-void State<state_t>::initialize_creg(uint_t num_memory, uint_t num_register) 
+void Base::initialize_creg(uint_t num_memory, uint_t num_register) 
 {
   creg_.initialize(num_memory, num_register);
 }
 
-
-template <class state_t>
-void State<state_t>::initialize_creg(uint_t num_memory,
-                                     uint_t num_register,
-                                     const std::string &memory_hex,
-                                     const std::string &register_hex) {
+void Base::initialize_creg(uint_t num_memory,
+                                uint_t num_register,
+                                const std::string &memory_hex,
+                                const std::string &register_hex) {
   creg_.initialize(num_memory, num_register, memory_hex, register_hex);
 }
 
 template <class state_t>
-void State<state_t>::save_creg(ExperimentResult &result,
-                               const std::string &key,
-                               DataSubType subtype) const {
-  if (creg_.memory_size() == 0)
-    return;
-  switch (subtype) {
-    case DataSubType::list:
-      result.data.add_list(creg_.memory_hex(), key);
-      result.metadata.add("creg", "result_types", key);
-      break;
-    case DataSubType::c_accum:
-      result.data.add_accum(1ULL, key, creg_.memory_hex());
-      result.metadata.add("creg", "result_types", key);
-      break;
-    default:
-      throw std::runtime_error("Invalid creg data subtype for data key: " + key);
-  }
-  result.metadata.add(subtype, "result_subtypes", key);
-}
+class State: public Base {
 
-template <class state_t>
-template <class T>
-void State<state_t>::save_data_average(ExperimentResult &result,
-                                       const std::string &key,
-                                       const T& datum, OpType type,
-                                       DataSubType subtype) const {
-  switch (subtype) {
-    case DataSubType::list:
-      result.data.add_list(datum, key);
-      break;
-    case DataSubType::c_list:
-      result.data.add_list(datum, key, creg_.memory_hex());
-      break;
-    case DataSubType::accum:
-      result.data.add_accum(datum, key);
-      break;
-    case DataSubType::c_accum:
-      result.data.add_accum(datum, key, creg_.memory_hex());
-      break;
-    case DataSubType::average:
-      result.data.add_average(datum, key);
-      break;
-    case DataSubType::c_average:
-      result.data.add_average(datum, key, creg_.memory_hex());
-      break;
-    default:
-      throw std::runtime_error("Invalid average data subtype for data key: " + key);
-  }
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(subtype, "result_subtypes", key);
-}
+public:
+  using ignore_argument = void;
+  using DataSubType = Operations::DataSubType;
+  using OpType = Operations::OpType;
 
-template <class state_t>
-template <class T>
-void State<state_t>::save_data_average(ExperimentResult &result,
-                                       const std::string &key,
-                                       T&& datum, OpType type,
-                                       DataSubType subtype) const {
-  switch (subtype) {
-    case DataSubType::list:
-      result.data.add_list(std::move(datum), key);
-      break;
-    case DataSubType::c_list:
-      result.data.add_list(std::move(datum), key, creg_.memory_hex());
-      break;
-    case DataSubType::accum:
-      result.data.add_accum(std::move(datum), key);
-      break;
-    case DataSubType::c_accum:
-      result.data.add_accum(std::move(datum), key, creg_.memory_hex());
-      break;
-    case DataSubType::average:
-      result.data.add_average(std::move(datum), key);
-      break;
-    case DataSubType::c_average:
-      result.data.add_average(std::move(datum), key, creg_.memory_hex());
-      break;
-    default:
-      throw std::runtime_error("Invalid average data subtype for data key: " + key);
-  }
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(subtype, "result_subtypes", key);
-}
+  //-----------------------------------------------------------------------
+  // Constructors
+  //-----------------------------------------------------------------------
 
-template <class state_t>
-template <class T>
-void State<state_t>::save_data_pershot(ExperimentResult &result,
-                                       const std::string &key,
-                                       const T& datum, OpType type,
-                                       DataSubType subtype) const {
-  switch (subtype) {
-  case DataSubType::single:
-    result.data.add_single(datum, key);
-    break;
-  case DataSubType::c_single:
-    result.data.add_single(datum, key, creg_.memory_hex());
-    break;
-  case DataSubType::list:
-    result.data.add_list(datum, key);
-    break;
-  case DataSubType::c_list:
-    result.data.add_list(datum, key, creg_.memory_hex());
-    break;
-  default:
-    throw std::runtime_error("Invalid pershot data subtype for data key: " + key);
-  }
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(subtype, "result_subtypes", key);
-}
+  // The constructor arguments are used to initialize the OpSet
+  // for the State class for checking supported simulator Operations
+  //
+  // Standard OpTypes that can be included here are:
+  // - `OpType::gate` if gates are supported
+  // - `OpType::measure` if measure is supported
+  // - `OpType::reset` if reset is supported
+  // - `OpType::snapshot` if any snapshots are supported
+  // - `OpType::barrier` if barrier is supported
+  // - `OpType::matrix` if arbitrary unitary matrices are supported
+  // - `OpType::kraus` if general Kraus noise channels are supported
+  //
+  // For gate ops allowed gates are specified by a set of string names,
+  // for example this could include {"u1", "u2", "u3", "U", "cx", "CX"}
+  //
+  // For snapshot ops allowed snapshots are specified by a set of string names,
+  // For example this could include {"probabilities", "pauli_observable"}
 
-template <class state_t>
-template <class T>
-void State<state_t>::save_data_pershot(ExperimentResult &result, 
-                                       const std::string &key,
-                                       T&& datum, OpType type,
-                                       DataSubType subtype) const {
-  switch (subtype) {
-    case DataSubType::single:
-      result.data.add_single(std::move(datum), key);
-      break;
-    case DataSubType::c_single:
-      result.data.add_single(std::move(datum), key, creg_.memory_hex());
-      break;
-    case DataSubType::list:
-      result.data.add_list(std::move(datum), key);
-      break;
-    case DataSubType::c_list:
-      result.data.add_list(std::move(datum), key, creg_.memory_hex());
-      break;
-    default:
-      throw std::runtime_error("Invalid pershot data subtype for data key: " + key);
-  }
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(subtype, "result_subtypes", key);
-}
+  State(const Operations::OpSet &opset) : Base(opset) {}
 
-template <class state_t>
-template <class T>
-void State<state_t>::save_data_single(ExperimentResult &result,
-                                      const std::string &key,
-                                      const T& datum, OpType type) const {
-  result.data.add_single(datum, key);
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(DataSubType::single, "result_subtypes", key);
-}
+  State(const Operations::OpSet::optypeset_t &optypes,
+        const stringset_t &gates,
+        const stringset_t &snapshots)
+    : State(Operations::OpSet(optypes, gates, snapshots)) {};
 
-template <class state_t>
-template <class T>
-void State<state_t>::save_data_single(ExperimentResult &result,
-                                      const std::string &key,
-                                      T&& datum, OpType type) const {
-  result.data.add_single(std::move(datum), key);
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(DataSubType::single, "result_subtypes", key);
-}
+  virtual ~State() {};
+
+  //-----------------------------------------------------------------------
+  // Data accessors
+  //-----------------------------------------------------------------------
+
+  // Return the state qreg object
+  auto &qreg() { return qreg_; }
+  const auto &qreg() const { return qreg_; }
+
+  // Initializes the State to a specific state.
+  virtual void initialize_qreg(uint_t num_qubits, const state_t &state) = 0;
+
+  //-----------------------------------------------------------------------
+  // Standard snapshots
+  //-----------------------------------------------------------------------
+
+  // Snapshot the current statevector (single-shot)
+  // if type_label is the empty string the operation type will be used for the type
+  virtual void snapshot_state(const Operations::Op &op, ExperimentResult &result,
+                      std::string name = "") const;
+
+protected:
+  // The quantum state data structure
+  state_t qreg_;
+};
+
 
 template <class state_t>
 void State<state_t>::snapshot_state(const Operations::Op &op,
                                     ExperimentResult &result,
                                     std::string name) const {
   name = (name.empty()) ? op.name : name;
-  result.legacy_data.add_pershot_snapshot(name, op.string_params[0], qreg_);
+  result.legacy_data.add_pershot_snapshot(name, op.string_params[0], qreg());
 }
 
+void Base::set_global_phase(double theta) {
+  if (Linalg::almost_equal(theta, 0.0)) {
+    has_global_phase_ = false;
+    global_phase_ = 1;
+  }
+  else {
+    has_global_phase_ = true;
+    global_phase_ = std::exp(complex_t(0.0, theta));
+  }
+}
 
-template <class state_t>
-void State<state_t>::snapshot_creg_memory(const Operations::Op &op,
+void Base::add_global_phase(double theta) {
+  if (Linalg::almost_equal(theta, 0.0)) 
+    return;
+  
+  has_global_phase_ = true;
+  global_phase_ *= std::exp(complex_t(0.0, theta));
+}
+
+void Base::snapshot_creg_memory(const Operations::Op &op,
                                           ExperimentResult &result,
                                           std::string name) const {
   result.legacy_data.add_pershot_snapshot(name,
@@ -654,8 +431,7 @@ void State<state_t>::snapshot_creg_memory(const Operations::Op &op,
 }
 
 
-template <class state_t>
-void State<state_t>::snapshot_creg_register(const Operations::Op &op,
+void Base::snapshot_creg_register(const Operations::Op &op,
                                             ExperimentResult &result,
                                             std::string name) const {
   result.legacy_data.add_pershot_snapshot(name,
@@ -664,8 +440,7 @@ void State<state_t>::snapshot_creg_register(const Operations::Op &op,
 }
 
 
-template <class state_t>
-void State<state_t>::apply_save_expval(const Operations::Op &op,
+void Base::apply_save_expval(const Operations::Op &op,
                                        ExperimentResult &result){
   // Check empty edge case
   if (op.expval_params.empty()) {
@@ -690,21 +465,9 @@ void State<state_t>::apply_save_expval(const Operations::Op &op,
     std::vector<double> expval_var(2);
     expval_var[0] = expval;  // mean
     expval_var[1] = sq_expval - expval * expval;  // variance
-    save_data_average(result, op.string_params[0], expval_var, op.type, op.save_type);
+    result.save_data_average(creg(), op.string_params[0], expval_var, op.type, op.save_type);
   } else {
-    save_data_average(result, op.string_params[0], expval, op.type, op.save_type);
-  }
-}
-
-template <class state_t>
-void State<state_t>::save_count_data(ExperimentResult& result,bool save_memory)
-{
-  if (creg_.memory_size() > 0) {
-    std::string memory_hex = creg_.memory_hex();
-    result.data.add_accum(static_cast<uint_t>(1ULL), "counts", memory_hex);
-    if(save_memory) {
-      result.data.add_list(std::move(memory_hex), "memory");
-    }
+    result.save_data_average(creg(), op.string_params[0], expval, op.type, op.save_type);
   }
 }
 

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -199,7 +199,7 @@ public:
   void apply_op(const Operations::Op &op,
                       ExperimentResult &result,
                       RngEngine& rng,
-                      bool final_op = false) override final {}
+                      bool final_op = false) override final { apply_op(0, op, result, rng, final_op); }
 
   //so this one is used
   virtual void apply_op(const int_t iChunk, const Operations::Op &op,

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -104,9 +104,9 @@ public:
   auto &qreg(int_t idx=0) { return qregs_[idx]; }
   const auto &qreg(int_t idx=0) const { return qregs_[idx]; }
 
-  // Return the state creg object
-  auto &creg(uint_t idx=0) { return cregs_[idx]; }
-  const auto &creg(uint_t idx=0) const { return cregs_[idx]; }
+  // Return the creg object
+  auto &chunk_creg(uint_t iChunk) { return BaseState::creg(get_global_shot_index(iChunk)); }
+  const auto &chunk_creg(uint_t iChunk) const { return BaseState::creg(get_global_shot_index(iChunk)); }
 
   //=======================================================================
   // Subclass Override Methods
@@ -156,29 +156,6 @@ public:
 
   // Load any settings for the StateChunk class from a config JSON
   virtual void set_config(const json_t &config);
-
-  //-----------------------------------------------------------------------
-  // Optional: Add information to metadata 
-  //-----------------------------------------------------------------------
-
-  // Every state can add information to the metadata structure
-  virtual void add_metadata(ExperimentResult &result) const {
-  }
-
-  //-----------------------------------------------------------------------
-  // Optional: measurement sampling
-  //
-  // This method is only required for a StateChunk subclass to be compatible with
-  // the measurement sampling optimization of a general the QasmController
-  //-----------------------------------------------------------------------
-
-  // Sample n-measurement outcomes without applying the measure operation
-  // to the system state. Even though this method is not marked as const
-  // at the end of sample the system should be left in the same state
-  // as before sampling
-  virtual std::vector<reg_t> sample_measure(const reg_t &qubits,
-                                            uint_t shots,
-                                            RngEngine &rng);
 
   //=======================================================================
   // Standard non-virtual methods
@@ -256,55 +233,6 @@ public:
                        const std::string &register_hex);
 
   //-----------------------------------------------------------------------
-  // Save result data
-  //-----------------------------------------------------------------------
-
-  // Save current value of all classical registers to result
-  // This supports DataSubTypes: c_accum (counts), list (memory)
-  // TODO: Make classical data allow saving only subset of specified clbit values
-  void save_creg(const int_t iChunk, ExperimentResult &result,
-                 const std::string &key,
-                 DataSubType subtype = DataSubType::c_accum) const;
-
-  // Save single shot data type. Typically this will be the value for the
-  // last shot of the simulation
-  template <class T>
-  void save_data_single(ExperimentResult &result,
-                        const std::string &key, const T& datum, OpType type) const;
-
-  template <class T>
-  void save_data_single(ExperimentResult &result,
-                        const std::string &key, T&& datum, OpType type) const;
-
-  // Save data type which can be averaged over all shots.
-  // This supports DataSubTypes: list, c_list, accum, c_accum, average, c_average
-  template <class T>
-  void save_data_average(const int_t iChunk, ExperimentResult &result,
-                         const std::string &key, const T& datum,
-                         OpType type, DataSubType subtype = DataSubType::average) const;
-
-  template <class T>
-  void save_data_average(const int_t iChunk, ExperimentResult &result,
-                         const std::string &key, T&& datum,
-                         OpType type, DataSubType subtype = DataSubType::average) const;
-  
-  // Save data type which is pershot and does not support accumulator or average
-  // This supports DataSubTypes: single, c_single, list, c_list
-  template <class T>
-  void save_data_pershot(const int_t iChunk, ExperimentResult &result,
-                         const std::string &key, const T& datum,
-                         OpType type, DataSubType subtype = DataSubType::list) const;
-
-  template <class T>
-  void save_data_pershot(const int_t iChunk, ExperimentResult &result,
-                         const std::string &key, T&& datum,
-                         OpType type, DataSubType subtype = DataSubType::list) const;
-
-
-  //save creg as count data 
-  virtual void save_count_data(ExperimentResult& result,bool save_memory);
-
-  //-----------------------------------------------------------------------
   // Common instructions
   //-----------------------------------------------------------------------
  
@@ -343,7 +271,6 @@ public:
     max_batched_shots_ = shots;
   }
 
-
   //Does this state support multi-chunk distribution?
   virtual bool multi_chunk_distribution_supported(void){return true;}
   //Does this state support multi-shot parallelization?
@@ -353,9 +280,6 @@ protected:
 
   // The array of the quantum state data structure
   std::vector<state_t> qregs_;
-
-  // The array of classical register data
-  std::vector<ClassicalRegister> cregs_;
 
   //number of qubits for the circuit
   uint_t num_qubits_;
@@ -628,7 +552,7 @@ bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t nu
     multi_shots_parallelization_ = false;
     num_global_chunks_ = 1ull << ((num_qubits_ - chunk_bits_)*qubit_scale());
 
-    cregs_.resize(1);
+    BaseState::cregs_.resize(1);
   }
   else{
     //multi-shots parallelization
@@ -640,7 +564,7 @@ bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t nu
     num_global_chunks_ = num_parallel_shots;
 
     //classical registers for all shots
-    cregs_.resize(num_parallel_shots);
+    BaseState::cregs_.resize(num_parallel_shots);
   }
 
   chunk_index_begin_.resize(distributed_procs_);
@@ -1017,7 +941,7 @@ bool StateChunk<state_t>::check_conditional(const int_t iChunk, const Operations
     return true;
   }
   else{
-    return cregs_[0].check_conditional(op);
+    return BaseState::cregs_[0].check_conditional(op);
   }
 }
 
@@ -1054,7 +978,7 @@ void StateChunk<state_t>::apply_ops_multi_shots(InputIterator first, InputIterat
         qregs_[j].initialize();
 
         //initialize creg here
-        qregs_[j].initialize_creg(cregs_[0].memory_size(), cregs_[0].register_size());
+        qregs_[j].initialize_creg(this->creg(0).memory_size(), this->creg(0).register_size());
       }
     };
     Utils::apply_omp_parallel_for((num_groups_ > 1 && chunk_omp_parallel_),0,num_groups_,init_group);
@@ -1078,7 +1002,7 @@ void StateChunk<state_t>::apply_ops_multi_shots(InputIterator first, InputIterat
 
     //collect measured bits and copy memory
     for(i=0;i<n_shots;i++){
-      qregs_[i].read_measured_data(cregs_[global_chunk_index_ + i_begin + i]);
+      qregs_[i].read_measured_data(this->creg(global_chunk_index_ + i_begin + i));
     }
 
     i_begin += n_shots;
@@ -1263,20 +1187,10 @@ void StateChunk<state_t>::apply_batched_noise_ops(const int_t i_group, const std
 }
 
 template <class state_t>
-std::vector<reg_t> StateChunk<state_t>::sample_measure(const reg_t &qubits,
-                                                  uint_t shots,
-                                                  RngEngine &rng) {
-  (ignore_argument)qubits;
-  (ignore_argument)shots;
-  return std::vector<reg_t>();
-}
-
-
-template <class state_t>
 void StateChunk<state_t>::initialize_creg(uint_t num_memory, uint_t num_register) 
 {
-  for(int_t i=0;i<cregs_.size();i++){
-    cregs_[i].initialize(num_memory, num_register);
+  for(int_t i=0;i<BaseState::cregs_.size();i++){
+    BaseState::cregs_[i].initialize(num_memory, num_register);
   }
 }
 
@@ -1286,172 +1200,9 @@ void StateChunk<state_t>::initialize_creg(uint_t num_memory,
                                      uint_t num_register,
                                      const std::string &memory_hex,
                                      const std::string &register_hex) {
-  for(int_t i=0;i<cregs_.size();i++){
-    cregs_[i].initialize(num_memory, num_register, memory_hex, register_hex);
+  for(int_t i=0;i<BaseState::cregs_.size();i++){
+    BaseState::cregs_[i].initialize(num_memory, num_register, memory_hex, register_hex);
   }
-}
-
-template <class state_t>
-void StateChunk<state_t>::save_creg(const int_t iChunk, ExperimentResult &result,
-                               const std::string &key,
-                               DataSubType subtype) const 
-{
-  int_t ishot = get_global_shot_index(iChunk);
-  if (cregs_[ishot].memory_size() == 0)
-    return;
-  switch (subtype) {
-    case DataSubType::list:
-      result.data.add_list(cregs_[ishot].memory_hex(), key);
-      result.metadata.add("creg", "result_types", key);
-      break;
-    case DataSubType::c_accum:
-      result.data.add_accum(1ULL, key, cregs_[ishot].memory_hex());
-      result.metadata.add("creg", "result_types", key);
-      break;
-    default:
-      throw std::runtime_error("Invalid creg data subtype for data key: " + key);
-  }
-  result.metadata.add(subtype, "result_subtypes", key);
-}
-
-template <class state_t>
-template <class T>
-void StateChunk<state_t>::save_data_average(const int_t iChunk, ExperimentResult &result,
-                                       const std::string &key,
-                                       const T& datum, OpType type,
-                                       DataSubType subtype) const {
-  int_t ishot = get_global_shot_index(iChunk);
-  switch (subtype) {
-    case DataSubType::list:
-      result.data.add_list(datum, key);
-      break;
-    case DataSubType::c_list:
-      result.data.add_list(datum, key, cregs_[ishot].memory_hex());
-      break;
-    case DataSubType::accum:
-      result.data.add_accum(datum, key);
-      break;
-    case DataSubType::c_accum:
-      result.data.add_accum(datum, key, cregs_[ishot].memory_hex());
-      break;
-    case DataSubType::average:
-      result.data.add_average(datum, key);
-      break;
-    case DataSubType::c_average:
-      result.data.add_average(datum, key, cregs_[ishot].memory_hex());
-      break;
-    default:
-      throw std::runtime_error("Invalid average data subtype for data key: " + key);
-  }
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(subtype, "result_subtypes", key);
-}
-
-template <class state_t>
-template <class T>
-void StateChunk<state_t>::save_data_average(const int_t iChunk, ExperimentResult &result,
-                                       const std::string &key,
-                                       T&& datum, OpType type,
-                                       DataSubType subtype) const {
-  int_t ishot = get_global_shot_index(iChunk);
-  switch (subtype) {
-    case DataSubType::list:
-      result.data.add_list(std::move(datum), key);
-      break;
-    case DataSubType::c_list:
-      result.data.add_list(std::move(datum), key, cregs_[ishot].memory_hex());
-      break;
-    case DataSubType::accum:
-      result.data.add_accum(std::move(datum), key);
-      break;
-    case DataSubType::c_accum:
-      result.data.add_accum(std::move(datum), key, cregs_[ishot].memory_hex());
-      break;
-    case DataSubType::average:
-      result.data.add_average(std::move(datum), key);
-      break;
-    case DataSubType::c_average:
-      result.data.add_average(std::move(datum), key, cregs_[ishot].memory_hex());
-      break;
-    default:
-      throw std::runtime_error("Invalid average data subtype for data key: " + key);
-  }
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(subtype, "result_subtypes", key);
-}
-
-template <class state_t>
-template <class T>
-void StateChunk<state_t>::save_data_pershot(const int_t iChunk, ExperimentResult &result,
-                                       const std::string &key,
-                                       const T& datum, OpType type,
-                                       DataSubType subtype) const {
-  int_t ishot = get_global_shot_index(iChunk);
-  switch (subtype) {
-  case DataSubType::single:
-    result.data.add_single(datum, key);
-    break;
-  case DataSubType::c_single:
-    result.data.add_single(datum, key, cregs_[ishot].memory_hex());
-    break;
-  case DataSubType::list:
-    result.data.add_list(datum, key);
-    break;
-  case DataSubType::c_list:
-    result.data.add_list(datum, key, cregs_[ishot].memory_hex());
-    break;
-  default:
-    throw std::runtime_error("Invalid pershot data subtype for data key: " + key);
-  }
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(subtype, "result_subtypes", key);
-}
-
-template <class state_t>
-template <class T>
-void StateChunk<state_t>::save_data_pershot(const int_t iChunk, ExperimentResult &result, 
-                                       const std::string &key,
-                                       T&& datum, OpType type,
-                                       DataSubType subtype) const {
-  int_t ishot = get_global_shot_index(iChunk);
-  switch (subtype) {
-    case DataSubType::single:
-      result.data.add_single(std::move(datum), key);
-      break;
-    case DataSubType::c_single:
-      result.data.add_single(std::move(datum), key, cregs_[ishot].memory_hex());
-      break;
-    case DataSubType::list:
-      result.data.add_list(std::move(datum), key);
-      break;
-    case DataSubType::c_list:
-      result.data.add_list(std::move(datum), key, cregs_[ishot].memory_hex());
-      break;
-    default:
-      throw std::runtime_error("Invalid pershot data subtype for data key: " + key);
-  }
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(subtype, "result_subtypes", key);
-}
-
-template <class state_t>
-template <class T>
-void StateChunk<state_t>::save_data_single(ExperimentResult &result,
-                                      const std::string &key,
-                                      const T& datum, OpType type) const {
-  result.data.add_single(datum, key);
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(DataSubType::single, "result_subtypes", key);
-}
-
-template <class state_t>
-template <class T>
-void StateChunk<state_t>::save_data_single(ExperimentResult &result,
-                                      const std::string &key,
-                                      T&& datum, OpType type) const {
-  result.data.add_single(std::move(datum), key);
-  result.metadata.add(type, "result_types", key);
-  result.metadata.add(DataSubType::single, "result_subtypes", key);
 }
 
 template <class state_t>
@@ -1472,7 +1223,7 @@ void StateChunk<state_t>::snapshot_creg_memory(const int_t iChunk, const Operati
   int_t ishot = get_global_shot_index(iChunk);
   result.legacy_data.add_pershot_snapshot(name,
                                op.string_params[0],
-                               cregs_[ishot].memory_hex());
+                               BaseState::cregs_[ishot].memory_hex());
 }
 
 
@@ -1484,7 +1235,7 @@ void StateChunk<state_t>::snapshot_creg_register(const int_t iChunk, const Opera
   int_t ishot = get_global_shot_index(iChunk);
   result.legacy_data.add_pershot_snapshot(name,
                                op.string_params[0],
-                               cregs_[ishot].register_hex());
+                               BaseState::cregs_[ishot].register_hex());
 }
 
 
@@ -1514,23 +1265,9 @@ void StateChunk<state_t>::apply_save_expval(const int_t iChunk, const Operations
     std::vector<double> expval_var(2);
     expval_var[0] = expval;  // mean
     expval_var[1] = sq_expval - expval * expval;  // variance
-    save_data_average(iChunk, result, op.string_params[0], expval_var, op.type, op.save_type);
+    result.save_data_average(BaseState::cregs_[get_global_shot_index(iChunk)], op.string_params[0], expval_var, op.type, op.save_type);
   } else {
-    save_data_average(iChunk, result, op.string_params[0], expval, op.type, op.save_type);
-  }
-}
-
-template <class state_t>
-void StateChunk<state_t>::save_count_data(ExperimentResult& result,bool save_memory)
-{
-  for(int_t i=0;i<cregs_.size();i++){
-    if (cregs_[i].memory_size() > 0) {
-      std::string memory_hex = cregs_[i].memory_hex();
-      result.data.add_accum(static_cast<uint_t>(1ULL), "counts", memory_hex);
-      if(save_memory) {
-        result.data.add_list(std::move(memory_hex), "memory");
-      }
-    }
+    result.save_data_average(BaseState::cregs_[get_global_shot_index(iChunk)], op.string_params[0], expval, op.type, op.save_type);
   }
 }
 
@@ -2504,20 +2241,20 @@ void StateChunk<state_t>::gather_creg_memory(void)
 
   if(distributed_procs_ == 1)
     return;
-  if(cregs_[0].memory_size() == 0)
+  if(BaseState::cregs_[0].memory_size() == 0)
     return;
 
   //number of 64-bit integers per memory
-  n64 = (cregs_[0].memory_size() + 63) >> 6;
+  n64 = (BaseState::cregs_[0].memory_size() + 63) >> 6;
 
   reg_t bin_memory(n64*num_local_chunks_,0);
   //compress memory string to binary
 #pragma omp parallel for private(i,j,i64,ibit)
   for(i=0;i<num_local_chunks_;i++){
-    for(j=0;j<cregs_[0].memory_size();j++){
+    for(j=0;j<BaseState::cregs_[0].memory_size();j++){
       i64 = j >> 6;
       ibit = j & 63;
-      if(cregs_[global_chunk_index_ + i].creg_memory()[j] == '1'){
+      if(BaseState::cregs_[global_chunk_index_ + i].creg_memory()[j] == '1'){
         bin_memory[i*n64 + i64] |= (1ull << ibit);
       }
     }
@@ -2538,13 +2275,13 @@ void StateChunk<state_t>::gather_creg_memory(void)
   //store gathered memory
 #pragma omp parallel for private(i,j,i64,ibit)
   for(i=0;i<num_global_chunks_;i++){
-    for(j=0;j<cregs_[0].memory_size();j++){
+    for(j=0;j<BaseState::cregs_[0].memory_size();j++){
       i64 = j >> 6;
       ibit = j & 63;
       if(((recv[i*n64 + i64] >> ibit) & 1) == 1)
-        cregs_[i].creg_memory()[j] = '1';
+        BaseState::cregs_[i].creg_memory()[j] = '1';
       else
-        cregs_[i].creg_memory()[j] = '0';
+        BaseState::cregs_[i].creg_memory()[j] = '0';
     }
   }
 #endif

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -33,7 +33,7 @@
 
 namespace AER {
 
-namespace Base {
+namespace QuantumState {
 
 #define STATE_APPLY_TO_ALL_CHUNKS     0
 

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -709,7 +709,7 @@ void QubitVector<data_t>::check_checkpoint() const {
 
 template <typename data_t>
 QubitVector<data_t>::QubitVector(size_t num_qubits, std::complex<data_t>* data, bool copy)
-  : num_qubits_(num_qubits), data_(data), checkpoint_(0) {
+  : num_qubits_(num_qubits), data_size_(BITS[num_qubits]), data_(data), checkpoint_(0) {
     set_transformer_method();
     if (copy) {
       checkpoint();

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -67,6 +67,7 @@ public:
   QubitVector();
   explicit QubitVector(size_t num_qubits);
   virtual ~QubitVector();
+  QubitVector(size_t num_qubits, std::complex<data_t>* data);
   QubitVector(const QubitVector& obj) {};
   QubitVector &operator=(const QubitVector& obj) {};
 
@@ -707,11 +708,17 @@ void QubitVector<data_t>::check_checkpoint() const {
 //------------------------------------------------------------------------------
 
 template <typename data_t>
+QubitVector<data_t>::QubitVector(size_t num_qubits, std::complex<data_t>* data)
+  : num_qubits_(num_qubits), data_(data), checkpoint_(0) {
+    set_transformer_method();
+}
+
+template <typename data_t>
 QubitVector<data_t>::QubitVector(size_t num_qubits)
   : num_qubits_(0), data_(nullptr), checkpoint_(0) {
     set_num_qubits(num_qubits);
     set_transformer_method();
-  }
+}
 
 template <typename data_t>
 QubitVector<data_t>::QubitVector() : QubitVector(0) {}

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -67,7 +67,7 @@ public:
   QubitVector();
   explicit QubitVector(size_t num_qubits);
   virtual ~QubitVector();
-  QubitVector(size_t num_qubits, std::complex<data_t>* data);
+  QubitVector(size_t num_qubits, std::complex<data_t>* data, bool copy=false);
   QubitVector(const QubitVector& obj) {};
   QubitVector &operator=(const QubitVector& obj) {};
 
@@ -708,9 +708,14 @@ void QubitVector<data_t>::check_checkpoint() const {
 //------------------------------------------------------------------------------
 
 template <typename data_t>
-QubitVector<data_t>::QubitVector(size_t num_qubits, std::complex<data_t>* data)
+QubitVector<data_t>::QubitVector(size_t num_qubits, std::complex<data_t>* data, bool copy)
   : num_qubits_(num_qubits), data_(data), checkpoint_(0) {
     set_transformer_method();
+    if (copy) {
+      checkpoint();
+      data_ = checkpoint_;
+      checkpoint_ = 0;
+    }
 }
 
 template <typename data_t>
@@ -919,7 +924,6 @@ void QubitVector<data_t>::checkpoint() {
   for (int_t k = 0; k < END; ++k)
     checkpoint_[k] = data_[k];
 }
-
 
 template <typename data_t>
 void QubitVector<data_t>::revert(bool keep) {

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -854,12 +854,12 @@ void State<statevec_t>::apply_save_probs(const int_t iChunk, const Operations::O
   auto probs = measure_probs(iChunk, op.qubits);
   if (op.type == Operations::OpType::save_probs_ket) {
     // Convert to ket dict
-    BaseState::save_data_average(iChunk, result, op.string_params[0],
-                                 Utils::vec2ket(probs, json_chop_threshold_, 16),
-                                 op.type, op.save_type);
+    result.save_data_average(BaseState::chunk_creg(iChunk), op.string_params[0],
+                             Utils::vec2ket(probs, json_chop_threshold_, 16),
+                             op.type, op.save_type);
   } else {
-    BaseState::save_data_average(iChunk, result, op.string_params[0],
-                                 std::move(probs), op.type, op.save_type);
+    result.save_data_average(BaseState::chunk_creg(iChunk), op.string_params[0],
+                             std::move(probs), op.type, op.save_type);
   }
 }
 
@@ -1032,10 +1032,10 @@ void State<statevec_t>::apply_save_statevector(const int_t iChunk, const Operati
                       : op.string_params[0];
 
   if (last_op) {
-    BaseState::save_data_pershot(iChunk, result, key, move_to_vector(iChunk),
+    result.save_data_pershot(BaseState::chunk_creg(iChunk), key, move_to_vector(iChunk),
                                  OpType::save_statevec, op.save_type);
   } else {
-    BaseState::save_data_pershot(iChunk, result, key, copy_to_vector(iChunk),
+    result.save_data_pershot(BaseState::chunk_creg(iChunk), key, copy_to_vector(iChunk),
                                  OpType::save_statevec, op.save_type);
   }
 }
@@ -1058,7 +1058,7 @@ void State<statevec_t>::apply_save_statevector_dict(const int_t iChunk, const Op
         result_state_ket.insert({key, vec[k]});
       }
     }
-    BaseState::save_data_pershot(iChunk, result, op.string_params[0],
+    result.save_data_pershot(BaseState::chunk_creg(iChunk), op.string_params[0],
                                  std::move(result_state_ket), op.type, op.save_type);
   }
   else{
@@ -1067,7 +1067,7 @@ void State<statevec_t>::apply_save_statevector_dict(const int_t iChunk, const Op
     for (auto const& it : state_ket){
       result_state_ket[it.first] = it.second;
     }
-    BaseState::save_data_pershot(iChunk, result, op.string_params[0],
+    result.save_data_pershot(BaseState::chunk_creg(iChunk), op.string_params[0],
                                  std::move(result_state_ket), op.type, op.save_type);
   }
 }
@@ -1105,8 +1105,8 @@ void State<statevec_t>::apply_save_density_matrix(const int_t iChunk, const Oper
     reduced_state = density_matrix(iChunk, op.qubits);
   }
 
-  BaseState::save_data_average(iChunk, result, op.string_params[0],
-                               std::move(reduced_state), op.type, op.save_type);
+  result.save_data_average(BaseState::chunk_creg(iChunk), op.string_params[0],
+                           std::move(reduced_state), op.type, op.save_type);
 }
 
 template <class statevec_t>
@@ -1139,7 +1139,7 @@ void State<statevec_t>::apply_save_amplitudes(const int_t iChunkIn, const Operat
 #endif
       }
     }
-    BaseState::save_data_pershot(iChunkIn, result, op.string_params[0],
+    result.save_data_pershot(BaseState::chunk_creg(iChunkIn), op.string_params[0],
                                  std::move(amps), op.type, op.save_type);
   }
   else{
@@ -1161,8 +1161,8 @@ void State<statevec_t>::apply_save_amplitudes(const int_t iChunkIn, const Operat
       BaseState::reduce_sum(amps_sq);
 #endif
     }
-    BaseState::save_data_average(iChunkIn, result, op.string_params[0],
-                                 std::move(amps_sq), op.type, op.save_type);
+   result.save_data_average(BaseState::chunk_creg(iChunkIn), op.string_params[0],
+                            std::move(amps_sq), op.type, op.save_type);
   }
 }
 

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -100,9 +100,9 @@ enum class SnapshotDataType { average, average_var, pershot };
 //=========================================================================
 
 template <class statevec_t = QV::QubitVector<double>>
-class State : public Base::StateChunk<statevec_t> {
+class State : public QuantumState::StateChunk<statevec_t> {
 public:
-  using BaseState = Base::StateChunk<statevec_t>;
+  using BaseState = QuantumState::StateChunk<statevec_t>;
 
   State() : BaseState(StateOpSet) {}
   virtual ~State() = default;

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -66,9 +66,9 @@ enum class Snapshots { superop };
 //=========================================================================
 
 template <class data_t = QV::Superoperator<double>>
-class State : public Base::State<data_t> {
+class State : public QuantumState::State<data_t> {
 public:
-  using BaseState = Base::State<data_t>;
+  using BaseState = QuantumState::State<data_t>;
 
   State() : BaseState(StateOpSet) {}
   virtual ~State() = default;
@@ -558,15 +558,15 @@ void State<statevec_t>::apply_save_state(const Operations::Op &op,
                       ? "superop"
                       : op.string_params[0];
   if (last_op) {
-    BaseState::save_data_pershot(result, key,
-                                 BaseState::qreg_.move_to_matrix(),
-                                 Operations::OpType::save_superop,
-                                 op.save_type);
+    result.save_data_pershot(BaseState::creg(), key,
+                             BaseState::qreg_.move_to_matrix(),
+                             Operations::OpType::save_superop,
+                             op.save_type);
   } else {
-    BaseState::save_data_pershot(result, key,
-                                 BaseState::qreg_.copy_to_matrix(),
-                                 Operations::OpType::save_superop,
-                                 op.save_type);
+    result.save_data_pershot(BaseState::creg(), key,
+                             BaseState::qreg_.copy_to_matrix(),
+                             Operations::OpType::save_superop,
+                             op.save_type);
   }
 }
 

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -247,7 +247,7 @@ void State<data_t>::apply_op(const Operations::Op &op,
                              ExperimentResult &result,
                              RngEngine &rng,
                              bool final_op) {
-  if (BaseState::creg_.check_conditional(op)) {
+  if (BaseState::creg().check_conditional(op)) {
     switch (op.type) {
       case Operations::OpType::barrier:
       case Operations::OpType::qerror_loc:
@@ -256,10 +256,10 @@ void State<data_t>::apply_op(const Operations::Op &op,
         apply_gate(op);
         break;
       case Operations::OpType::bfunc:
-          BaseState::creg_.apply_bfunc(op);
+          BaseState::creg().apply_bfunc(op);
         break;
       case Operations::OpType::roerror:
-          BaseState::creg_.apply_roerror(op, rng);
+          BaseState::creg().apply_roerror(op, rng);
         break;
       case Operations::OpType::reset:
         apply_reset(op.qubits);

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -836,11 +836,11 @@ void State<unitary_matrix_t>::apply_save_unitary(const int_t iChunk, const Opera
   std::string key = (op.string_params[0] == "_method_") ? "unitary" : op.string_params[0];
 
   if (last_op) {
-    BaseState::save_data_pershot(iChunk, result, key, move_to_matrix(iChunk),
+    result.save_data_pershot(BaseState::chunk_creg(iChunk), key, move_to_matrix(iChunk),
                                  Operations::OpType::save_unitary,
                                  op.save_type);
   } else {
-    BaseState::save_data_pershot(iChunk, result, key, copy_to_matrix(iChunk),
+    result.save_data_pershot(BaseState::chunk_creg(iChunk), key, copy_to_matrix(iChunk),
                                  Operations::OpType::save_unitary,
                                  op.save_type);
   }

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -65,9 +65,9 @@ enum class Gates {
 //=========================================================================
 
 template <class unitary_matrix_t = QV::UnitaryMatrix<double>>
-class State : public virtual Base::StateChunk<unitary_matrix_t> {
+class State : public virtual QuantumState::StateChunk<unitary_matrix_t> {
 public:
-  using BaseState = Base::StateChunk<unitary_matrix_t>;
+  using BaseState = QuantumState::StateChunk<unitary_matrix_t>;
 
   State() : BaseState(StateOpSet) {}
   virtual ~State() = default;

--- a/test/runtime/runtime_sample.c
+++ b/test/runtime/runtime_sample.c
@@ -13,7 +13,7 @@ int main() {
 
   printf("%d-qubits GHZ\n", num_of_qubits);
 
-  void* state = aer_state_initialize();
+  void* state = aer_state();
 
   aer_state_configure(state, "method", "statevector");
   aer_state_configure(state, "device", "CPU");
@@ -21,6 +21,8 @@ int main() {
 
   int start_qubit = aer_allocate_qubits(state, num_of_qubits);
   
+  aer_state_initialize(state);
+
   int* qubits = (int*) malloc(sizeof(int) * num_of_qubits);
   for (int i = 0; i < num_of_qubits; ++i)
     qubits[i] = start_qubit + i;
@@ -29,19 +31,19 @@ int main() {
   for (int i = 0; i < num_of_qubits - 1; ++i)
       aer_apply_cx(state, qubits[i], qubits[i + 1]);
 
-  printf("non-zero probabilities and amplitudes:\n", num_of_qubits);
+  printf("non-zero probabilities and amplitudes:\n");
   for (uint_t i = 0; i < (1UL << num_of_qubits); ++i) {
     double prob = aer_probability(state, i);
     if (prob > 0.0) {
       double complex amp = aer_amplitude(state, i);
-      printf("  %08x %lf [%lf, %lf]\n", i, prob, creal(amp), cimag(amp));
+      printf("  %08llx %lf [%lf, %lf]\n", i, prob, creal(amp), cimag(amp));
     }
   }
   
-  printf("all the amplitudes:\n", num_of_qubits);
+  printf("all the amplitudes:\n");
   double complex* sv = aer_release_statevector(state);
   for (uint_t i = 0; i < (1UL << num_of_qubits); ++i) {
-      printf("  %08x [%lf, %lf]\n", i, creal(sv[i]), cimag(sv[i]));
+      printf("  %08llx [%lf, %lf]\n", i, creal(sv[i]), cimag(sv[i]));
   }
 
   aer_state_finalize(state);

--- a/test/runtime/runtime_sample.c
+++ b/test/runtime/runtime_sample.c
@@ -1,0 +1,53 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <complex.h>
+
+#include "aer_runtime_api.h"
+
+typedef uint_fast64_t uint_t; 
+
+int main() {
+  int num_of_qubits = 8;
+
+  printf("%d-qubits GHZ\n", num_of_qubits);
+
+  void* state = aer_state_initialize();
+
+  aer_state_configure(state, "method", "statevector");
+  aer_state_configure(state, "device", "CPU");
+  aer_state_configure(state, "precision", "double");
+
+  int start_qubit = aer_allocate_qubits(state, num_of_qubits);
+  
+  int* qubits = (int*) malloc(sizeof(int) * num_of_qubits);
+  for (int i = 0; i < num_of_qubits; ++i)
+    qubits[i] = start_qubit + i;
+
+  aer_apply_h(state, qubits[0]);
+  for (int i = 0; i < num_of_qubits - 1; ++i)
+      aer_apply_cx(state, qubits[i], qubits[i + 1]);
+
+  printf("non-zero probabilities and amplitudes:\n", num_of_qubits);
+  for (uint_t i = 0; i < (1UL << num_of_qubits); ++i) {
+    double prob = aer_probability(state, i);
+    if (prob > 0.0) {
+      double complex amp = aer_amplitude(state, i);
+      printf("  %08x %lf [%lf, %lf]\n", i, prob, creal(amp), cimag(amp));
+    }
+  }
+  
+  printf("all the amplitudes:\n", num_of_qubits);
+  double complex* sv = aer_release_statevector(state);
+  for (uint_t i = 0; i < (1UL << num_of_qubits); ++i) {
+      printf("  %08x [%lf, %lf]\n", i, creal(sv[i]), cimag(sv[i]));
+  }
+
+  aer_state_finalize(state);
+
+  free(qubits);
+  free(sv);
+
+  return 1;
+}

--- a/test/terra/states/test_aer_state.py
+++ b/test/terra/states/test_aer_state.py
@@ -1,0 +1,465 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019, 2020, 2021, 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Integration Tests for Parameterized Qobj execution, testing qasm_simulator,
+statevector_simulator, and expectation value snapshots.
+"""
+
+import unittest
+from math import pi
+import numpy as np
+
+from qiskit.circuit import QuantumCircuit, Gate
+from qiskit.quantum_info.random import random_unitary
+from qiskit.quantum_info.states.random import random_statevector
+from qiskit.providers.aer import AerSimulator
+
+from test.terra import common
+from qiskit.providers.aer.aererror import AerError
+
+class TestAerState(common.QiskitAerTestCase):
+    """AerState tests"""
+
+    def test_load_library(self):
+        """Test load library."""
+        from qiskit.providers.aer.backends.controller_wrappers import AerStateWrapper
+        state_wrapper = AerStateWrapper()
+
+    def test_generate_aer_state(self):
+        """Test generation of AerState"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+        state = AerState()
+
+    def test_move_from_aer_state(self):
+        """Test move of aer state to python"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+        state = AerState()
+        state.allocate_qubits(4)
+        state.initialize()
+        sv = state.move_to_ndarray()
+        state.close()
+
+    def test_error_reuse_aer_state(self):
+        """Test reuse AerState after move of aer state to python"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+        state = AerState()
+        state.allocate_qubits(4)
+        state.initialize()
+        sv = state.move_to_ndarray()
+
+        try:
+            state.allocate_qubits(4)
+            self.fail("do not reach here")
+        except:
+            pass
+
+        state.close()
+
+    def test_initialize_statevector(self):
+        """Test initialization of AerState with statevector"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        state1 = AerState()
+        state1.allocate_qubits(4)
+        state1.initialize()
+        sv1 = state1.move_to_ndarray()
+        sv1[0] = complex(0., 0.)
+        sv1[len(sv1) - 1] = complex(1., 0.)
+        state1.close()
+
+        for idx in range(len(sv1) - 1):
+            self.assertEqual(sv1[idx], complex(0., 0.))
+        self.assertEqual(sv1[len(sv1) - 1], complex(1., 0.))
+
+        state2 = AerState()
+        state2.initialize(sv1)
+        sv2 = state2.move_to_ndarray()
+        state2.close()
+
+        for idx in range(len(sv2) - 2):
+            self.assertEqual(sv2[idx], complex(0., 0.))
+        self.assertEqual(sv2[len(sv2) - 1], complex(1., 0.))
+
+
+    def test_fail_initialize_statevector_with_data_twice(self):
+        """Test initialization of AerState with statevector"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        state1 = AerState()
+        state1.allocate_qubits(4)
+        state1.initialize()
+        sv1 = state1.move_to_ndarray()
+        state1.close()
+
+        state2 = AerState()
+        state2.initialize(sv1)
+
+        # sv1 has already be used by state2
+        state3 = AerState()
+        try:
+            # this must be failed
+            state3.initialize(sv1)
+            self.fail("do not reach here")
+        except AerError:
+            pass
+        
+        state2.close()
+        state3.initialize(sv1) # must be successful after clear()
+
+        # sv1 has already be used by state3
+        state4 = AerState()
+        try:
+            # this must be failed
+            state4.initialize(sv1)
+            self.fail("do not reach here")
+        except AerError:
+            pass
+
+        sv3 = state3.move_to_ndarray()
+        self.assertEqual(id(sv1), id(sv3))
+
+        state4.initialize(sv1) # must be successful after move_to_ndarray() in owner
+
+        state3.close()
+        state4.close()
+
+
+    def test_initialize_with_normal_ndarray(self):
+        """Test initialization of AerState with normal ndarray"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        sv1 = np.zeros((2 ** 4), dtype=np.complex128)
+        sv1[len(sv1) - 1] = 1.
+
+        state1 = AerState()
+        state1.initialize(sv1)
+
+        sv2 = state1.move_to_ndarray()
+        self.assertTrue(id(sv1) != id(sv2))
+        self.assertEqual(len(sv1), len(sv2))
+        self.assertEqual(sv1[len(sv1) - 1], sv2[len(sv2) - 1])
+
+        state1.close()
+
+    def test_appply_unitary(self):
+        """Test applying a unitary matrix"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        unitary_1 = random_unitary(2, seed=1111)
+        unitary_2 = random_unitary(4, seed=2222)
+        unitary_3 = random_unitary(8, seed=3333)
+
+        circuit = QuantumCircuit(5)
+        circuit.unitary(unitary_1, [0])
+        circuit.unitary(unitary_2, [1, 2])
+        circuit.unitary(unitary_3, [3, 4, 0])
+        circuit.save_statevector()
+
+        aer_simulator = AerSimulator(method='statevector')
+        result = aer_simulator.run(circuit).result()
+        expected = result.get_statevector(0)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.initialize()
+
+        state.apply_unitary([0], unitary_1)
+        state.apply_unitary([1, 2], unitary_2)
+        state.apply_unitary([3, 4, 0], unitary_3)
+        actual = state.move_to_ndarray()
+
+        for i, amp in enumerate(actual):
+            self.assertAlmostEqual(expected[i], amp)
+
+
+    def test_appply_multiplexer(self):
+        """Test applying a multiplexer operation"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        class CustomMultiplexer(Gate):
+
+            def validate_parameter(self, param):
+                return param
+
+        def multiplexer_multi_controlled_x(num_control):
+            identity = np.array(np.array([[1, 0], [0, 1]], dtype=complex))
+            x_gate = np.array(np.array([[0, 1], [1, 0]], dtype=complex))
+            num_qubits = num_control + 1
+            multiplexer = CustomMultiplexer('multiplexer',
+                    num_qubits, (2 ** num_control-1) * [identity] + [x_gate],
+            )
+            return multiplexer
+
+        multiplexr_1 = multiplexer_multi_controlled_x(1)
+        multiplexr_2 = multiplexer_multi_controlled_x(2)
+        multiplexr_3 = multiplexer_multi_controlled_x(3)
+
+        init_state = random_statevector(2**5, seed=111)
+
+        circuit = QuantumCircuit(5)
+        circuit.initialize(init_state, [0, 1, 2, 3, 4])
+        circuit.append(multiplexr_1, [0, 1])
+        circuit.append(multiplexr_2, [1, 2, 3])
+        circuit.append(multiplexr_3, [3, 4, 0, 1])
+        circuit.save_statevector()
+
+        aer_simulator = AerSimulator(method='statevector')
+        result = aer_simulator.run(circuit).result()
+        expected = result.get_statevector(0)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.initialize(init_state.data)
+
+        state.apply_multiplexer([1], [0], multiplexr_1.params)
+        state.apply_multiplexer([2, 3], [1], multiplexr_2.params)
+        state.apply_multiplexer([4, 0, 1], [3], multiplexr_3.params)
+        actual = state.move_to_ndarray()
+
+        for i, amp in enumerate(actual):
+            self.assertAlmostEqual(expected[i], amp)
+
+    def test_appply_diagonal(self):
+        """Test applying a diagonal gate"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        diag_1 = [1, -1]
+        diag_2 = [1, -1, -1, 1]
+        diag_3 = [1, -1, 1, -1, 1, -1, 1, -1]
+
+        init_state = random_statevector(2**5, seed=111)
+
+        circuit = QuantumCircuit(5)
+        circuit.initialize(init_state, [0, 1, 2, 3, 4])
+        circuit.diagonal(diag_1, [0])
+        circuit.diagonal(diag_2, [1, 2])
+        circuit.diagonal(diag_3, [3, 4, 0])
+        circuit.save_statevector()
+
+        aer_simulator = AerSimulator(method='statevector')
+        result = aer_simulator.run(circuit).result()
+        expected = result.get_statevector(0)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.initialize(init_state.data)
+
+        state.apply_diagonal([0], diag_1)
+        state.apply_diagonal([1, 2], diag_2)
+        state.apply_diagonal([3, 4, 0], diag_3)
+        actual = state.move_to_ndarray()
+
+        for i, amp in enumerate(actual):
+            self.assertAlmostEqual(expected[i], amp)
+
+
+    def test_appply_mcx(self):
+        """Test applying a mcx gate"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        class MCX(Gate):
+
+            def validate_parameter(self, param):
+                return param
+
+        def mcx(num_control):
+            return MCX('mcx', num_control + 1, [])
+
+        init_state = random_statevector(2**5, seed=111)
+
+        circuit = QuantumCircuit(5)
+        circuit.initialize(init_state, [0, 1, 2, 3, 4])
+        circuit.append(mcx(1), [0, 1])
+        circuit.append(mcx(2), [1, 2, 3])
+        circuit.append(mcx(3), [4, 0, 1, 2])
+        circuit.save_statevector()
+
+        aer_simulator = AerSimulator(method='statevector')
+        result = aer_simulator.run(circuit).result()
+        expected = result.get_statevector(0)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.initialize(init_state.data)
+
+        state.apply_mcx([0], 1)
+        state.apply_mcx([1, 2], 3)
+        state.apply_mcx([4, 0, 1], 2)
+        actual = state.move_to_ndarray()
+
+        for i, amp in enumerate(actual):
+            self.assertAlmostEqual(expected[i], amp)
+
+    def test_appply_mcy(self):
+        """Test applying a mcy gate"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        class MCY(Gate):
+
+            def validate_parameter(self, param):
+                return param
+
+        def mcy(num_control):
+            return MCY('mcy', num_control + 1, [])
+
+        init_state = random_statevector(2**5, seed=111)
+
+        circuit = QuantumCircuit(5)
+        circuit.initialize(init_state, [0, 1, 2, 3, 4])
+        circuit.append(mcy(1), [0, 1])
+        circuit.append(mcy(2), [1, 2, 3])
+        circuit.append(mcy(3), [4, 0, 1, 2])
+        circuit.save_statevector()
+
+        aer_simulator = AerSimulator(method='statevector')
+        result = aer_simulator.run(circuit).result()
+        expected = result.get_statevector(0)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.initialize(init_state.data)
+
+        state.apply_mcy([0], 1)
+        state.apply_mcy([1, 2], 3)
+        state.apply_mcy([4, 0, 1], 2)
+        actual = state.move_to_ndarray()
+
+        for i, amp in enumerate(actual):
+            self.assertAlmostEqual(expected[i], amp)
+
+    def test_appply_mcz(self):
+        """Test applying a mcz gate"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        class MCZ(Gate):
+
+            def validate_parameter(self, param):
+                return param
+
+        def mcz(num_control):
+            return MCZ('mcz', num_control + 1, [])
+
+        init_state = random_statevector(2**5, seed=111)
+
+        circuit = QuantumCircuit(5)
+        circuit.initialize(init_state, [0, 1, 2, 3, 4])
+        circuit.append(mcz(1), [0, 1])
+        circuit.append(mcz(2), [1, 2, 3])
+        circuit.append(mcz(3), [4, 0, 1, 2])
+        circuit.save_statevector()
+
+        aer_simulator = AerSimulator(method='statevector')
+        result = aer_simulator.run(circuit).result()
+        expected = result.get_statevector(0)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.initialize(init_state.data)
+
+        state.apply_mcz([0], 1)
+        state.apply_mcz([1, 2], 3)
+        state.apply_mcz([4, 0, 1], 2)
+        actual = state.move_to_ndarray()
+
+        for i, amp in enumerate(actual):
+            self.assertAlmostEqual(expected[i], amp)
+
+    def test_appply_reset(self):
+        """Test applying a rest gate"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        seed = 1234
+        init_state = random_statevector(2**5, seed=111)
+
+        circuit = QuantumCircuit(5)
+        circuit.initialize(init_state, [0, 1, 2, 3, 4])
+        circuit.reset(0)
+        circuit.reset([2, 4])
+        circuit.save_statevector()
+
+        aer_simulator = AerSimulator(method='statevector', seed_simulator=seed)
+        result = aer_simulator.run(circuit).result()
+        expected = result.get_statevector(0)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.configure('seed_simulator', seed)
+        state.initialize(init_state.data)
+
+        state.apply_reset([0])
+        state.apply_reset([2, 4])
+        actual = state.move_to_ndarray()
+
+        for i, amp in enumerate(actual):
+            self.assertAlmostEqual(expected[i], amp)
+
+    def test_appply_measure(self):
+        """Test applying a measure"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        seed = 1234
+        init_state = random_statevector(2**5, seed=111)
+
+        circuit = QuantumCircuit(5, 1)
+        circuit.initialize(init_state, [0, 1, 2, 3, 4])
+        circuit.measure(0, 0)
+        circuit.save_statevector()
+
+        aer_simulator = AerSimulator(method='statevector', seed_simulator=seed)
+        result = aer_simulator.run(circuit).result()
+        expected = result.get_statevector(0)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.configure('seed_simulator', seed)
+        state.initialize(init_state.data)
+
+        state.apply_measure([0])
+        actual = state.move_to_ndarray()
+
+        for i, amp in enumerate(actual):
+            self.assertAlmostEqual(expected[i], amp)
+
+    def test_probability(self):
+        """Test applying a measure"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        init_state = random_statevector(2**5, seed=111)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.initialize(init_state.data)
+
+        expected = init_state.probabilities()
+
+        for idx in range(0, 2**5):
+            self.assertAlmostEqual(state.probability(idx), expected[idx])
+
+    def test_probabilities(self):
+        """Test applying a measure"""
+        from qiskit.providers.aer.quantum_info.states.aer_state import AerState
+
+        init_state = random_statevector(2**5, seed=111)
+
+        state = AerState()
+        state.allocate_qubits(5)
+        state.initialize(init_state.data)
+
+        expected = init_state.probabilities()
+        actual = state.probabilities()
+
+        for idx in range(0, 2**5):
+            self.assertAlmostEqual(actual[idx], expected[idx])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -95,5 +95,18 @@ class TestAerStatevector(common.QiskitAerTestCase):
         self.assertNotEqual(id(state1._data), id(state2._data))
 
 
+    def test_initialize_with_ndarray(self):
+        """Test ndarray initialization """
+        from qiskit.providers.aer.quantum_info.states import AerStatevector
+        circ = QuantumVolume(5, seed=1111)
+        expected = Statevector(circ)
+        state = AerStatevector(expected.data)
+
+        self.assertTrue(state.aer())
+
+        for e, s in zip(expected, state):
+            self.assertAlmostEqual(e, s)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -67,12 +67,32 @@ class TestAerStatevector(common.QiskitAerTestCase):
         from qiskit.providers.aer.quantum_info.states import AerStatevector
         circ1 = QuantumVolume(5, seed=1111)
         circ2 = circ1.compose(circ1)
+        circ3 = circ2.compose(circ1)
 
-        state1 = AerStatevector(circ1).evolve(circ1)
+        state1 = AerStatevector(circ1)
         state2 = AerStatevector(circ2)
+        state3 = AerStatevector(circ3)
+
+        for pa1, pa2 in zip(state1.evolve(circ1), state2):
+            self.assertAlmostEqual(pa1, pa2)
+
+        for pa1, pa2 in zip(state1.evolve(circ1).evolve(circ1), state3):
+            self.assertAlmostEqual(pa1, pa2)
+
+
+    def test_deepcopy(self):
+        """Test deep copy"""
+        import copy
+        from qiskit.providers.aer.quantum_info.states import AerStatevector
+        circ1 = QuantumVolume(5, seed=1111)
+
+        state1 = AerStatevector(circ1)
+        state2 = copy.deepcopy(state1)
 
         for pa1, pa2 in zip(state1, state2):
             self.assertAlmostEqual(pa1, pa2)
+        
+        self.assertNotEqual(id(state1._data), id(state2._data))
 
 
 if __name__ == '__main__':

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -62,6 +62,18 @@ class TestAerStatevector(common.QiskitAerTestCase):
         for pa1, pa2 in zip(state1, state2):
             self.assertAlmostEqual(pa1, pa2)
 
+    def test_evolve(self):
+        """Test method and device properties"""
+        from qiskit.providers.aer.quantum_info.states import AerStatevector
+        circ1 = QuantumVolume(5, seed=1111)
+        circ2 = circ1.compose(circ1)
+
+        state1 = AerStatevector(circ1).evolve(circ1)
+        state2 = AerStatevector(circ2)
+
+        for pa1, pa2 in zip(state1, state2):
+            self.assertAlmostEqual(pa1, pa2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -1,0 +1,51 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019, 2020, 2021, 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Integration Tests for Parameterized Qobj execution, testing qasm_simulator,
+statevector_simulator, and expectation value snapshots.
+"""
+
+import unittest
+from math import pi
+import numpy as np
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.quantum_info.random import random_unitary
+from qiskit.quantum_info.states import Statevector
+from qiskit.circuit.library import QuantumVolume
+from qiskit.providers.aer import AerSimulator
+
+from test.terra import common
+from qiskit.providers.aer.aererror import AerError
+
+class TestAerStatevector(common.QiskitAerTestCase):
+    """AerState tests"""
+
+    def test_generate_aer_statevector(self):
+        """Test generation of Aer's StateVector"""
+        from qiskit.providers.aer.quantum_info.states import AerStatevector
+        circ = QuantumCircuit(5)
+        state = AerStatevector(circ)
+
+    def test_qv(self):
+        """Test generation of Aer's StateVector with QV """
+        from qiskit.providers.aer.quantum_info.states import AerStatevector
+        circ = QuantumVolume(5, seed=1111)
+        state = AerStatevector(circ)
+        expected = Statevector(circ)
+
+        for e, s in zip(expected, state):
+            self.assertAlmostEqual(e, s)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -46,6 +46,22 @@ class TestAerStatevector(common.QiskitAerTestCase):
         for e, s in zip(expected, state):
             self.assertAlmostEqual(e, s)
 
+    def test_method_and_device_properties(self):
+        """Test method and device properties"""
+        from qiskit.providers.aer.quantum_info.states import AerStatevector
+        circ = QuantumVolume(5, seed=1111)
+        state1 = AerStatevector(circ)
+
+        self.assertEqual('statevector', state1.method)
+        self.assertEqual('CPU', state1.device)
+
+        state2 = AerStatevector(circ, method='matrix_product_state')
+        self.assertEqual('matrix_product_state', state2.method)
+        self.assertEqual('CPU', state2.device)
+
+        for pa1, pa2 in zip(state1, state2):
+            self.assertAlmostEqual(pa1, pa2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A new API for shared library and interactive simulator

### Details and comments

This PR adds a new pybind for users to allow interactive access to quantum state.

```
state = AerState()
state.configure('method', 'statevector')
state.configure('device', 'CPU')

state.allocate_qubits(10)

state.apply_unitary([0, 1], random_unitary(2**2))
state.apply_unitary([1, 2], random_unitary(2**2))
state.apply_unitary([2, 3], random_unitary(2**2))
state.apply_unitary([3, 4], random_unitary(2**2))
state.apply_unitary([4, 5], random_unitary(2**2))
state.apply_unitary([5, 6], random_unitary(2**2))
state.apply_unitary([6, 7], random_unitary(2**2))
state.apply_unitary([7, 8], random_unitary(2**2))
state.apply_unitary([8, 9], random_unitary(2**2))
state.apply_unitary([9, 0], random_unitary(2**2))

print(state.sample_measure(10))
# {669: 1, 941: 1, 61: 1, 876: 1, 172: 1, 535: 1, 428: 1, 615: 1, 44: 1, 1014: 1}

state.clear_qubits()
```

All of the methods and devices will be available and `ndarray` of statevector and densitymatrix will be returned with zero-copy. Because the simulator can skip qobj construction and parsing, performance for low-qubits becomes better.

![image](https://user-images.githubusercontent.com/13864484/171134021-3b870a04-825c-4ed0-81c3-ffc9a3763b26.png)
(Note that currently gate fusion is not supported and performance with 16 or more qubits is worse than `AerSimulator`).

In addition, standalone build will produce a shared library `libaer.so`, which wraps `AerState` for C and C++ programs.

- [x] Buffer gates and fuse buffered gates
- [x] Support all the methods
- [x] Support GPUs
- [x] Add tests