### PR TITLE
Add control-flow instruction names to basis gates

### DIFF
--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -436,12 +436,14 @@ class AerSimulator(AerBackend):
             'save_amplitudes', 'save_amplitudes_sq',
             'save_density_matrix', 'save_state', 'save_statevector',
             'save_statevector_dict', 'set_statevector',
+            'if_else', 'for_loop', 'while_loop',
         ]),
         'density_matrix': sorted([
             'quantum_channel', 'qerror_loc', 'roerror', 'kraus', 'superop',
             'save_state', 'save_expval', 'save_expval_var',
             'save_probabilities', 'save_probabilities_dict',
-            'save_density_matrix', 'save_amplitudes_sq', 'set_density_matrix'
+            'save_density_matrix', 'save_amplitudes_sq', 'set_density_matrix',
+            'if_else', 'for_loop', 'while_loop',
         ]),
         'matrix_product_state': sorted([
             'quantum_channel', 'qerror_loc', 'roerror', 'kraus',
@@ -450,23 +452,25 @@ class AerSimulator(AerBackend):
             'save_state', 'save_matrix_product_state', 'save_statevector',
             'save_density_matrix', 'save_amplitudes', 'save_amplitudes_sq',
             'set_matrix_product_state',
+            'if_else', 'for_loop', 'while_loop',
         ]),
         'stabilizer': sorted([
             'quantum_channel', 'qerror_loc', 'roerror',
             'save_expval', 'save_expval_var',
             'save_probabilities', 'save_probabilities_dict',
             'save_amplitudes_sq', 'save_state', 'save_clifford',
-            'save_stabilizer', 'set_stabilizer'
+            'save_stabilizer', 'set_stabilizer',
+            'if_else', 'for_loop', 'while_loop',
         ]),
         'extended_stabilizer': sorted([
-            'quantum_channel', 'qerror_loc', 'roerror', 'save_statevector'
+            'quantum_channel', 'qerror_loc', 'roerror', 'save_statevector',
         ]),
         'unitary': sorted([
-            'save_state', 'save_unitary', 'set_unitary'
+            'save_state', 'save_unitary', 'set_unitary',
         ]),
         'superop': sorted([
             'quantum_channel', 'qerror_loc', 'kraus', 'superop', 'save_state',
-            'save_superop', 'set_superop'
+            'save_superop', 'set_superop',
         ])
     }
 


### PR DESCRIPTION
### Summary

This adds the Terra control-flow instructions to the custom instructions lists for the simulator methods that support them.  This is likely to be a temporary measure; as classical-processing descriptions are expanded in Terra, this method of describing them feels like it will become unworkable, but for now, this is sufficient to allow `qiskit.transpile(qc, AerSimulator(...))` to work as expected when there is control flow.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

I mostly just added these gates to the simulator methods that could run a test circuit:
```python
import qiskit
from qiskit.providers.aer import AerSimulator

qc = qiskit.QuantumCircuit(2, 2)
qc.x(0)
qc.measure(0, 0)
with qc.if_test((qc.clbits[0], True)):
    qc.x(1)
with qc.for_loop((0, 1)):
    qc.x(1)
```

`unitary` and `superop` seem to clearly not work with classical control-flow, but I'm not sure if `extended_stabilizer` should.

I didn't add a release note because I don't know if we want to publicise this yet.