### PR TITLE
fix an issue of while_loop at the tail of a circuit

### DIFF
--- a/releasenotes/notes/fix_bug_in_tail_while-6a9201d1ad6ba6e8.yaml
+++ b/releasenotes/notes/fix_bug_in_tail_while-6a9201d1ad6ba6e8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue when while_loop is the tail of QuantumCircuit. while_loop
+    is translated to jump and mark instructions. However, if a while_loop is
+    at the end of a circuit, its mark instruction is truncated wrongly. This
+    fix corrects the truncation algorithm to always remain mark instructions.

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -269,6 +269,8 @@ void Circuit::set_params(bool truncation) {
   for (size_t i = 0; i < size; ++ i) {
     const size_t rpos = size - i - 1;
     const auto& op = ops[rpos];
+    if (op.type == OpType::mark && last_ancestor_pos == 0)
+        last_ancestor_pos = rpos;
     if (!truncation || check_result_ancestor(op, ancestor_qubits)) {
       add_op_metadata(op);
       ancestor[rpos] = true;
@@ -391,7 +393,7 @@ void Circuit::set_params(bool truncation) {
     head_end = last_ancestor_pos + 1;
   }
   for (size_t pos = 0; pos < head_end; ++pos) {
-    if (ops_to_remove && !ancestor[pos]) {
+    if (ops_to_remove && !ancestor[pos] && ops[pos].type != OpType::mark && ops[pos].type != OpType::jump) {
       // Skip if not ancestor
       continue;
     }

--- a/test/terra/backends/aer_simulator/test_control_flow.py
+++ b/test/terra/backends/aer_simulator/test_control_flow.py
@@ -514,3 +514,17 @@ class TestControlFlow(SimulatorTestCase):
         counts = result.get_counts()
         self.assertEqual(len(counts), 1)
         self.assertIn('011', counts)
+
+    @data('statevector', 'density_matrix', 'matrix_product_state')
+    def test_while_loop_last(self, method):
+        backend = self.backend(method=method)
+    
+        circ = QuantumCircuit(1, 1)
+        circ.h(0)
+        circ.measure(0, 0)
+        with circ.while_loop((circ.clbits[0], True)):
+            circ.h(0)
+            circ.measure(0, 0)
+    
+        result = backend.run(circ, method=method).result()
+        self.assertSuccess(result)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes a bug of simulation of while loops.

### Details and comments

while_loop is translated to mark and jump instructions. However, some of instructions are truncated before simulation runs. This PR is to always leave mark and jump instructions.