### PR TITLE
Sphinx warning box broken in `QuantumError` docstring

### DIFF
--- a/qiskit/providers/aer/noise/errors/quantum_error.py
+++ b/qiskit/providers/aer/noise/errors/quantum_error.py
@@ -42,7 +42,8 @@ class QuantumError(BaseOperator, TolerancesMixin):
     """
     Quantum error class for Qiskit Aer noise model
 
-    WARNING: The init interface for this class is not finalized and may
+    .. warning::
+             The init interface for this class is not finalized and may
              change in future releases. For maximum backwards compatibility
              use the QuantumError generating functions in the `noise.errors`
              module.


### PR DESCRIPTION
In [the `QuantumError` class API reference documentation](https://qiskit.org/documentation/stubs/qiskit.providers.aer.noise.QuantumError.html#qiskit.providers.aer.noise.QuantumError), there is a small error that looks like this:
<img width="801" alt="Screenshot 2022-08-03 at 12 19 50" src="https://user-images.githubusercontent.com/766693/182585661-632a3502-dc74-4d3e-b230-c7b24051c753.png">

This PR converts the box into a [Sphinx warning box](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/notes_warnings.html#warnings), which looks like this:
<img width="994" alt="Screenshot 2022-08-03 at 14 37 23" src="https://user-images.githubusercontent.com/766693/182609591-2cb5183c-114e-4e8d-bb46-08f7b75dc3ce.png">

