### PR TITLE
Fix cache blocking parallelization to support large multi-control gates 

### DIFF
--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -148,9 +148,16 @@ class AerSimulator(AerBackend):
     initialization or with :meth:`set_options`. The list of supported devices
     for the current system can be returned using :meth:`available_devices`.
 
+    For multiple shots simulation, OpenMP threads should be exploited for
+    multi-GPUs. Number of GPUs used for multi-shots is reported in
+    metadata ``gpu_parallel_shots_`` or is batched execution is done reported
+    in metadata ``batched_shots_optimization_parallel_gpus``.
+    For large qubits circuits with multiple GPUs, number of GPUs is reported
+    in metadata ``chunk_parallel_gpus`` in ``cacheblocking``.
+
     If AerSimulator is built with cuStateVec support, cuStateVec APIs are enabled
-    by setting ``cuStateVec_enable=True``. This is experimental implementation
-    based on cuQuantum Beta 2.
+    by setting ``cuStateVec_enable=True``.
+
 
     **Additional Backend Options**
 
@@ -237,6 +244,8 @@ class AerSimulator(AerBackend):
       ``"statevector"``, ``"density_matrix"`` and ``"unitary"``.
       This option should be set when using option ``blocking_enable=True``
       (Default: 0).
+      If multiple GPUs are used for parallelization number of GPUs is
+      reported to ``chunk_parallel_gpus`` in ``cacheblocking`` metadata.
 
     * ``chunk_swap_buffer_qubits`` (int): Sets the number of qubits of
       maximum buffer size (=2^chunk_swap_buffer_qubits) used for multiple
@@ -253,6 +262,8 @@ class AerSimulator(AerBackend):
       on GPUs. If there are multiple GPUs on the system, shots are distributed
       automatically across available GPUs. Also this option distributes multiple
       shots to parallel processes of MPI (Default: True).
+      If multiple GPUs are used for batched exectuion number of GPUs is
+      reported to ``batched_shots_optimization_parallel_gpus`` metadata.
 
     * ``batched_shots_gpu_max_qubits`` (int): This option sets the maximum
       number of qubits for enabling the ``batched_shots_gpu`` option. If the

--- a/releasenotes/notes/fix_cacheblocking__multi_control_gates-f6a7fca4f3db2f61.yaml
+++ b/releasenotes/notes/fix_cacheblocking__multi_control_gates-f6a7fca4f3db2f61.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    This is fix for cache blocking transpiler and chunk parallelization for
+    GPUs or MPI. This fix fixes issue with qubits which has many control or
+    target qubits (> blocking_qubits). From this fix, only target qubits of
+    the multi-controlled gate is cache blocked in blocking_qubits.
+    But it does not support case if number of target qubits is still larger
+    than blocking_qubits (i.e. large unitary matrix multiplication)

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -1499,6 +1499,13 @@ void Controller::run_circuit_without_sampled_noise(Circuit &circ,
       for (auto &res : par_results) {
         result.combine(std::move(res));
       }
+
+      if (sim_device_name_ == "GPU"){
+        if(parallel_shots_ >= num_gpus_)
+          result.metadata.add(num_gpus_, "gpu_parallel_shots_");
+        else
+          result.metadata.add(parallel_shots_, "gpu_parallel_shots_");
+      }
     }
     // Add measure sampling metadata
     result.metadata.add(true, "measure_sampling");
@@ -1559,6 +1566,12 @@ void Controller::run_circuit_without_sampled_noise(Circuit &circ,
 
       for (auto &res : par_results) {
         result.combine(std::move(res));
+      }
+      if (sim_device_name_ == "GPU"){
+        if(par_shots >= num_gpus_)
+          result.metadata.add(num_gpus_, "gpu_parallel_shots_");
+        else
+          result.metadata.add(par_shots, "gpu_parallel_shots_");
       }
     }
   }
@@ -1624,6 +1637,13 @@ void Controller::run_circuit_with_sampled_noise(
 
   for (auto &res : par_results) {
     result.combine(std::move(res));
+  }
+
+  if (sim_device_name_ == "GPU"){
+    if(parallel_shots_ >= num_gpus_)
+      result.metadata.add(num_gpus_, "gpu_parallel_shots_");
+    else
+      result.metadata.add(parallel_shots_, "gpu_parallel_shots_");
   }
 }
 

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -828,7 +828,8 @@ size_t Controller::get_gpu_memory_mb() {
 Transpile::CacheBlocking
 Controller::transpile_cache_blocking(Controller::Method method, const Circuit &circ,
                                      const Noise::NoiseModel &noise,
-                                     const json_t &config) const {
+                                     const json_t &config) const 
+{
   Transpile::CacheBlocking cache_block_pass;
 
   const bool is_matrix = (method == Method::density_matrix
@@ -837,7 +838,9 @@ Controller::transpile_cache_blocking(Controller::Method method, const Circuit &c
                               ? sizeof(std::complex<float>)
                               : sizeof(std::complex<double>);
 
+  cache_block_pass.set_num_processes(num_process_per_experiment_);
   cache_block_pass.set_config(config);
+
   if (!cache_block_pass.enabled()) {
     // if blocking is not set by config, automatically set if required
     if (multiple_chunk_required(circ, noise, method)) {

--- a/src/simulators/density_matrix/densitymatrix.hpp
+++ b/src/simulators/density_matrix/densitymatrix.hpp
@@ -102,6 +102,9 @@ public:
   // Apply a 2-qubit Controlled-NOT gate to the state vector
   void apply_cnot(const uint_t qctrl, const uint_t qtrgt);
 
+ // Apply a 2-qubit Controlled-Y gate to the state vector
+  void apply_cy(const uint_t qctrl, const uint_t qtrgt);
+
   // Apply 2-qubit controlled-phase gate
   void apply_cphase(const uint_t q0, const uint_t q1, const complex_t &phase);
 
@@ -291,6 +294,13 @@ void DensityMatrix<data_t>::apply_cnot(const uint_t qctrl, const uint_t qtrgt) {
   const size_t nq = num_qubits();
   const reg_t qubits = {{qctrl, qtrgt, qctrl + nq, qtrgt + nq}};
   BaseVector::apply_permutation_matrix(qubits, pairs);
+}
+
+template <typename data_t>
+void DensityMatrix<data_t>::apply_cy(const uint_t qctrl, const uint_t qtrgt)
+{
+  const reg_t qubits = {{qctrl, qtrgt}};
+  apply_unitary_matrix(qubits, Linalg::VMatrix::CY);
 }
 
 template <typename data_t>

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -399,14 +399,16 @@ void State<densmat_t>::initialize_qreg(uint_t num_qubits)
   }
 
   if(BaseState::multi_chunk_distribution_){
-    if(BaseState::chunk_omp_parallel_){
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for 
-      for(int_t i=0;i<BaseState::qregs_.size();i++){
-        if(BaseState::global_chunk_index_ + i == 0){
-          BaseState::qregs_[i].initialize();
-        }
-        else{
-          BaseState::qregs_[i].zero();
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          if(BaseState::global_chunk_index_ + iChunk == 0){
+            BaseState::qregs_[iChunk].initialize();
+          }
+          else{
+            BaseState::qregs_[iChunk].zero();
+          }
         }
       }
     }
@@ -449,21 +451,23 @@ void State<densmat_t>::initialize_qreg(uint_t num_qubits,
   if(BaseState::multi_chunk_distribution_){
     auto input = state.copy_to_matrix();
 
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-        uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
-        uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
 
-        //copy part of state for this chunk
-        uint_t i,row,col;
-        cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
-        for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
-          uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
-          uint_t irow = i >> (BaseState::chunk_bits_);
-          tmp[i] = input[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+          for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+            uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+            uint_t irow = i >> (BaseState::chunk_bits_);
+            tmp[i] = input[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          }
+          BaseState::qregs_[iChunk].initialize_from_vector(tmp);
         }
-        BaseState::qregs_[iChunk].initialize_from_vector(tmp);
       }
     }
     else{
@@ -509,21 +513,23 @@ void State<densmat_t>::initialize_qreg(uint_t num_qubits,
   }
 
   if(BaseState::multi_chunk_distribution_){
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-        uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
-        uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
 
-        //copy part of state for this chunk
-        uint_t i,row,col;
-        cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
-        for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
-          uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
-          uint_t irow = i >> (BaseState::chunk_bits_);
-          tmp[i] = state[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+          for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+            uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+            uint_t irow = i >> (BaseState::chunk_bits_);
+            tmp[i] = state[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          }
+          BaseState::qregs_[iChunk].initialize_from_vector(tmp);
         }
-        BaseState::qregs_[iChunk].initialize_from_vector(tmp);
       }
     }
     else{
@@ -568,21 +574,23 @@ void State<densmat_t>::initialize_qreg(uint_t num_qubits,
   }
 
   if(BaseState::multi_chunk_distribution_){
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-        uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
-        uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
 
-        //copy part of state for this chunk
-        uint_t i,row,col;
-        cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
-        for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
-          uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
-          uint_t irow = i >> (BaseState::chunk_bits_);
-          tmp[i] = state[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+          for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+            uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+            uint_t irow = i >> (BaseState::chunk_bits_);
+            tmp[i] = state[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          }
+          BaseState::qregs_[iChunk].initialize_from_vector(tmp);
         }
-        BaseState::qregs_[iChunk].initialize_from_vector(tmp);
       }
     }
     else{
@@ -629,22 +637,24 @@ void State<densmat_t>::initialize_from_vector(const int_t iChunkIn, const list_t
   else if((1ull << (BaseState::num_qubits_*2)) == vec.size() * vec.size()) {
     int_t iChunk;
     if(BaseState::multi_chunk_distribution_){
-      if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(iChunk) 
-        for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
-          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+            uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+            uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
 
-          //copy part of state for this chunk
-          uint_t i,row,col;
-          list_t vec1(1ull << BaseState::chunk_bits_);
-          list_t vec2(1ull << BaseState::chunk_bits_);
+            //copy part of state for this chunk
+            uint_t i,row,col;
+            list_t vec1(1ull << BaseState::chunk_bits_);
+            list_t vec2(1ull << BaseState::chunk_bits_);
 
-          for(i=0;i<(1ull << BaseState::chunk_bits_);i++){
-            vec1[i] = vec[(irow_chunk << BaseState::chunk_bits_) + i];
-            vec2[i] = std::conj(vec[(icol_chunk << BaseState::chunk_bits_) + i]);
+            for(i=0;i<(1ull << BaseState::chunk_bits_);i++){
+              vec1[i] = vec[(irow_chunk << BaseState::chunk_bits_) + i];
+              vec2[i] = std::conj(vec[(icol_chunk << BaseState::chunk_bits_) + i]);
+            }
+            BaseState::qregs_[iChunk].initialize_from_vector(AER::Utils::tensor_product(vec1, vec2));
           }
-          BaseState::qregs_[iChunk].initialize_from_vector(AER::Utils::tensor_product(vec1, vec2));
         }
       }
       else{
@@ -957,76 +967,35 @@ double State<densmat_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
       const uint_t mask_u = ~((1ull << (x_max + 1)) - 1);
       const uint_t mask_l = (1ull << x_max) - 1;
 
-      if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(i) reduction(+:expval)
-        for(i=0;i<nrows/2;i++){
-          uint_t irow = ((i << 1) & mask_u) | (i & mask_l);
-          uint_t iChunk = (irow ^ x_mask) + irow * nrows;
+      for(i=0;i<nrows/2;i++){
+        uint_t irow = ((i << 1) & mask_u) | (i & mask_l);
+        uint_t iChunk = (irow ^ x_mask) + irow * nrows;
 
-          if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-            double sign = 2.0;
-            if (z_mask && (AER::Utils::popcount(irow & z_mask) & 1))
-              sign = -2.0;
-            expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli_non_diagonal_chunk(qubits_in_chunk, pauli_in_chunk,phase);
-          }
-        }
-      }
-      else{
-        for(i=0;i<nrows/2;i++){
-          uint_t irow = ((i << 1) & mask_u) | (i & mask_l);
-          uint_t iChunk = (irow ^ x_mask) + irow * nrows;
-
-          if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-            double sign = 2.0;
-            if (z_mask && (AER::Utils::popcount(irow & z_mask) & 1))
-              sign = -2.0;
-            expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli_non_diagonal_chunk(qubits_in_chunk, pauli_in_chunk,phase);
-          }
+        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+          double sign = 2.0;
+          if (z_mask && (AER::Utils::popcount(irow & z_mask) & 1))
+            sign = -2.0;
+          expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli_non_diagonal_chunk(qubits_in_chunk, pauli_in_chunk,phase);
         }
       }
     }
     else{
-      if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(i) reduction(+:expval)
-        for(i=0;i<nrows;i++){
-          uint_t iChunk = i * (nrows+1);
-          if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-            double sign = 1.0;
-            if (z_mask && (AER::Utils::popcount(i & z_mask) & 1))
-              sign = -1.0;
-            expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,1.0);
-          }
-        }
-      }
-      else{
-        for(i=0;i<nrows;i++){
-          uint_t iChunk = i * (nrows+1);
-          if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-            double sign = 1.0;
-            if (z_mask && (AER::Utils::popcount(i & z_mask) & 1))
-              sign = -1.0;
-            expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,1.0);
-          }
+      for(i=0;i<nrows;i++){
+        uint_t iChunk = i * (nrows+1);
+        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+          double sign = 1.0;
+          if (z_mask && (AER::Utils::popcount(i & z_mask) & 1))
+            sign = -1.0;
+          expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,1.0);
         }
       }
     }
   }
   else{ //all bits are inside chunk
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(i) reduction(+:expval)
-      for(i=0;i<nrows;i++){
-        uint_t iChunk = i * (nrows+1);
-        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-          expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits, pauli,1.0);
-        }
-      }
-    }
-    else{
-      for(i=0;i<nrows;i++){
-        uint_t iChunk = i * (nrows+1);
-        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-          expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits, pauli,1.0);
-        }
+    for(i=0;i<nrows;i++){
+      uint_t iChunk = i * (nrows+1);
+      if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+        expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits, pauli,1.0);
       }
     }
   }
