### PR TITLE
Make CI to build OpenMP from source through conan for mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
         run: python -m pip install -U cibuildwheel==2.2.2
       - name: Build Wheels
         env:
-          AER_CMAKE_OPENMP_BUILD: build
+          AER_CMAKE_OPENMP_BUILD: 1
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,8 @@ jobs:
       - name: Install deps
         run: python -m pip install -U cibuildwheel==2.2.2
       - name: Build Wheels
+        env:
+          AER_CMAKE_OPENMP_BUILD: build
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           python -m pip install cibuildwheel==2.2.2
       - name: Build wheels
+        env:
+          AER_CMAKE_OPENMP_BUILD: build
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           python -m pip install cibuildwheel==2.2.2
       - name: Build wheels
         env:
-          AER_CMAKE_OPENMP_BUILD: build
+          AER_CMAKE_OPENMP_BUILD: 1
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
         with:

--- a/cmake/conan_utils.cmake
+++ b/cmake/conan_utils.cmake
@@ -14,21 +14,24 @@ macro(setup_conan)
     list(APPEND AER_CONAN_LIBS nlohmann_json spdlog)
     if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND AER_CONAN_LIBS llvm-openmp)
-        if(SKBUILD)
-            if (DEFINED ENV{AER_CMAKE_OPENMP_BUILD})
-                conan_cmake_run(REQUIRES "llvm-openmp/12.0.1"
-                                OPTIONS "llvm-openmp:shared=True"
-                                ENV CONAN_CMAKE_PROGRAM=${CMAKE_COMMAND}
-                                BASIC_SETUP
-                                CMAKE_TARGETS
-                                KEEP_RPATHS
-                                BUILD llvm-openmp*)
+        if (DEFINED ENV{AER_CMAKE_OPENMP_BUILD})
+            if(SKBUILD)
+                set(AER_CONAN_OPTIONS "llvm-openmp:shared=True")
             else()
-                set(REQUIREMENTS ${REQUIREMENTS} llvm-openmp/12.0.1)
-                set(CONAN_OPTIONS ${CONAN_OPTIONS} "llvm-openmp:shared=True")
+                set(AER_CONAN_OPTIONS "llvm-openmp:shared=False")
             endif()
+            conan_cmake_run(REQUIRES "llvm-openmp/12.0.1"
+                            OPTIONS ${AER_CONAN_OPTIONS}
+                            ENV CONAN_CMAKE_PROGRAM=${CMAKE_COMMAND}
+                            BASIC_SETUP
+                            CMAKE_TARGETS
+                            KEEP_RPATHS
+                            BUILD llvm-openmp*)
         else()
             set(REQUIREMENTS ${REQUIREMENTS} llvm-openmp/12.0.1)
+            if(SKBUILD)
+                set(CONAN_OPTIONS ${CONAN_OPTIONS} "llvm-openmp:shared=True")
+            endif()
         endif()
     endif()
 

--- a/cmake/conan_utils.cmake
+++ b/cmake/conan_utils.cmake
@@ -13,10 +13,22 @@ macro(setup_conan)
     set(REQUIREMENTS nlohmann_json/3.1.1 spdlog/1.5.0)
     list(APPEND AER_CONAN_LIBS nlohmann_json spdlog)
     if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(REQUIREMENTS ${REQUIREMENTS} llvm-openmp/12.0.1)
         list(APPEND AER_CONAN_LIBS llvm-openmp)
         if(SKBUILD)
-            set(CONAN_OPTIONS ${CONAN_OPTIONS} "llvm-openmp:shared=True")
+            if (DEFINED ENV{AER_CMAKE_OPENMP_BUILD})
+                conan_cmake_run(REQUIRES "llvm-openmp/12.0.1"
+                                OPTIONS "llvm-openmp:shared=True"
+                                ENV CONAN_CMAKE_PROGRAM=${CMAKE_COMMAND}
+                                BASIC_SETUP
+                                CMAKE_TARGETS
+                                KEEP_RPATHS
+                                BUILD llvm-openmp*)
+            else()
+                set(REQUIREMENTS ${REQUIREMENTS} llvm-openmp/12.0.1)
+                set(CONAN_OPTIONS ${CONAN_OPTIONS} "llvm-openmp:shared=True")
+            endif()
+        else()
+            set(REQUIREMENTS ${REQUIREMENTS} llvm-openmp/12.0.1)
         endif()
     endif()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

llvm-openmp in conan is built for macosx_11

### Details and comments

The reason why recent CI encounters errors in build of mac is that generated wheel file is for macosx_11 though OS target is 10.9.
Binaries of llvm-openmp in conan were for macosx_11 and then skbuild generates a wheel for 11.

With this PR, CI builds llvm-openmp from source in conan. The built library files are for 10.9 and then skbuild generates a wheel for 10.9.