### PR TITLE
Add qiskit-sphinx-theme to tutorial job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,7 +74,7 @@ jobs:
           pip install -U -r requirements-dev.txt -c constraints.txt
           pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
           pip install -c constraints.txt .
-          pip install -U "qiskit-ibmq-provider" "z3-solver" "qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" jupyter pylatexenc nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
+          pip install -U "qiskit-ibmq-provider" "z3-solver" "qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" jupyter pylatexenc nbsphinx cvxpy qiskit-sphinx-theme -c constraints.txt
           sudo apt install -y graphviz pandoc libopenblas-dev
           pip check
         shell: bash


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-tutorials#1337 the theme used for the sphinx builds of
the tutorials changed to use the qiskit theme package. This is breaking
CI because we didn't have the package installed. This commit fixes this
failure by swapping out the theme package.

### Details and comments