@@ -1339,7 +1308,7 @@ void State<densmat_t>::snapshot_density_matrix(const int_t iChunk, const Operati
 template <class densmat_t>
 void State<densmat_t>::apply_gate(const int_t iChunk, const Operations::Op &op) 
 {
-  if(!BaseState::global_index_optimization_){
+  if(!BaseState::global_chunk_indexing_){
     reg_t qubits_in,qubits_out;
     bool ctrl_chunk = true;
     bool ctrl_chunk_sp = true;
@@ -1533,7 +1502,7 @@ void State<densmat_t>::apply_gate_u3(const int_t iChunk, uint_t qubit, double th
 template <class densmat_t>
 void State<densmat_t>::apply_diagonal_unitary_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t & diag)
 {
-  if(BaseState::global_index_optimization_ || !BaseState::multi_chunk_distribution_){
+  if(BaseState::global_chunk_indexing_ || !BaseState::multi_chunk_distribution_){
     //GPU computes all chunks in one kernel, so pass qubits and diagonal matrix as is
     BaseState::qregs_[iChunk].apply_diagonal_unitary_matrix(qubits,diag);
   }
@@ -1630,52 +1599,54 @@ rvector_t State<densmat_t>::measure_probs(const int_t iChunk, const reg_t &qubit
     }
   }
 
-  if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(i,j,k) 
-    for(i=0;i<BaseState::qregs_.size();i++){
-      uint_t irow,icol;
-      irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
-      icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
+  if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for private(i,j,k)
+    for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+      for(i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++){
+        uint_t irow,icol;
+        irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
+        icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
 
-      if(irow == icol){   //diagonal chunk
-        if(qubits_in_chunk.size() > 0){
-          auto chunkSum = BaseState::qregs_[i].probabilities(qubits_in_chunk);
-          if(qubits_in_chunk.size() == qubits.size()){
-            for(j=0;j<dim;j++){
+        if(irow == icol){   //diagonal chunk
+          if(qubits_in_chunk.size() > 0){
+            auto chunkSum = BaseState::qregs_[i].probabilities(qubits_in_chunk);
+            if(qubits_in_chunk.size() == qubits.size()){
+              for(j=0;j<dim;j++){
 #pragma omp atomic
-              sum[j] += chunkSum[j];
+                sum[j] += chunkSum[j];
+              }
             }
-          }
-          else{
-            for(j=0;j<chunkSum.size();j++){
-              int idx = 0;
-              int i_in = 0;
-              for(k=0;k<qubits.size();k++){
-                if(qubits[k] < (BaseState::chunk_bits_)){
-                  idx += (((j >> i_in) & 1) << k);
-                  i_in++;
-                }
-                else{
-                  if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits[k]) & 1){
-                    idx += 1ull << k;
+            else{
+              for(j=0;j<chunkSum.size();j++){
+                int idx = 0;
+                int i_in = 0;
+                for(k=0;k<qubits.size();k++){
+                  if(qubits[k] < (BaseState::chunk_bits_)){
+                    idx += (((j >> i_in) & 1) << k);
+                    i_in++;
+                  }
+                  else{
+                    if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits[k]) & 1){
+                      idx += 1ull << k;
+                    }
                   }
                 }
+#pragma omp atomic
+                sum[idx] += chunkSum[j];
               }
-#pragma omp atomic
-              sum[idx] += chunkSum[j];
             }
           }
-        }
-        else{ //there is no bit in chunk
-          auto tr = std::real(BaseState::qregs_[i].trace());
-          int idx = 0;
-          for(k=0;k<qubits_out_chunk.size();k++){
-            if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits_out_chunk[k]) & 1){
-              idx += 1ull << k;
+          else{ //there is no bit in chunk
+            auto tr = std::real(BaseState::qregs_[i].trace());
+            int idx = 0;
+            for(k=0;k<qubits_out_chunk.size();k++){
+              if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits_out_chunk[k]) & 1){
+                idx += 1ull << k;
+              }
             }
-          }
 #pragma omp atomic
-          sum[idx] += tr;
+            sum[idx] += tr;
+          }
         }
       }
     }
@@ -1768,10 +1739,12 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
     if(!BaseState::multi_chunk_distribution_)
       apply_diagonal_unitary_matrix(iChunk, qubits, mdiag);
     else{
-      if(BaseState::chunk_omp_parallel_){
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          apply_diagonal_unitary_matrix(i, qubits, mdiag);
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
+            apply_diagonal_unitary_matrix(i, qubits, mdiag);
+        }
       }
       else{
         for(int_t i=0;i<BaseState::qregs_.size();i++)
@@ -1785,10 +1758,12 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
         BaseState::qregs_[iChunk].apply_x(qubits[0]);
       else{
         if(qubits[0] < BaseState::chunk_bits_){
-          if(BaseState::chunk_omp_parallel_){
+          if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
-            for(int_t i=0;i<BaseState::qregs_.size();i++)
-              BaseState::qregs_[i].apply_x(qubits[0]);
+            for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+              for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
+                BaseState::qregs_[i].apply_x(qubits[0]);
+            }
           }
           else{
             for(int_t i=0;i<BaseState::qregs_.size();i++)
@@ -1811,10 +1786,12 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
     if(!BaseState::multi_chunk_distribution_)
       apply_diagonal_unitary_matrix(iChunk, qubits, mdiag);
     else{
-      if(BaseState::chunk_omp_parallel_){
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          apply_diagonal_unitary_matrix(i, qubits, mdiag);
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
+            apply_diagonal_unitary_matrix(i, qubits, mdiag);
+        }
       }
       else{
         for(int_t i=0;i<BaseState::qregs_.size();i++)
@@ -1849,10 +1826,12 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
           }
         }
         if(qubits_in_chunk.size() > 0){   //in chunk exchange
-          if(BaseState::chunk_omp_parallel_){
+          if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
-            for(int_t i=0;i<BaseState::qregs_.size();i++)
-              BaseState::qregs_[i].apply_unitary_matrix(qubits, perm);
+            for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+              for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
+                BaseState::qregs_[i].apply_unitary_matrix(qubits, perm);
+            }
           }
           else{
             for(int_t i=0;i<BaseState::qregs_.size();i++)
@@ -1889,16 +1868,18 @@ std::vector<reg_t> State<densmat_t>::sample_measure(const reg_t &qubits,
     std::vector<double> chunkSum(BaseState::qregs_.size()+1,0);
     double sum,localSum;
    //calculate per chunk sum
-    if(BaseState::chunk_omp_parallel_){
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for private(i) 
-      for(i=0;i<BaseState::qregs_.size();i++){
-        uint_t irow,icol;
-        irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
-        icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
-        if(irow == icol)   //only diagonal chunk has probabilities
-          chunkSum[i] = std::real( BaseState::qregs_[i].trace() );
-        else
-          chunkSum[i] = 0.0;
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++){
+          uint_t irow,icol;
+          irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
+          icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
+          if(irow == icol)   //only diagonal chunk has probabilities
+            chunkSum[i] = std::real( BaseState::qregs_[i].trace() );
+          else
+            chunkSum[i] = 0.0;
+        }
       }
     }
     else{

--- a/src/simulators/density_matrix/densitymatrix_thrust.hpp
+++ b/src/simulators/density_matrix/densitymatrix_thrust.hpp
@@ -104,6 +104,9 @@ public:
   // Apply a 2-qubit Controlled-NOT gate to the state vector
   void apply_cnot(const uint_t qctrl, const uint_t qtrgt);
 
+ // Apply a 2-qubit Controlled-Y gate to the state vector
+  void apply_cy(const uint_t qctrl, const uint_t qtrgt);
+
   // Apply 2-qubit controlled-phase gate
   void apply_cphase(const uint_t q0, const uint_t q1, const complex_t &phase);
 
@@ -512,88 +515,198 @@ void DensityMatrixThrust<data_t>::apply_diagonal_unitary_matrix(const reg_t &qub
 // Apply Specialized Gates
 //-----------------------------------------------------------------------
 template <typename data_t>
-class DensityCX : public Chunk::GateFuncBase<data_t>
+class DensityMCX : public Chunk::GateFuncBase<data_t>
 {
 protected:
-  uint_t offset;
-  uint_t offset_sp;
-  uint_t cmask;
-  uint_t cmask_sp;
+  int total_qubits_;
+  int chunk_qubits_;
+  uint_t offset_;
+  uint_t offset_sp_;
+  uint_t cmask_;
 public:
-  DensityCX(uint_t qc,uint_t qt,uint_t qs)
+  DensityMCX(reg_t& qubits, uint_t num_cqubits, uint_t num_qubits)
   {
-    offset = 1ull << qt;
-    offset_sp = 1ull << (qt + qs);
-    cmask = 1ull << qc;
-    cmask_sp = 1ull << (qc + qs);
+    total_qubits_ = num_qubits;
+    chunk_qubits_ = num_cqubits;
+
+    offset_ = 1ull << qubits[qubits.size()-1];
+    offset_sp_ = 1ull << (qubits[qubits.size()-1] + chunk_qubits_);
+    cmask_ = 0;
+    for(int i=0;i<qubits.size()-1;i++)
+      cmask_ |= (1ull << qubits[i]);
   }
-  int qubits_count(void)
+  bool is_diagonal(void)
   {
-    return 2;
+    return true;
   }
 
   __host__ __device__ void operator()(const uint_t &i) const
   {
-    uint_t i0,i1,i2;
     thrust::complex<data_t>* vec0;
-    thrust::complex<data_t>* vec1;
-    thrust::complex<data_t>* vec2;
-    thrust::complex<data_t>* vec3;
-    thrust::complex<data_t> q0,q1,q2,q3,t;
+    thrust::complex<data_t>* vec1 = nullptr;
+    thrust::complex<data_t> q0,q1;
+
+    uint_t irow,icol,gid,local_mask,gcid;
+    uint_t irow_chunk,icol_chunk;
+
+    gid = this->base_index_;
+
+    gcid = (gid + i) >> (chunk_qubits_*2);
+    irow_chunk = gcid >> (total_qubits_ - chunk_qubits_);
+    icol_chunk = gcid & ((1ull << (total_qubits_ - chunk_qubits_))-1);
+
+    local_mask = (1ull << (chunk_qubits_*2)) - 1;
+    irow = (i & local_mask) >> chunk_qubits_;
+    icol = (i & local_mask) & ((1ull << chunk_qubits_)-1);
+
+    irow += (irow_chunk << chunk_qubits_);
+    icol += (icol_chunk << chunk_qubits_);
 
     vec0 = this->data_;
-    vec1 = vec0 + offset;
-    vec2 = vec0 + offset_sp;
-    vec3 = vec2 + offset;
-
-    i0 = i & (offset - 1);
-    i2 = (i - i0) << 1;
-    i1 = i2 & (offset_sp - 1);
-    i2 = (i2 - i1) << 1;
-
-    i0 = i0 + i1 + i2;
-
-    q0 = vec0[i0];
-    q1 = vec1[i0];
-    q2 = vec2[i0];
-    q3 = vec3[i0];
-
-    if((i0 & cmask) == cmask){
-      t = q0;
-      q0 = q1;
-      q1 = t;
-
-      t = q2;
-      q2 = q3;
-      q3 = t;
+    if((icol & cmask_) == cmask_){
+      if((irow & cmask_) == cmask_){
+        if(i < (i ^ offset_)){
+          if(i < (i ^ offset_sp_)){
+            vec1 = vec0 + offset_sp_ + offset_;
+          }
+          else{
+            vec1 = vec0 - offset_sp_ + offset_;
+          }
+        }
+      }
+      else if(i < (i ^ offset_)){
+        vec1 = vec0 + offset_;
+      }
+    }
+    else if((irow & cmask_) == cmask_ && i < (i ^ offset_sp_)){
+      vec1 = vec0 + offset_sp_;
     }
 
-    if((i0 & cmask_sp) == cmask_sp){
-      vec0[i0] = q2;
-      vec1[i0] = q3;
-      vec2[i0] = q0;
-      vec3[i0] = q1;
-    }
-    else{
-      vec0[i0] = q0;
-      vec1[i0] = q1;
-      vec2[i0] = q2;
-      vec3[i0] = q3;
+    if(vec1 != nullptr){
+      q0 = vec0[i];
+      q1 = vec1[i];
+
+      vec0[i] = q1;
+      vec1[i] = q0;
     }
   }
   const char* name(void)
   {
-    return "DensityCX";
+    return "DensityMCXY";
   }
 };
 
 template <typename data_t>
 void DensityMatrixThrust<data_t>::apply_cnot(const uint_t qctrl, const uint_t qtrgt) 
 {
-  BaseVector::apply_function(DensityCX<data_t>(qctrl, qtrgt, num_qubits()));
+  reg_t qubits = {qctrl, qtrgt};
+  BaseVector::apply_function(DensityMCX<data_t>(qubits, num_qubits(), BaseVector::chunk_manager_->num_qubits()/2));
 
 #ifdef AER_DEBUG
   BaseVector::DebugMsg(" density::apply_cnot");
+  DebugDump();
+#endif
+}
+
+template <typename data_t>
+class DensityMCY : public Chunk::GateFuncBase<data_t>
+{
+protected:
+  int total_qubits_;
+  int chunk_qubits_;
+  uint_t offset_;
+  uint_t offset_sp_;
+  uint_t cmask_;
+public:
+  DensityMCY(reg_t& qubits, uint_t num_cqubits, uint_t num_qubits)
+  {
+    total_qubits_ = num_qubits;
+    chunk_qubits_ = num_cqubits;
+
+    offset_ = 1ull << qubits[qubits.size()-1];
+    offset_sp_ = 1ull << (qubits[qubits.size()-1] + chunk_qubits_);
+    cmask_ = 0;
+    for(int i=0;i<qubits.size()-1;i++)
+      cmask_ |= (1ull << qubits[i]);
+  }
+  bool is_diagonal(void)
+  {
+    return true;
+  }
+
+  __host__ __device__ void operator()(const uint_t &i) const
+  {
+    thrust::complex<data_t>* vec0;
+    thrust::complex<data_t>* vec1 = nullptr;
+    thrust::complex<data_t> q0,q1,t0,t1;
+    thrust::complex<data_t> s0,s1;
+
+    uint_t irow,icol,gid,local_mask,gcid;
+    uint_t irow_chunk,icol_chunk;
+
+    gid = this->base_index_;
+
+    gcid = (gid + i) >> (chunk_qubits_*2);
+    irow_chunk = gcid >> (total_qubits_ - chunk_qubits_);
+    icol_chunk = gcid & ((1ull << (total_qubits_ - chunk_qubits_))-1);
+
+    local_mask = (1ull << (chunk_qubits_*2)) - 1;
+    irow = (i & local_mask) >> chunk_qubits_;
+    icol = (i & local_mask) & ((1ull << chunk_qubits_)-1);
+
+    irow += (irow_chunk << chunk_qubits_);
+    icol += (icol_chunk << chunk_qubits_);
+
+    vec0 = this->data_;
+    if((icol & cmask_) == cmask_){
+      if((irow & cmask_) == cmask_){
+        if(i < (i ^ offset_)){
+          if(i < (i ^ offset_sp_)){
+            vec1 = vec0 + offset_sp_ + offset_;
+            s0 = 1.0;
+            s1 = 1.0;
+          }
+          else{
+            vec1 = vec0 - offset_sp_ + offset_;
+            s0 = -1.0;
+            s1 = -1.0;
+          }
+        }
+      }
+      else if(i < (i ^ offset_)){
+        vec1 = vec0 + offset_;
+        s0 = thrust::complex<double>(0.0,-1.0);
+        s1 = thrust::complex<double>(0.0,1.0);
+      }
+    }
+    else if((irow & cmask_) == cmask_ && i < (i ^ offset_sp_)){
+      vec1 = vec0 + offset_sp_;
+      s0 = thrust::complex<double>(0.0,1.0);
+      s1 = thrust::complex<double>(0.0,-1.0);
+    }
+
+    if(vec1 != nullptr){
+      q0 = vec0[i];
+      q1 = vec1[i];
+
+      vec0[i] = s0*q1;
+      vec1[i] = s1*q0;
+    }
+  }
+  const char* name(void)
+  {
+    return "DensityMCXY";
+  }
+};
+
+template <typename data_t>
+void DensityMatrixThrust<data_t>::apply_cy(const uint_t qctrl, const uint_t qtrgt)
+{
+  reg_t qubits = {qctrl, qtrgt};
+  BaseVector::apply_function(DensityMCY<data_t>(qubits, num_qubits(), BaseVector::chunk_manager_->num_qubits()/2));
+
+#ifdef AER_DEBUG
+  BaseVector::DebugMsg(" density::apply_cy");
   DebugDump();
 #endif
 }
@@ -909,14 +1022,11 @@ void DensityMatrixThrust<data_t>::apply_y(const uint_t qubit)
 template <typename data_t>
 void DensityMatrixThrust<data_t>::apply_toffoli(const uint_t qctrl0,
                                           const uint_t qctrl1,
-                                          const uint_t qtrgt) {
-  std::vector<std::pair<uint_t, uint_t>> pairs = {
-    {{3, 7}, {11, 15}, {19, 23}, {24, 56}, {25, 57}, {26, 58}, {27, 63},
-    {28, 60}, {29, 61}, {30, 62}, {31, 59}, {35, 39}, {43,47}, {51, 55}}
-  };
-  const reg_t qubits = {{qctrl0, qctrl1, qtrgt,
-                         qctrl0 + num_qubits(), qctrl1 + num_qubits(), qtrgt + num_qubits()}};
-  BaseVector::apply_permutation_matrix(qubits, pairs);
+                                          const uint_t qtrgt) 
+{
+  reg_t qubits = {qctrl0, qctrl1, qtrgt};
+  BaseVector::apply_function(DensityMCX<data_t>(qubits, num_qubits(), BaseVector::chunk_manager_->num_qubits()/2));
+
 #ifdef AER_DEBUG
 	BaseVector::DebugMsg(" density::apply_toffoli",qubits);
 #endif

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -87,7 +87,7 @@ public:
     distributed_proc_bits_ = 0;
 
     chunk_omp_parallel_ = false;
-    global_index_optimization_ = false;
+    global_chunk_indexing_ = false;
 
 #ifdef AER_MPI
     distributed_comm_ = MPI_COMM_WORLD;
@@ -379,7 +379,7 @@ protected:
   int_t distributed_proc_bits_; //distributed_procs_=2^distributed_proc_bits_  (if nprocs != power of 2, set -1)
 
   bool chunk_omp_parallel_;     //using thread parallel to process loop of chunks or not
-  bool global_index_optimization_;  //using global index for control qubits and diagonal matrix
+  bool global_chunk_indexing_;  //using global index for control qubits and diagonal matrix
 
   bool multi_chunk_distribution_ = false; //distributing chunks to apply cache blocking parallelization
   bool multi_shots_parallelization_ = false; //using chunks as multiple shots parallelization
@@ -654,7 +654,7 @@ bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t nu
   global_chunk_index_ = chunk_index_begin_[distributed_rank_];
   local_shot_index_ = 0;
 
-  global_index_optimization_ = false;
+  global_chunk_indexing_ = false;
   chunk_omp_parallel_ = false;
   if(BaseState::sim_device_name_ == "GPU"){
 #ifdef _OPENMP
@@ -670,11 +670,11 @@ bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t nu
     }
 
     if(!cuStateVec_enable_)
-      global_index_optimization_ = true;    //cuStateVec does not handle global chunk index for diagonal matrix
+      global_chunk_indexing_ = true;    //cuStateVec does not handle global chunk index for diagonal matrix
 #endif
   }
   else if(BaseState::sim_device_name_ == "Thrust"){
-    global_index_optimization_ = true;
+    global_chunk_indexing_ = true;
     chunk_omp_parallel_ = false;
   }
 
@@ -911,9 +911,23 @@ void StateChunk<state_t>::apply_ops_chunks(InputIterator first, InputIterator la
     for(int_t ig=0;ig<num_groups_;ig++)
       qregs_[top_chunk_of_group_[ig]].synchronize();
   }
-#ifdef AER_CUSTATEVEC
-  result.metadata.add(cuStateVec_enable_, "cuStateVec_enable");
+
+  if(BaseState::sim_device_name_ == "GPU"){
+#ifdef AER_THRUST_CUDA
+    int nDev;
+    if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
+      cudaGetLastError();
+      nDev = 0;
+    }
+    if(nDev > num_groups_)
+      nDev = num_groups_;
+    result.metadata.add(nDev,"cacheblocking", "chunk_parallel_gpus");
 #endif
+
+#ifdef AER_CUSTATEVEC
+    result.metadata.add(cuStateVec_enable_, "cuStateVec_enable");
+#endif
+  }
 
 #ifdef AER_MPI
   result.metadata.add(multi_chunk_swap_enable_,"cacheblocking", "multiple_chunk_swaps_enable");
@@ -1071,6 +1085,19 @@ void StateChunk<state_t>::apply_ops_multi_shots(InputIterator first, InputIterat
   }
 
   gather_creg_memory();
+
+#ifdef AER_THRUST_CUDA
+  if(BaseState::sim_device_name_ == "GPU"){
+    int nDev;
+    if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
+      cudaGetLastError();
+      nDev = 0;
+    }
+    if(nDev > num_groups_)
+      nDev = num_groups_;
+    result.metadata.add(nDev,"batched_shots_optimization_parallel_gpus");
+  }
+#endif
 }
 
 template <class state_t>
@@ -1572,14 +1599,16 @@ void StateChunk<state_t>::initialize_from_vector(const int_t iChunkIn, const lis
   int_t iChunk;
 
   if(multi_chunk_distribution_){
-    if(chunk_omp_parallel_){
-#pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<num_local_chunks_;iChunk++){
-        list_t tmp(1ull << (chunk_bits_*qubit_scale()));
-        for(int_t i=0;i<(1ull << (chunk_bits_*qubit_scale()));i++){
-          tmp[i] = vec[((global_chunk_index_ + iChunk) << (chunk_bits_*qubit_scale())) + i];
+    if(chunk_omp_parallel_ && num_groups_ > 1){
+#pragma omp parallel for private(iChunk)
+      for(int_t ig=0;ig<num_groups_;ig++){
+        for(iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++){
+          list_t tmp(1ull << (chunk_bits_*qubit_scale()));
+          for(int_t i=0;i<(1ull << (chunk_bits_*qubit_scale()));i++){
+            tmp[i] = vec[((global_chunk_index_ + iChunk) << (chunk_bits_*qubit_scale())) + i];
+          }
+          qregs_[iChunk].initialize_from_vector(tmp);
         }
-        qregs_[iChunk].initialize_from_vector(tmp);
       }
     }
     else{
@@ -1609,21 +1638,23 @@ void StateChunk<state_t>::initialize_from_matrix(const int_t iChunkIn, const lis
 {
   int_t iChunk;
   if(multi_chunk_distribution_){
-    if(chunk_omp_parallel_){
-#pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<num_local_chunks_;iChunk++){
-        list_t tmp(1ull << (chunk_bits_),1ull << (chunk_bits_));
-        uint_t irow_chunk = ((iChunk + global_chunk_index_) >> ((num_qubits_ - chunk_bits_))) << (chunk_bits_);
-        uint_t icol_chunk = ((iChunk + global_chunk_index_) & ((1ull << ((num_qubits_ - chunk_bits_)))-1)) << (chunk_bits_);
+    if(chunk_omp_parallel_ && num_groups_ > 1){
+#pragma omp parallel for private(iChunk)
+      for(int_t ig=0;ig<num_groups_;ig++){
+        for(iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++){
+          list_t tmp(1ull << (chunk_bits_),1ull << (chunk_bits_));
+          uint_t irow_chunk = ((iChunk + global_chunk_index_) >> ((num_qubits_ - chunk_bits_))) << (chunk_bits_);
+          uint_t icol_chunk = ((iChunk + global_chunk_index_) & ((1ull << ((num_qubits_ - chunk_bits_)))-1)) << (chunk_bits_);
 
-        //copy part of state for this chunk
-        uint_t i,row,col;
-        for(i=0;i<(1ull << (chunk_bits_*qubit_scale()));i++){
-          uint_t icol = i & ((1ull << chunk_bits_)-1);
-          uint_t irow = i >> chunk_bits_;
-          tmp[i] = mat[icol_chunk + icol + ((irow_chunk + irow) << num_qubits_)];
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          for(i=0;i<(1ull << (chunk_bits_*qubit_scale()));i++){
+            uint_t icol = i & ((1ull << chunk_bits_)-1);
+            uint_t irow = i >> chunk_bits_;
+            tmp[i] = mat[icol_chunk + icol + ((irow_chunk + irow) << num_qubits_)];
+          }
+          qregs_[iChunk].initialize_from_matrix(tmp);
         }
-        qregs_[iChunk].initialize_from_matrix(tmp);
       }
     }
     else{
@@ -1742,7 +1773,6 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
   uint_t nLarge = 1;
   uint_t q0,q1;
   int_t iChunk;
-  reg_t large_qubits;
 
   q0 = qubits[qubits.size() - 2];
   q1 = qubits[qubits.size() - 1];
@@ -1759,28 +1789,20 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
     //inside chunk
     if(chunk_omp_parallel_ && num_groups_ > 1){
 #pragma omp parallel for num_threads(num_groups_) 
-      for(int_t ig=0;ig<num_groups_;ig++)
-        qregs_[top_chunk_of_group_[ig]].apply_mcswap(qubits);
+      for(int_t ig=0;ig<num_groups_;ig++){
+        for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
+          qregs_[iChunk].apply_mcswap(qubits);
+      }
     }
     else{
-      for(int_t ig=0;ig<num_groups_;ig++)
-        qregs_[top_chunk_of_group_[ig]].apply_mcswap(qubits);
+      for(int_t ig=0;ig<num_groups_;ig++){
+        for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
+          qregs_[iChunk].apply_mcswap(qubits);
+      }
     }
   }
   else{ //swap over chunks
-    int_t iPair;
-    uint_t nPair,mask0,mask1;
-    uint_t baseChunk,iChunk1,iChunk2;
-
-    if(q0 < chunk_bits_*qubit_scale()){
-      nLarge = 1;
-      large_qubits.push_back(q1-chunk_bits_*qubit_scale());
-    }
-    else{
-      nLarge = 2;
-      large_qubits.push_back(q0-chunk_bits_*qubit_scale());
-      large_qubits.push_back(q1-chunk_bits_*qubit_scale());
-    }
+    uint_t mask0,mask1;
 
     mask0 = (1ull << q0);
     mask1 = (1ull << q1);
@@ -1788,36 +1810,42 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
     mask1 >>= (chunk_bits_*qubit_scale());
 
     if(distributed_procs_ == 1 || (distributed_proc_bits_ >= 0 && q1 < (num_qubits_*qubit_scale() - distributed_proc_bits_))){   //no data transfer between processes is needed
-      if(q0 < chunk_bits_*qubit_scale()){
-        nPair = num_local_chunks_ >> 1;
-      }
-      else{
-        nPair = num_local_chunks_ >> 2;
-      }
-
-      auto apply_chunk_swap = [this, mask0, mask1, q0, q1, qubits](int_t iPair)
+      auto apply_chunk_swap_1qubit = [this, mask1, qubits](int_t iGroup)
       {
-        uint_t baseChunk;
-        if(q0 < chunk_bits_*qubit_scale()){
-          baseChunk = iPair & (mask1-1);
-          baseChunk += ((iPair - baseChunk) << 1);
+        for(int_t ic = top_chunk_of_group_[iGroup];ic < top_chunk_of_group_[iGroup + 1];ic++){
+          uint_t baseChunk;
+          baseChunk = ic & (~mask1);
+          if(ic == baseChunk)
+            qregs_[ic].apply_chunk_swap(qubits,qregs_[ic | mask1],true);
         }
-        else{
-          uint_t t0,t1;
-          t0 = iPair & (mask0-1);
-          baseChunk = (iPair - t0) << 1;
-          t1 = baseChunk & (mask1-1);
-          baseChunk = (baseChunk - t1) << 1;
-          baseChunk += t0 + t1;
-        }
-        uint_t iChunk1 = baseChunk | mask0;
-        uint_t iChunk2 = baseChunk | mask1;
-        qregs_[iChunk1].apply_chunk_swap(qubits,qregs_[iChunk2],true);
       };
-      Utils::apply_omp_parallel_for(chunk_omp_parallel_, 0, nPair, apply_chunk_swap);
+      auto apply_chunk_swap_2qubits = [this, mask0, mask1, qubits](int_t iGroup)
+      {
+        for(int_t ic = top_chunk_of_group_[iGroup];ic < top_chunk_of_group_[iGroup + 1];ic++){
+          uint_t baseChunk;
+          baseChunk = ic & (~(mask0 | mask1));
+          uint_t iChunk1 = baseChunk | mask0;
+          uint_t iChunk2 = baseChunk | mask1;
+          if(ic == iChunk1)
+            qregs_[iChunk1].apply_chunk_swap(qubits,qregs_[iChunk2],true);
+        }
+      };
+      if(q0 < chunk_bits_*qubit_scale())
+        Utils::apply_omp_parallel_for((chunk_omp_parallel_ && num_groups_ > 1), 0, num_groups_, apply_chunk_swap_1qubit);
+      else
+        Utils::apply_omp_parallel_for((chunk_omp_parallel_ && num_groups_ > 1), 0, num_groups_, apply_chunk_swap_2qubits);
     }
 #ifdef AER_MPI
     else{
+      int_t iPair;
+      uint_t nPair;
+      uint_t baseChunk,iChunk1,iChunk2;
+
+      if(q0 < chunk_bits_*qubit_scale())
+        nLarge = 1;
+      else
+        nLarge = 2;
+
       //chunk scheduler that supports any number of processes
       uint_t nu[3];
       uint_t ub[3];
@@ -1953,15 +1981,17 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
     chunk_shuffle_qubits[i] -= chunk_bits_*qubit_scale();
 
   //swap inside chunks to prepare for all-to-all shuffle
-  if(num_groups_ > 1){
+  if(chunk_omp_parallel_ && num_groups_ > 1){
 #pragma omp parallel for 
     for(int_t ig=0;ig<num_groups_;ig++){
-      qregs_[top_chunk_of_group_[ig]].apply_multi_swaps(local_swaps);
+      for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
+        qregs_[iChunk].apply_multi_swaps(local_swaps);
     }
   }
   else{
     for(int_t ig=0;ig<num_groups_;ig++){
-      qregs_[top_chunk_of_group_[ig]].apply_multi_swaps(local_swaps);
+      for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
+        qregs_[iChunk].apply_multi_swaps(local_swaps);
     }
   }
 
@@ -2091,15 +2121,17 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
   }
 
   //restore qubits order
-  if(num_groups_ > 1){
+  if(chunk_omp_parallel_ && num_groups_ > 1){
 #pragma omp parallel for 
     for(int_t ig=0;ig<num_groups_;ig++){
-      qregs_[top_chunk_of_group_[ig]].apply_multi_swaps(local_swaps);
+      for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
+        qregs_[iChunk].apply_multi_swaps(local_swaps);
     }
   }
   else{
     for(int_t ig=0;ig<num_groups_;ig++){
-      qregs_[top_chunk_of_group_[ig]].apply_multi_swaps(local_swaps);
+      for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
+        qregs_[iChunk].apply_multi_swaps(local_swaps);
     }
   }
 }
@@ -2116,8 +2148,8 @@ void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
     auto apply_mcx = [this, qubit](int_t ig)
     {
       reg_t qubits(1,qubit);
-      uint_t istate = top_chunk_of_group_[ig];
-      qregs_[istate].apply_mcx(qubits);
+      for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
+        qregs_[iChunk].apply_mcx(qubits);
     };
     Utils::apply_omp_parallel_for((chunk_omp_parallel_ && num_groups_ > 1),0,num_groups_,apply_mcx);
   }
@@ -2135,17 +2167,16 @@ void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
     if(distributed_procs_ == 1 || (distributed_proc_bits_ >= 0 && qubit < (num_qubits_*qubit_scale() - distributed_proc_bits_))){   //no data transfer between processes is needed
       nPair = num_local_chunks_ >> 1;
 
-      auto apply_chunk_swap = [this, mask, qubits](int_t iPair)
+      auto apply_chunk_swap = [this, mask, qubits](int_t iGroup)
       {
-        int_t baseChunk = iPair & (mask-1);
-        baseChunk += ((iPair - baseChunk) << 1);
-
-        int_t iChunk1 = baseChunk;
-        int_t iChunk2 = baseChunk | mask;
-
-        qregs_[iChunk1].apply_chunk_swap(qubits,qregs_[iChunk2],true);
+        for(int_t ic = top_chunk_of_group_[iGroup];ic < top_chunk_of_group_[iGroup + 1];ic++){
+          uint_t pairChunk;
+          pairChunk = ic ^ mask;
+          if(ic < pairChunk)
+            qregs_[ic].apply_chunk_swap(qubits,qregs_[pairChunk],true);
+        }
       };
-      Utils::apply_omp_parallel_for(chunk_omp_parallel_,0, nPair, apply_chunk_swap);
+      Utils::apply_omp_parallel_for((chunk_omp_parallel_ && num_groups_ > 1),0, nPair, apply_chunk_swap);
     }
 #ifdef AER_MPI
     else{

--- a/src/simulators/statevector/chunk/chunk.hpp
+++ b/src/simulators/statevector/chunk/chunk.hpp
@@ -119,8 +119,11 @@ public:
   }
   void unmap_cache(void)
   {
-    cache_->unmap();
-    cache_.reset();
+    if(cache_){
+      cache_->unmap();
+      cache_.reset();
+      cache_ = nullptr;
+    }
   }
   
   bool is_mapped(void)
@@ -141,6 +144,10 @@ public:
   void set_chunk_index(uint_t id)
   {
     chunk_index_ = id;
+  }
+  uint_t chunk_index(void)
+  {
+    return chunk_index_;
   }
 
   uint_t matrix_bits(void)
@@ -237,10 +244,10 @@ public:
   void Execute(Function func,uint_t count)
   {
     if(cache_){
-      cache_->Execute(func,count);
+      cache_->chunk_container_.lock()->Execute(func,cache_->chunk_pos_,chunk_index_,count);
     }
     else{
-      chunk_container_.lock()->Execute(func,chunk_pos_,count);
+      chunk_container_.lock()->Execute(func,chunk_pos_,chunk_index_,count);
     }
   }
 
@@ -371,48 +378,75 @@ public:
   //apply matrix
   void apply_matrix(const reg_t& qubits,const int_t control_bits,const cvector_t<double> &mat,const uint_t count)
   {
-    chunk_container_.lock()->apply_matrix(chunk_pos_,qubits,control_bits,mat,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_matrix(cache_->chunk_pos_, qubits,control_bits,mat,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_matrix(chunk_pos_,qubits,control_bits,mat,chunk_index_,count);
   }
   //apply diagonal matrix
   void apply_diagonal_matrix(const reg_t& qubits,const int_t control_bits,const cvector_t<double> &diag,const uint_t count)
   {
-    chunk_container_.lock()->apply_diagonal_matrix(chunk_pos_,qubits,control_bits,diag,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_diagonal_matrix(cache_->chunk_pos_, qubits,control_bits,diag,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_diagonal_matrix(chunk_pos_,qubits,control_bits,diag,chunk_index_,count);
   }
   //apply (controlled) X
   void apply_X(const reg_t& qubits,const uint_t count)
   {
-    chunk_container_.lock()->apply_X(chunk_pos_,qubits,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_X(cache_->chunk_pos_, qubits,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_X(chunk_pos_,qubits,chunk_index_,count);
   }
   //apply (controlled) Y
   void apply_Y(const reg_t& qubits,const uint_t count)
   {
-    chunk_container_.lock()->apply_Y(chunk_pos_,qubits,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_Y(cache_->chunk_pos_, qubits,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_Y(chunk_pos_,qubits,chunk_index_,count);
   }
   //apply (controlled) phase
   void apply_phase(const reg_t& qubits,const int_t control_bits,const std::complex<double> phase,const uint_t count)
   {
-    chunk_container_.lock()->apply_phase(chunk_pos_,qubits,control_bits,phase,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_phase(cache_->chunk_pos_, qubits,control_bits,phase,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_phase(chunk_pos_,qubits,control_bits,phase,chunk_index_,count);
   }
   //apply (controlled) swap gate
   void apply_swap(const reg_t& qubits,const int_t control_bits,const uint_t count)
   {
-    chunk_container_.lock()->apply_swap(chunk_pos_,qubits,control_bits,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_swap(cache_->chunk_pos_, qubits,control_bits,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_swap(chunk_pos_,qubits,control_bits,chunk_index_,count);
   }
   //apply multiple swap gates
   void apply_multi_swaps(const reg_t& qubits,const uint_t count)
   {
-    chunk_container_.lock()->apply_multi_swaps(chunk_pos_,qubits,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_multi_swaps(cache_->chunk_pos_, qubits,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_multi_swaps(chunk_pos_,qubits,chunk_index_,count);
   }
   //apply permutation
   void apply_permutation(const reg_t& qubits,const std::vector<std::pair<uint_t, uint_t>> &pairs, const uint_t count)
   {
-    chunk_container_.lock()->apply_permutation(chunk_pos_,qubits,pairs,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_permutation(cache_->chunk_pos_, qubits,pairs,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_permutation(chunk_pos_,qubits,pairs,chunk_index_,count);
   }
 
   //apply rotation around axis
   void apply_rotation(const reg_t &qubits, const Rotation r, const double theta, const uint_t count)
   {
-    chunk_container_.lock()->apply_rotation(chunk_pos_,qubits,r,theta,count);
+    if(cache_)
+      cache_->chunk_container_.lock()->apply_rotation(cache_->chunk_pos_, qubits,r,theta,chunk_index_,count);
+    else
+      chunk_container_.lock()->apply_rotation(chunk_pos_,qubits,r,theta,chunk_index_,count);
   }
 
   //get probabilities of chunk

--- a/src/simulators/statevector/chunk/chunk_manager.hpp
+++ b/src/simulators/statevector/chunk/chunk_manager.hpp
@@ -308,8 +308,9 @@ uint_t ChunkManager<data_t>::Allocate(int chunk_bits,int nqubits,uint_t nchunks,
       nc = ie - is;
       if(hybrid){
         nc /= 2;
+        if(nc < 1)
+          nc = 1;
       }
-      chunks_[iDev]->set_place(iDev,num_places_);
       chunks_[iDev]->set_chunk_index(chunk_index_ + chunks_allocated);  //set first chunk index for the container
       if(num_devices_ > 0)
         chunks_allocated += chunks_[iDev]->Allocate((iDev + idev_start)%num_devices_,chunk_bits,nqubits,nc,num_buffers,multi_shots_,matrix_bit,density_matrix_);
@@ -317,21 +318,25 @@ uint_t ChunkManager<data_t>::Allocate(int chunk_bits,int nqubits,uint_t nchunks,
         chunks_allocated += chunks_[iDev]->Allocate(iDev,chunk_bits,nqubits,nc,num_buffers,multi_shots_,matrix_bit,density_matrix_);
     }
     if(chunks_allocated < num_chunks_){
-      int nplace_add = 0;
+      int nplaces_add = num_places_;
+      if((num_chunks_ - chunks_allocated) < nplaces_add)
+        nplaces_add = (num_chunks_ - chunks_allocated);
       //rest of chunks are stored on host
-      for(iDev=0;iDev<num_places_;iDev++){
-        is = (num_chunks_ - chunks_allocated) * (uint_t)iDev / (uint_t)num_places_;
-        ie = (num_chunks_ - chunks_allocated) * (uint_t)(iDev + 1) / (uint_t)num_places_;
+      for(iDev=0;iDev<nplaces_add;iDev++){
+        is = (num_chunks_ - chunks_allocated) * (uint_t)iDev / (uint_t)nplaces_add;
+        ie = (num_chunks_ - chunks_allocated) * (uint_t)(iDev + 1) / (uint_t)nplaces_add;
         nc = ie - is;
         if(nc > 0){
-          chunks_[num_places_+nplace_add]->set_chunk_index(chunk_index_ + chunks_allocated + is);  //set first chunk index for the container
           chunks_.push_back(std::make_shared<HostChunkContainer<data_t>>());
-          chunks_[num_places_+nplace_add]->Allocate(-1,chunk_bits,nqubits,nc,num_buffers,multi_shots_,matrix_bit,density_matrix_);
-          nplace_add++;
+          chunks_[chunks_.size()-1]->set_chunk_index(chunk_index_ + chunks_allocated + is);  //set first chunk index for the container
+          chunks_[chunks_.size()-1]->Allocate(-1,chunk_bits,nqubits,nc,num_buffers,multi_shots_,matrix_bit,density_matrix_);
         }
       }
-      num_places_ += nplace_add;
+      num_places_ += nplaces_add;
     }
+
+    for(iDev=0;iDev<num_places_;iDev++)
+      chunks_[iDev]->set_place(iDev,num_places_);
 
 #ifdef AER_DISABLE_GDR
     //additional host buffer

--- a/src/simulators/statevector/chunk/chunk_manager.hpp
+++ b/src/simulators/statevector/chunk/chunk_manager.hpp
@@ -275,6 +275,7 @@ uint_t ChunkManager<data_t>::Allocate(int chunk_bits,int nqubits,uint_t nchunks,
           num_places_ = 1;
         }
       }
+
 #else
       num_places_ = 1;
 #endif
@@ -316,18 +317,20 @@ uint_t ChunkManager<data_t>::Allocate(int chunk_bits,int nqubits,uint_t nchunks,
         chunks_allocated += chunks_[iDev]->Allocate(iDev,chunk_bits,nqubits,nc,num_buffers,multi_shots_,matrix_bit,density_matrix_);
     }
     if(chunks_allocated < num_chunks_){
+      int nplace_add = 0;
       //rest of chunks are stored on host
       for(iDev=0;iDev<num_places_;iDev++){
         is = (num_chunks_ - chunks_allocated) * (uint_t)iDev / (uint_t)num_places_;
         ie = (num_chunks_ - chunks_allocated) * (uint_t)(iDev + 1) / (uint_t)num_places_;
         nc = ie - is;
         if(nc > 0){
-          chunks_[num_places_]->set_chunk_index(chunk_index_ + chunks_allocated + is);  //set first chunk index for the container
+          chunks_[num_places_+nplace_add]->set_chunk_index(chunk_index_ + chunks_allocated + is);  //set first chunk index for the container
           chunks_.push_back(std::make_shared<HostChunkContainer<data_t>>());
-          chunks_[num_places_]->Allocate(-1,chunk_bits,nqubits,nc,num_buffers,multi_shots_,matrix_bit,density_matrix_);
-          num_places_ += 1;
+          chunks_[num_places_+nplace_add]->Allocate(-1,chunk_bits,nqubits,nc,num_buffers,multi_shots_,matrix_bit,density_matrix_);
+          nplace_add++;
         }
       }
+      num_places_ += nplace_add;
     }
 
 #ifdef AER_DISABLE_GDR

--- a/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
@@ -53,28 +53,28 @@ public:
   double norm(uint_t iChunk,uint_t count) const override;
 
   //apply matrix
-  void apply_matrix(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const cvector_t<double> &mat,const uint_t count) override;
+  void apply_matrix(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const cvector_t<double> &mat,const uint_t gid, const uint_t count) override;
 
   //apply diagonal matrix
-  void apply_diagonal_matrix(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const cvector_t<double> &diag,const uint_t count) override;
+  void apply_diagonal_matrix(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const cvector_t<double> &diag,const uint_t gid, const uint_t count) override;
 
   //apply (controlled) X
-  void apply_X(const uint_t iChunk,const reg_t& qubits,const uint_t count) override;
+  void apply_X(const uint_t iChunk,const reg_t& qubits,const uint_t gid, const uint_t count) override;
 
   //apply (controlled) Y
-  void apply_Y(const uint_t iChunk,const reg_t& qubits,const uint_t count) override;
+  void apply_Y(const uint_t iChunk,const reg_t& qubits,const uint_t gid, const uint_t count) override;
 
   //apply (controlled) phase
-  virtual void apply_phase(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const std::complex<double> phase,const uint_t count) override;
+  virtual void apply_phase(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const std::complex<double> phase,const uint_t gid, const uint_t count) override;
 
   //apply (controlled) swap gate
-  void apply_swap(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const uint_t count) override;
+  void apply_swap(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const uint_t gid, const uint_t count) override;
 
   //apply permutation
-  void apply_permutation(const uint_t iChunk,const reg_t& qubits,const std::vector<std::pair<uint_t, uint_t>> &pairs, const uint_t count) override;
+  void apply_permutation(const uint_t iChunk,const reg_t& qubits,const std::vector<std::pair<uint_t, uint_t>> &pairs, const uint_t gid, const uint_t count) override;
 
   //apply rotation around axis
-  void apply_rotation(const uint_t iChunk,const reg_t &qubits, const Rotation r, const double theta, const uint_t count) override;
+  void apply_rotation(const uint_t iChunk,const reg_t &qubits, const Rotation r, const double theta, const uint_t gid, const uint_t count) override;
 
   //get probabilities of chunk
   void probabilities(std::vector<double>& probs, const uint_t iChunk, const reg_t& qubits) const override;
@@ -247,7 +247,7 @@ reg_t cuStateVecChunkContainer<data_t>::sample_measure(uint_t iChunk,const std::
 }
 
 template <typename data_t>
-void cuStateVecChunkContainer<data_t>::apply_matrix(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const cvector_t<double> &mat,const uint_t count)
+void cuStateVecChunkContainer<data_t>::apply_matrix(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const cvector_t<double> &mat,const uint_t gid, const uint_t count)
 {
   thrust::complex<double>* pMat;
   int_t num_qubits = qubits.size()-control_bits;
@@ -273,7 +273,7 @@ void cuStateVecChunkContainer<data_t>::apply_matrix(const uint_t iChunk,const re
   else{
     nc = count;
     bits = this->chunk_bits_;
-    if(nc > 0){
+    if(nc > 1){
       while((nc & 1) == 0){
         nc >>= 1;
         bits++;
@@ -305,7 +305,7 @@ void cuStateVecChunkContainer<data_t>::apply_matrix(const uint_t iChunk,const re
 }
 
 template <typename data_t>
-void cuStateVecChunkContainer<data_t>::apply_diagonal_matrix(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const cvector_t<double> &diag,const uint_t count)
+void cuStateVecChunkContainer<data_t>::apply_diagonal_matrix(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const cvector_t<double> &diag,const uint_t gid, const uint_t count)
 {
   thrust::complex<double>* pMat;
   int_t num_qubits = qubits.size();
@@ -320,7 +320,7 @@ void cuStateVecChunkContainer<data_t>::apply_diagonal_matrix(const uint_t iChunk
     for(int_t i=0;i<diag.size();i++)
       diag_ctrl[(i << control_bits)+offset] = diag[i];
 
-    return apply_diagonal_matrix(iChunk, qubits, 0, diag_ctrl, count);
+    return apply_diagonal_matrix(iChunk, qubits, 0, diag_ctrl, gid, count);
   }
 
   pMat = (thrust::complex<double>*)&diag[0];
@@ -344,7 +344,7 @@ void cuStateVecChunkContainer<data_t>::apply_diagonal_matrix(const uint_t iChunk
   else{
     nc = count;
     bits = this->chunk_bits_;
-    if(nc > 0){
+    if(nc > 1){
       while((nc & 1) == 0){
         nc >>= 1;
         bits++;
@@ -372,7 +372,7 @@ void cuStateVecChunkContainer<data_t>::apply_diagonal_matrix(const uint_t iChunk
 }
 
 template <typename data_t>
-void cuStateVecChunkContainer<data_t>::apply_X(const uint_t iChunk,const reg_t& qubits,const uint_t count)
+void cuStateVecChunkContainer<data_t>::apply_X(const uint_t iChunk,const reg_t& qubits,const uint_t gid, const uint_t count)
 {
   int_t num_qubits = qubits.size();
 
@@ -403,7 +403,7 @@ void cuStateVecChunkContainer<data_t>::apply_X(const uint_t iChunk,const reg_t& 
   else{
     nc = count;
     bits = this->chunk_bits_;
-    if(nc > 0){
+    if(nc > 1){
       while((nc & 1) == 0){
         nc >>= 1;
         bits++;
@@ -431,7 +431,7 @@ void cuStateVecChunkContainer<data_t>::apply_X(const uint_t iChunk,const reg_t& 
 }
 
 template <typename data_t>
-void cuStateVecChunkContainer<data_t>::apply_Y(const uint_t iChunk,const reg_t& qubits,const uint_t count)
+void cuStateVecChunkContainer<data_t>::apply_Y(const uint_t iChunk,const reg_t& qubits,const uint_t gid, const uint_t count)
 {
   int_t num_qubits = qubits.size();
 
@@ -467,7 +467,7 @@ void cuStateVecChunkContainer<data_t>::apply_Y(const uint_t iChunk,const reg_t& 
   else{
     nc = count;
     bits = this->chunk_bits_;
-    if(nc > 0){
+    if(nc > 1){
       while((nc & 1) == 0){
         nc >>= 1;
         bits++;
@@ -495,7 +495,7 @@ void cuStateVecChunkContainer<data_t>::apply_Y(const uint_t iChunk,const reg_t& 
 }
 
 template <typename data_t>
-void cuStateVecChunkContainer<data_t>::apply_phase(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const std::complex<double> phase,const uint_t count)
+void cuStateVecChunkContainer<data_t>::apply_phase(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const std::complex<double> phase,const uint_t gid, const uint_t count)
 {
   uint_t size = 1ull << qubits.size();
   cvector_t<double> diag(size);
@@ -503,11 +503,11 @@ void cuStateVecChunkContainer<data_t>::apply_phase(const uint_t iChunk,const reg
     diag[i] = 1.0;
   diag[size-1] = phase;
 
-  apply_diagonal_matrix(iChunk, qubits, 0, diag, count);
+  apply_diagonal_matrix(iChunk, qubits, 0, diag, gid, count);
 }
 
 template <typename data_t>
-void cuStateVecChunkContainer<data_t>::apply_swap(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const uint_t count)
+void cuStateVecChunkContainer<data_t>::apply_swap(const uint_t iChunk,const reg_t& qubits,const int_t control_bits,const uint_t gid, const uint_t count)
 {
   int_t num_qubits = qubits.size();
 
@@ -539,7 +539,7 @@ void cuStateVecChunkContainer<data_t>::apply_swap(const uint_t iChunk,const reg_
   else{
     nc = count;
     bits = this->chunk_bits_;
-    if(nc > 0){
+    if(nc > 1){
       while((nc & 1) == 0){
         nc >>= 1;
         bits++;
@@ -567,7 +567,7 @@ void cuStateVecChunkContainer<data_t>::apply_swap(const uint_t iChunk,const reg_
 }
 
 template <typename data_t>
-void cuStateVecChunkContainer<data_t>::apply_permutation(const uint_t iChunk,const reg_t& qubits,const std::vector<std::pair<uint_t, uint_t>> &pairs, const uint_t count)
+void cuStateVecChunkContainer<data_t>::apply_permutation(const uint_t iChunk,const reg_t& qubits,const std::vector<std::pair<uint_t, uint_t>> &pairs, const uint_t gid, const uint_t count)
 {
   BaseContainer::set_device();
 
@@ -593,7 +593,7 @@ void cuStateVecChunkContainer<data_t>::apply_permutation(const uint_t iChunk,con
   else{
     nc = count;
     bits = this->chunk_bits_;
-    if(nc > 0){
+    if(nc > 1){
       while((nc & 1) == 0){
         nc >>= 1;
         bits++;
@@ -621,7 +621,7 @@ void cuStateVecChunkContainer<data_t>::apply_permutation(const uint_t iChunk,con
 }
 
 template <typename data_t>
-void cuStateVecChunkContainer<data_t>::apply_rotation(const uint_t iChunk,const reg_t &qubits, const Rotation r, const double theta, const uint_t count)
+void cuStateVecChunkContainer<data_t>::apply_rotation(const uint_t iChunk,const reg_t &qubits, const Rotation r, const double theta, const uint_t gid, const uint_t count)
 {
   custatevecPauli_t pauli[2];
   int nPauli = 1;
@@ -687,7 +687,7 @@ void cuStateVecChunkContainer<data_t>::apply_rotation(const uint_t iChunk,const 
   else{
     nc = count;
     bits = this->chunk_bits_;
-    if(nc > 0){
+    if(nc > 1){
       while((nc & 1) == 0){
         nc >>= 1;
         bits++;
@@ -730,7 +730,7 @@ double cuStateVecChunkContainer<data_t>::norm(uint_t iChunk,uint_t count) const
   else{
     nc = count;
     bits = this->chunk_bits_;
-    if(nc > 0){
+    if(nc > 1){
       while((nc & 1) == 0){
         nc >>= 1;
         bits++;

--- a/src/simulators/statevector/chunk/host_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/host_chunk_container.hpp
@@ -222,23 +222,18 @@ void HostChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iC
 template <typename data_t>
 void HostChunkContainer<data_t>::Swap(Chunk<data_t>& src,uint_t iChunk, uint_t dest_offset, uint_t src_offset, uint_t size_in, bool write_back)
 {
-  uint_t size = 1ull << this->chunk_bits_;
-  if(src.device() >= 0){
-    src.set_device();
-
-    AERHostVector<thrust::complex<data_t>> tmp1(size);
-    auto src_cont = std::static_pointer_cast<DeviceChunkContainer<data_t>>(src.container());
-    
-    thrust::copy_n(thrust::omp::par,data_.begin() + (iChunk << this->chunk_bits_),size,tmp1.begin());
-
-    thrust::copy_n(src_cont->vector().begin() + (src.pos() << this->chunk_bits_),size,data_.begin() + (iChunk << this->chunk_bits_));
-    thrust::copy_n(tmp1.begin(),size,src_cont->vector().begin() + (src.pos() << this->chunk_bits_));
-  }
-  else{
+  uint_t size = size_in;
+  if(size == 0)
+    size = 1ull << this->chunk_bits_;
+//  if(src.device() >= 0){
+//    src.swap(*this,dest_offset,src_offset,size_in,write_back);
+//  }
+//  else{
     auto src_cont = std::static_pointer_cast<HostChunkContainer<data_t>>(src.container());
 
-    thrust::swap_ranges(thrust::omp::par,data_.begin() + (iChunk << this->chunk_bits_),data_.begin() + (iChunk << this->chunk_bits_) + size,src_cont->vector().begin() + (src.pos() << this->chunk_bits_));
-  }
+    this->Execute(BufferSwap_func<data_t>(chunk_pointer(iChunk) + dest_offset,src.pointer() + src_offset, size, write_back), iChunk,0, 1);
+//    thrust::swap_ranges(thrust::omp::par,data_.begin() + (iChunk << this->chunk_bits_) + dest_offset,data_.begin() + (iChunk << this->chunk_bits_) + dest_offset + size,src_cont->vector().begin() + (src.pos() << this->chunk_bits_) + src_offset);
+//  }
 }
 
 

--- a/src/simulators/statevector/chunk/thrust_kernels.hpp
+++ b/src/simulators/statevector/chunk/thrust_kernels.hpp
@@ -1372,7 +1372,7 @@ public:
     i0 = (i - i1) << 1;
     i0 += i1;
 
-    if((i0 & cmask) == cmask){
+    if(((i0 + this->base_index_) & cmask) == cmask){
       q0 = vec0[i0];
       q1 = vec1[i0];
 
@@ -1753,7 +1753,7 @@ public:
     i0 = (i - i1) << 1;
     i0 += i1;
 
-    if((i0 & cmask) == cmask){
+    if(((i0 + this->base_index_) & cmask) == cmask){
       q0 = vec0[i0];
       q1 = vec1[i0];
 
@@ -1819,7 +1819,7 @@ public:
     i0 = (i - i1) << 1;
     i0 += i1;
 
-    if((i0 & cmask) == cmask){
+    if(((i0 + this->base_index_) & cmask) == cmask){
       q0 = vec0[i0];
       q1 = vec1[i0];
 
@@ -1903,7 +1903,7 @@ public:
 
     i0 = i0 + i1 + i2;
 
-    if((i0 & cmask) == cmask){
+    if(((i0 + this->base_index_) & cmask) == cmask){
       q1 = vec1[i0];
       q2 = vec2[i0];
       vec1[i0] = q2;

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -462,14 +462,16 @@ void State<statevec_t>::initialize_qreg(uint_t num_qubits)
   }
 
   if(BaseState::multi_chunk_distribution_){
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(i) 
-      for(i=0;i<BaseState::qregs_.size();i++){
-        if(BaseState::global_chunk_index_ + i == 0 || this->num_qubits_ == this->chunk_bits_){
-          BaseState::qregs_[i].initialize();
-        }
-        else{
-          BaseState::qregs_[i].zero();
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          if(BaseState::global_chunk_index_ + iChunk == 0 || this->num_qubits_ == this->chunk_bits_){
+            BaseState::qregs_[iChunk].initialize();
+          }
+          else{
+            BaseState::qregs_[iChunk].zero();
+          }
         }
       }
     }
@@ -510,10 +512,12 @@ void State<statevec_t>::initialize_qreg(uint_t num_qubits,
 
   if(BaseState::multi_chunk_distribution_){
     uint_t local_offset = BaseState::global_chunk_index_ << BaseState::chunk_bits_;
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++)
-        BaseState::qregs_[iChunk].initialize_from_data(state.data() + local_offset + (iChunk << BaseState::chunk_bits_), 1ull << BaseState::chunk_bits_);
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for private(iChunk)
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++)
+          BaseState::qregs_[iChunk].initialize_from_data(state.data() + local_offset + (iChunk << BaseState::chunk_bits_), 1ull << BaseState::chunk_bits_);
+      }
     }
     else{
       for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++)
@@ -571,10 +575,12 @@ void State<statevec_t>::apply_global_phase()
 {
   if (BaseState::has_global_phase_) {
     int_t i;
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(i) 
-      for(i=0;i<BaseState::qregs_.size();i++)
-        BaseState::qregs_[i].apply_diagonal_matrix({0}, {BaseState::global_phase_, BaseState::global_phase_});
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++)
+          BaseState::qregs_[iChunk].apply_diagonal_matrix({0}, {BaseState::global_phase_, BaseState::global_phase_});
+      }
     }
     else{
       for(i=0;i<BaseState::qregs_.size();i++)
@@ -919,44 +925,64 @@ double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
       z_mask >>= BaseState::chunk_bits_;
       x_max -= BaseState::chunk_bits_;
 
-      auto apply_expval_pauli_chunk = [this, x_mask, z_mask, x_max, qubits_in_chunk, pauli_in_chunk, phase](int_t i)
-      {
-        const uint_t mask_u = ~((1ull << (x_max + 1)) - 1);
-        const uint_t mask_l = (1ull << x_max) - 1;
-        uint_t iChunk = ((i << 1) & mask_u) | (i & mask_l);
-        uint_t pair_chunk = iChunk ^ x_mask;
-        uint_t iProc = BaseState::get_process_by_chunk(pair_chunk);
-        double expval;
-        if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-          uint_t z_count,z_count_pair;
-          z_count = AER::Utils::popcount(iChunk & z_mask);
-          z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
+      const uint_t mask_u = ~((1ull << (x_max + 1)) - 1);
+      const uint_t mask_l = (1ull << x_max) - 1;
+      if(on_same_process){
+        auto apply_expval_pauli_chunk = [this, x_mask, z_mask, x_max,mask_u,mask_l, qubits_in_chunk, pauli_in_chunk, phase](int_t iGroup)
+        {
+          double expval = 0.0;
+          for(int_t iChunk = BaseState::top_chunk_of_group_[iGroup];iChunk < BaseState::top_chunk_of_group_[iGroup + 1];iChunk++){
+            uint_t pair_chunk = iChunk ^ x_mask;
+            if(iChunk < pair_chunk){
+              uint_t z_count,z_count_pair;
+              z_count = AER::Utils::popcount(iChunk & z_mask);
+              z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
 
-          if(iProc == BaseState::distributed_rank_){  //pair is on the same process
-            expval = BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,phase);
+              expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk],z_count,z_count_pair,phase);
+            }
           }
-          else{
-            BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
-            //refer receive buffer to calculate expectation value
-            expval = BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,phase);
+          return expval;
+        };
+        expval += Utils::apply_omp_parallel_for_reduction((BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0),0,BaseState::num_global_chunks_/2,apply_expval_pauli_chunk);
+      }
+      else{
+        for(int_t i=0;i<BaseState::num_global_chunks_/2;i++){
+          uint_t iChunk = ((i << 1) & mask_u) | (i & mask_l);
+          uint_t pair_chunk = iChunk ^ x_mask;
+          uint_t iProc = BaseState::get_process_by_chunk(pair_chunk);
+          if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
+            uint_t z_count,z_count_pair;
+            z_count = AER::Utils::popcount(iChunk & z_mask);
+            z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
+
+            if(iProc == BaseState::distributed_rank_){  //pair is on the same process
+              expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,phase);
+            }
+            else{
+              BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+              //refer receive buffer to calculate expectation value
+              expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,phase);
+            }
+          }
+          else if(iProc == BaseState::distributed_rank_){  //pair is on this process
+            BaseState::send_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
           }
         }
-        else if(iProc == BaseState::distributed_rank_){  //pair is on this process
-          BaseState::send_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
-        }
-        return expval;
-      };
-      expval += Utils::apply_omp_parallel_for_reduction((BaseState::chunk_omp_parallel_ && on_same_process),0,BaseState::num_global_chunks_/2,apply_expval_pauli_chunk);
+      }
     }
     else{ //no exchange between chunks
       z_mask >>= BaseState::chunk_bits_;
-      if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(i) reduction(+:expval)
-        for(i=0;i<BaseState::qregs_.size();i++){
-          double sign = 1.0;
-          if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
-            sign = -1.0;
-          expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk);
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
+#pragma omp parallel for reduction(+:expval)
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          double e_tmp = 0.0;
+          for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+            double sign = 1.0;
+            if (z_mask && (AER::Utils::popcount((iChunk + BaseState::global_chunk_index_) & z_mask) & 1))
+              sign = -1.0;
+            e_tmp += sign * BaseState::qregs_[iChunk].expval_pauli(qubits_in_chunk, pauli_in_chunk);
+          }
+          expval += e_tmp;
         }
       }
       else{
@@ -970,10 +996,14 @@ double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
     }
   }
   else{ //all bits are inside chunk
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for private(i) reduction(+:expval)
-      for(i=0;i<BaseState::qregs_.size();i++)
-        expval += BaseState::qregs_[i].expval_pauli(qubits, pauli);
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
+#pragma omp parallel for reduction(+:expval)
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        double e_tmp = 0.0;
+        for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++)
+          e_tmp += BaseState::qregs_[iChunk].expval_pauli(qubits, pauli);
+        expval += e_tmp;
+      }
     }
     else{
       for(i=0;i<BaseState::qregs_.size();i++)
@@ -1530,7 +1560,7 @@ cmatrix_t State<statevec_t>::vec2density(const reg_t &qubits, const T &vec) {
 template <class statevec_t>
 void State<statevec_t>::apply_gate(const int_t iChunk, const Operations::Op &op) 
 {
-  if(!BaseState::global_index_optimization_){
+  if(!BaseState::global_chunk_indexing_){
     reg_t qubits_in,qubits_out;
     BaseState::get_inout_ctrl_qubits(op,qubits_out,qubits_in);
     if(qubits_out.size() > 0){
@@ -1688,7 +1718,7 @@ void State<statevec_t>::apply_matrix(const int_t iChunk, const reg_t &qubits,
 template <class statevec_t>
 void State<statevec_t>::apply_diagonal_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t & diag)
 {
-  if(BaseState::global_index_optimization_ || !BaseState::multi_chunk_distribution_){
+  if(BaseState::global_chunk_indexing_ || !BaseState::multi_chunk_distribution_){
     //GPU computes all chunks in one kernel, so pass qubits and diagonal matrix as is
     BaseState::qregs_[iChunk].apply_diagonal_matrix(qubits,diag);
   }
@@ -1747,34 +1777,36 @@ rvector_t State<statevec_t>::measure_probs(const int_t iChunk, const reg_t &qubi
   BaseState::qubits_inout(qubits,qubits_in_chunk,qubits_out_chunk);
 
   if(qubits_in_chunk.size() > 0){
-    if(BaseState::chunk_omp_parallel_){
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for private(i,j,k) 
-      for(i=0;i<BaseState::qregs_.size();i++){
-        auto chunkSum = BaseState::qregs_[i].probabilities(qubits_in_chunk);
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++){
+          auto chunkSum = BaseState::qregs_[i].probabilities(qubits_in_chunk);
 
-        if(qubits_in_chunk.size() == qubits.size()){
-          for(j=0;j<dim;j++){
+          if(qubits_in_chunk.size() == qubits.size()){
+            for(j=0;j<dim;j++){
 #pragma omp atomic 
-            sum[j] += chunkSum[j];
+              sum[j] += chunkSum[j];
+            }
           }
-        }
-        else{
-          for(j=0;j<chunkSum.size();j++){
-            int idx = 0;
-            int i_in = 0;
-            for(k=0;k<qubits.size();k++){
-              if(qubits[k] < BaseState::chunk_bits_){
-                idx += (((j >> i_in) & 1) << k);
-                i_in++;
-              }
-              else{
-                if((((i + BaseState::global_chunk_index_) << BaseState::chunk_bits_) >> qubits[k]) & 1){
-                  idx += 1ull << k;
+          else{
+            for(j=0;j<chunkSum.size();j++){
+              int idx = 0;
+              int i_in = 0;
+              for(k=0;k<qubits.size();k++){
+                if(qubits[k] < BaseState::chunk_bits_){
+                  idx += (((j >> i_in) & 1) << k);
+                  i_in++;
+                }
+                else{
+                  if((((i + BaseState::global_chunk_index_) << BaseState::chunk_bits_) >> qubits[k]) & 1){
+                    idx += 1ull << k;
+                  }
                 }
               }
-            }
 #pragma omp atomic 
-            sum[idx] += chunkSum[j];
+              sum[idx] += chunkSum[j];
+            }
           }
         }
       }
@@ -1810,18 +1842,20 @@ rvector_t State<statevec_t>::measure_probs(const int_t iChunk, const reg_t &qubi
     }
   }
   else{ //there is no bit in chunk
-    if(BaseState::chunk_omp_parallel_){
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for private(i,j,k) 
-      for(i=0;i<BaseState::qregs_.size();i++){
-        auto nr = std::real(BaseState::qregs_[i].norm());
-        int idx = 0;
-        for(k=0;k<qubits_out_chunk.size();k++){
-          if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits_out_chunk[k]) & 1){
-            idx += 1ull << k;
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++){
+          auto nr = std::real(BaseState::qregs_[i].norm());
+          int idx = 0;
+          for(k=0;k<qubits_out_chunk.size();k++){
+            if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits_out_chunk[k]) & 1){
+              idx += 1ull << k;
+            }
           }
-        }
 #pragma omp atomic
-        sum[idx] += nr;
+          sum[idx] += nr;
+        }
       }
     }
     else{
@@ -1886,14 +1920,14 @@ void State<statevec_t>::measure_reset_update(const int_t iChunk, const std::vect
       if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for  
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          uint_t istate = BaseState::top_chunk_of_group_[ig];
-          apply_diagonal_matrix(istate, qubits, mdiag);
+          for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+            apply_diagonal_matrix(ic, qubits, mdiag);
         }
       }
       else{
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          uint_t istate = BaseState::top_chunk_of_group_[ig];
-          apply_diagonal_matrix(istate, qubits, mdiag);
+          for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+            apply_diagonal_matrix(ic, qubits, mdiag);
         }
       }
     }
@@ -1919,14 +1953,14 @@ void State<statevec_t>::measure_reset_update(const int_t iChunk, const std::vect
       if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          uint_t istate = BaseState::top_chunk_of_group_[ig];
-          apply_diagonal_matrix(istate, qubits, mdiag);
+          for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+            apply_diagonal_matrix(ic, qubits, mdiag);
         }
       }
       else{
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          uint_t istate = BaseState::top_chunk_of_group_[ig];
-          apply_diagonal_matrix(istate, qubits, mdiag);
+          for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+            apply_diagonal_matrix(ic, qubits, mdiag);
         }
       }
     }
@@ -1983,19 +2017,23 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
     double sum,localSum;
 
     //calculate per chunk sum
-    if(BaseState::chunk_omp_parallel_){
-#pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(i) 
-      for(i=0;i<BaseState::qregs_.size();i++){
-        bool batched = BaseState::qregs_[i].enable_batch(true);   //return sum of all chunks in group
-        chunkSum[i] = BaseState::qregs_[i].norm();
-        BaseState::qregs_[i].enable_batch(batched);
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
+#pragma omp parallel for 
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++){
+          bool batched = BaseState::qregs_[ic].enable_batch(true);   //return sum of all chunks in group
+          chunkSum[ic] = BaseState::qregs_[ic].norm();
+          BaseState::qregs_[ic].enable_batch(batched);
+        }
       }
     }
     else{
-      for(i=0;i<BaseState::qregs_.size();i++){
-        bool batched = BaseState::qregs_[i].enable_batch(true);   //return sum of all chunks in group
-        chunkSum[i] = BaseState::qregs_[i].norm();
-        BaseState::qregs_[i].enable_batch(batched);
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++){
+          bool batched = BaseState::qregs_[ic].enable_batch(true);   //return sum of all chunks in group
+          chunkSum[ic] = BaseState::qregs_[ic].norm();
+          BaseState::qregs_[ic].enable_batch(batched);
+        }
       }
     }
 
@@ -2049,6 +2087,7 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
       }
     }
 
+
 #ifdef AER_MPI
     BaseState::reduce_sum(local_samples);
 #endif
@@ -2098,10 +2137,12 @@ void State<statevec_t>::apply_initialize(const int_t iChunk, const reg_t &qubits
     BaseState::qubits_inout(qubits,qubits_in_chunk,qubits_out_chunk);
 
     if(qubits_out_chunk.size() == 0){   //no qubits outside of chunk
-      if(BaseState::chunk_omp_parallel_){
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for 
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          BaseState::qregs_[i].initialize_component(qubits, params);
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
+            BaseState::qregs_[i].initialize_component(qubits, params);
+        }
       }
       else{
         for(int_t i=0;i<BaseState::qregs_.size();i++)
@@ -2173,10 +2214,12 @@ void State<statevec_t>::apply_initialize(const int_t iChunk, const reg_t &qubits
       }
 
       //initialize by params
-      if(BaseState::chunk_omp_parallel_){
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for 
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          apply_diagonal_matrix(i, qubits,params );
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
+            apply_diagonal_matrix(i, qubits,params );
+        }
       }
       else{
         for(int_t i=0;i<BaseState::qregs_.size();i++)
@@ -2257,10 +2300,12 @@ void State<statevec_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
     }
     else{
       p = 0.0;
-      if(BaseState::chunk_omp_parallel_){
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for reduction(+:p)
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          p += BaseState::qregs_[i].norm(qubits, vmat);
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
+            p += BaseState::qregs_[i].norm(qubits, vmat);
+        }
       }
       else{
         for(int_t i=0;i<BaseState::qregs_.size();i++)
@@ -2284,14 +2329,14 @@ void State<statevec_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
         if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
           for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-            uint_t istate = BaseState::top_chunk_of_group_[ig];
-            apply_matrix(istate, qubits, vmat);
+            for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+              apply_matrix(ic, qubits, vmat);
           }
         }
         else{
           for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-            uint_t istate = BaseState::top_chunk_of_group_[ig];
-            apply_matrix(istate, qubits, vmat);
+            for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+              apply_matrix(ic, qubits, vmat);
           }
         }
       }
@@ -2311,14 +2356,14 @@ void State<statevec_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
       if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          uint_t istate = BaseState::top_chunk_of_group_[ig];
-          apply_matrix(istate, qubits, vmat);
+          for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+            apply_matrix(ic, qubits, vmat);
         }
       }
       else{
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          uint_t istate = BaseState::top_chunk_of_group_[ig];
-          apply_matrix(istate, qubits, vmat);
+          for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+            apply_matrix(ic, qubits, vmat);
         }
       }
     }

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -400,16 +400,18 @@ void State<unitary_matrix_t>::initialize_qreg(uint_t num_qubits)
   }
 
   if(BaseState::multi_chunk_distribution_){
-    if(BaseState::chunk_omp_parallel_){
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-        uint_t irow,icol;
-        irow = (BaseState::global_chunk_index_ + iChunk) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
-        icol = (BaseState::global_chunk_index_ + iChunk) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
-        if(irow == icol)
-          BaseState::qregs_[iChunk].initialize();
-        else
-          BaseState::qregs_[iChunk].zero();
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          uint_t irow,icol;
+          irow = (BaseState::global_chunk_index_ + iChunk) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
+          icol = (BaseState::global_chunk_index_ + iChunk) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
+          if(irow == icol)
+            BaseState::qregs_[iChunk].initialize();
+          else
+            BaseState::qregs_[iChunk].zero();
+        }
       }
     }
     else{
@@ -454,22 +456,24 @@ void State<unitary_matrix_t>::initialize_qreg(uint_t num_qubits,
     auto input = unitary.copy_to_matrix();
     uint_t mask = (1ull << (BaseState::chunk_bits_)) - 1;
 
-    if(BaseState::chunk_omp_parallel_){
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-        uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
-        uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1));
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
+          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1));
 
-        //copy part of state for this chunk
-        uint_t i,row,col;
-        cvector_t tmp(1ull << BaseState::chunk_bits_);
-        for(i=0;i<(1ull << BaseState::chunk_bits_);i++){
-          uint_t icol = i >> (BaseState::chunk_bits_);
-          uint_t irow = i & mask;
-          uint_t idx = ((icol+(irow_chunk << BaseState::chunk_bits_)) << (BaseState::num_qubits_)) + (icol_chunk << BaseState::chunk_bits_) + irow;
-          tmp[i] = input[idx];
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          cvector_t tmp(1ull << BaseState::chunk_bits_);
+          for(i=0;i<(1ull << BaseState::chunk_bits_);i++){
+            uint_t icol = i >> (BaseState::chunk_bits_);
+            uint_t irow = i & mask;
+            uint_t idx = ((icol+(irow_chunk << BaseState::chunk_bits_)) << (BaseState::num_qubits_)) + (icol_chunk << BaseState::chunk_bits_) + irow;
+            tmp[i] = input[idx];
+          }
+          BaseState::qregs_[iChunk].initialize_from_vector(tmp);
         }
-        BaseState::qregs_[iChunk].initialize_from_vector(tmp);
       }
     }
     else{
@@ -521,22 +525,24 @@ void State<unitary_matrix_t>::initialize_qreg(uint_t num_qubits,
       BaseState::qregs_[iChunk].set_num_qubits(BaseState::chunk_bits_);
     }
 
-    if(BaseState::chunk_omp_parallel_){
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for private(iChunk) 
-      for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-        uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
-        uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1));
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
+          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1));
 
-        //copy part of state for this chunk
-        uint_t i,row,col;
-        cvector_t tmp(1ull << BaseState::chunk_bits_);
-        for(i=0;i<(1ull << BaseState::chunk_bits_);i++){
-          uint_t icol = i >> (BaseState::chunk_bits_);
-          uint_t irow = i & mask;
-          uint_t idx = ((icol+(irow_chunk << BaseState::chunk_bits_)) << (BaseState::num_qubits_)) + (icol_chunk << BaseState::chunk_bits_) + irow;
-          tmp[i] = unitary[idx];
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          cvector_t tmp(1ull << BaseState::chunk_bits_);
+          for(i=0;i<(1ull << BaseState::chunk_bits_);i++){
+            uint_t icol = i >> (BaseState::chunk_bits_);
+            uint_t irow = i & mask;
+            uint_t idx = ((icol+(irow_chunk << BaseState::chunk_bits_)) << (BaseState::num_qubits_)) + (icol_chunk << BaseState::chunk_bits_) + irow;
+            tmp[i] = unitary[idx];
+          }
+          BaseState::qregs_[iChunk].initialize_from_vector(tmp);
         }
-        BaseState::qregs_[iChunk].initialize_from_vector(tmp);
       }
     }
     else{
@@ -597,6 +603,22 @@ auto State<unitary_matrix_t>::copy_to_matrix(const int_t iChunk)
 template <class unitary_matrix_t>
 void State<unitary_matrix_t>::apply_gate(const int_t iChunk, const Operations::Op &op) 
 {
+  if(!BaseState::global_chunk_indexing_){
+    reg_t qubits_in,qubits_out;
+    BaseState::get_inout_ctrl_qubits(op,qubits_out,qubits_in);
+    if(qubits_out.size() > 0){
+      uint_t mask = 0;
+      for(int i=0;i<qubits_out.size();i++){
+        mask |= (1ull << (qubits_out[i] - BaseState::chunk_bits_));
+      }
+      if(((BaseState::global_chunk_index_ + iChunk) & mask) == mask){
+        Operations::Op new_op = BaseState::remake_gate_in_chunk_qubits(op,qubits_in);
+        apply_gate(iChunk, new_op);
+      }
+      return;
+    }
+  }
+
   // Look for gate name in gateset
   auto it = gateset_.find(op.name);
   if (it == gateset_.end())
@@ -724,7 +746,7 @@ void State<unitary_matrix_t>::apply_matrix(const int_t iChunk, const reg_t &qubi
 template <class unitary_matrix_t>
 void State<unitary_matrix_t>::apply_diagonal_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t &diag)
 {
-  if(BaseState::global_index_optimization_ || !BaseState::multi_chunk_distribution_){
+  if(BaseState::global_chunk_indexing_ || !BaseState::multi_chunk_distribution_){
     //GPU computes all chunks in one kernel, so pass qubits and diagonal matrix as is
     reg_t qubits_chunk = qubits;
     for(uint_t i=0;i<qubits.size();i++){
@@ -787,10 +809,12 @@ template <class unitary_matrix_t>
 void State<unitary_matrix_t>::apply_global_phase() 
 {
   if (BaseState::has_global_phase_) {
-    if(BaseState::chunk_omp_parallel_){
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for 
-      for(int_t i=0;i<BaseState::qregs_.size();i++)
-        apply_diagonal_matrix(i, {0}, {BaseState::global_phase_, BaseState::global_phase_});
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
+          apply_diagonal_matrix(i, {0}, {BaseState::global_phase_, BaseState::global_phase_});
+      }
     }
     else{
       for(int_t i=0;i<BaseState::qregs_.size();i++)

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -724,7 +724,7 @@ void State<unitary_matrix_t>::apply_matrix(const int_t iChunk, const reg_t &qubi
 template <class unitary_matrix_t>
 void State<unitary_matrix_t>::apply_diagonal_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t &diag)
 {
-  if(BaseState::thrust_optimization_ || !BaseState::multi_chunk_distribution_){
+  if(BaseState::global_index_optimization_ || !BaseState::multi_chunk_distribution_){
     //GPU computes all chunks in one kernel, so pass qubits and diagonal matrix as is
     reg_t qubits_chunk = qubits;
     for(uint_t i=0;i<qubits.size();i++){


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is fix for issue #1522 
Cache blocking transpiler did not support multi-control gates with large number of control qubits (larger than `blocking_qubits` ) that causes segmentation fault for MPI simulator.

### Details and comments
Now cache blocking transpiler only blocks target qubits inside `blocking_qubits` to parallelize circuits for multi-GPU or MPI. 
But it still does not support unitary matrix whose qubits is larger than `blocking_qubits` in this case program will abort (WIP)

I also added number of GPUs used for simulation if cacheblocking is enabled or batched multi-shots optimization is enabled.
