### PR TITLE
Set Sphinx language to explicitly English

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ numfig_format = {
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
### Summary

Since Sphinx 5, `language = None` is a warning that defaults to "en".

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

Fixes failing CI.
