### PR TITLE
Avoid using inversed isometry gate in multiplexer test

### DIFF
--- a/test/terra/reference/ref_multiplexer.py
+++ b/test/terra/reference/ref_multiplexer.py
@@ -20,7 +20,7 @@ from test.terra.reference.ref_2q_clifford import (cx_gate_counts_nondeterministi
                                                   cx_gate_counts_deterministic)
 from test.terra.reference.ref_non_clifford import (ccx_gate_counts_nondeterministic,
                                                    ccx_gate_counts_deterministic)
-
+from qiskit.quantum_info.states import Statevector
 
 def multiplexer_cx_gate_circuits_deterministic(final_measure=True):
     """multiplexer-gate simulating cx gate, test circuits with deterministic counts."""
@@ -291,6 +291,12 @@ def multiplexer_no_control_qubits(final_measure=True):
     vector_circuit.isometry(vector / np.linalg.norm(vector), [0], None)
     vector_circuit = vector_circuit.inverse()
     qc.append(vector_circuit, [0])
+
+    sv = Statevector(qc)
+    gate_list = [np.array([[sv[0], -sv[1]], [sv[1], sv[0]]])]
+    qc = QuantumCircuit(1,1)
+    qc.uc(gate_list, [], [0])
+
     if final_measure:
       qc.measure(0,0)
     return [transpile(qc, basis_gates=['multiplexer', 'measure'])]

--- a/test/terra/reference/ref_multiplexer.py
+++ b/test/terra/reference/ref_multiplexer.py
@@ -294,7 +294,7 @@ def multiplexer_no_control_qubits(final_measure=True):
 
     sv = Statevector(qc)
     gate_list = [np.array([[sv[0], -sv[1]], [sv[1], sv[0]]])]
-    qc = QuantumCircuit(1,1)
+    qc = QuantumCircuit(1, 1)
     qc.uc(gate_list, [], [0])
 
     if final_measure:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

https://github.com/Qiskit/qiskit-terra/pull/8231 breaks transpilation to generate `multiplexer`. https://github.com/Qiskit/qiskit-terra/pull/8454 will fix the error by producing no `multiplexer` gate.
`test_multiplexer_without_control_qubits` needs `multiplexer` gate and this PR generates it by manually calling `uc()`.

### Details and comments

[multiplexer_no_control_qubits](https://github.com/Qiskit/qiskit-aer/blob/8ca389a53314cf0f5d921277006ebf1795a51697/test/terra/reference/ref_multiplexer.py#L287-L296) generates a circuit with `multiplexer` gate by transpiling inversed `isometry` gate. However, `isometry` gate does not produce `multiplexer` gate correctly.

```
    qc = QuantumCircuit(1,1)
    vector = [0.2, 0.1]
    vector_circuit = QuantumCircuit(1)
    vector_circuit.isometry(vector / np.linalg.norm(vector), [0], None)
    vector_circuit = vector_circuit.inverse()
    qc.append(vector_circuit, [0])
    if final_measure:
      qc.measure(0,0)
    return [transpile(qc, basis_gates=['multiplexer', 'measure'])]
```

This PR provides a work around by calling `uc()` directly as follows:
```
    qc = QuantumCircuit(1,1)
    vector = [0.2, 0.1]
    vector_circuit = QuantumCircuit(1)
    vector_circuit.isometry(vector / np.linalg.norm(vector), [0], None)
    vector_circuit = vector_circuit.inverse()
    qc.append(vector_circuit, [0])

    sv = Statevector(qc)
    gate_list = [np.array([[sv[0], -sv[1]], [sv[1], sv[0]]])]
    qc = QuantumCircuit(1,1)
    qc.uc(gate_list, [], [0])

    if final_measure:
      qc.measure(0,0)
    return [transpile(qc, basis_gates=['multiplexer', 'measure'])]
```