### PR TITLE
Removing usage of the deprecated U1Gate from parallel processing examples.

### DIFF
--- a/docs/apidocs/parallel.rst
+++ b/docs/apidocs/parallel.rst
@@ -51,14 +51,14 @@ Example: Threadpool execution
     circ.h(0)
     circ.cx(0, 1)
     circ.cx(1, 2)
-    circ.u1(pi/2,2)
+    circ.p(pi/2, 2)
     circ.measure([0, 1, 2], [0, 1 ,2])
 
     circ2 = qiskit.QuantumCircuit(15, 15)
     circ2.h(0)
     circ2.cx(0, 1)
     circ2.cx(1, 2)
-    circ2.u1(pi/2,2)
+    circ2.p(pi/2, 2)
     circ2.measure([0, 1, 2], [0, 1 ,2])
     circ_list = [circ, circ2]
 
@@ -87,14 +87,14 @@ guard it by an ``if __name__ == "__main__":`` block.
         circ.h(0)
         circ.cx(0, 1)
         circ.cx(1, 2)
-        circ.u1(pi/2,2)
+        circ.p(pi/2, 2)
         circ.measure([0, 1, 2], [0, 1 ,2])
 
         circ2 = qiskit.QuantumCircuit(15, 15)
         circ2.h(0)
         circ2.cx(0, 1)
         circ2.cx(1, 2)
-        circ2.u1(pi/2,2)
+        circ2.p(pi/2, 2)
         circ2.measure([0, 1, 2], [0, 1 ,2])
 
         circ_list = [circ, circ2]

--- a/releasenotes/notes/remove-deprecated-u1-calls-from-examples-04d092002966617e.yaml
+++ b/releasenotes/notes/remove-deprecated-u1-calls-from-examples-04d092002966617e.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Parallel processing examples have been updated to no longer use the
-    deprecated :class:`~.circuit.gate.U1Gate`.
+    deprecated :class:`~qiskit.circuit.library.U1Gate`.

--- a/releasenotes/notes/remove-deprecated-u1-calls-from-examples-04d092002966617e.yaml
+++ b/releasenotes/notes/remove-deprecated-u1-calls-from-examples-04d092002966617e.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    Parallel processing examples have been updated to no longer use the
-    deprecated :class:`~qiskit.circuit.library.U1Gate`.

--- a/releasenotes/notes/remove-deprecated-u1-calls-from-examples-04d092002966617e.yaml
+++ b/releasenotes/notes/remove-deprecated-u1-calls-from-examples-04d092002966617e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Parallel processing examples have been updated to no longer use the
+    deprecated :class:`~.circuit.gate.U1Gate`.


### PR DESCRIPTION
### Summary

Fixes #1532 by replacing usage of the `U1Gate` with usage of the `PhaseGate`.

