### PR TITLE
set_options in get_backend

### DIFF
--- a/qiskit/providers/aer/aerprovider.py
+++ b/qiskit/providers/aer/aerprovider.py
@@ -59,7 +59,9 @@ class AerProvider(Provider):
             AerProvider._BACKENDS = backends
 
     def get_backend(self, name=None, **kwargs):
-        return super().get_backend(name=name, **kwargs)
+        backend = super().get_backend(name=name, **kwargs)
+        backend.set_options(**kwargs)
+        return backend
 
     def backends(self, name=None, filters=None, **kwargs):
         # pylint: disable=arguments-differ

--- a/releasenotes/notes/set_options_in_get_backends-853c4acf2b1ccb76.yaml
+++ b/releasenotes/notes/set_options_in_get_backends-853c4acf2b1ccb76.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Previously ``Aer.get_backend`` method ignores all options. With this fix,
+    all keyword arguments of ``get_backend`` are set to a returned backend
+    by calling its `set_options` metehod.

--- a/test/terra/backends/test_aerprovider.py
+++ b/test/terra/backends/test_aerprovider.py
@@ -1,0 +1,53 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Integration Tests for AerProvider.
+"""
+
+import unittest
+from math import pi
+import numpy as np
+
+from test.terra import common
+from qiskit.providers.aer import Aer, AerSimulator
+
+class TestAerProvider(common.QiskitAerTestCase):
+    """AerProvider tests"""
+
+    def test_get_aer_simulator(self):
+        """Test Aer.get_backend."""
+        backend = Aer.get_backend('aer_simulator')
+        self.assertEqual(backend.__class__, AerSimulator)
+        self.assertEqual(backend.options.get('method'), 'automatic')
+
+    def test_get_aer_simulator_with_statevector(self):
+        """Test Aer.get_backend with statevector."""
+        backend = Aer.get_backend('aer_simulator', method='statevector')
+        self.assertEqual(backend.__class__, AerSimulator)
+        self.assertEqual(backend.options.get('method'), 'statevector')
+
+    def test_get_aer_simulator_with_mps(self):
+        """Test Aer.get_backend with mps."""
+        backend = Aer.get_backend('aer_simulator', method='matrix_product_state')
+        self.assertEqual(backend.__class__, AerSimulator)
+        self.assertEqual(backend.options.get('method'), 'matrix_product_state')
+
+    def test_get_aer_simulator_with_statevector_parallel_threshold(self):
+        """Test Aer.get_backend with statevector."""
+        backend = Aer.get_backend('aer_simulator', method='statevector', statevector_parallel_threshold=1)
+        self.assertEqual(backend.__class__, AerSimulator)
+        self.assertEqual(backend.options.get('method'), 'statevector')
+        self.assertEqual(backend.options.get('statevector_parallel_threshold'), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #1568 by calling `set_options()` in `Aer.get_backend()`

### Details and comments

Keyword options are ignored in original `Aer.get_backend()`. This PR adds a call of `set_options()` to set keyword arguments as backend options.
