### PR TITLE
Remove deprecated use of `qiskit.test.mock`

### DIFF
--- a/releasenotes/notes/terra-version-bump-68eac37136428805.yaml
+++ b/releasenotes/notes/terra-version-bump-68eac37136428805.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The required version of Qiskit Terra has been bumped to 0.20.0.

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ extras_requirements = {
 if not _DISABLE_CONAN:
     setup_requirements.append('conan>=1.22.2')
 
-requirements = common_requirements + ['qiskit-terra>=0.19.1', 'scipy>=1.0']
+requirements = common_requirements + ['qiskit-terra>=0.20.0', 'scipy>=1.0']
 
 if not hasattr(setuptools,
                'find_namespace_packages') or not inspect.ismethod(

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -20,8 +20,7 @@ import numpy as np
 from test.terra import common
 
 from qiskit import QuantumCircuit, transpile, schedule
-from qiskit.providers.fake_provider.backends.armonk.fake_armonk import FakeArmonk
-from qiskit.providers.fake_provider.backends.athens.fake_athens import FakeAthens
+from qiskit.providers.fake_provider import FakeArmonk, FakeAthens
 
 from qiskit.providers.aer.backends import PulseSimulator
 from qiskit.pulse import (Schedule, Play, ShiftPhase, SetPhase, Delay, Acquire,

--- a/test/terra/backends/test_config_pulse_simulator.py
+++ b/test/terra/backends/test_config_pulse_simulator.py
@@ -20,8 +20,8 @@ import numpy as np
 from test.terra import common
 
 from qiskit import QuantumCircuit, transpile, schedule
-from qiskit.test.mock.backends.armonk.fake_armonk import FakeArmonk
-from qiskit.test.mock.backends.athens.fake_athens import FakeAthens
+from qiskit.providers.fake_provider.backends.armonk.fake_armonk import FakeArmonk
+from qiskit.providers.fake_provider.backends.athens.fake_athens import FakeAthens
 
 from qiskit.providers.aer.backends import PulseSimulator
 from qiskit.pulse import (Schedule, Play, ShiftPhase, SetPhase, Delay, Acquire,

--- a/test/terra/backends/test_pulse_simulator.py
+++ b/test/terra/backends/test_pulse_simulator.py
@@ -36,7 +36,7 @@ from qiskit.providers.aer.pulse.system_models.pulse_system_model import PulseSys
 from qiskit.providers.aer.pulse.system_models.hamiltonian_model import HamiltonianModel
 from qiskit.providers.models.backendconfiguration import UchannelLO
 from qiskit.providers.aer.aererror import AerError
-from qiskit.test.mock import FakeArmonk
+from qiskit.providers.fake_provider import FakeArmonk
 
 from .pulse_sim_independent import (simulate_1q_model,
                                     simulate_2q_exchange_model,

--- a/test/terra/pulse/test_system_models.py
+++ b/test/terra/pulse/test_system_models.py
@@ -18,10 +18,10 @@ import warnings
 import numpy as np
 from numpy.linalg import norm
 from test.terra.common import QiskitAerTestCase
-from qiskit.test.mock import FakeOpenPulse2Q
+from qiskit.providers.fake_provider import FakeOpenPulse2Q
 from qiskit.providers.aer.pulse.system_models.pulse_system_model import PulseSystemModel
 from qiskit.providers.aer.pulse.system_models.hamiltonian_model import HamiltonianModel
-from qiskit.test.mock import FakeArmonk
+from qiskit.providers.fake_provider import FakeArmonk
 from qiskit.providers.models.backendconfiguration import UchannelLO
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-terra#8121, we triggered deprecation warnings for `qiskit.test.mock`, preferring the new location (since Terra 0.20).  The only uses in Aer are in the tests, but it still technically requires a version bump in the requirements.  It's pretty likely that something else will need/use features of Terra 0.20/0.21 before the Aer 0.11 release anyway.


### Details and comments


