### PR TITLE
Fixed crash (SegFault) in apply_diagonal_matrix_avx

### DIFF
--- a/src/simulators/statevector/qv_avx2.cpp
+++ b/src/simulators/statevector/qv_avx2.cpp
@@ -1169,13 +1169,11 @@ Avx apply_diagonal_matrix_avx<double>(double* qv_data_,
 #if defined(_OPENMP)
 #pragma omp parallel if (omp_threads > 1) num_threads(omp_threads)
   {
+#endif
 #if !defined(_WIN64) && !defined(_WIN32)
   void* data = nullptr;
   posix_memalign(&data, 64, sizeof(std::complex<double>) * 2);
   auto double_tmp = reinterpret_cast<std::complex<double>*>(data);
-#else
-  auto double_tmp = reinterpret_cast<std::complex<double>*>(malloc(sizeof(std::complex<double>) * 2));
-#endif
 #else
   auto double_tmp = reinterpret_cast<std::complex<double>*>(malloc(sizeof(std::complex<double>) * 2));
 #endif


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixing intermittent Segfault crashes in `apply_diagonal_matrix_avx` when building without OpenMP.

### Details and comments

The temporary double array of size 4 needed for `_mm256_load_pd` should be allocated with `posix_memalign` on Linux platforms. It is accidentally wrapped within `_OPENMP` switch; hence causing the default `malloc` to be used in all cases when that compiler flag is not defined. This may cause Segfault when `_mm256_load_pd` is called on Linux builds. It occurs intermittently, especially in DEBUG builds (no optimization).

The need for `posix_memalign` should not depend on OpenMP. I think this bug was first introduced when we varied the size of the temporary array depending on the number of threads. I suppose when that logic was implemented, the else code path (`_OPENMP` is not defined) should have also had two paths for Windows/non-Windows but it was not.

Since the array size is now fixed, move the entire allocation logic out of the  `#if defined(_OPENMP)` block.

cc @hhorii 
