### PR TITLE
Add release note for namespace migration

### DIFF
--- a/releasenotes/notes/new-namespace-9c3b9fd73ed504e6.yaml
+++ b/releasenotes/notes/new-namespace-9c3b9fd73ed504e6.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    The ``qiskit-aer`` Python package has moved to be a self contained
+    namespace, ``qiskit_aer``. Previously, the ``qiskit-aer`` package shared
+    a namespace with ``qiskit-terra``, ``qiskit.providers.aer``, however this
+    was problematic for several reasons (refer to
+    https://github.com/Qiskit/qiskit/issues/559 for more details) and this
+    release moved away from it. For the time being the ``qiskit.providers.aer``
+    import will continue to work and imports and usage of it will be redirected
+    to ``qiskit_aer`` automatically. The imports from the legacy
+    ``qiskit.provider.aer`` namespace will emit a ``DeprecationWarning`` in the
+    future. To avoid any potential issues starting with this release
+    updating all imports from ``qiskit.providers.aer`` to ``qiskit_aer`` and
+    from ``qiskit.Aer`` to ``qiskit_aer.Aer`` is recommended.

--- a/releasenotes/notes/new-namespace-9c3b9fd73ed504e6.yaml
+++ b/releasenotes/notes/new-namespace-9c3b9fd73ed504e6.yaml
@@ -1,15 +1,13 @@
 ---
 upgrade:
   - |
-    The ``qiskit-aer`` Python package has moved to be a self contained
-    namespace, ``qiskit_aer``. Previously, the ``qiskit-aer`` package shared
-    a namespace with ``qiskit-terra``, ``qiskit.providers.aer``, however this
-    was problematic for several reasons (refer to
-    https://github.com/Qiskit/qiskit/issues/559 for more details) and this
-    release moved away from it. For the time being the ``qiskit.providers.aer``
-    import will continue to work and imports and usage of it will be redirected
-    to ``qiskit_aer`` automatically. The imports from the legacy
+    The ``qiskit-aer`` Python package has moved to be a self-contained
+    namespace, ``qiskit_aer``. Previously, it shared
+    a namespace with ``qiskit-terra`` by being ``qiskit.providers.aer``.
+    `This was problematic for several reasons <https://github.com/Qiskit/qiskit/issues/559>`__,
+    and this release moves away from it. For the time being ``import qiskit.providers.aer``
+    will continue to work and redirect to ``qiskit_aer`` automatically. Imports from the legacy
     ``qiskit.provider.aer`` namespace will emit a ``DeprecationWarning`` in the
-    future. To avoid any potential issues starting with this release
+    future. To avoid any potential issues starting with this release,
     updating all imports from ``qiskit.providers.aer`` to ``qiskit_aer`` and
     from ``qiskit.Aer`` to ``qiskit_aer.Aer`` is recommended.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #1526 we moved the qiskit-aer package to move
it's python namespace from qiskit.providers.aer to qiskit_aer. However,
in that PR a release note was missing. This commit adds the missing
release note to document the upgrade implications about the change. We
should also mention this in the release notes prelude section, but that
will occur in the release PR.

### Details and comments


