### PR TITLE
Use qiskit.providers.fake_provider instead of qiskit.test.mock and correct rccx and rcccx usages in tests

### DIFF
--- a/test/terra/backends/aer_simulator/test_standard_gates.py
+++ b/test/terra/backends/aer_simulator/test_standard_gates.py
@@ -84,8 +84,8 @@ MC_GATES = [
     (C3XGate, 0, False),
     (C4XGate, 0, False),
     # Parameterized Gates
-    (RC3XGate, 1, False),
-    (RCCXGate, 1, False),
+    (RC3XGate, 0, False),
+    (RCCXGate, 0, False),
     (MCXGate, 0, True),
     (MCPhaseGate, 1, True),
     (MCXGrayCode, 0, True),

--- a/test/terra/backends/aer_simulator/test_truncate.py
+++ b/test/terra/backends/aer_simulator/test_truncate.py
@@ -11,7 +11,7 @@ AerSimulator Integration Tests
 from ddt import ddt
 from qiskit import transpile, QuantumCircuit, Aer
 from qiskit.providers.aer.noise import NoiseModel
-from qiskit.test import mock
+from qiskit.providers.fake_provider import FakeQuito
 from test.terra.backends.simulator_test_case import (
     SimulatorTestCase, supported_methods)
 
@@ -41,7 +41,7 @@ class TestTruncateQubits(SimulatorTestCase):
         return circuit
 
     def device_backend(self):
-        return mock.FakeQuito()
+        return FakeQuito()
 
     def test_truncate_ideal_sparse_circuit(self):
         """Test qubit truncation for large circuit with unused qubits."""

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -32,7 +32,7 @@ from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit.library.generalized_gates import PauliGate
 from qiskit.circuit.library.standard_gates import IGate, XGate
 from qiskit.compiler import transpile
-from qiskit.test import mock
+from qiskit.providers.fake_provider import FakeBackend, FakeSingapore, FakeAlmaden, FakeMumbai, FakeLagos
 from test.terra.common import QiskitAerTestCase
 
 
@@ -203,7 +203,7 @@ class TestNoiseModel(QiskitAerTestCase):
         circ.x(1)
         circ.measure_all()
 
-        backend = mock.FakeSingapore()
+        backend = FakeSingapore()
         noise_model = NoiseModel.from_backend(backend)
         circ = transpile(circ, backend, optimization_level=0)
         result = AerSimulator().run(circ, noise_model=noise_model).result()
@@ -215,7 +215,7 @@ class TestNoiseModel(QiskitAerTestCase):
         circ.x(1)
         circ.measure_all()
 
-        backend = mock.FakeAlmaden()
+        backend = FakeAlmaden()
         noise_model = NoiseModel.from_backend(backend)
         circ = transpile(circ, backend, optimization_level=0)
         result = AerSimulator().run(circ, noise_model=noise_model).result()
@@ -227,7 +227,7 @@ class TestNoiseModel(QiskitAerTestCase):
         circ.x(1)
         circ.measure_all()
 
-        backend = mock.FakeMumbai()
+        backend = FakeMumbai()
         noise_model = NoiseModel.from_backend(backend)
         circ = transpile(circ, backend, optimization_level=0)
         result = AerSimulator().run(circ, noise_model=noise_model).result()
@@ -242,7 +242,7 @@ class TestNoiseModel(QiskitAerTestCase):
         u3_time_ns = 320
         frequency = 4919.96800692
 
-        class InvalidT2Fake1Q(mock.FakeBackend):
+        class InvalidT2Fake1Q(FakeBackend):
             def __init__(self):
                 mock_time = datetime.datetime.now()
                 dt = 1.3333
@@ -320,7 +320,7 @@ class TestNoiseModel(QiskitAerTestCase):
         circ.cx(0, 1)
         circ.measure_all()
 
-        backend = mock.FakeLagos()
+        backend = FakeLagos()
         noise_model = NoiseModel.from_backend(backend)
 
         qc = transpile(circ, backend, scheduling_method="alap")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

terra 0.22 started deprecation of qiskit.test.mock
existing wrong usages of rccx and rcccx are now in error

### Details and comments

This PR changes some tests to use `qiskit.providers.fake_provider` instead of `qiskit.test.mock`.
Existing tests specify float numbers as labels of rccx and rcccx gates. 0.22 raises errors in this situation.