### PR TITLE
Fix for save_statevector and fix for global indexing for Thrust

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -765,6 +765,13 @@ myrank = meta['mpi_rank']
 Multiple shots are also distributed to multiple nodes when setting `device=GPU` and `batched_shots_gpu=True`. The results are distributed to each processes.
 
 
+Note : In the script, make sure that the same random seed should be used for all processes so that the consistent circuits and parameters are passed to Qiskit Aer. To do so add following option to the script.
+```
+from qiskit.utils import algorithm_globals
+algorithm_globals.random_seed = consistent_seed_to_all_processes
+```
+
+
 ### Building a statically linked wheel
 
 If you encounter an error similar to the following, you may are likely in the need of compiling a

--- a/releasenotes/notes/MPI_chunk_fixes-1ea74548cd3c3515.yaml
+++ b/releasenotes/notes/MPI_chunk_fixes-1ea74548cd3c3515.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes for MPI chunk distribution. Including fix for global indexing
+    for Thrust implementations, fix for cache blocking of non-gate operations.
+    Also savestatevector returns same statevector to all processes
+    (only 1st process received statevector previously.)
+

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -662,7 +662,6 @@ bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t nu
       chunk_omp_parallel_ = true;
 #endif
 
-#ifdef AER_CUSTATEVEC
     //set cuStateVec_enable_ 
     if(cuStateVec_enable_){
       if(multi_shots_parallelization_)
@@ -671,7 +670,6 @@ bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t nu
 
     if(!cuStateVec_enable_)
       global_chunk_indexing_ = true;    //cuStateVec does not handle global chunk index for diagonal matrix
-#endif
   }
   else if(BaseState::sim_device_name_ == "Thrust"){
     global_chunk_indexing_ = true;
@@ -825,6 +823,7 @@ void StateChunk<state_t>::apply_ops_chunks(InputIterator first, InputIterator la
 
   nOp = std::distance(first, last);
   iOp = 0;
+
   while(iOp < nOp){
     const Operations::Op op_iOp = *(first + iOp);
 
@@ -985,12 +984,6 @@ Operations::Op StateChunk<state_t>::remake_gate_in_chunk_qubits(const Operations
       new_op.name = "x";
     else
       new_op.name = "cx";
-  }
-  else if(qubits_in.size() == 1){
-    if(op.name[0] == 'c')
-      new_op.name = op.name.substr(1);
-    else
-      new_op.name = op.name.substr(2);  //remove "mc"
   }
   return new_op;
 }
@@ -2415,37 +2408,29 @@ void StateChunk<state_t>::gather_state(std::vector<std::complex<data_t>>& state)
   if(distributed_procs_ > 1){
     uint_t size,local_size,global_size,offset;
     int i;
-    MPI_Status st;
-    MPI_Request reqSend,reqRecv;
+    std::vector<int> recv_counts(distributed_procs_);
+    std::vector<int> recv_offset(distributed_procs_);
 
-    local_size = state.size();
-    MPI_Allreduce(&local_size,&global_size,1,MPI_UINT64_T,MPI_SUM,distributed_comm_);
-
+    global_size = 0;
+    for(i=0;i<distributed_procs_;i++){
+      recv_offset[i] = (int)(chunk_index_begin_[i] << (chunk_bits_*qubit_scale()))*2;
+      recv_counts[i] = (int)((chunk_index_end_[i] - chunk_index_begin_[i]) << (chunk_bits_*qubit_scale()));
+      global_size += recv_counts[i];
+      recv_counts[i] *= 2;
+    }
     if((global_size >> 21) > Utils::get_system_memory_mb()){
       throw std::runtime_error(std::string("There is not enough memory to gather state"));
     }
+    std::vector<std::complex<data_t>> local_state = state;
+    state.resize(global_size);
 
-    if(distributed_rank_ == 0){
-      if((global_size >> 21) > Utils::get_system_memory_mb()){
-        throw std::runtime_error(std::string("There is not enough memory to gather state"));
-      }
-
-      state.resize(global_size);
-
-      offset = 0;
-      for(i=1;i<distributed_procs_;i++){
-        MPI_Irecv(&size,1,MPI_UINT64_T,i,i*2,distributed_comm_,&reqRecv);
-        MPI_Wait(&reqRecv,&st);
-        MPI_Irecv(&state[offset],size*sizeof(std::complex<data_t>),MPI_BYTE,i,i*2+1,distributed_comm_,&reqRecv);
-        MPI_Wait(&reqRecv,&st);
-        offset += size;
-      }
+    if(sizeof(std::complex<data_t>) == 16){
+      MPI_Allgatherv(local_state.data(),recv_counts[distributed_rank_],MPI_DOUBLE_PRECISION,
+                     state.data(),&recv_counts[0],&recv_offset[0],MPI_DOUBLE_PRECISION,distributed_comm_);
     }
     else{
-      MPI_Isend(&local_size,1,MPI_UINT64_T,0,i*2,distributed_comm_,&reqSend);
-      MPI_Wait(&reqSend,&st);
-      MPI_Isend(&state[0],local_size*sizeof(std::complex<data_t>),MPI_BYTE,0,i*2+1,distributed_comm_,&reqSend);
-      MPI_Wait(&reqSend,&st);
+      MPI_Allgatherv(local_state.data(),recv_counts[distributed_rank_],MPI_FLOAT,
+                     state.data(),&recv_counts[0],&recv_offset[0],MPI_FLOAT,distributed_comm_);
     }
   }
 #endif
@@ -2459,37 +2444,30 @@ void StateChunk<state_t>::gather_state(AER::Vector<std::complex<data_t>>& state)
   if(distributed_procs_ > 1){
     uint_t size,local_size,global_size,offset;
     int i;
-    MPI_Status st;
-    MPI_Request reqSend,reqRecv;
 
-    local_size = state.size();
-    MPI_Allreduce(&local_size,&global_size,1,MPI_UINT64_T,MPI_SUM,distributed_comm_);
+    std::vector<int> recv_counts(distributed_procs_);
+    std::vector<int> recv_offset(distributed_procs_);
 
+    global_size = 0;
+    for(i=0;i<distributed_procs_;i++){
+      recv_offset[i] = (int)(chunk_index_begin_[i] << (chunk_bits_*qubit_scale()))*2;
+      recv_counts[i] = (int)((chunk_index_end_[i] - chunk_index_begin_[i]) << (chunk_bits_*qubit_scale()));
+      global_size += recv_counts[i];
+      recv_counts[i] *= 2;
+    }
     if((global_size >> 21) > Utils::get_system_memory_mb()){
       throw std::runtime_error(std::string("There is not enough memory to gather state"));
     }
+    AER::Vector<std::complex<data_t>> local_state = state;
+    state.resize(global_size);
 
-    if(distributed_rank_ == 0){
-      if((global_size >> 21) > Utils::get_system_memory_mb()){
-        throw std::runtime_error(std::string("There is not enough memory to gather state"));
-      }
-
-      state.resize(global_size);
-
-      offset = 0;
-      for(i=1;i<distributed_procs_;i++){
-        MPI_Irecv(&size,1,MPI_UINT64_T,i,i*2,distributed_comm_,&reqRecv);
-        MPI_Wait(&reqRecv,&st);
-        MPI_Irecv(state.data() + offset,size*sizeof(std::complex<data_t>),MPI_BYTE,i,i*2+1,distributed_comm_,&reqRecv);
-        MPI_Wait(&reqRecv,&st);
-        offset += size;
-      }
+    if(sizeof(std::complex<data_t>) == 16){
+      MPI_Allgatherv(local_state.data(),recv_counts[distributed_rank_],MPI_DOUBLE_PRECISION,
+                     state.data(),&recv_counts[0],&recv_offset[0],MPI_DOUBLE_PRECISION,distributed_comm_);
     }
     else{
-      MPI_Isend(&local_size,1,MPI_UINT64_T,0,i*2,distributed_comm_,&reqSend);
-      MPI_Wait(&reqSend,&st);
-      MPI_Isend(state.data(),local_size*sizeof(std::complex<data_t>),MPI_BYTE,0,i*2+1,distributed_comm_,&reqSend);
-      MPI_Wait(&reqSend,&st);
+      MPI_Allgatherv(local_state.data(),recv_counts[distributed_rank_],MPI_FLOAT,
+                     state.data(),&recv_counts[0],&recv_offset[0],MPI_FLOAT,distributed_comm_);
     }
   }
 #endif

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -985,6 +985,14 @@ Operations::Op StateChunk<state_t>::remake_gate_in_chunk_qubits(const Operations
     else
       new_op.name = "cx";
   }
+  else if(qubits_in.size() == 1){
+    if(op.name[0] == 'c')
+      new_op.name = op.name.substr(1);
+    else if(op.name == "mcphase")
+      new_op.name = "p";
+    else
+      new_op.name = op.name.substr(2);  //remove "mc"
+  }
   return new_op;
 }
 

--- a/src/transpile/cacheblocking.hpp
+++ b/src/transpile/cacheblocking.hpp
@@ -225,10 +225,12 @@ void CacheBlocking::optimize_circuit(Circuit& circ,
     //loop over operations to find max number of parameters for cross-qubits operations
     int_t max_params = 1;
     for(uint_t i=0;i<circ.ops.size();i++){
-      reg_t targets;
-      target_qubits(circ.ops[i],targets);
-      if(targets.size() > max_params)
-        max_params = targets.size();
+      if(is_blockable_operation(circ.ops[i]) && is_cross_qubits_op(circ.ops[i])){
+        reg_t targets;
+        target_qubits(circ.ops[i],targets);
+        if(targets.size() > max_params)
+          max_params = targets.size();
+      }
     }
     if(block_bits_ < max_params){
       block_bits_ = max_params;   //change blocking qubits so that we can put op with many params
@@ -237,7 +239,7 @@ void CacheBlocking::optimize_circuit(Circuit& circ,
     if(num_processes_ > 1){
       if(block_bits_ >= qubits_){
         blocking_enabled_ = false;
-        std::string error = "cache blocking : there are gates operation can not chache blocked in blocking_qubits = " + std::to_string(block_bits_);
+        std::string error = "cache blocking : there are gates operation can not cache blocked in blocking_qubits = " + std::to_string(block_bits_);
         throw std::runtime_error(error);
         return;
       }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is fix for issue #1565 

### Details and comments
Non-gate operations such as save_statevector are not recognized correctly in cache blocking transpiler that causes error if there are full-qubits operations.
The  save_statevector operation only returns statevector to the 1st MPI process previously. Now all the process receive statevector.

Also this PR included fix for global chunk indexing for Thrust implementations. 
