### PR TITLE
use system version of cmake/ninja/make if possible

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include MANIFEST.in
 include README.md
 include pyproject.toml
+include _custom_build/backend.py
 recursive-include qiskit *pyx
 recursive-include qiskit *pxd
 recursive-include qiskit *.pxi

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,0 +1,52 @@
+from setuptools import build_meta as _orig
+from packaging import version as _version
+from packaging.tags import sys_tags as _sys_tags
+from skbuild.exceptions import SKBuildError as _SKBuildError
+from skbuild.cmaker import get_cmake_version as _get_cmake_version
+import subprocess as _subprocess
+import platform as _platform
+
+prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
+build_wheel = _orig.build_wheel
+build_sdist = _orig.build_sdist
+get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
+
+
+def _cmake_required():
+    try:
+        version = _version.parse(_get_cmake_version())
+        if version in {_version.parse("3.17.0"), _version.parse("3.17.1")}:
+            return True
+        if version >= _version.parse("3.8"):
+            print("Using System version of cmake")
+            return False
+    except _SKBuildError:
+        pass
+
+    return True
+
+
+def _ninja_required():
+    if _platform.system() == "Windows":
+        print("Ninja is part of the MSVC installation on Windows")
+        return False
+
+    for generator in ("ninja", "make"):
+        try:
+            _subprocess.check_output([generator, "--version"])
+            print(f"Using System version of {generator}")
+            return False
+        except (OSError, _subprocess.CalledProcessError):
+            pass
+
+    return True
+
+
+def get_requires_for_build_wheel(self, config_settings=None):
+    packages = []
+    if _cmake_required():
+        packages.append("cmake!=3.17.1,!=3.17.0")
+    if _ninja_required():
+        packages.append("ninja")
+
+    return _orig.get_requires_for_build_wheel(config_settings) + packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,12 @@ requires = [
   "wheel",
   "conan>=1.40.0",
   "scikit-build>=0.11.0",
-  "cmake!=3.17.1,!=3.17.0",
-  "ninja",
   "pybind11>2.6",
   "oldest-supported-numpy; python_version>'3.7' or platform_machine=='aarch64' or platform_python_implementation=='PyPy'",
   "numpy==1.16.3; python_version<='3.7' and platform_machine!='aarch64' or platform_python_implementation=='PyPy'",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "backend"
+backend-path = ["_custom_build"]
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ common_requirements = [
 
 setup_requirements = common_requirements + [
     'scikit-build>=0.11.0',
-    'cmake!=3.17,!=3.17.0',
+    #'cmake!=3.17,!=3.17.0',
     'pybind11>=2.6',
 ]
 


### PR DESCRIPTION
### Summary

This dynamically checks whether a sufficient version of cmake + ninja/make is available on the system and uses it this version instead of reinstalling when possible. This is helpful on systems like termux where the cmake python package does not provide wheels. This fixes problems on termux: https://github.com/Qiskit/qiskit/issues/1584.



