### PR TITLE
Treat CMAKE_HOST_SYSTEM_PROCESSOR=amd64 same as AMD64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ endif()
 
 message(STATUS "BLAS library found: ${BLAS_LIBRARIES}")
 
-if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
     if(APPLE OR UNIX)
         if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
             set(SIMD_FLAGS_LIST "-mfma;-mavx2")
@@ -331,7 +331,7 @@ if(SKBUILD) # Terra Addon build
 	add_subdirectory(src/open_pulse)
 else() # Standalone build
 
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
       if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
           # We build SIMD filed separately, because they will be reached only if the
           # machine running the code has SIMD support

--- a/qiskit/providers/aer/backends/wrappers/CMakeLists.txt
+++ b/qiskit/providers/aer/backends/wrappers/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(Pybind11 REQUIRED)
 # shared library.
 string(REPLACE " -static " "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
-if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
     if (NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
       # We build SIMD filed separately, because they will be reached only if the
       # machine running the code has SIMD support


### PR DESCRIPTION
FreeBSD has CMAKE_HOST_SYSTEM_PROCESSOR=amd64.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


