### PR TITLE
Add `ibmq_semantics` to support semantics of IBMQ provider

### DIFF
--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -566,6 +566,7 @@ class AerSimulator(AerBackend):
             memory=None,
             noise_model=None,
             seed_simulator=None,
+            ibmq_semantics=False,
             # cuStateVec (cuQuantum) option
             cuStateVec_enable=False,
             # cache blocking for multi-GPUs/MPI options

--- a/releasenotes/notes/support_ibmqprovider_semantics-bbe61e1bbb364a13.yaml
+++ b/releasenotes/notes/support_ibmqprovider_semantics-bbe61e1bbb364a13.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Introduce a new option ``ibmq_semantics`` that support the same semantics
+    with IBMQ Provider: `JobStatus.ERROR` is returned when simulation fails and
+    list of ``dict`` as a ``parameter_binds`` (``[{param0:1.0, param1:2.0}]``).

--- a/test/terra/backends/test_ibmq_semantics.py
+++ b/test/terra/backends/test_ibmq_semantics.py
@@ -1,0 +1,73 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Integration Tests for Parameterized Qobj execution, testing qasm_simulator,
+statevector_simulator, and expectation value snapshots.
+"""
+
+import unittest
+from math import pi
+import numpy as np
+
+from test.terra import common
+from qiskit.providers import JobStatus, JobError
+
+from qiskit.circuit import QuantumCircuit, Parameter
+from qiskit.providers.aer import AerSimulator
+
+class TestIBMQSemantics(common.QiskitAerTestCase):
+    """Test ibmq_semantics option"""
+
+    def test_jobstatus_error(self):
+        """Test JobStatus.Error is set when simulation fails"""
+
+        backend = AerSimulator(method="stabilizer")
+
+        circ = QuantumCircuit(1, 1)
+        circ.t(0)
+        circ.measure(0, 0)
+
+        job = backend.run(circ, ibmq_semantics=True)
+
+        try:
+            job.result()
+        except Exception as e:
+            pass
+
+        self.assertEqual(job.status(), JobStatus.ERROR)
+
+    def test_parameter_binds_convert(self):
+        """Test paramter binding conversion"""
+
+        backend = AerSimulator()
+
+        p = Parameter('a')
+        circ = QuantumCircuit(1, 1)
+        circ.ry(p, 0)
+        circ.measure(0, 0)
+
+        result_aer = backend.run(circ, parameter_binds=[{p:[1.0]}], seed_simulator=0).result()
+        result_ibmq = backend.run(circ, parameter_binds=[{p:1.0}], ibmq_semantics=True, seed_simulator=0).result()
+        self.assertEqual(len(result_aer.results), len(result_ibmq.results))
+        for idx in range(len(result_ibmq.results)):
+            self.assertEqual(result_aer.get_counts(idx), result_ibmq.get_counts(idx))
+
+        result_aer = backend.run([circ, circ], parameter_binds=[{p:[1.0, 2.0]}, {p:[1.0, 2.0]}], seed_simulator=0).result()
+        result_ibmq = backend.run([circ, circ], parameter_binds=[{p:1.0}, {p:2.0}], ibmq_semantics=True, seed_simulator=0).result()
+
+        self.assertEqual(len(result_aer.results), len(result_ibmq.results))
+        for idx in range(len(result_ibmq.results)):
+            self.assertEqual(result_aer.get_counts(idx), result_ibmq.get_counts(idx))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fill semantics differences when `ibmq_semantics=True`

### Details and comments

As reported in #1567 and #1551, ibmq provider and Aer have different semantics. A new parameter `ibmq_semantics` converts their semantics:

**1. Job status**

**IBMQ**: `JobStatus.ERROR` if experiments or Job scheduler fail
**Aer**: `JobStatus.ERROR` if Job scheduler (thread pool executor) fails

**2. Parameter binds**

**IBMQ**: list of parameter sets (`dict` with a parameter as a key and its value as a value). If multiple circuits are specified, all the parameter sets are applied to all the circuits (if `n` circuits and `m` parameter sets are specified, `n*m` experiments run). 
**Aer**: list of parameter vector sets (`dict` with a parameter as a key and a list of values as value). The number of circuits and parameter vector sets must be the same. All the length of parameter vector in a `dict` must be the same.

If `ibmq_semantics=True` is set, Aer uses `IBMQ` semantics, otherwise uses `Aer` semantics.