### PR TITLE
Disable BLAS if many threads run

### DIFF
--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -1052,7 +1052,7 @@ std::vector<reg_t> State::
     rnds_list.push_back(rands);
   }
 
-  #pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
+  #pragma omp parallel if (BaseState::threads_ > 1) num_threads(std::min(50, BaseState::threads_))
   {
     MPS temp;
     #pragma omp for


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Work around BLAS fails when many threads run.

### Details and comments

OpenBLAS has issues when many threads attempt to allocate memory in BLAS. 

https://github.com/xianyi/OpenBLAS/issues/1882

This PR disables use of BLAS when a number of threads are more than 50.
(My 76-core machine fails when OMP_NUM_THREADS is more than 56).