### PR TITLE
avaraging seed of cirucits among all MPI processes

### DIFF
--- a/releasenotes/notes/fix-seed-generation-MPI-ee1f0ad44e913d4f.yaml
+++ b/releasenotes/notes/fix-seed-generation-MPI-ee1f0ad44e913d4f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    This is the fix for Issue #1557. Different seed numbers are generated for
+    each process if `seed_simulator` option is not set. This fix average seed
+    set in Circuit for all processes to use the same seed number.

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -978,6 +978,19 @@ Result Controller::execute(std::vector<Circuit> &circuits,
     }
 #endif
 
+#ifdef AER_MPI
+    //average random seed to set the same seed to each process (when seed_simulator is not set)
+    if(num_processes_ > 1){
+      reg_t seeds(circuits.size());
+      reg_t avg_seeds(circuits.size());
+      for(int_t i=0;i<circuits.size();i++)
+        seeds[i] = circuits[i].seed;
+      MPI_Allreduce(seeds.data(), avg_seeds.data(), circuits.size(), MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+      for(int_t i=0;i<circuits.size();i++)
+        circuits[i].seed = avg_seeds[i]/num_processes_;
+    }
+#endif
+
     const int NUM_RESULTS = result.results.size();
     //following looks very similar but we have to separate them to avoid omp nested loops that causes performance degradation
     //(DO NOT use if statement in #pragma omp)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is fix for issue #1557 

### Details and comments
Each MPI process had different seed numbers when `seed_simulator` is not set.
So I added MPI_Allreduce to average seed numbers for each circuit so that all the process has the same seed.
