### PR TITLE
Pin macOS version in wheel jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macOS-latest", "ubuntu-latest", "windows-2019"]
+        os: ["macos-10.15", "ubuntu-latest", "windows-2019"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
@@ -121,7 +121,7 @@ jobs:
     needs: ["standalone"]
     strategy:
       matrix:
-        os: ["macOS-latest", "ubuntu-latest", "windows-2019"]
+        os: ["macos-10.15", "ubuntu-latest", "windows-2019"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python Python 3.8
@@ -142,7 +142,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macOS-latest"]
+        os: ["macos-10.15"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python Python 3.8

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build qiskit-aer wheels
     strategy:
       matrix:
-        os: ["macOS-latest", "ubuntu-latest", "windows-2019"]
+        os: ["macos-10.15", "ubuntu-latest", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macOS-latest"]
+        os: ["macos-10.15"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python Python 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ before-all = "yum install -y openblas-devel"
 [tool.cibuildwheel.windows]
 environment = { CMAKE_GENERATOR = "Visual Studio 16 2019"}
 
+[tool.cibuildwheel.macos]
+environment = {MACOSX_DEPLOYMENT_TARGET = "10.9"}
+
 [[tool.cibuildwheel.overrides]]
 select = "cp3{7,8,9,10}-manylinux_i686"
 before-all = "yum install -y openblas-devel wget && bash {project}/tools/install_rust.sh"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent version of macOS 11 stopped including the necessary headers
to 10.x compatible builds. This is causing failures in CI and would also
bump our published binaries. To avoid this issue, this commit pins the
macOS version we use in the wheel jobs to the 10.15 image which will
maintain compatibility moving forward.

### Details and comments