### PR TITLE
Move away from `qiskit.providers.aer` in 0.11 release notes

### DIFF
--- a/releasenotes/notes/0.11/fix-for-loop-no-parameter-aa5b04b1da0e956b.yaml
+++ b/releasenotes/notes/0.11/fix-for-loop-no-parameter-aa5b04b1da0e956b.yaml
@@ -8,7 +8,7 @@ fixes:
     .. code-block:: python
 
         import qiskit
-        from qiskit.providers.aer import AerSimulator
+        from qiskit_aer import AerSimulator
 
         qc = qiskit.QuantumCircuit(2)
         with qc.for_loop(range(4)) as i:

--- a/releasenotes/notes/0.11/support_initialize_with_label-bc08f29928d3e3f3.yaml
+++ b/releasenotes/notes/0.11/support_initialize_with_label-bc08f29928d3e3f3.yaml
@@ -7,7 +7,7 @@ features:
     .. code-block:: python
 
         import qiskit
-        from qiskit.providers.aer import AerSimulator
+        from qiskit_aer import AerSimulator
 
         qc = qiskit.QuantumCircuit(4)
         qc.initialize('+-rl')


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The qiskit-aer release notes for 0.11 say that the release moves away from `qiskit.providers.aer`.  However, some of the other release notes for this release actually use this soon-to-be-deprecated import location, including one that is displayed before the one about the new namespace.  This fixes that awkwardness by using `qiskit_aer` uniformly throughout the 0.11 release notes.

### Details and comments


