### PR TITLE
fix issues from mismatch of binding specs in assemble and backend of aer

### DIFF
--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -384,13 +384,18 @@ class AerBackend(Backend, ABC):
             if parameter_binds:
                 # Handle parameter binding
                 parameterizations = self._convert_binds(circuits, parameter_binds)
-                circuits = [circuit.bind_parameters({param: 1 for param in circuit.parameters})
-                            for circuit in circuits]
-
-                qobj = assemble(
-                    circuits,
-                    backend=self,
-                    parameterizations=parameterizations)
+                qobj = None
+                for circuit in circuits:
+                    assemble_bind = {param: 1 for param in circuit.parameters}
+                    qobj_tmp = assemble(
+                        [circuit],
+                        backend=self,
+                        parameter_binds=[assemble_bind],
+                        parameterizations=parameterizations)
+                    if qobj:
+                        qobj.experiments.append(qobj_tmp.experiments[0])
+                    else:
+                        qobj = qobj_tmp
             else:
                 qobj = assemble(circuits, backend=self)
 

--- a/qiskit/providers/aer/backends/aerbackend.py
+++ b/qiskit/providers/aer/backends/aerbackend.py
@@ -384,13 +384,12 @@ class AerBackend(Backend, ABC):
             if parameter_binds:
                 # Handle parameter binding
                 parameterizations = self._convert_binds(circuits, parameter_binds)
-                assemble_binds = []
-                assemble_binds.append({param: 1 for bind in parameter_binds for param in bind})
+                circuits = [circuit.bind_parameters({param: 1 for param in circuit.parameters})
+                            for circuit in circuits]
 
                 qobj = assemble(
                     circuits,
                     backend=self,
-                    parameter_binds=assemble_binds,
                     parameterizations=parameterizations)
             else:
                 qobj = assemble(circuits, backend=self)

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -231,6 +231,39 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         counts = res.get_counts()
         self.assertEqual(counts, [{'00': shots}, {'11': shots}, {'00': shots}] * 3)
 
+    def test_run_path_multiple_different_circuits(self):
+        """Test parameterized circuit path via backed.run()"""
+        shots = 1000
+        backend = AerSimulator()
+
+        circuit1 = QuantumCircuit(2)
+        theta1 = Parameter('theta1')
+        circuit1.rx(theta1, 0)
+        circuit1.cx(0, 1)
+        circuit1.measure_all()
+
+        circuit2 = QuantumCircuit(2)
+        theta2 = Parameter('theta2')
+        circuit2.rx(theta2, 0)
+        circuit2.cx(0, 1)
+        circuit2.measure_all()
+
+        circuit3 = QuantumCircuit(2)
+        theta3_1 = Parameter('theta3_1')
+        theta3_2 = Parameter('theta3_2')
+        circuit3.rx(theta3_1, 0)
+        circuit3.rx(theta3_2, 0)
+        circuit3.cx(0, 1)
+        circuit3.measure_all()
+
+        parameter_binds = [{theta1: [0, pi, 2 * pi]},
+                           {theta2: [0, pi, 2 * pi]},
+                           {theta3_1: [0, pi / 2, pi], theta3_2: [0, pi / 2, pi]}]
+        res = backend.run([circuit1, circuit2, circuit3], shots=shots, parameter_binds=parameter_binds).result()
+        counts = res.get_counts()
+        self.assertEqual(counts, [{'00': shots}, {'11': shots}, {'00': shots}] * 3)
+
+
     def test_run_path_with_expressions_multiple_circuits(self):
         """Test parameterized circuit path via backed.run()"""
         shots = 1000


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #1530

### Details and comments

To use Aer's parameterized qobj, all `Parameter` must be resolved.
Originally, parameters were resolved with `assemble` by setting all pairs of parameters specified for circuits.
However, `assemble` will raise an error if unrelated parameters are specified.

This PR changes parameter resolving outside of `assemble` by calling `bind_parameters` directly.