### PR TITLE
Shot branching optimization for multi-shots simulations

### DIFF
--- a/cmake/conan_utils.cmake
+++ b/cmake/conan_utils.cmake
@@ -10,7 +10,7 @@ macro(setup_conan)
     # Right now every dependency shall be static
     set(CONAN_OPTIONS ${CONAN_OPTIONS} "*:shared=False")
 
-    set(REQUIREMENTS nlohmann_json/3.1.1 spdlog/1.9.2)
+    set(REQUIREMENTS nlohmann_json/3.1.1 spdlog/1.5.0)
     list(APPEND AER_CONAN_LIBS nlohmann_json spdlog)
     if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         list(APPEND AER_CONAN_LIBS llvm-openmp)

--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -275,6 +275,15 @@ class AerSimulator(AerBackend):
       threads per GPU. This parameter is used to optimize Pauli noise
       simulation with multiple-GPUs (Default: 1).
 
+    * ``shot_branching_enable`` (bool): This option enables/disables
+      optimized multi-shots simulation starting from single state and
+      state will be branched when some operations with randomness
+      (i.e. measure, reset, noises, etc.) is applied (Default: True).
+
+    * ``runtime_noise_sampling_enable`` (bool): This option enables/disables
+      runtime noise sampling. This option is only enabled when
+      ``shot_branching_enable`` is also True. (Default: False).
+
     These backend options only apply when using the ``"statevector"``
     simulation method:
 
@@ -580,6 +589,9 @@ class AerSimulator(AerBackend):
             batched_shots_gpu=True,
             batched_shots_gpu_max_qubits=16,
             num_threads_per_device=1,
+            # multi-shot branching
+            shot_branching_enable=True,
+            runtime_noise_sampling_enable=False,
             # statevector options
             statevector_parallel_threshold=14,
             statevector_sample_measure_opt=10,

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -373,6 +373,9 @@ protected:
   int_t batched_shots_gpu_max_qubits_ = 16;   //multi-shot parallelization is applied if qubits is less than max qubits
   bool enable_batch_multi_shots_ = false;   //multi-shot parallelization can be applied
 
+  bool shot_branching_enable_ = true;
+  bool runtime_noise_sampling_enable_ = false;
+
   //settings for cuStateVec
   bool cuStateVec_enable_ = false;
 };
@@ -462,6 +465,14 @@ void Controller::set_config(const json_t &config) {
   }
   if(JSON::check_key("batched_shots_gpu_max_qubits", config)) {
     JSON::get_value(batched_shots_gpu_max_qubits_, "batched_shots_gpu_max_qubits", config);
+  }
+
+  //shot branching optimization
+  if(JSON::check_key("shot_branching_enable", config)) {
+    JSON::get_value(shot_branching_enable_, "shot_branching_enable", config);
+  }
+  if(JSON::check_key("runtime_noise_sampling_enable", config)) {
+    JSON::get_value(runtime_noise_sampling_enable_, "runtime_noise_sampling_enable", config);
   }
 
   //cuStateVec configs
@@ -654,6 +665,7 @@ void Controller::set_parallelization_circuit(const Circuit &circ,
      circ.shots > 1 && max_batched_states_ >= num_gpus_ && 
      batched_shots_gpu_max_qubits_ >= circ.num_qubits ){
       enable_batch_multi_shots_ = true;
+      shot_branching_enable_ = false; //disable shot branch mode
   }
 
   if(sim_device_ == Device::GPU && cuStateVec_enable_){
@@ -1173,50 +1185,50 @@ size_t Controller::required_memory_mb(const Circuit &circ,
   case Method::statevector: {
     if (sim_precision_ == Precision::Single) {
       Statevector::State<QV::QubitVector<float>> state;
-      return state.required_memory_mb(circ.num_qubits, circ.ops);
+      return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
     } else {
       Statevector::State<QV::QubitVector<double>> state;
-      return state.required_memory_mb(circ.num_qubits, circ.ops);
+      return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
     }
   }
   case Method::density_matrix: {
     if (sim_precision_ == Precision::Single) {
       DensityMatrix::State<QV::DensityMatrix<float>> state;
-      return state.required_memory_mb(circ.num_qubits, circ.ops);
+      return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
     } else {
       DensityMatrix::State<QV::DensityMatrix<double>> state;
-      return state.required_memory_mb(circ.num_qubits, circ.ops);
+      return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
     }
   }
   case Method::unitary: {
     if (sim_precision_ == Precision::Single) {
       QubitUnitary::State<QV::UnitaryMatrix<float>> state;
-      return state.required_memory_mb(circ.num_qubits, circ.ops);
+      return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
     } else {
       QubitUnitary::State<QV::UnitaryMatrix<double>> state;
-      return state.required_memory_mb(circ.num_qubits, circ.ops);
+      return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
     }
   }
   case Method::superop: {
     if (sim_precision_ == Precision::Single) {
       QubitSuperoperator::State<QV::Superoperator<float>> state;
-      return state.required_memory_mb(circ.num_qubits, circ.ops);
+      return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
     } else {
       QubitSuperoperator::State<QV::Superoperator<double>> state;
-      return state.required_memory_mb(circ.num_qubits, circ.ops);
+      return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
     }
   }
   case Method::stabilizer: {
     Stabilizer::State state;
-    return state.required_memory_mb(circ.num_qubits, circ.ops);
+    return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
   }
   case Method::extended_stabilizer: {
     ExtendedStabilizer::State state;
-    return state.required_memory_mb(circ.num_qubits, circ.ops);
+    return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
   }
   case Method::matrix_product_state: {
     MatrixProductState::State state;
-    return state.required_memory_mb(circ.num_qubits, circ.ops);
+    return state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend());
   }
   default:
     // We shouldn't get here, so throw an exception if we do
@@ -1345,7 +1357,8 @@ void Controller::run_circuit_helper(const Circuit &circ,
       }
       // General circuit noise sampling
       else {
-        if(enable_batch_multi_shots_ && !multi_chunk_required_){
+        State_t t;
+        if(!multi_chunk_required_ && (enable_batch_multi_shots_ || (runtime_noise_sampling_enable_ && shot_branching_enable_ && t.runtime_noise_sampling_supported()))){
           //batched optimization samples noise at runtime
           opt_circ = noise.sample_noise(circ, rng, Noise::NoiseModel::Method::circuit, true);
         }
@@ -1394,7 +1407,7 @@ void Controller::run_single_shot(const Circuit &circ, State_t &state,
   state.initialize_qreg(circ.num_qubits);
   state.initialize_creg(circ.num_memory, circ.num_registers);
   state.apply_ops(circ.ops.cbegin(), circ.ops.cend(), result, rng, true);
-  result.save_count_data(state.cregs(), save_creg_memory_);
+  result.save_count_data(state.creg(), save_creg_memory_);
 }
 
 template <class State_t>
@@ -1403,7 +1416,8 @@ void Controller::run_with_sampling(const Circuit &circ,
                                    ExperimentResult &result,
                                    RngEngine &rng,
                                    const uint_t block_bits,
-                                   const uint_t shots) const {
+                                   const uint_t shots) const 
+{
   auto& ops = circ.ops;
   auto first_meas = circ.first_measure_pos; // Position of first measurement op
   bool final_ops = (first_meas == ops.size());
@@ -1418,7 +1432,8 @@ void Controller::run_with_sampling(const Circuit &circ,
   state.apply_ops(ops.cbegin(), ops.cbegin() + first_meas, result, rng, final_ops);
 
   // Get measurement operations and set of measured qubits
-  measure_sampler(circ.ops.begin() + first_meas, circ.ops.end(), shots, state, result, rng);
+  state.measure_sampler(circ.ops.begin() + first_meas, circ.ops.end(), shots, result, rng);
+//  measure_sampler(circ.ops.begin() + first_meas, circ.ops.end(), shots, state, result, rng);
 }
 
 template <class State_t>
@@ -1513,65 +1528,31 @@ void Controller::run_circuit_without_sampled_noise(Circuit &circ,
     // Perform standard execution if we cannot apply the
     // measurement sampling optimization
 
-    if(block_bits == circ.num_qubits && enable_batch_multi_shots_ && state.multi_shot_parallelization_supported()){
-      //apply batched multi-shots optimization (currenly only on GPU)
-      state.set_max_bached_shots(max_batched_states_);
-      state.set_distribution(num_processes_);
-      state.set_max_matrix_qubits(max_bits);
-      state.allocate(circ.num_qubits, circ.num_qubits, circ.shots);    //allocate multiple-shots
-
-      //qreg is initialized inside state class
-      state.initialize_creg(circ.num_memory, circ.num_registers);
-
-      state.apply_ops_multi_shots(circ.ops.cbegin(), circ.ops.cend(), noise, result, circ.seed, true);
-
-      result.save_count_data(state.cregs(), save_creg_memory_);
-
-      // Add batched multi-shots optimizaiton metadata
-      result.metadata.add(true, "batched_shots_optimization");
-    }
+    uint_t num_state = 1;
+    //enable batch execution when circuit does not contain control flow ops
+    if(circ.opset().contains(Operations::OpType::jump) ||circ.opset().contains(Operations::OpType::mark))
+      state.enable_batch_execution(false);
     else{
-      std::vector<ExperimentResult> par_results(parallel_shots_);
-      int_t par_shots = parallel_shots_;
-      if(block_bits != circ.num_qubits)
-        par_shots = 1;
-
-      auto run_circuit_without_sampled_noise_lambda = [this,&par_results,circ,noise,config,method,block_bits,max_bits,par_shots](int_t i){
-        uint_t i_shot,shot_end;
-        i_shot = circ.shots*i/par_shots;
-        shot_end = circ.shots*(i+1)/par_shots;
-
-        State_t par_state;
-        // Set state config
-        par_state.set_config(config);
-        par_state.set_parallelization(parallel_state_update_);
-        par_state.set_global_phase(circ.global_phase_angle);
-
-        par_state.set_distribution(num_process_per_experiment_);
-        par_state.set_max_matrix_qubits(max_bits );
-
-        // allocate qubit register
-        par_state.allocate(circ.num_qubits, block_bits);
-
-        for(;i_shot<shot_end;i_shot++){
-          RngEngine rng;
-          rng.set_seed(circ.seed + i_shot);
-          run_single_shot(circ, par_state, par_results[i], rng);
-        }
-        par_state.add_metadata(par_results[i]);
-      };
-      Utils::apply_omp_parallel_for((par_shots > 1),0,par_shots,run_circuit_without_sampled_noise_lambda);
-
-      for (auto &res : par_results) {
-        result.combine(std::move(res));
+      if(shot_branching_enable_)
+        state.enable_batch_execution(true);
+      else if(!multi_chunk_required_ && enable_batch_multi_shots_ && state.multi_shot_parallelization_supported()){
+        state.enable_batch_execution(true);   //enable batched execution for GPU
+        state.set_max_bached_shots(max_batched_states_);
+        num_state =  circ.shots;
       }
-      if (sim_device_name_ == "GPU"){
-        if(par_shots >= num_gpus_)
-          result.metadata.add(num_gpus_, "gpu_parallel_shots_");
-        else
-          result.metadata.add(par_shots, "gpu_parallel_shots_");
-      }
+      else
+        state.enable_batch_execution(false);
     }
+    state.enable_shot_branching(shot_branching_enable_);
+
+    state.set_distribution(num_process_per_experiment_);
+    state.set_max_matrix_qubits(max_bits);
+    state.allocate(circ.num_qubits, block_bits, num_state);
+    state.set_parallel_shots(parallel_shots_);
+    state.initialize_qreg(circ.num_qubits);
+    state.initialize_creg(circ.num_memory, circ.num_registers);
+
+    state.run_shots(circ.ops.cbegin(), circ.ops.cend(), config, noise, result, circ.seed, circ.shots);
   }
   state.add_metadata(result);
 }
@@ -1679,7 +1660,8 @@ bool Controller::check_measure_sampling_opt(const Circuit &circ,
       circ.opset().contains(Operations::OpType::kraus) ||
       circ.opset().contains(Operations::OpType::superop) ||
       circ.opset().contains(Operations::OpType::jump) ||
-      circ.opset().contains(Operations::OpType::mark )) {
+      circ.opset().contains(Operations::OpType::mark ) ||
+      circ.opset().contains(Operations::OpType::sample_noise )) {
     return false;
   }
   // Otherwise true
@@ -1694,7 +1676,7 @@ void Controller::measure_sampler(
   // Check if meas_circ is empty, and if so return initial creg
   if (first_meas == last_meas) {
     while (shots-- > 0) {
-      result.save_count_data(state.cregs(), save_creg_memory_);
+      result.save_count_data(state.creg(), save_creg_memory_);
     }
     return;
   }
@@ -1921,7 +1903,7 @@ bool Controller::validate_state(const state_t &state, const Circuit &circ,
   // Validate memory requirements
   bool memory_valid = true;
   if (max_memory_mb_ > 0) {
-    size_t required_mb = state.required_memory_mb(circ.num_qubits, circ.ops) / num_process_per_experiment_;                                        
+    size_t required_mb = state.required_memory_mb(circ.num_qubits, circ.ops.cbegin(), circ.ops.cend()) / num_process_per_experiment_;                                        
     size_t mem_size = (sim_device_ == Device::GPU) ? max_memory_mb_ + max_gpu_memory_mb_ : max_memory_mb_;
     memory_valid = (required_mb <= mem_size);
     if (throw_except && !memory_valid) {

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -683,7 +683,7 @@ reg_t AerState::initialize_statevector(uint_t num_of_qubits, complex_t* data, bo
   auto qv = QV::QubitVector<double>(num_of_qubits_, data, copy);
   state->initialize_qreg(num_of_qubits_);
   state->initialize_creg(num_of_qubits_, num_of_qubits_);
-  state->initialize_statevector(num_of_qubits_, std::move(qv));
+  state->initialize_qreg(std::move(qv));
   state_ = state;
   rng_.set_seed(seed_);
   initialized_ = true;

--- a/src/framework/creg.hpp
+++ b/src/framework/creg.hpp
@@ -29,6 +29,10 @@ namespace AER {
 class ClassicalRegister {
 
 public:
+  ClassicalRegister(){}
+  ClassicalRegister(const ClassicalRegister& src);
+
+  ClassicalRegister &operator=(const ClassicalRegister& src);
 
   // Return the current value of the memory as little-endian hex-string
   inline std::string memory_hex() const {return Utils::bin2hex(creg_memory_);}
@@ -92,6 +96,12 @@ protected:
 //============================================================================
 // Implementations
 //============================================================================
+ClassicalRegister::ClassicalRegister(const ClassicalRegister& src)
+{
+  creg_memory_ = src.creg_memory_;
+  creg_register_ = src.creg_register_;
+  return_hex_strings_ = src.return_hex_strings_;
+}
 
 void ClassicalRegister::initialize(size_t num_memory, size_t num_register) {
   // Set registers to the all 0 bit state
@@ -99,6 +109,13 @@ void ClassicalRegister::initialize(size_t num_memory, size_t num_register) {
   creg_register_ = std::string(num_register, '0');
 }
 
+ClassicalRegister& ClassicalRegister::operator=(const ClassicalRegister& src)
+{
+  creg_memory_ = src.creg_memory_;
+  creg_register_ = src.creg_register_;
+  return_hex_strings_ = src.return_hex_strings_;
+  return *this;
+}
 
 void ClassicalRegister::initialize(size_t num_memory,
                                    size_t num_register,

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -40,7 +40,7 @@ enum class OpType {
   gate, measure, reset, bfunc, barrier, qerror_loc, snapshot,
   matrix, diagonal_matrix, multiplexer, initialize, sim_op, nop,
   // Noise instructions
-  kraus, superop, roerror, noise_switch,
+  kraus, superop, roerror, noise_switch, sample_noise, 
   // Save instructions
   save_state, save_expval, save_expval_var, save_statevec, save_statevec_dict,
   save_densmat, save_probs, save_probs_ket, save_amps, save_amps_sq,
@@ -185,6 +185,9 @@ inline std::ostream& operator<<(std::ostream& stream, const OpType& type) {
     break;
   case OpType::jump:
     stream << "jump";
+    break;
+  case OpType::sample_noise:
+    stream << "sample_noise";
     break;
   default:
     stream << "unknown";

--- a/src/framework/results/experiment_result.hpp
+++ b/src/framework/results/experiment_result.hpp
@@ -91,12 +91,12 @@ public:
   template <class T>
   void save_data_pershot(const ClassicalRegister& creg,
                          const std::string &key, const T& datum, OpType type,
-                         DataSubType subtype = DataSubType::list);
+                         DataSubType subtype = DataSubType::list, int_t nshots = 1);
 
   template <class T>
   void save_data_pershot(const ClassicalRegister& creg,
                          const std::string &key, T&& datum, OpType type,
-                         DataSubType subtype = DataSubType::list);
+                         DataSubType subtype = DataSubType::list, int_t nshots = 1);
 
 
  };
@@ -225,19 +225,24 @@ template <class T>
 void ExperimentResult::save_data_pershot(const ClassicalRegister& creg,
                                        const std::string &key,
                                        const T& datum, OpType type,
-                                       DataSubType subtype) {
+                                       DataSubType subtype, int_t nshots) 
+{
   switch (subtype) {
   case DataSubType::single:
-    data.add_single(datum, key);
+    for(int_t i=0;i<nshots;i++)
+      data.add_single(datum, key);
     break;
   case DataSubType::c_single:
-    data.add_single(datum, key, creg.memory_hex());
+    for(int_t i=0;i<nshots;i++)
+      data.add_single(datum, key, creg.memory_hex());
     break;
   case DataSubType::list:
-    data.add_list(datum, key);
+    for(int_t i=0;i<nshots;i++)
+      data.add_list(datum, key);
     break;
   case DataSubType::c_list:
-    data.add_list(datum, key, creg.memory_hex());
+    for(int_t i=0;i<nshots;i++)
+      data.add_list(datum, key, creg.memory_hex());
     break;
   default:
     throw std::runtime_error("Invalid pershot data subtype for data key: " + key);
@@ -250,18 +255,27 @@ template <class T>
 void ExperimentResult::save_data_pershot(const ClassicalRegister& creg, 
                                          const std::string &key,
                                          T&& datum, OpType type,
-                                         DataSubType subtype) {
+                                         DataSubType subtype, int_t nshots)
+{
   switch (subtype) {
     case DataSubType::single:
+      for(int_t i=0;i<nshots-1;i++)
+        data.add_single(datum, key);
       data.add_single(std::move(datum), key);
       break;
     case DataSubType::c_single:
+      for(int_t i=0;i<nshots-1;i++)
+        data.add_single(datum, key, creg.memory_hex());
       data.add_single(std::move(datum), key, creg.memory_hex());
       break;
     case DataSubType::list:
+      for(int_t i=0;i<nshots-1;i++)
+        data.add_list(datum, key);
       data.add_list(std::move(datum), key);
       break;
     case DataSubType::c_list:
+      for(int_t i=0;i<nshots-1;i++)
+        data.add_list(datum, key, creg.memory_hex());
       data.add_list(std::move(datum), key, creg.memory_hex());
       break;
     default:

--- a/src/framework/rng.hpp
+++ b/src/framework/rng.hpp
@@ -42,6 +42,12 @@ public:
   // Seeded constructor initialize RNG engine with a fixed seed
   explicit RngEngine(size_t seed) { set_seed(seed); }
 
+  RngEngine(const RngEngine& src)
+  {
+    rng = src.rng;
+    initial_seed_ = src.initial_seed_;
+  }
+
   //-----------------------------------------------------------------------
   // Set fixed or random seed for RNG
   //-----------------------------------------------------------------------

--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -107,6 +107,11 @@ template <class T> void split (const matrix<T> &A, matrix<T> &B, matrix<T> &C, u
 //Elementwise matrix multiplication
 template <class T> matrix<T> elementwise_multiplication(const matrix<T> &A, const matrix<T> &B);
 
+// Inplace multiply each entry in a matrix by a scalar and returns a reference to
+// the input matrix argument. The product of types T1 * T2 must be valid.
+template <typename T1, typename T2>
+matrix<T1>& scalar_multiply_inplace(matrix<T1> &mat, T2 scalar);
+
 //Matrix sum of elements
 template <class T> T sum(const matrix<T> &A);
 
@@ -623,6 +628,17 @@ matrix<T> elementwise_multiplication(const matrix<T> &A, const matrix<T> &B) {
     for (size_t j = 0; j < cols1; j++)
       temp(i, j) = A(i, j) * B(i, j);
   return temp;
+}
+
+template <typename T1, typename T2>
+matrix<T1>& scalar_multiply_inplace(matrix<T1> &mat, T2 val) 
+{
+  const auto nrows = mat.GetRows();
+  const auto ncols = mat.GetColumns();
+  for (size_t i=0; i < nrows; i++)
+    for (size_t j=0; j < ncols; j++)
+      mat(i,j) *= val;
+  return mat;
 }
 
 template <class T>
@@ -1289,6 +1305,26 @@ size_t get_system_memory_mb()
   return total_physical_memory >> 20;
 }
 
+size_t get_free_memory_mb() 
+{
+  size_t total_physical_memory = 0;
+#if defined(__linux__) || defined(__APPLE__)
+#if defined _SC_AVPHYS_PAGES
+  size_t pages = (size_t)sysconf(_SC_AVPHYS_PAGES);
+#else
+  size_t pages = (size_t)sysconf(_SC_PHYS_PAGES);
+#endif
+  size_t page_size = (size_t)sysconf(_SC_PAGE_SIZE);
+  total_physical_memory = pages * page_size;
+#elif defined(_WIN64) || defined(_WIN32)
+  MEMORYSTATUSEX status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatusEx(&status);
+  total_physical_memory = status.ullAvailPhys;
+#endif
+  return total_physical_memory >> 20;
+}
+
 //apply OpenMP parallel loop to lambda function if enabled
 template<typename Lambda>
 void apply_omp_parallel_for(bool enabled, int_t i_begin, int_t i_end, Lambda& func, int nthreads = 0)
@@ -1335,6 +1371,29 @@ double apply_omp_parallel_for_reduction(bool enabled, int_t i_begin, int_t i_end
   return val;
 }
 
+//apply OpenMP parallel loop to lambda function and return reduced integer if enabled
+template<typename Lambda>
+int apply_omp_parallel_for_reduction_int(bool enabled, int_t i_begin, int_t i_end, Lambda& func, int nthreads = 0)
+{
+  int val = 0;
+  if(enabled){
+    if(nthreads > 0){
+#pragma omp parallel for reduction(+:val) num_threads(nthreads)
+      for(int_t i=i_begin;i<i_end;i++)
+        val += func(i);
+    }
+    else{
+#pragma omp parallel for reduction(+:val)
+      for(int_t i=i_begin;i<i_end;i++)
+        val += func(i);
+    }
+  }
+  else{
+    for(int_t i=i_begin;i<i_end;i++)
+      val += func(i);
+  }
+  return val;
+}
 
 //------------------------------------------------------------------------------
 } // end namespace Utils

--- a/src/noise/noise_model.hpp
+++ b/src/noise/noise_model.hpp
@@ -517,7 +517,7 @@ NoiseModel::NoiseOps NoiseModel::sample_noise_helper(const Operations::Op &op,
   // Combine errors
   auto &noise_ops = noise_before;
   noise_ops.reserve(noise_before.size() + noise_after.size() + 1);
-  if (op.type != Operations::OpType::qerror_loc) {
+  if (op.type != Operations::OpType::sample_noise) {
     noise_ops.push_back(op);
   }
   noise_ops.insert(noise_ops.end(),
@@ -792,7 +792,7 @@ NoiseModel::NoiseOps NoiseModel::create_noise_loc(const Operations::Op &op) cons
 {
   NoiseOps ops(1);
   ops[0] = op;
-  ops[0].type = Operations::OpType::qerror_loc;
+  ops[0].type = Operations::OpType::sample_noise;
   return ops;
 }
 

--- a/src/simulators/density_matrix/densitymatrix.hpp
+++ b/src/simulators/density_matrix/densitymatrix.hpp
@@ -46,8 +46,15 @@ public:
 
   DensityMatrix() : DensityMatrix(0) {};
   explicit DensityMatrix(size_t num_qubits);
-  DensityMatrix(const DensityMatrix& obj) {};
-  DensityMatrix &operator=(const DensityMatrix& obj) {};
+  DensityMatrix(const DensityMatrix& obj) : BaseMatrix(obj)
+  {
+    apply_unitary_threshold_ = obj.apply_unitary_threshold_;
+  }
+  DensityMatrix &operator=(const DensityMatrix& obj)
+  {
+    apply_unitary_threshold_ = obj.apply_unitary_threshold_;
+    return *this;
+  }
 
   //-----------------------------------------------------------------------
   // Utility functions
@@ -58,6 +65,12 @@ public:
 
   // Initializes the current vector so that all qubits are in the |0> state.
   void initialize();
+
+  //initialize from existing state (copy)
+  void initialize(const DensityMatrix<data_t>& obj)
+  {
+    BaseMatrix::initialize(obj);
+  }
 
   // Initializes the vector to a custom initial state.
   // The vector can be either a statevector or a vectorized density matrix

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -97,120 +97,141 @@ public:
 
   // Apply an operation
   // If the op is not in allowed_ops an exeption will be raised.
-  virtual void apply_op(const int_t iChunk, const Operations::Op &op,
+  void apply_op(QuantumState::RegistersBase& state, const Operations::Op &op,
                         ExperimentResult &result,
                         RngEngine &rng,
                         bool final_op = false) override;
-
-  // Initializes an n-qubit state to the all |0> state
-  virtual void initialize_qreg(uint_t num_qubits) override;
+  //apply_op for specific chunk
+  void apply_op_chunk(uint_t iChunk, QuantumState::RegistersBase& state, 
+                        const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine& rng,
+                        bool final_op = false) override;
 
   // Returns the required memory for storing an n-qubit state in megabytes.
   // For this state the memory is indepdentent of the number of ops
   // and is approximately 16 * 1 << num_qubits bytes
   virtual size_t
   required_memory_mb(uint_t num_qubits,
-                     const std::vector<Operations::Op> &ops) const override;
-
-  // Load the threshold for applying OpenMP parallelization
-  // if the controller/engine allows threads for it
-  virtual void set_config(const json_t &config) override;
+                     QuantumState::OpItr first, QuantumState::OpItr last) const override;
 
   // Sample n-measurement outcomes without applying the measure operation
   // to the system state
-  virtual std::vector<reg_t> sample_measure(const reg_t &qubits, uint_t shots,
+  virtual std::vector<reg_t> sample_measure(QuantumState::RegistersBase& state, const reg_t &qubits, uint_t shots,
                                             RngEngine &rng) override;
 
-  // Initialize OpenMP settings for the underlying DensityMatrix class
-  void initialize_omp();
+  //-----------------------------------------------------------------------
+  // Additional methods
+  //-----------------------------------------------------------------------
 
-  auto move_to_matrix(const int_t iChunk);
-  auto copy_to_matrix(const int_t iChunk);
+  // Initializes to a specific n-qubit state given as a complex std::vector
+  void initialize_qreg_from_data(uint_t num_qubits, const cvector_t &vector);
+
+  // Initializes to a specific n-qubit state given as a complex matrix
+  void initialize_qreg_from_data(uint_t num_qubits, const cmatrix_t &matrix);
+
+  // Initialize OpenMP settings for the underlying DensityMatrix class
+  void initialize_omp(QuantumState::Registers<densmat_t>& state);
+
+  auto move_to_matrix(QuantumState::Registers<densmat_t>& state);
+  auto copy_to_matrix(QuantumState::Registers<densmat_t>& state);
 
 protected:
+  void initialize_creg_state(QuantumState::RegistersBase& state, const ClassicalRegister& creg) override;
+
   template <typename list_t>
-  void initialize_from_vector(const int_t iChunk, const list_t &vec);
+  void initialize_from_vector(QuantumState::Registers<densmat_t>& state, const list_t &vec);
+
+  // Initializes an n-qubit state to the all |0> state
+  void initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits) override;
+
+  // Initializes to a specific n-qubit state
+  void initialize_qreg_state(QuantumState::RegistersBase& state_in, const densmat_t &mat) override;
+
+  // Load the threshold for applying OpenMP parallelization
+  // if the controller/engine allows threads for it
+  void set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) override;
 
   //-----------------------------------------------------------------------
   // Apply instructions
   //-----------------------------------------------------------------------
   //apply op to multiple shots , return flase if op is not supported to execute in a batch
-  bool apply_batched_op(const int_t iChunk, const Operations::Op &op,
+  bool apply_batched_op(const int_t iChunk, QuantumState::RegistersBase& state_in, const Operations::Op &op,
                                 ExperimentResult &result,
                                 std::vector<RngEngine> &rng,
                                 bool final_op = false) override;
 
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
-  void apply_gate(const int_t iChunk, const Operations::Op &op);
+  void apply_gate(densmat_t& qreg, const Operations::Op &op);
 
   //apply (multi) control gate by statevector
-  void apply_gate_statevector(const int_t iChunk, const Operations::Op &op);
+  void apply_gate_statevector(densmat_t& qreg, const Operations::Op &op);
 
   // Measure qubits and return a list of outcomes [q0, q1, ...]
   // If a state subclass supports this function it then "measure"
   // should be contained in the set returned by the 'allowed_ops'
   // method.
-  virtual void apply_measure(const int_t iChunk, const reg_t &qubits, const reg_t &cmemory,
+  virtual void apply_measure(QuantumState::Registers<densmat_t>& state, const reg_t &qubits, const reg_t &cmemory,
                              const reg_t &cregister, RngEngine &rng);
 
   // Reset the specified qubits to the |0> state by tracing out qubits
-  void apply_reset(const int_t iChunk, const reg_t &qubits);
+  void apply_reset(densmat_t& qreg, const reg_t &qubits);
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const int_t iChunk, const Operations::Op &op,
+  virtual void apply_snapshot(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                               ExperimentResult &result,
                               bool last_op = false);
 
   // Apply a matrix to given qubits (identity on all other qubits)
-  void apply_matrix(const int_t iChunk, const reg_t &qubits, const cmatrix_t &mat);
+  void apply_matrix(densmat_t& qreg, const reg_t &qubits, const cmatrix_t &mat);
 
   // Apply a vectorized matrix to given qubits (identity on all other qubits)
-  void apply_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t &vmat);
+  void apply_matrix(densmat_t& qreg, const reg_t &qubits, const cvector_t &vmat);
 
   //apply diagonal matrix
-  void apply_diagonal_unitary_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t & diag);
+  void apply_diagonal_unitary_matrix(densmat_t& qreg, const reg_t &qubits, const cvector_t & diag);
 
   // Apply a Kraus error operation
-  void apply_kraus(const int_t iChunk, const reg_t &qubits, const std::vector<cmatrix_t> &kraus);
+  void apply_kraus(densmat_t& qreg, const reg_t &qubits, const std::vector<cmatrix_t> &kraus);
 
   // Apply an N-qubit Pauli gate
-  void apply_pauli(const int_t iChunk, const reg_t &qubits, const std::string &pauli);
+  void apply_pauli(densmat_t& qreg, const reg_t &qubits, const std::string &pauli);
 
   // apply phase
-  void apply_phase(const int_t iChunk, const uint_t qubit, const complex_t phase);
-  void apply_phase(const int_t iChunk, const reg_t& qubits, const complex_t phase);
+  void apply_phase(densmat_t& qreg, const uint_t qubit, const complex_t phase);
+  void apply_phase(densmat_t& qreg, const reg_t& qubits, const complex_t phase);
 
   //-----------------------------------------------------------------------
   // Save data instructions
   //-----------------------------------------------------------------------
 
   // Save the current full density matrix
-  void apply_save_state(const int_t iChunk, const Operations::Op &op,
+  void apply_save_state(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                         ExperimentResult &result,
                         bool last_op = false);
 
   // Save the current density matrix or reduced density matrix
-  void apply_save_density_matrix(const int_t iChunk, const Operations::Op &op,
+  void apply_save_density_matrix(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                  ExperimentResult &result,
                                  bool last_op = false);
 
   // Helper function for computing expectation value
-  void apply_save_probs(const int_t iChunk, const Operations::Op &op,
+  void apply_save_probs(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                         ExperimentResult &result);
 
   // Helper function for saving amplitudes squared
-  void apply_save_amplitudes_sq(const int_t iChunk, const Operations::Op &op,
+  void apply_save_amplitudes_sq(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                 ExperimentResult &result);
 
   // Helper function for computing expectation value
-  virtual double expval_pauli(const int_t iChunk, const reg_t &qubits,
+  virtual double expval_pauli(QuantumState::RegistersBase& state,  const reg_t &qubits,
                               const std::string& pauli) override;
 
   // Return the reduced density matrix for the simulator
-  cmatrix_t reduced_density_matrix(const int_t iChunk, const reg_t &qubits, bool last_op = false);
-  cmatrix_t reduced_density_matrix_helper(const int_t iChunk, const reg_t &qubits,
+  cmatrix_t reduced_density_matrix(QuantumState::Registers<densmat_t>& state, const reg_t &qubits, bool last_op = false);
+  cmatrix_t reduced_density_matrix_helper(QuantumState::Registers<densmat_t>& state, const reg_t &qubits,
                                           const reg_t &qubits_sorted);
 
   //-----------------------------------------------------------------------
@@ -222,7 +243,7 @@ protected:
   // should be contained in the set returned by the 'allowed_ops'
   // method.
   // TODO: move to private (no longer part of base class)
-  rvector_t measure_probs(const int_t iChunk, const reg_t &qubits) const;
+  rvector_t measure_probs(QuantumState::Registers<densmat_t>& state, const reg_t &qubits) const;
 
   // Sample the measurement outcome for qubits
   // return a pair (m, p) of the outcome m, and its corresponding
@@ -232,12 +253,17 @@ protected:
   // 1 -> |q1 = 0, q0 = 1> state
   // 2 -> |q1 = 1, q0 = 0> state
   // 3 -> |q1 = 1, q0 = 1> state
-  std::pair<uint_t, double> sample_measure_with_prob(const int_t iChunk, const reg_t &qubits,
+  std::pair<uint_t, double> sample_measure_with_prob(QuantumState::Registers<densmat_t>& state, const reg_t &qubits,
                                                      RngEngine &rng);
+  rvector_t sample_measure_with_prob_shot_branching(QuantumState::Registers<densmat_t>& state, const reg_t &qubits);
 
-  void measure_reset_update(const int_t iChunk, const std::vector<uint_t> &qubits,
+  void measure_reset_update(QuantumState::Registers<densmat_t>& state, const std::vector<uint_t> &qubits,
                             const uint_t final_state, const uint_t meas_state,
                             const double meas_prob);
+  void measure_reset_update_shot_branching(
+                             QuantumState::Registers<densmat_t>& state, const std::vector<uint_t> &qubits,
+                             const int_t final_state,
+                             const rvector_t& meas_probs);
 
   //-----------------------------------------------------------------------
   // Special snapshot types
@@ -248,20 +274,20 @@ protected:
   //-----------------------------------------------------------------------
 
   // Snapshot reduced density matrix
-  void snapshot_density_matrix(const int_t iChunk, const Operations::Op &op,
+  void snapshot_density_matrix(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                ExperimentResult &result,
                                bool last_op = false);
                           
   // Snapshot current qubit probabilities for a measurement (average)
-  void snapshot_probabilities(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
+  void snapshot_probabilities(QuantumState::Registers<densmat_t>& state, const Operations::Op &op, ExperimentResult &result,
                               bool variance);
 
   // Snapshot the expectation value of a Pauli operator
-  void snapshot_pauli_expval(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
+  void snapshot_pauli_expval(QuantumState::Registers<densmat_t>& state, const Operations::Op &op, ExperimentResult &result,
                              bool variance);
 
   // Snapshot the expectation value of a matrix operator
-  void snapshot_matrix_expval(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
+  void snapshot_matrix_expval(QuantumState::Registers<densmat_t>& state, const Operations::Op &op, ExperimentResult &result,
                               bool variance);
 
   //-----------------------------------------------------------------------
@@ -269,7 +295,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Apply a waltz gate specified by parameters u3(theta, phi, lambda)
-  void apply_gate_u3(const int_t iChunk, const uint_t qubit, const double theta, const double phi,
+  void apply_gate_u3(densmat_t& qreg, const uint_t qubit, const double theta, const double phi,
                      const double lambda);
 
   //-----------------------------------------------------------------------
@@ -297,14 +323,21 @@ protected:
     return 2;
   }
 
+  bool shot_branching_supported(void) override
+  {
+    if(BaseState::multi_chunk_distribution_)
+      return false;   //disable shot branching if multi-chunk distribution is used
+    return true;
+  }
+
   //-----------------------------------------------------------------------
   //Functions for multi-chunk distribution
   //-----------------------------------------------------------------------
   //swap between chunks
-  void apply_chunk_swap(const reg_t &qubits) override;
+  void apply_chunk_swap(QuantumState::RegistersBase& state,  const reg_t &qubits) override;
 
   //apply multiple swaps between chunks
-  void apply_multi_chunk_swap(const reg_t &qubits) override;
+  void apply_multi_chunk_swap(QuantumState::RegistersBase& state,  const reg_t &qubits) override;
 };
 
 //=========================================================================
@@ -374,14 +407,16 @@ const stringmap_t<Snapshots> State<densmat_t>::snapshotset_(
 // Initialization
 //-------------------------------------------------------------------------
 template <class densmat_t>
-void State<densmat_t>::initialize_qreg(uint_t num_qubits) 
+void State<densmat_t>::initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits) 
 {
-  if(BaseState::qregs_.size() == 0)
-    BaseState::allocate(num_qubits,num_qubits,1);
-  initialize_omp();
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
 
-  for(int_t i=0;i<BaseState::qregs_.size();i++){
-    BaseState::qregs_[i].set_num_qubits(BaseState::chunk_bits_);
+  if(state.qregs().size() == 0)
+    BaseState::allocate(num_qubits,BaseState::chunk_bits_,1);
+  initialize_omp(state);
+
+  for(int_t i=0;i<state.qregs().size();i++){
+    state.qregs()[i].set_num_qubits(BaseState::chunk_bits_);
   }
 
   if(BaseState::multi_chunk_distribution_){
@@ -390,48 +425,241 @@ void State<densmat_t>::initialize_qreg(uint_t num_qubits)
       for(int_t ig=0;ig<BaseState::num_groups_;ig++){
         for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
           if(BaseState::global_chunk_index_ + iChunk == 0){
-            BaseState::qregs_[iChunk].initialize();
+            state.qregs()[iChunk].initialize();
           }
           else{
-            BaseState::qregs_[iChunk].zero();
+            state.qregs()[iChunk].zero();
           }
         }
       }
     }
     else{
-      for(int_t i=0;i<BaseState::qregs_.size();i++){
+      for(int_t i=0;i<state.qregs().size();i++){
         if(BaseState::global_chunk_index_ + i == 0){
-          BaseState::qregs_[i].initialize();
+          state.qregs()[i].initialize();
         }
         else{
-          BaseState::qregs_[i].zero();
+          state.qregs()[i].zero();
         }
       }
     }
   }
   else{
-    for(int_t i=0;i<BaseState::qregs_.size();i++){
-      BaseState::qregs_[i].initialize();
+    for(int_t i=0;i<state.qregs().size();i++){
+      state.qregs()[i].initialize();
     }
   }
 }
 
-template <class densmat_t> void State<densmat_t>::initialize_omp() 
+template <class densmat_t>
+void State<densmat_t>::initialize_qreg_state(QuantumState::RegistersBase& state_in, const densmat_t &mat) 
+{
+  // Check dimension of state
+  if (mat.num_qubits() != BaseState::num_qubits_){
+    throw std::invalid_argument("DensityMatrix::State::initialize: initial "
+                                "state does not match qubit number");
+  }
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
+  if(state.qregs().size() == 0)
+    BaseState::allocate(BaseState::num_qubits_,BaseState::chunk_bits_,1);
+  initialize_omp(state);
+
+  int_t iChunk;
+  for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+    state.qregs()[iChunk].set_num_qubits(BaseState::chunk_bits_);
+  }
+
+  if(BaseState::multi_chunk_distribution_){
+    auto input = mat.copy_to_matrix();
+
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+          for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+            uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+            uint_t irow = i >> (BaseState::chunk_bits_);
+            tmp[i] = input[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          }
+          state.qregs()[iChunk].initialize_from_vector(tmp);
+        }
+      }
+    }
+    else{
+      for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+        uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+        uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+
+        //copy part of state for this chunk
+        uint_t i,row,col;
+        cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+        for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+          uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+          uint_t irow = i >> (BaseState::chunk_bits_);
+          tmp[i] = input[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+        }
+        state.qregs()[iChunk].initialize_from_vector(tmp);
+      }
+    }
+  }
+  else{
+    for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+      state.qregs()[iChunk].initialize_from_data(mat.data(), 1ULL << 2 * BaseState::num_qubits_);
+    }
+  }
+}
+
+template <class densmat_t>
+void State<densmat_t>::initialize_qreg_from_data(uint_t num_qubits,
+                                       const cmatrix_t &matrix) 
+{
+  if (matrix.size() != 1ULL << 2 * num_qubits) {
+    throw std::invalid_argument("DensityMatrix::State::initialize: initial "
+                                "state does not match qubit number");
+  }
+  for(int_t istate=0;istate<BaseState::states_.size();istate++){
+    QuantumState::Registers<densmat_t>& state = BaseState::states_[istate];
+    if(state.qregs().size() == 0)
+      BaseState::allocate(num_qubits,BaseState::chunk_bits_,1);
+
+    initialize_omp(state);
+
+    int_t iChunk;
+    for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+      state.qregs()[iChunk].set_num_qubits(BaseState::chunk_bits_);
+    }
+
+    if(BaseState::multi_chunk_distribution_){
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+            uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+            uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+
+            //copy part of state for this chunk
+            uint_t i,row,col;
+            cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+            for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+              uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+              uint_t irow = i >> (BaseState::chunk_bits_);
+              tmp[i] = matrix[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+            }
+            state.qregs()[iChunk].initialize_from_vector(tmp);
+          }
+        }
+      }
+      else{
+        for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+          for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+            uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+            uint_t irow = i >> (BaseState::chunk_bits_);
+            tmp[i] = matrix[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          }
+          state.qregs()[iChunk].initialize_from_vector(tmp);
+        }
+      }
+    }
+    else{
+      for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+        state.qregs()[iChunk].initialize_from_matrix(matrix);
+      }
+    }
+  }
+}
+
+template <class densmat_t>
+void State<densmat_t>::initialize_qreg_from_data(uint_t num_qubits,
+                                       const cvector_t &vector) 
+{
+  if (vector.size() != 1ULL << 2 * num_qubits) {
+    throw std::invalid_argument("DensityMatrix::State::initialize: initial "
+                                "state does not match qubit number");
+  }
+  for(int_t istate=0;istate<BaseState::states_.size();istate++){
+    QuantumState::Registers<densmat_t>& state = BaseState::states_[istate];
+    if(state.qregs().size() == 0)
+      BaseState::allocate(num_qubits,BaseState::chunk_bits_,1);
+
+    initialize_omp(state);
+    int_t iChunk;
+    for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+      state.qregs()[iChunk].set_num_qubits(BaseState::chunk_bits_);
+    }
+
+    if(BaseState::multi_chunk_distribution_){
+      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+#pragma omp parallel for 
+        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+          for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
+            uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+            uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+
+            //copy part of state for this chunk
+            uint_t i,row,col;
+            cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+            for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+              uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+              uint_t irow = i >> (BaseState::chunk_bits_);
+              tmp[i] = vector[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+            }
+            state.qregs()[iChunk].initialize_from_vector(tmp);
+          }
+        }
+      }
+      else{
+        for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+          uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
+          uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
+
+          //copy part of state for this chunk
+          uint_t i,row,col;
+          cvector_t tmp(1ull << (BaseState::chunk_bits_*2));
+          for(i=0;i<(1ull << (BaseState::chunk_bits_*2));i++){
+            uint_t icol = i & ((1ull << (BaseState::chunk_bits_))-1);
+            uint_t irow = i >> (BaseState::chunk_bits_);
+            tmp[i] = vector[icol_chunk + icol + ((irow_chunk + irow) << (BaseState::num_qubits_))];
+          }
+          state.qregs()[iChunk].initialize_from_vector(tmp);
+        }
+      }
+    }
+    else{
+      for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+        state.qregs()[iChunk].initialize_from_vector(vector);
+      }
+    }
+  }
+}
+
+template <class densmat_t> void State<densmat_t>::initialize_omp(QuantumState::Registers<densmat_t>& state ) 
 {
   uint_t i;
-  for(i=0;i<BaseState::qregs_.size();i++){
-    BaseState::qregs_[i].set_omp_threshold(omp_qubit_threshold_);
+  for(i=0;i<state.qregs().size();i++){
+    state.qregs()[i].set_omp_threshold(omp_qubit_threshold_);
     if (BaseState::threads_ > 0)
-      BaseState::qregs_[i].set_omp_threads(BaseState::threads_); // set allowed OMP threads in qubitvector
+      state.qregs()[i].set_omp_threads(BaseState::threads_); // set allowed OMP threads in qubitvector
   }
 }
 
 template <class densmat_t>
 template <typename list_t>
-void State<densmat_t>::initialize_from_vector(const int_t iChunkIn, const list_t &vec)
+void State<densmat_t>::initialize_from_vector(QuantumState::Registers<densmat_t>& state, const list_t &vec)
 {
   if((1ull << (BaseState::num_qubits_*2)) == vec.size()){
-    BaseState::initialize_from_vector(iChunkIn, vec);
+    BaseState::initialize_from_vector(state, vec);
   }
   else if((1ull << (BaseState::num_qubits_*2)) == vec.size() * vec.size()) {
     int_t iChunk;
@@ -452,12 +680,12 @@ void State<densmat_t>::initialize_from_vector(const int_t iChunkIn, const list_t
               vec1[i] = vec[(irow_chunk << BaseState::chunk_bits_) + i];
               vec2[i] = std::conj(vec[(icol_chunk << BaseState::chunk_bits_) + i]);
             }
-            BaseState::qregs_[iChunk].initialize_from_vector(AER::Utils::tensor_product(vec1, vec2));
+            state.qregs()[iChunk].initialize_from_vector(AER::Utils::tensor_product(vec1, vec2));
           }
         }
       }
       else{
-        for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
+        for(iChunk=0;iChunk<state.qregs().size();iChunk++){
           uint_t irow_chunk = ((iChunk + BaseState::global_chunk_index_) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << (BaseState::chunk_bits_);
           uint_t icol_chunk = ((iChunk + BaseState::global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << (BaseState::chunk_bits_);
 
@@ -470,12 +698,12 @@ void State<densmat_t>::initialize_from_vector(const int_t iChunkIn, const list_t
             vec1[i] = vec[(irow_chunk << BaseState::chunk_bits_) + i];
             vec2[i] = std::conj(vec[(icol_chunk << BaseState::chunk_bits_) + i]);
           }
-          BaseState::qregs_[iChunk].initialize_from_vector(AER::Utils::tensor_product(vec1, vec2));
+          state.qregs()[iChunk].initialize_from_vector(AER::Utils::tensor_product(vec1, vec2));
         }
       }
     }
     else{
-      BaseState::qregs_[iChunkIn].initialize_from_vector(AER::Utils::tensor_product(AER::Utils::conjugate(vec), vec));
+      state.qreg().initialize_from_vector(AER::Utils::tensor_product(AER::Utils::conjugate(vec), vec));
     }
   }
   else {
@@ -486,19 +714,31 @@ void State<densmat_t>::initialize_from_vector(const int_t iChunkIn, const list_t
 }
 
 template <class densmat_t>
-auto State<densmat_t>::move_to_matrix(const int_t iChunk)
+void State<densmat_t>::initialize_creg_state(QuantumState::RegistersBase& state_in, const ClassicalRegister& creg)
+{
+  BaseState::initialize_creg_state(state_in, creg);
+
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
+
+  for(int_t i=0;i<state.qregs().size();i++)
+    state.qreg(i).initialize_creg(creg.memory_size(), creg.register_size(), creg.memory_hex(), creg.register_hex());
+}
+
+
+template <class densmat_t>
+auto State<densmat_t>::move_to_matrix(QuantumState::Registers<densmat_t>& state)
 {
   if(!BaseState::multi_chunk_distribution_)
-    return BaseState::qregs_[iChunk].move_to_matrix();
-  return BaseState::apply_to_matrix(false);
+    return state.qreg().move_to_matrix();
+  return BaseState::apply_to_matrix(state, false);
 }
 
 template <class densmat_t>
-auto State<densmat_t>::copy_to_matrix(const int_t iChunk)
+auto State<densmat_t>::copy_to_matrix(QuantumState::Registers<densmat_t>& state)
 {
   if(!BaseState::multi_chunk_distribution_)
-    return BaseState::qregs_[iChunk].copy_to_matrix();
-  return BaseState::apply_to_matrix(true);
+    return state.qreg().copy_to_matrix();
+  return BaseState::apply_to_matrix(state, true);
 }
 
 //-------------------------------------------------------------------------
@@ -507,29 +747,33 @@ auto State<densmat_t>::copy_to_matrix(const int_t iChunk)
 
 template <class densmat_t>
 size_t State<densmat_t>::required_memory_mb(
-    uint_t num_qubits, const std::vector<Operations::Op> &ops) const 
+    uint_t num_qubits, QuantumState::OpItr first, QuantumState::OpItr last) const 
 {
-  (void)ops; // avoid unused variable compiler warning
-  (void)ops; // avoid unused variable compiler warning
+  (void)first; // avoid unused variable compiler warning
+  (void)last; // avoid unused variable compiler warning
   densmat_t tmp;
   return tmp.required_memory_mb(2*num_qubits);
 }
 
 template <class densmat_t>
-void State<densmat_t>::set_config(const json_t &config) 
+void State<densmat_t>::set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) 
 {
-  BaseState::set_config(config);
+  double thresh;
 
   // Set threshold for truncating snapshots
   JSON::get_value(json_chop_threshold_, "chop_threshold", config);
-  uint_t i;
-  for(i=0;i<BaseState::qregs_.size();i++){
-    BaseState::qregs_[i].set_json_chop_threshold(json_chop_threshold_);
-  }
 
   // Set OMP threshold for state update functions
   JSON::get_value(omp_qubit_threshold_, "statevector_parallel_threshold",
-                  config);
+              config);
+  thresh = json_chop_threshold_;
+
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
+  uint_t i;
+  for(i=0;i<state.qregs().size();i++){
+    state.qregs()[i].set_json_chop_threshold(thresh);
+  }
+
 }
 
 
@@ -538,68 +782,131 @@ void State<densmat_t>::set_config(const json_t &config)
 //=========================================================================
 
 template <class densmat_t>
-void State<densmat_t>::apply_op(const int_t iChunk, const Operations::Op &op,
+void State<densmat_t>::apply_op(QuantumState::RegistersBase& state_in, const Operations::Op &op,
                                  ExperimentResult &result,
                                  RngEngine &rng,
                                  bool final_ops) 
 {
-  if(BaseState::check_conditional(iChunk, op)) {
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
+
+  if(BaseState::enable_batch_execution_ && state.qreg().batched_optimization_supported()){
+    if(op.conditional){
+      state.qreg().set_conditional(op.conditional_reg);
+    }
+    if(state.additional_ops().size() == 0)
+      state.qreg().enable_batch(true);
+    else
+      state.qreg().enable_batch(false);
+  }
+  else if(!state.creg().check_conditional(op))
+    return;
+
+  switch (op.type) {
+    case OpType::barrier:
+    case OpType::qerror_loc:
+      break;
+    case OpType::reset:
+      for(int_t i=0;i<state.qregs().size();i++)
+        apply_reset(state.qreg(i), op.qubits);
+      break;
+    case OpType::measure:
+      apply_measure(state, op.qubits, op.memory, op.registers, rng);
+      break;
+    case OpType::bfunc:
+      state.creg().apply_bfunc(op);
+      break;
+    case OpType::roerror:
+      state.creg().apply_roerror(op, rng);
+      break;
+    case OpType::gate:
+      for(int_t i=0;i<state.qregs().size();i++)
+        apply_gate(state.qreg(i), op);
+      break;
+    case OpType::snapshot:
+      apply_snapshot(state, op, result, final_ops);
+      break;
+    case OpType::matrix:
+      for(int_t i=0;i<state.qregs().size();i++)
+        apply_matrix(state.qreg(i), op.qubits, op.mats[0]);
+      break;
+    case OpType::diagonal_matrix:
+      for(int_t i=0;i<state.qregs().size();i++)
+        apply_diagonal_unitary_matrix(state.qreg(i), op.qubits, op.params);
+      break;
+    case OpType::superop:
+      for(int_t i=0;i<state.qregs().size();i++)
+        state.qreg(i).apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
+      break;
+    case OpType::kraus:
+      for(int_t i=0;i<state.qregs().size();i++)
+        apply_kraus(state.qreg(i), op.qubits, op.mats);
+      break;
+    case OpType::set_statevec:
+      initialize_from_vector(state, op.params);
+      break;
+    case OpType::set_densmat:
+      BaseState::initialize_from_matrix(state, op.mats[0]);
+      break;
+    case OpType::save_expval:
+    case OpType::save_expval_var:
+      BaseState::apply_save_expval(state, op, result);
+      break;
+    case OpType::save_state:
+      apply_save_state(state, op, result, final_ops);
+      break;
+    case OpType::save_densmat:
+      apply_save_density_matrix(state, op, result, final_ops);
+      break;
+    case OpType::save_probs:
+    case OpType::save_probs_ket:
+      apply_save_probs(state, op, result);
+      break;
+    case OpType::save_amps_sq:
+      apply_save_amplitudes_sq(state, op, result);
+      break;
+    default:
+      throw std::invalid_argument("DensityMatrix::State::invalid instruction \'" +
+                                  op.name + "\'.");
+  }
+}
+
+template <class densmat_t>
+void State<densmat_t>::apply_op_chunk(uint_t iChunk, QuantumState::RegistersBase& state_in, 
+                                 const Operations::Op &op,
+                                 ExperimentResult &result,
+                                 RngEngine &rng,
+                                 bool final_ops) 
+{
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
+
+  if(state.creg().check_conditional(op)) {
     switch (op.type) {
       case OpType::barrier:
       case OpType::qerror_loc:
         break;
       case OpType::reset:
-        apply_reset(iChunk, op.qubits);
-        break;
-      case OpType::measure:
-        apply_measure(iChunk, op.qubits, op.memory, op.registers, rng);
+        apply_reset(state.qreg(iChunk), op.qubits);
         break;
       case OpType::bfunc:
-        BaseState::cregs_[0].apply_bfunc(op);
+        state.creg().apply_bfunc(op);
         break;
       case OpType::roerror:
-        BaseState::cregs_[0].apply_roerror(op, rng);
+        state.creg().apply_roerror(op, rng);
         break;
       case OpType::gate:
-        apply_gate(iChunk, op);
-        break;
-      case OpType::snapshot:
-        apply_snapshot(iChunk, op, result, final_ops);
+        apply_gate(state.qreg(iChunk), op);
         break;
       case OpType::matrix:
-        apply_matrix(iChunk, op.qubits, op.mats[0]);
+        apply_matrix(state.qreg(iChunk), op.qubits, op.mats[0]);
         break;
       case OpType::diagonal_matrix:
-        apply_diagonal_unitary_matrix(iChunk, op.qubits, op.params);
+        apply_diagonal_unitary_matrix(state.qreg(iChunk), op.qubits, op.params);
         break;
       case OpType::superop:
-        BaseState::qregs_[iChunk].apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
+        state.qreg(iChunk).apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
         break;
       case OpType::kraus:
-        apply_kraus(iChunk, op.qubits, op.mats);
-        break;
-      case OpType::set_statevec:
-        initialize_from_vector(iChunk, op.params);
-        break;
-      case OpType::set_densmat:
-        BaseState::initialize_from_matrix(iChunk, op.mats[0]);
-        break;
-      case OpType::save_expval:
-      case OpType::save_expval_var:
-        BaseState::apply_save_expval(iChunk, op, result);
-        break;
-      case OpType::save_state:
-        apply_save_state(iChunk, op, result, final_ops);
-        break;
-      case OpType::save_densmat:
-        apply_save_density_matrix(iChunk, op, result, final_ops);
-        break;
-      case OpType::save_probs:
-      case OpType::save_probs_ket:
-        apply_save_probs(iChunk, op, result);
-        break;
-      case OpType::save_amps_sq:
-        apply_save_amplitudes_sq(iChunk, op, result);
+        apply_kraus(state.qreg(iChunk), op.qubits, op.mats);
         break;
       default:
         throw std::invalid_argument("DensityMatrix::State::invalid instruction \'" +
@@ -609,13 +916,15 @@ void State<densmat_t>::apply_op(const int_t iChunk, const Operations::Op &op,
 }
 
 template <class densmat_t>
-bool State<densmat_t>::apply_batched_op(const int_t iChunk, const Operations::Op &op,
+bool State<densmat_t>::apply_batched_op(const int_t iChunk, QuantumState::RegistersBase& state_in, const Operations::Op &op,
                                   ExperimentResult &result,
                                   std::vector<RngEngine> &rng,
                                   bool final_ops) 
 {
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
+
   if(op.conditional)
-    BaseState::qregs_[iChunk].set_conditional(op.conditional_reg);
+    state.qreg(iChunk).set_conditional(op.conditional_reg);
 
   switch (op.type) {
     case OpType::barrier:
@@ -623,36 +932,37 @@ bool State<densmat_t>::apply_batched_op(const int_t iChunk, const Operations::Op
     case OpType::qerror_loc:
       break;
     case OpType::reset:
-      BaseState::qregs_[iChunk].apply_reset(op.qubits);
+      state.qreg(iChunk).apply_reset(op.qubits);
       break;
     case OpType::measure:
-      BaseState::qregs_[iChunk].apply_batched_measure(op.qubits,rng,op.memory,op.registers);
+      state.qreg(iChunk).apply_batched_measure(op.qubits,rng,op.memory,op.registers);
       break;
     case OpType::bfunc:
-      BaseState::qregs_[iChunk].apply_bfunc(op);
+      state.qreg(iChunk).apply_bfunc(op);
       break;
     case OpType::roerror:
-      BaseState::qregs_[iChunk].apply_roerror(op, rng);
+      state.qreg(iChunk).apply_roerror(op, rng);
       break;
     case OpType::gate:
-      apply_gate(iChunk, op);
+      apply_gate(state.qreg(iChunk), op);
       break;
     case OpType::matrix:
-      apply_matrix(iChunk, op.qubits, op.mats[0]);
+      apply_matrix(state.qreg(iChunk), op.qubits, op.mats[0]);
       break;
     case OpType::diagonal_matrix:
-      BaseState::qregs_[iChunk].apply_diagonal_unitary_matrix(op.qubits, op.params);
+      state.qreg(iChunk).apply_diagonal_unitary_matrix(op.qubits, op.params);
       break;
     case OpType::superop:
-      BaseState::qregs_[iChunk].apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
+      state.qreg(iChunk).apply_superop_matrix(op.qubits, Utils::vectorize_matrix(op.mats[0]));
       break;
     case OpType::kraus:
-      apply_kraus(iChunk, op.qubits, op.mats);
+      apply_kraus(state.qreg(iChunk), op.qubits, op.mats);
       break;
     default:
       //other operations should be called to indivisual chunks by apply_op
       return false;
   }
+
   return true;
 }
 
@@ -661,23 +971,22 @@ bool State<densmat_t>::apply_batched_op(const int_t iChunk, const Operations::Op
 //=========================================================================
 
 template <class densmat_t>
-void State<densmat_t>::apply_save_probs(const int_t iChunk, const Operations::Op &op,
+void State<densmat_t>::apply_save_probs(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                             ExperimentResult &result) 
 {
-  auto probs = measure_probs(iChunk, op.qubits);
-  auto cr = this->creg(BaseState::get_global_shot_index(iChunk));
+  auto probs = measure_probs(state, op.qubits);
   if (op.type == OpType::save_probs_ket) {
-    result.save_data_average(cr, op.string_params[0],
+    result.save_data_average(state.creg(), op.string_params[0],
                              Utils::vec2ket(probs, json_chop_threshold_, 16),
                              op.type, op.save_type);
   } else {
-    result.save_data_average(cr, op.string_params[0],
+    result.save_data_average(state.creg(), op.string_params[0],
                              std::move(probs), op.type, op.save_type);
   }
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_save_amplitudes_sq(const int_t iChunkIn, const Operations::Op &op,
+void State<densmat_t>::apply_save_amplitudes_sq(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                                 ExperimentResult &result) {
   if (op.int_params.empty()) {
     throw std::invalid_argument("Invalid save_amplitudes_sq instructions (empty params).");
@@ -688,7 +997,7 @@ void State<densmat_t>::apply_save_amplitudes_sq(const int_t iChunkIn, const Oper
   if(BaseState::multi_chunk_distribution_){
     int_t iChunk;
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(iChunk) 
-    for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
+    for(iChunk=0;iChunk<state.qregs().size();iChunk++){
       uint_t irow,icol;
       irow = (BaseState::global_chunk_index_ + iChunk) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
       icol = (BaseState::global_chunk_index_ + iChunk) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
@@ -699,9 +1008,9 @@ void State<densmat_t>::apply_save_amplitudes_sq(const int_t iChunkIn, const Oper
                                  BaseState::threads_ > 1 && !BaseState::chunk_omp_parallel_)  \
                           num_threads(BaseState::threads_)
       for (int_t i = 0; i < size; ++i) {
-        uint_t idx = BaseState::mapped_index(op.int_params[i]);
+        uint_t idx = state.get_mapped_index(op.int_params[i]);
         if(idx >= (irow << BaseState::chunk_bits_) && idx < ((irow+1) << BaseState::chunk_bits_))
-          amps_sq[i] = BaseState::qregs_[iChunk].probability(idx - (irow << BaseState::chunk_bits_));
+          amps_sq[i] = state.qregs()[iChunk].probability(idx - (irow << BaseState::chunk_bits_));
       }
     }
 #ifdef AER_MPI
@@ -713,19 +1022,21 @@ void State<densmat_t>::apply_save_amplitudes_sq(const int_t iChunkIn, const Oper
                                  BaseState::threads_ > 1)                       \
                           num_threads(BaseState::threads_)
     for (int_t i = 0; i < size; ++i) {
-      amps_sq[i] = BaseState::qregs_[iChunkIn].probability(op.int_params[i]);
+      amps_sq[i] = state.qreg().probability(op.int_params[i]);
     }
   }
-  auto cr = this->creg(BaseState::get_global_shot_index(iChunkIn));
-  result.save_data_average(cr, op.string_params[0],
+  result.save_data_average(state.creg(), op.string_params[0],
                            std::move(amps_sq), op.type, op.save_type);
 }
 
 template <class densmat_t>
-double State<densmat_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
-                                      const std::string& pauli)  {
+double State<densmat_t>::expval_pauli(QuantumState::RegistersBase& state_in, const reg_t &qubits,
+                                      const std::string& pauli)  
+{
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
+
   if(!BaseState::multi_chunk_distribution_)
-    return BaseState::qregs_[iChunk].expval_pauli(qubits, pauli);
+    return state.qreg().expval_pauli(qubits, pauli);
 
   reg_t qubits_in_chunk;
   reg_t qubits_out_chunk;
@@ -776,7 +1087,7 @@ double State<densmat_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
           double sign = 2.0;
           if (z_mask && (AER::Utils::popcount(irow & z_mask) & 1))
             sign = -2.0;
-          expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli_non_diagonal_chunk(qubits_in_chunk, pauli_in_chunk,phase);
+          expval += sign * state.qregs()[iChunk-BaseState::global_chunk_index_].expval_pauli_non_diagonal_chunk(qubits_in_chunk, pauli_in_chunk,phase);
         }
       }
     }
@@ -787,7 +1098,7 @@ double State<densmat_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
           double sign = 1.0;
           if (z_mask && (AER::Utils::popcount(i & z_mask) & 1))
             sign = -1.0;
-          expval += sign * BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,1.0);
+          expval += sign * state.qregs()[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,1.0);
         }
       }
     }
@@ -796,7 +1107,7 @@ double State<densmat_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
     for(i=0;i<nrows;i++){
       uint_t iChunk = i * (nrows+1);
       if(BaseState::chunk_index_begin_[BaseState::distributed_rank_] <= iChunk && BaseState::chunk_index_end_[BaseState::distributed_rank_] > iChunk){  //on this process
-        expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits, pauli,1.0);
+        expval += state.qregs()[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits, pauli,1.0);
       }
     }
   }
@@ -808,17 +1119,17 @@ double State<densmat_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_save_density_matrix(const int_t iChunk, const Operations::Op &op,
+void State<densmat_t>::apply_save_density_matrix(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                                  ExperimentResult &result,
-                                                 bool last_op) {
-  auto cr = this->creg(BaseState::get_global_shot_index(iChunk));
-  result.save_data_average(cr, op.string_params[0],
-                           reduced_density_matrix(iChunk, op.qubits, last_op),
+                                                 bool last_op) 
+{
+  result.save_data_average(state.creg(), op.string_params[0],
+                           reduced_density_matrix(state, op.qubits, last_op),
                            op.type, op.save_type);
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_save_state(const int_t iChunk, const Operations::Op &op,
+void State<densmat_t>::apply_save_state(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                         ExperimentResult &result,
                                         bool last_op) 
 {
@@ -844,19 +1155,18 @@ void State<densmat_t>::apply_save_state(const int_t iChunk, const Operations::Op
   std::string key = (op.string_params[0] == "_method_")
                       ? "density_matrix"
                       : op.string_params[0];
-  auto cr = this->creg(BaseState::get_global_shot_index(iChunk));
   if (last_op) {
-    result.save_data_average(cr, key, move_to_matrix(iChunk),
+    result.save_data_average(state.creg(), key, move_to_matrix(state),
                              OpType::save_densmat, save_type);
   } else {
-    result.save_data_average(cr, key, copy_to_matrix(iChunk),
+    result.save_data_average(state.creg(), key, copy_to_matrix(state),
                              OpType::save_densmat, save_type);
   }
 }
 
 
 template <class densmat_t>
-cmatrix_t State<densmat_t>::reduced_density_matrix(const int_t iChunk, const reg_t& qubits, bool last_op) 
+cmatrix_t State<densmat_t>::reduced_density_matrix(QuantumState::Registers<densmat_t>& state, const reg_t& qubits, bool last_op) 
 {
   cmatrix_t reduced_state;
 
@@ -864,12 +1174,12 @@ cmatrix_t State<densmat_t>::reduced_density_matrix(const int_t iChunk, const reg
   if (qubits.empty()) {
     reduced_state = cmatrix_t(1, 1);
     if(!BaseState::multi_chunk_distribution_){
-      reduced_state[0] = BaseState::qregs_[iChunk].trace();
+      reduced_state[0] = state.qreg().trace();
     }
     else{
       std::complex<double> sum = 0.0;
-      for(int_t i=0;i<BaseState::qregs_.size();i++){
-        sum += BaseState::qregs_[i].trace();
+      for(int_t i=0;i<state.qregs().size();i++){
+        sum += state.qregs()[i].trace();
       }
 #ifdef AER_MPI
       BaseState::reduce_sum(sum);
@@ -883,35 +1193,35 @@ cmatrix_t State<densmat_t>::reduced_density_matrix(const int_t iChunk, const reg
 
     if ((qubits.size() == BaseState::num_qubits_) && (qubits == qubits_sorted)) {
       if (last_op) {
-        reduced_state = move_to_matrix(iChunk);
+        reduced_state = move_to_matrix(state);
       } else {
-        reduced_state = copy_to_matrix(iChunk);
+        reduced_state = copy_to_matrix(state);
       }
     } else {
-      reduced_state = reduced_density_matrix_helper(iChunk, qubits, qubits_sorted);
+      reduced_state = reduced_density_matrix_helper(state, qubits, qubits_sorted);
     }
   }
   return reduced_state;
 }
 
 template <class densmat_t>
-cmatrix_t State<densmat_t>::reduced_density_matrix_helper(const int_t iChunkIn, const reg_t &qubits,
+cmatrix_t State<densmat_t>::reduced_density_matrix_helper(QuantumState::Registers<densmat_t>& state, const reg_t &qubits,
                                           const reg_t &qubits_sorted) 
 {
   if(!BaseState::multi_chunk_distribution_){
     // Get superoperator qubits
-    const reg_t squbits = BaseState::qregs_[iChunkIn].superop_qubits(qubits);
-    const reg_t squbits_sorted = BaseState::qregs_[iChunkIn].superop_qubits(qubits_sorted);
+    const reg_t squbits = state.qreg().superop_qubits(qubits);
+    const reg_t squbits_sorted = state.qreg().superop_qubits(qubits_sorted);
 
     // Get dimensions
     const size_t N = qubits.size();
     const size_t DIM = 1ULL << N;
     const int_t VDIM = 1ULL << (2 * N);
-    const size_t END = 1ULL << (BaseState::qregs_[iChunkIn].num_qubits() - N);
+    const size_t END = 1ULL << (state.qreg().num_qubits() - N);
     const size_t SHIFT = END + 1;
 
     // Copy vector to host memory
-    auto vmat = BaseState::qregs_[iChunkIn].vector();
+    auto vmat = state.qreg().vector();
     cmatrix_t reduced_state(DIM, DIM, false);
     {
       // Fill matrix with first iteration
@@ -933,7 +1243,7 @@ cmatrix_t State<densmat_t>::reduced_density_matrix_helper(const int_t iChunkIn, 
   int_t iChunk;
   uint_t size = 1ull << (BaseState::chunk_bits_*2);
   uint_t mask = (1ull << (BaseState::chunk_bits_)) - 1;
-  uint_t num_threads = BaseState::qregs_[0].get_omp_threads();
+  uint_t num_threads = state.qregs()[0].get_omp_threads();
 
   size_t size_required = (sizeof(std::complex<double>) << (qubits.size()*2)) + (sizeof(std::complex<double>) << (BaseState::chunk_bits_*2))*BaseState::num_local_chunks_;
   if((size_required>>20) > Utils::get_system_memory_mb()){
@@ -942,14 +1252,14 @@ cmatrix_t State<densmat_t>::reduced_density_matrix_helper(const int_t iChunkIn, 
   cmatrix_t reduced_state(1ull << qubits.size(),1ull << qubits.size(),true);
 
   if(BaseState::distributed_rank_ == 0){
-    auto tmp = BaseState::qregs_[0].copy_to_matrix();
+    auto tmp = state.qregs()[0].copy_to_matrix();
     for(iChunk=0;iChunk<BaseState::num_global_chunks_;iChunk++){
       int_t i;
       uint_t irow_chunk = (iChunk >> ((BaseState::num_qubits_ - BaseState::chunk_bits_))) << BaseState::chunk_bits_;
       uint_t icol_chunk = (iChunk & ((1ull << ((BaseState::num_qubits_ - BaseState::chunk_bits_)))-1)) << BaseState::chunk_bits_;
 
       if(iChunk < BaseState::num_local_chunks_)
-        tmp = BaseState::qregs_[iChunk].copy_to_matrix();
+        tmp = state.qregs()[iChunk].copy_to_matrix();
 #ifdef AER_MPI
       else
         BaseState::recv_data(tmp.data(),size,0,iChunk);
@@ -985,7 +1295,7 @@ cmatrix_t State<densmat_t>::reduced_density_matrix_helper(const int_t iChunkIn, 
     for(iChunk=0;iChunk<BaseState::num_global_chunks_;iChunk++){
       uint_t iProc = BaseState::get_process_by_chunk(iChunk);
       if(iProc == BaseState::distributed_rank_){
-        auto tmp = BaseState::qregs_[iChunk-BaseState::global_chunk_index_].copy_to_matrix();
+        auto tmp = state.qregs()[iChunk-BaseState::global_chunk_index_].copy_to_matrix();
         BaseState::send_data(tmp.data(),size,iChunk,0);
       }
     }
@@ -1000,7 +1310,7 @@ cmatrix_t State<densmat_t>::reduced_density_matrix_helper(const int_t iChunkIn, 
 //=========================================================================
 
 template <class densmat_t>
-void State<densmat_t>::apply_snapshot(const int_t iChunk, const Operations::Op &op,
+void State<densmat_t>::apply_snapshot(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                       ExperimentResult &result,
                                       bool last_op) {
 
@@ -1012,27 +1322,27 @@ void State<densmat_t>::apply_snapshot(const int_t iChunk, const Operations::Op &
         "\'.");
   switch (it->second) {
     case Snapshots::densitymatrix:
-      snapshot_density_matrix(iChunk, op, result, last_op);
+      snapshot_density_matrix(state, op, result, last_op);
       break;
     case Snapshots::cmemory:
-      BaseState::snapshot_creg_memory(iChunk, op, result);
+      BaseState::snapshot_creg_memory(state, op, result);
       break;
     case Snapshots::cregister:
-      BaseState::snapshot_creg_register(iChunk, op, result);
+      BaseState::snapshot_creg_register(state, op, result);
       break;
     case Snapshots::probs:
       // get probs as hexadecimal
-      snapshot_probabilities(iChunk, op, result, false);
+      snapshot_probabilities(state, op, result, false);
       break;
     case Snapshots::probs_var:
       // get probs as hexadecimal
-      snapshot_probabilities(iChunk, op, result, true);
+      snapshot_probabilities(state, op, result, true);
       break;
     case Snapshots::expval_pauli: {
-      snapshot_pauli_expval(iChunk, op, result, false);
+      snapshot_pauli_expval(state, op, result, false);
     } break;
     case Snapshots::expval_pauli_var: {
-      snapshot_pauli_expval(iChunk, op, result, true);
+      snapshot_pauli_expval(state, op, result, true);
     } break;
     /* TODO
     case Snapshots::expval_matrix: {
@@ -1051,23 +1361,22 @@ void State<densmat_t>::apply_snapshot(const int_t iChunk, const Operations::Op &
 }
 
 template <class densmat_t>
-void State<densmat_t>::snapshot_probabilities(const int_t iChunk, const Operations::Op &op,
+void State<densmat_t>::snapshot_probabilities(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                               ExperimentResult &result,
                                               bool variance) 
 {
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
   // get probs as hexadecimal
-  auto probs = Utils::vec2ket(measure_probs(iChunk, op.qubits),
+  auto probs = Utils::vec2ket(measure_probs(state, op.qubits),
                               json_chop_threshold_, 16);
   result.legacy_data.add_average_snapshot("probabilities",
                             op.string_params[0],
-                            BaseState::cregs_[ishot].memory_hex(),
+                            state.creg().memory_hex(),
                             std::move(probs),
                             variance);
 }
 
 template <class densmat_t>
-void State<densmat_t>::snapshot_pauli_expval(const int_t iChunk, const Operations::Op &op,
+void State<densmat_t>::snapshot_pauli_expval(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                              ExperimentResult &result,
                                              bool variance) 
 {
@@ -1076,31 +1385,28 @@ void State<densmat_t>::snapshot_pauli_expval(const int_t iChunk, const Operation
     throw std::invalid_argument(
         "Invalid expval snapshot (Pauli components are empty).");
   }
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
-
   // Accumulate expval components
   complex_t expval(0., 0.);
   for (const auto &param : op.params_expval_pauli) {
     const auto &coeff = param.first;
     const auto &pauli = param.second;
-    expval += coeff * expval_pauli(iChunk, op.qubits, pauli);
+    expval += coeff * expval_pauli(state, op.qubits, pauli);
   }
 
   // Add to snapshot
   Utils::chop_inplace(expval, json_chop_threshold_);
   result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                            BaseState::cregs_[ishot].memory_hex(), expval, variance);
+                                          state.creg().memory_hex(), expval, variance);
 }
 
 template <class densmat_t>
-void State<densmat_t>::snapshot_density_matrix(const int_t iChunk, const Operations::Op &op,
+void State<densmat_t>::snapshot_density_matrix(QuantumState::Registers<densmat_t>& state, const Operations::Op &op,
                                                ExperimentResult &result,
                                                bool last_op) 
 {
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
   result.legacy_data.add_average_snapshot("density_matrix", op.string_params[0],
-                                          BaseState::cregs_[ishot].memory_hex(),
-                                          reduced_density_matrix(iChunk, op.qubits, last_op),
+                                          state.creg().memory_hex(),
+                                          reduced_density_matrix(state, op.qubits, last_op),
                                           false);
 }
 
@@ -1109,7 +1415,7 @@ void State<densmat_t>::snapshot_density_matrix(const int_t iChunk, const Operati
 //=========================================================================
 
 template <class densmat_t>
-void State<densmat_t>::apply_gate(const int_t iChunk, const Operations::Op &op) 
+void State<densmat_t>::apply_gate(densmat_t& qreg, const Operations::Op &op) 
 {
   if(!BaseState::global_chunk_indexing_){
     reg_t qubits_in,qubits_out;
@@ -1121,10 +1427,10 @@ void State<densmat_t>::apply_gate(const int_t iChunk, const Operations::Op &op)
       for(int i=0;i<qubits_out.size();i++){
         mask |= (1ull << (qubits_out[i] - BaseState::chunk_bits_));
       }
-      if(((BaseState::global_chunk_index_ + iChunk) & mask) != mask){
+      if((qreg.chunk_index() & mask) != mask){
         ctrl_chunk = false;
       }
-      if((((BaseState::global_chunk_index_ + iChunk) >> (BaseState::num_qubits_ - BaseState::chunk_bits_)) & mask) != mask){
+      if(((qreg.chunk_index() >> (BaseState::num_qubits_ - BaseState::chunk_bits_)) & mask) != mask){
         ctrl_chunk_sp = false;
       }
       if(!ctrl_chunk && !ctrl_chunk_sp)
@@ -1132,13 +1438,13 @@ void State<densmat_t>::apply_gate(const int_t iChunk, const Operations::Op &op)
       else{
         Operations::Op new_op = BaseState::remake_gate_in_chunk_qubits(op,qubits_in);
         if(ctrl_chunk && ctrl_chunk_sp)
-          apply_gate(iChunk,new_op);  //apply gate by using op with internal qubits
+          apply_gate(qreg,new_op);  //apply gate by using op with internal qubits
         else if(ctrl_chunk)
-          apply_gate_statevector(iChunk,new_op);
+          apply_gate_statevector(qreg,new_op);
         else{
           for(int i=0;i<new_op.qubits.size();i++)
             new_op.qubits[i] += BaseState::chunk_bits_;
-          apply_gate_statevector(iChunk,new_op);
+          apply_gate_statevector(qreg,new_op);
         }
         return;
       }
@@ -1152,95 +1458,95 @@ void State<densmat_t>::apply_gate(const int_t iChunk, const Operations::Op &op)
         "DensityMatrixState::invalid gate instruction \'" + op.name + "\'.");
   switch (it->second) {
     case Gates::u3:
-      apply_gate_u3(iChunk, op.qubits[0], std::real(op.params[0]),
+      apply_gate_u3(qreg, op.qubits[0], std::real(op.params[0]),
                     std::real(op.params[1]), std::real(op.params[2]));
       break;
     case Gates::u2:
-      apply_gate_u3(iChunk, op.qubits[0], M_PI / 2., std::real(op.params[0]),
+      apply_gate_u3(qreg, op.qubits[0], M_PI / 2., std::real(op.params[0]),
                     std::real(op.params[1]));
       break;
     case Gates::u1:
-      apply_phase(iChunk, op.qubits[0], std::exp(complex_t(0., 1.) * op.params[0]));
+      apply_phase(qreg, op.qubits[0], std::exp(complex_t(0., 1.) * op.params[0]));
       break;
     case Gates::cx:
-      BaseState::qregs_[iChunk].apply_cnot(op.qubits[0], op.qubits[1]);
+      qreg.apply_cnot(op.qubits[0], op.qubits[1]);
       break;
     case Gates::cy:
-      BaseState::qregs_[iChunk].apply_cy(op.qubits[0], op.qubits[1]);
+      qreg.apply_cy(op.qubits[0], op.qubits[1]);
       break;
     case Gates::cz:
-      BaseState::qregs_[iChunk].apply_cphase(op.qubits[0], op.qubits[1], -1);
+      qreg.apply_cphase(op.qubits[0], op.qubits[1], -1);
       break;
     case Gates::cp:
-      BaseState::qregs_[iChunk].apply_cphase(op.qubits[0], op.qubits[1],
+      qreg.apply_cphase(op.qubits[0], op.qubits[1],
                                     std::exp(complex_t(0., 1.) * op.params[0]));
       break;
     case Gates::id:
       break;
     case Gates::x:
-      BaseState::qregs_[iChunk].apply_x(op.qubits[0]);
+      qreg.apply_x(op.qubits[0]);
       break;
     case Gates::y:
-      BaseState::qregs_[iChunk].apply_y(op.qubits[0]);
+      qreg.apply_y(op.qubits[0]);
       break;
     case Gates::z:
-      apply_phase(iChunk, op.qubits[0], -1);
+      apply_phase(qreg, op.qubits[0], -1);
       break;
     case Gates::h:
-      apply_gate_u3(iChunk, op.qubits[0], M_PI / 2., 0., M_PI);
+      apply_gate_u3(qreg, op.qubits[0], M_PI / 2., 0., M_PI);
       break;
     case Gates::s:
-      apply_phase(iChunk, op.qubits[0], complex_t(0., 1.));
+      apply_phase(qreg, op.qubits[0], complex_t(0., 1.));
       break;
     case Gates::sdg:
-      apply_phase(iChunk, op.qubits[0], complex_t(0., -1.));
+      apply_phase(qreg, op.qubits[0], complex_t(0., -1.));
       break;
     case Gates::sx:
-      BaseState::qregs_[iChunk].apply_unitary_matrix(op.qubits, Linalg::VMatrix::SX);
+      qreg.apply_unitary_matrix(op.qubits, Linalg::VMatrix::SX);
       break;
     case Gates::sxdg:
-      BaseState::qregs_[iChunk].apply_unitary_matrix(op.qubits, Linalg::VMatrix::SXDG);
+      qreg.apply_unitary_matrix(op.qubits, Linalg::VMatrix::SXDG);
       break;
     case Gates::t: {
       const double isqrt2{1. / std::sqrt(2)};
-      apply_phase(iChunk, op.qubits[0], complex_t(isqrt2, isqrt2));
+      apply_phase(qreg, op.qubits[0], complex_t(isqrt2, isqrt2));
     } break;
     case Gates::tdg: {
       const double isqrt2{1. / std::sqrt(2)};
-      apply_phase(iChunk, op.qubits[0], complex_t(isqrt2, -isqrt2));
+      apply_phase(qreg, op.qubits[0], complex_t(isqrt2, -isqrt2));
     } break;
     case Gates::swap: {
-      BaseState::qregs_[iChunk].apply_swap(op.qubits[0], op.qubits[1]);
+      qreg.apply_swap(op.qubits[0], op.qubits[1]);
     } break;
     case Gates::ccx:
-      BaseState::qregs_[iChunk].apply_toffoli(op.qubits[0], op.qubits[1], op.qubits[2]);
+      qreg.apply_toffoli(op.qubits[0], op.qubits[1], op.qubits[2]);
       break;
     case Gates::r:
-      BaseState::qregs_[iChunk].apply_unitary_matrix(op.qubits, Linalg::VMatrix::r(op.params[0], op.params[1]));
+      qreg.apply_unitary_matrix(op.qubits, Linalg::VMatrix::r(op.params[0], op.params[1]));
       break;
     case Gates::rx:
-      BaseState::qregs_[iChunk].apply_unitary_matrix(op.qubits, Linalg::VMatrix::rx(op.params[0]));
+      qreg.apply_unitary_matrix(op.qubits, Linalg::VMatrix::rx(op.params[0]));
       break;
     case Gates::ry:
-      BaseState::qregs_[iChunk].apply_unitary_matrix(op.qubits, Linalg::VMatrix::ry(op.params[0]));
+      qreg.apply_unitary_matrix(op.qubits, Linalg::VMatrix::ry(op.params[0]));
       break;
     case Gates::rz:
-      apply_diagonal_unitary_matrix(iChunk, op.qubits, Linalg::VMatrix::rz_diag(op.params[0]));
+      apply_diagonal_unitary_matrix(qreg, op.qubits, Linalg::VMatrix::rz_diag(op.params[0]));
       break;
     case Gates::rxx:
-      BaseState::qregs_[iChunk].apply_unitary_matrix(op.qubits, Linalg::VMatrix::rxx(op.params[0]));
+      qreg.apply_unitary_matrix(op.qubits, Linalg::VMatrix::rxx(op.params[0]));
       break;
     case Gates::ryy:
-      BaseState::qregs_[iChunk].apply_unitary_matrix(op.qubits, Linalg::VMatrix::ryy(op.params[0]));
+      qreg.apply_unitary_matrix(op.qubits, Linalg::VMatrix::ryy(op.params[0]));
       break;
     case Gates::rzz:
-      apply_diagonal_unitary_matrix(iChunk, op.qubits, Linalg::VMatrix::rzz_diag(op.params[0]));
+      apply_diagonal_unitary_matrix(qreg, op.qubits, Linalg::VMatrix::rzz_diag(op.params[0]));
       break;
     case Gates::rzx:
-      BaseState::qregs_[iChunk].apply_unitary_matrix(op.qubits, Linalg::VMatrix::rzx(op.params[0]));
+      qreg.apply_unitary_matrix(op.qubits, Linalg::VMatrix::rzx(op.params[0]));
       break;
     case Gates::pauli:
-      apply_pauli(iChunk, op.qubits, op.string_params[0]);
+      apply_pauli(qreg, op.qubits, op.string_params[0]);
       break;
     default:
       // We shouldn't reach here unless there is a bug in gateset
@@ -1250,7 +1556,7 @@ void State<densmat_t>::apply_gate(const int_t iChunk, const Operations::Op &op)
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_gate_statevector(const int_t iChunk, const Operations::Op &op)
+void State<densmat_t>::apply_gate_statevector(densmat_t& qreg, const Operations::Op &op)
 {
   // Look for gate name in gateset
   auto it = gateset_.find(op.name);
@@ -1260,23 +1566,23 @@ void State<densmat_t>::apply_gate_statevector(const int_t iChunk, const Operatio
   switch (it->second) {
     case Gates::x:
     case Gates::cx:
-      BaseState::qregs_[iChunk].apply_mcx(op.qubits);
+      qreg.apply_mcx(op.qubits);
       break;
     case Gates::u1:
       if(op.qubits[op.qubits.size()-1] < BaseState::chunk_bits_){
-        BaseState::qregs_[iChunk].apply_mcphase(op.qubits,
+        qreg.apply_mcphase(op.qubits,
                                     std::exp(complex_t(0., 1.) * op.params[0]));
       }
       else{
-        BaseState::qregs_[iChunk].apply_mcphase(op.qubits,
+        qreg.apply_mcphase(op.qubits,
                                     std::conj(std::exp(complex_t(0., 1.) * op.params[0])));
       }
       break;
     case Gates::y:
-      BaseState::qregs_[iChunk].apply_mcy(op.qubits);
+      qreg.apply_mcy(op.qubits);
       break;
     case Gates::z:
-      BaseState::qregs_[iChunk].apply_mcphase(op.qubits, -1);
+      qreg.apply_mcphase(op.qubits, -1);
       break;
     default:
       // We shouldn't reach here unless there is a bug in gateset
@@ -1286,28 +1592,30 @@ void State<densmat_t>::apply_gate_statevector(const int_t iChunk, const Operatio
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_matrix(const int_t iChunk, const reg_t &qubits, const cmatrix_t &mat) {
+void State<densmat_t>::apply_matrix(densmat_t& qreg, const reg_t &qubits, const cmatrix_t &mat) 
+{
   if (mat.GetRows() == 1) {
-    apply_diagonal_unitary_matrix(iChunk, 
+    apply_diagonal_unitary_matrix(qreg, 
         qubits, Utils::vectorize_matrix(mat));
   } else {
-    BaseState::qregs_[iChunk].apply_unitary_matrix(qubits, Utils::vectorize_matrix(mat));
+    qreg.apply_unitary_matrix(qubits, Utils::vectorize_matrix(mat));
   }
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_gate_u3(const int_t iChunk, uint_t qubit, double theta, double phi,
-                                     double lambda) {
-  BaseState::qregs_[iChunk].apply_unitary_matrix(
+void State<densmat_t>::apply_gate_u3(densmat_t& qreg, uint_t qubit, double theta, double phi,
+                                     double lambda) 
+{
+  qreg.apply_unitary_matrix(
       reg_t({qubit}), Linalg::VMatrix::u3(theta, phi, lambda));
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_diagonal_unitary_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t & diag)
+void State<densmat_t>::apply_diagonal_unitary_matrix(densmat_t& qreg, const reg_t &qubits, const cvector_t & diag)
 {
   if(BaseState::global_chunk_indexing_ || !BaseState::multi_chunk_distribution_){
     //GPU computes all chunks in one kernel, so pass qubits and diagonal matrix as is
-    BaseState::qregs_[iChunk].apply_diagonal_unitary_matrix(qubits,diag);
+    qreg.apply_diagonal_unitary_matrix(qubits,diag);
   }
   else{
     reg_t qubits_in = qubits;
@@ -1315,53 +1623,52 @@ void State<densmat_t>::apply_diagonal_unitary_matrix(const int_t iChunk, const r
     cvector_t diag_in = diag;
     cvector_t diag_row = diag;
 
-    BaseState::block_diagonal_matrix(iChunk,qubits_in,diag_in);
+    BaseState::block_diagonal_matrix(qreg.chunk_index(),qubits_in,diag_in);
 
     if(qubits_in.size() == qubits.size()){
-      BaseState::qregs_[iChunk].apply_diagonal_unitary_matrix(qubits,diag);
+      qreg.apply_diagonal_unitary_matrix(qubits,diag);
     }
     else{
       for(int_t i=0;i<qubits.size();i++){
         if(qubits[i] >= BaseState::chunk_bits_)
           qubits_row[i] = qubits[i] + BaseState::num_qubits_ - BaseState::chunk_bits_;
       }
-      BaseState::block_diagonal_matrix(iChunk,qubits_row,diag_row);
+      BaseState::block_diagonal_matrix(qreg.chunk_index(),qubits_row,diag_row);
 
       reg_t qubits_chunk(qubits_in.size()*2);
       for(int_t i=0;i<qubits_in.size();i++){
         qubits_chunk[i] = qubits_in[i];
         qubits_chunk[i+qubits_in.size()] = qubits_in[i] + BaseState::chunk_bits_;
       }
-      BaseState::qregs_[iChunk].apply_diagonal_matrix(qubits_chunk,AER::Utils::tensor_product(AER::Utils::conjugate(diag_row),diag_in));
+      qreg.apply_diagonal_matrix(qubits_chunk,AER::Utils::tensor_product(AER::Utils::conjugate(diag_row),diag_in));
     }
   }
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_phase(const int_t iChunk, const uint_t qubit, const complex_t phase)
+void State<densmat_t>::apply_phase(densmat_t& qreg, const uint_t qubit, const complex_t phase)
 {
   cvector_t diag(2);
   diag[0] = 1.0;
   diag[1] = phase;
-  apply_diagonal_unitary_matrix(iChunk, reg_t({qubit}), diag);
+  apply_diagonal_unitary_matrix(qreg, reg_t({qubit}), diag);
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_phase(const int_t iChunk, const reg_t& qubits, const complex_t phase)
+void State<densmat_t>::apply_phase(densmat_t& qreg, const reg_t& qubits, const complex_t phase)
 {
   cvector_t diag((1 << qubits.size()),1.0);
   diag[(1 << qubits.size()) - 1] = phase;
-  apply_diagonal_unitary_matrix(iChunk, qubits, diag);
+  apply_diagonal_unitary_matrix(qreg, qubits, diag);
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_pauli(const int_t iChunk, const reg_t &qubits,
+void State<densmat_t>::apply_pauli(densmat_t& qreg, const reg_t &qubits,
                                    const std::string &pauli) 
 {
   // Pauli as a superoperator is (-1)^num_y P\otimes P
   complex_t coeff = (std::count(pauli.begin(), pauli.end(), 'Y') % 2) ? -1 : 1;
-  BaseState::qregs_[iChunk].apply_pauli(
-      BaseState::qregs_[iChunk].superop_qubits(qubits), pauli + pauli, coeff);
+  qreg.apply_pauli(qreg.superop_qubits(qubits), pauli + pauli, coeff);
 }
 
 //=========================================================================
@@ -1369,23 +1676,36 @@ void State<densmat_t>::apply_pauli(const int_t iChunk, const reg_t &qubits,
 //=========================================================================
 
 template <class densmat_t>
-void State<densmat_t>::apply_measure(const int_t iChunk, const reg_t &qubits, const reg_t &cmemory,
+void State<densmat_t>::apply_measure(QuantumState::Registers<densmat_t>& state, const reg_t &qubits, const reg_t &cmemory,
                                      const reg_t &cregister, RngEngine &rng) 
 {
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
-  // Actual measurement outcome
-  const auto meas = sample_measure_with_prob(iChunk, qubits, rng);
-  // Implement measurement update
-  measure_reset_update(iChunk, qubits, meas.first, meas.first, meas.second);
-  const reg_t outcome = Utils::int2reg(meas.first, 2, qubits.size());
-  BaseState::cregs_[ishot].store_measure(outcome, cmemory, cregister);
+  //shot branching
+  if(BaseState::enable_shot_branching_){
+    rvector_t probs = sample_measure_with_prob_shot_branching(state, qubits);
+
+    //save result to cregs
+    for(int_t i=0;i<probs.size();i++){
+      const reg_t outcome = Utils::int2reg(i, 2, qubits.size());
+      state.branch(i).creg_.store_measure(outcome, cmemory, cregister);
+    }
+
+    measure_reset_update_shot_branching(state, qubits, -1, probs);
+  }
+  else{
+    // Actual measurement outcome
+    const auto meas = sample_measure_with_prob(state, qubits, rng);
+    // Implement measurement update
+    measure_reset_update(state, qubits, meas.first, meas.first, meas.second);
+    const reg_t outcome = Utils::int2reg(meas.first, 2, qubits.size());
+    state.creg().store_measure(outcome, cmemory, cregister);
+  }
 }
 
 template <class densmat_t>
-rvector_t State<densmat_t>::measure_probs(const int_t iChunk, const reg_t &qubits) const 
+rvector_t State<densmat_t>::measure_probs(QuantumState::Registers<densmat_t>& state, const reg_t &qubits) const 
 {
   if(!BaseState::multi_chunk_distribution_)
-    return BaseState::qregs_[iChunk].probabilities(qubits);
+    return state.qreg().probabilities(qubits);
 
   uint_t dim = 1ull << qubits.size();
   rvector_t sum(dim,0.0);
@@ -1412,7 +1732,7 @@ rvector_t State<densmat_t>::measure_probs(const int_t iChunk, const reg_t &qubit
 
         if(irow == icol){   //diagonal chunk
           if(qubits_in_chunk.size() > 0){
-            auto chunkSum = BaseState::qregs_[i].probabilities(qubits_in_chunk);
+            auto chunkSum = state.qregs()[i].probabilities(qubits_in_chunk);
             if(qubits_in_chunk.size() == qubits.size()){
               for(j=0;j<dim;j++){
 #pragma omp atomic
@@ -1440,7 +1760,7 @@ rvector_t State<densmat_t>::measure_probs(const int_t iChunk, const reg_t &qubit
             }
           }
           else{ //there is no bit in chunk
-            auto tr = std::real(BaseState::qregs_[i].trace());
+            auto tr = std::real(state.qregs()[i].trace());
             int idx = 0;
             for(k=0;k<qubits_out_chunk.size();k++){
               if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits_out_chunk[k]) & 1){
@@ -1455,14 +1775,14 @@ rvector_t State<densmat_t>::measure_probs(const int_t iChunk, const reg_t &qubit
     }
   }
   else{
-    for(i=0;i<BaseState::qregs_.size();i++){
+    for(i=0;i<state.qregs().size();i++){
       uint_t irow,icol;
       irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
       icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
 
       if(irow == icol){   //diagonal chunk
         if(qubits_in_chunk.size() > 0){
-          auto chunkSum = BaseState::qregs_[i].probabilities(qubits_in_chunk);
+          auto chunkSum = state.qregs()[i].probabilities(qubits_in_chunk);
           if(qubits_in_chunk.size() == qubits.size()){
             for(j=0;j<dim;j++){
               sum[j] += chunkSum[j];
@@ -1488,7 +1808,7 @@ rvector_t State<densmat_t>::measure_probs(const int_t iChunk, const reg_t &qubit
           }
         }
         else{ //there is no bit in chunk
-          auto tr = std::real(BaseState::qregs_[i].trace());
+          auto tr = std::real(state.qregs()[i].trace());
           int idx = 0;
           for(k=0;k<qubits_out_chunk.size();k++){
             if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits_out_chunk[k]) & 1){
@@ -1510,24 +1830,41 @@ rvector_t State<densmat_t>::measure_probs(const int_t iChunk, const reg_t &qubit
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_reset(const int_t iChunk, const reg_t &qubits) 
+void State<densmat_t>::apply_reset(densmat_t& qreg, const reg_t &qubits) 
 {
-  BaseState::qregs_[iChunk].apply_reset(qubits);
+  qreg.apply_reset(qubits);
 }
 
 template <class densmat_t>
 std::pair<uint_t, double>
-State<densmat_t>::sample_measure_with_prob(const int_t iChunk, const reg_t &qubits,
+State<densmat_t>::sample_measure_with_prob(QuantumState::Registers<densmat_t>& state, const reg_t &qubits,
                                            RngEngine &rng) 
 {
-  rvector_t probs = measure_probs(iChunk, qubits);
+  rvector_t probs = measure_probs(state, qubits);
   // Randomly pick outcome and return pair
   uint_t outcome = rng.rand_int(probs);
   return std::make_pair(outcome, probs[outcome]);
 }
 
 template <class densmat_t>
-void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qubits,
+rvector_t State<densmat_t>::sample_measure_with_prob_shot_branching(QuantumState::Registers<densmat_t>& state, const reg_t &qubits)
+{
+  rvector_t probs = measure_probs(state, qubits);
+  uint_t nshots = state.num_shots();
+  reg_t shot_branch(nshots);
+
+  for(int_t i=0;i<nshots;i++){
+    shot_branch[i] = state.rng_shots(i).rand_int(probs);
+  }
+
+  //branch shots
+  state.branch_shots(shot_branch, probs.size());
+
+  return probs;
+}
+
+template <class densmat_t>
+void State<densmat_t>::measure_reset_update(QuantumState::Registers<densmat_t>& state, const reg_t &qubits,
                                             const uint_t final_state,
                                             const uint_t meas_state,
                                             const double meas_prob) 
@@ -1540,42 +1877,42 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
     cvector_t mdiag(2, 0.);
     mdiag[meas_state] = 1. / std::sqrt(meas_prob);
     if(!BaseState::multi_chunk_distribution_)
-      apply_diagonal_unitary_matrix(iChunk, qubits, mdiag);
+      apply_diagonal_unitary_matrix(state.qreg(), qubits, mdiag);
     else{
       if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
-            apply_diagonal_unitary_matrix(i, qubits, mdiag);
+            apply_diagonal_unitary_matrix(state.qreg(i), qubits, mdiag);
         }
       }
       else{
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          apply_diagonal_unitary_matrix(i, qubits, mdiag);
+        for(int_t i=0;i<state.qregs().size();i++)
+          apply_diagonal_unitary_matrix(state.qreg(i), qubits, mdiag);
       }
     }
 
     // If it doesn't agree with the reset state update
     if (final_state != meas_state) {
       if(!BaseState::multi_chunk_distribution_)
-        BaseState::qregs_[iChunk].apply_x(qubits[0]);
+        state.qreg().apply_x(qubits[0]);
       else{
         if(qubits[0] < BaseState::chunk_bits_){
           if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
             for(int_t ig=0;ig<BaseState::num_groups_;ig++){
               for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
-                BaseState::qregs_[i].apply_x(qubits[0]);
+                state.qregs()[i].apply_x(qubits[0]);
             }
           }
           else{
-            for(int_t i=0;i<BaseState::qregs_.size();i++)
-              BaseState::qregs_[i].apply_x(qubits[0]);
+            for(int_t i=0;i<state.qregs().size();i++)
+              state.qregs()[i].apply_x(qubits[0]);
           }
         }
         else{
-          BaseState::apply_chunk_x(qubits[0]);
-          BaseState::apply_chunk_x(qubits[0]+BaseState::chunk_bits_);
+          BaseState::apply_chunk_x(state, qubits[0]);
+          BaseState::apply_chunk_x(state, qubits[0]+BaseState::chunk_bits_);
         }
       }
     }
@@ -1587,18 +1924,18 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
     cvector_t mdiag(dim, 0.);
     mdiag[meas_state] = 1. / std::sqrt(meas_prob);
     if(!BaseState::multi_chunk_distribution_)
-      apply_diagonal_unitary_matrix(iChunk, qubits, mdiag);
+      apply_diagonal_unitary_matrix(state.qreg(), qubits, mdiag);
     else{
       if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
-            apply_diagonal_unitary_matrix(i, qubits, mdiag);
+            apply_diagonal_unitary_matrix(state.qreg(i), qubits, mdiag);
         }
       }
       else{
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          apply_diagonal_unitary_matrix(i, qubits, mdiag);
+        for(int_t i=0;i<state.qregs().size();i++)
+          apply_diagonal_unitary_matrix(state.qreg(i), qubits, mdiag);
       }
     }
 
@@ -1615,7 +1952,7 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
       }
       // apply permutation to swap state
       if(!BaseState::multi_chunk_distribution_)
-        BaseState::qregs_[iChunk].apply_unitary_matrix(qubits, perm);
+        state.qreg().apply_unitary_matrix(qubits, perm);
       else{
         reg_t qubits_in_chunk;
         reg_t qubits_out_chunk;
@@ -1633,18 +1970,18 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
 #pragma omp parallel for 
             for(int_t ig=0;ig<BaseState::num_groups_;ig++){
               for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
-                BaseState::qregs_[i].apply_unitary_matrix(qubits, perm);
+                state.qregs()[i].apply_unitary_matrix(qubits, perm);
             }
           }
           else{
-            for(int_t i=0;i<BaseState::qregs_.size();i++)
-              BaseState::qregs_[i].apply_unitary_matrix(qubits, perm);
+            for(int_t i=0;i<state.qregs().size();i++)
+              state.qregs()[i].apply_unitary_matrix(qubits, perm);
           }
         }
         if(qubits_out_chunk.size() > 0){  //out of chunk exchange
           for(int_t i=0;i<qubits_out_chunk.size();i++){
-            BaseState::apply_chunk_x(qubits_out_chunk[i]);
-            BaseState::apply_chunk_x(qubits_out_chunk[i]+(BaseState::num_qubits_ - BaseState::chunk_bits_));
+            BaseState::apply_chunk_x(state,qubits_out_chunk[i]);
+            BaseState::apply_chunk_x(state,qubits_out_chunk[i]+(BaseState::num_qubits_ - BaseState::chunk_bits_));
           }
         }
       }
@@ -1653,22 +1990,103 @@ void State<densmat_t>::measure_reset_update(const int_t iChunk, const reg_t &qub
 }
 
 template <class densmat_t>
-std::vector<reg_t> State<densmat_t>::sample_measure(const reg_t &qubits,
+void State<densmat_t>::measure_reset_update_shot_branching(
+                                             QuantumState::Registers<densmat_t>& state, const std::vector<uint_t> &qubits,
+                                             const int_t final_state,
+                                             const rvector_t& meas_probs)
+{
+  // Update a state vector based on an outcome pair [m, p] from
+  // sample_measure_with_prob function, and a desired post-measurement
+  // final_state
+
+  // Single-qubit case
+  if (qubits.size() == 1) {
+    // Diagonal matrix for projecting and renormalizing to measurement outcome
+    for(int_t i=0;i<2;i++){
+      cvector_t mdiag(2, 0.);
+      mdiag[i] = 1. / std::sqrt(meas_probs[i]);
+
+      Operations::Op op;
+      op.type = OpType::diagonal_matrix;
+      op.qubits = qubits;
+      op.params = mdiag;
+      state.add_op_after_branch(i, op);
+
+      if(final_state >= 0 && final_state != i) {
+        Operations::Op op;
+        op.type = OpType::gate;
+        op.name = "x";
+        op.qubits = qubits;
+        state.add_op_after_branch(i, op);
+      }
+    }
+  }
+  // Multi qubit case
+  else {
+    // Diagonal matrix for projecting and renormalizing to measurement outcome
+    const size_t dim = 1ULL << qubits.size();
+    for(int_t i=0;i<dim;i++){
+      cvector_t mdiag(dim, 0.);
+      mdiag[i] = 1. / std::sqrt(meas_probs[i]);
+
+      Operations::Op op;
+      op.type = OpType::diagonal_matrix;
+      op.qubits = qubits;
+      op.params = mdiag;
+      state.add_op_after_branch(i, op);
+
+      if(final_state >= 0 && final_state != i) {
+        // build vectorized permutation matrix
+        cvector_t perm(dim * dim, 0.);
+        perm[final_state * dim + i] = 1.;
+        perm[i * dim + final_state] = 1.;
+        for (size_t j = 0; j < dim; j++) {
+          if (j != final_state && j != i)
+            perm[j * dim + j] = 1.;
+        }
+        Operations::Op op;
+        op.type = OpType::matrix;
+        op.qubits = qubits;
+        op.mats.push_back(Utils::devectorize_matrix(perm));
+        state.add_op_after_branch(i, op);
+      }
+    }
+  }
+}
+
+
+template <class densmat_t>
+std::vector<reg_t> State<densmat_t>::sample_measure(QuantumState::RegistersBase& state_in, const reg_t &qubits,
                                                     uint_t shots,
                                                     RngEngine &rng) 
 {
+  QuantumState::Registers<densmat_t>& state = dynamic_cast<QuantumState::Registers<densmat_t>&>(state_in);
+
   // Generate flat register for storing
-  std::vector<double> rnds;
-  rnds.reserve(shots);
-  for (uint_t i = 0; i < shots; ++i)
-    rnds.push_back(rng.rand(0, 1));
+  std::vector<double> rnds(shots);
   reg_t allbit_samples(shots,0);
 
-  if(!BaseState::multi_chunk_distribution_)
-    allbit_samples = BaseState::qregs_[0].sample_measure(rnds);
+  if(!BaseState::multi_chunk_distribution_){
+    bool tmp = state.qregs()[0].enable_batch(false);
+
+    if(state.num_shots() > 1){
+      double norm = std::real( state.qregs()[0].trace() );
+
+      //use independent rng for each shot
+      for (int_t i = 0; i < state.num_shots(); ++i)
+        rnds[i] = state.rng_shots(i).rand(0, norm);
+    }
+    else{
+      for (int_t i = 0; i < shots; ++i)
+        rnds[i] = rng.rand(0, 1);
+    }
+    allbit_samples = state.qregs()[0].sample_measure(rnds);
+
+    state.qregs()[0].enable_batch(tmp);
+  }
   else{
     int_t i,j;
-    std::vector<double> chunkSum(BaseState::qregs_.size()+1,0);
+    std::vector<double> chunkSum(state.qregs().size()+1,0);
     double sum,localSum;
    //calculate per chunk sum
     if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
@@ -1679,30 +2097,30 @@ std::vector<reg_t> State<densmat_t>::sample_measure(const reg_t &qubits,
           irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
           icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
           if(irow == icol)   //only diagonal chunk has probabilities
-            chunkSum[i] = std::real( BaseState::qregs_[i].trace() );
+            chunkSum[i] = std::real( state.qregs()[i].trace() );
           else
             chunkSum[i] = 0.0;
         }
       }
     }
     else{
-      for(i=0;i<BaseState::qregs_.size();i++){
+      for(i=0;i<state.qregs().size();i++){
         uint_t irow,icol;
         irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
         icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
         if(irow == icol)   //only diagonal chunk has probabilities
-          chunkSum[i] = std::real( BaseState::qregs_[i].trace() );
+          chunkSum[i] = std::real( state.qregs()[i].trace() );
         else
           chunkSum[i] = 0.0;
       }
     }
     localSum = 0.0;
-    for(i=0;i<BaseState::qregs_.size();i++){
+    for(i=0;i<state.qregs().size();i++){
       sum = localSum;
       localSum += chunkSum[i];
       chunkSum[i] = sum;
     }
-    chunkSum[BaseState::qregs_.size()] = localSum;
+    chunkSum[state.qregs().size()] = localSum;
 
     double globalSum = 0.0;
     if(BaseState::nprocs_ > 1){
@@ -1718,10 +2136,13 @@ std::vector<reg_t> State<densmat_t>::sample_measure(const reg_t &qubits,
       }
     }
 
+    for (int_t i = 0; i < shots; ++i)
+      rnds[i] = rng.rand(0, 1);
+
     reg_t local_samples(shots,0);
 
     //get rnds positions for each chunk
-    for(i=0;i<BaseState::qregs_.size();i++){
+    for(i=0;i<state.qregs().size();i++){
       uint_t irow,icol;
       irow = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
       icol = (BaseState::global_chunk_index_ + i) - (irow << ((BaseState::num_qubits_ - BaseState::chunk_bits_)));
@@ -1743,7 +2164,7 @@ std::vector<reg_t> State<densmat_t>::sample_measure(const reg_t &qubits,
       }
 
       if(nIn > 0){
-        auto chunkSamples = BaseState::qregs_[i].sample_measure(vRnd);
+        auto chunkSamples = state.qregs()[i].sample_measure(vRnd);
         uint_t ir;
         ir = (BaseState::global_chunk_index_ + i) >> ((BaseState::num_qubits_ - BaseState::chunk_bits_));
 
@@ -1780,11 +2201,10 @@ std::vector<reg_t> State<densmat_t>::sample_measure(const reg_t &qubits,
 //=========================================================================
 
 template <class densmat_t>
-void State<densmat_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
+void State<densmat_t>::apply_kraus(densmat_t& qreg, const reg_t &qubits,
                                    const std::vector<cmatrix_t> &kmats) 
 {
-  BaseState::qregs_[iChunk].apply_superop_matrix(
-      qubits, Utils::vectorize_matrix(Utils::kraus_superop(kmats)));
+  qreg.apply_superop_matrix(qubits, Utils::vectorize_matrix(Utils::kraus_superop(kmats)));
 }
 
 
@@ -1793,13 +2213,13 @@ void State<densmat_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
 //-----------------------------------------------------------------------
 //swap between chunks
 template <class densmat_t>
-void State<densmat_t>::apply_chunk_swap(const reg_t &qubits)
+void State<densmat_t>::apply_chunk_swap(QuantumState::RegistersBase& state, const reg_t &qubits)
 {
   uint_t q0,q1;
   q0 = qubits[0];
   q1 = qubits[1];
 
-  std::swap(BaseState::qubit_map_[q0],BaseState::qubit_map_[q1]);
+  state.swap_qubit_map(q0,q1);
 
   if(qubits[0] >= BaseState::chunk_bits_){
     q0 += BaseState::chunk_bits_;
@@ -1808,7 +2228,7 @@ void State<densmat_t>::apply_chunk_swap(const reg_t &qubits)
     q1 += BaseState::chunk_bits_;
   }
   reg_t qs0 = {{q0, q1}};
-  BaseState::apply_chunk_swap(qs0);
+  BaseState::apply_chunk_swap(state, qs0);
 
   if(qubits[0] >= BaseState::chunk_bits_){
     q0 += (BaseState::num_qubits_ - BaseState::chunk_bits_);
@@ -1823,11 +2243,11 @@ void State<densmat_t>::apply_chunk_swap(const reg_t &qubits)
     q1 += BaseState::chunk_bits_;
   }
   reg_t qs1 = {{q0, q1}};
-  BaseState::apply_chunk_swap(qs1);
+  BaseState::apply_chunk_swap(state, qs1);
 }
 
 template <class densmat_t>
-void State<densmat_t>::apply_multi_chunk_swap(const reg_t &qubits)
+void State<densmat_t>::apply_multi_chunk_swap(QuantumState::RegistersBase& state, const reg_t &qubits)
 {
   reg_t qubits_density;
 
@@ -1836,7 +2256,7 @@ void State<densmat_t>::apply_multi_chunk_swap(const reg_t &qubits)
     q0 = qubits[i*2];
     q1 = qubits[i*2+1];
 
-    std::swap(BaseState::qubit_map_[q0],BaseState::qubit_map_[q1]);
+    state.swap_qubit_map(q0,q1);
 
     if(q1 >= BaseState::chunk_bits_){
       q1 += BaseState::chunk_bits_;
@@ -1850,7 +2270,7 @@ void State<densmat_t>::apply_multi_chunk_swap(const reg_t &qubits)
     }
   }
 
-  BaseState::apply_multi_chunk_swap(qubits_density);
+  BaseState::apply_multi_chunk_swap(state, qubits_density);
 }
 
 

--- a/src/simulators/extended_stabilizer/ch_runner.hpp
+++ b/src/simulators/extended_stabilizer/ch_runner.hpp
@@ -79,6 +79,10 @@ public:
   virtual ~Runner() = default;
 
   void initialize(uint_t n_qubits);
+
+  //initialize from existing state (copy)
+  void initialize(const Runner& obj){}
+
   void initialize_omp(uint_t n_threads, uint_t threshold_rank);
 
   bool empty() const

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -30,6 +30,10 @@
 namespace AER{
 namespace ExtendedStabilizer {
 
+using chpauli_t = CHSimulator::pauli_t;
+using chstate_t = CHSimulator::Runner;
+using Gates = CHSimulator::Gates;
+
 // OpSet of supported instructions
 const Operations::OpSet StateOpSet(
   // Op types
@@ -45,10 +49,6 @@ const Operations::OpSet StateOpSet(
   // Snapshots
   {"statevector", "probabilities", "memory", "register"}
 );
-
-using chpauli_t = CHSimulator::pauli_t;
-using chstate_t = CHSimulator::Runner;
-using Gates = CHSimulator::Gates;
 
 uint_t zero = 0ULL;
 uint_t toff_branch_max = 7ULL;
@@ -86,30 +86,38 @@ public:
 
   // Apply a single operation
   // If the op is not in allowed_ops an exeption will be raised.
-  virtual void apply_op(const Operations::Op &op,
+  void apply_op(QuantumState::RegistersBase& state,
+                        const Operations::Op &op,
                         ExperimentResult &result,
                         RngEngine &rng,
                         bool final_op = false) override;
 
-  void initialize_qreg(uint_t num_qubits) override;
-
   size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops)
+                                    QuantumState::OpItr first, QuantumState::OpItr last)
                                     const override;
 
-  void set_config(const json_t &config) override;
-
-  std::vector<reg_t> sample_measure(const reg_t& qubits,
+  std::vector<reg_t> sample_measure(QuantumState::RegistersBase& state_in, const reg_t& qubits,
                                     uint_t shots,
                                     RngEngine &rng) override;
 
 protected:
+  void initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits) override;
+
+  void initialize_qreg_state(QuantumState::RegistersBase& state_in, const chstate_t &state) override;
+
+  void set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) override;
+
+  template <typename InputIterator>
+  void apply_ops_state(QuantumState::Registers<chstate_t>& state, InputIterator first, InputIterator last,
+                  ExperimentResult &result,
+                  RngEngine &rng,
+                  bool final_ops = false);
 
   //Alongside the sample measure optimisaiton, we can parallelise
   //circuit applicaiton over the states. This reduces the threading overhead
   //as we only have to fork once per circuit.
   template <typename InputIterator>
-  void apply_ops_parallel(InputIterator first, InputIterator last,
+  void apply_ops_parallel(QuantumState::Registers<chstate_t>& state, InputIterator first, InputIterator last,
                           ExperimentResult &result,
                           RngEngine &rng);
 
@@ -117,7 +125,7 @@ protected:
   //circuit to a single state. This is used to optimize a circuit with a large
   //initial clifford fraction, or for running stabilizer circuits.
   template <typename InputIterator>
-  void apply_stabilizer_circuit(InputIterator first, InputIterator last,
+  void apply_stabilizer_circuit(QuantumState::Registers<chstate_t>& state, InputIterator first, InputIterator last,
                                 ExperimentResult &result,
                                 RngEngine &rng);
 
@@ -125,30 +133,30 @@ protected:
   // If the input is not in allowed_gates an exeption will be raised.
   // TODO: Investigate OMP synchronisation over stattes to remove these different versions
   // One option would be tasks, but the memory overhead isn't clear
-  void apply_gate(const Operations::Op &op, RngEngine &rng);
-  void apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank);
+  void apply_gate(QuantumState::Registers<chstate_t>& state,const Operations::Op &op, RngEngine &rng);
+  void apply_gate(QuantumState::Registers<chstate_t>& state,const Operations::Op &op, RngEngine &rng, uint_t rank);
 
   // Apply a multi-qubit Pauli gate
-  void apply_pauli(const reg_t &qubits, const std::string& pauli, uint_t rank);
+  void apply_pauli(QuantumState::Registers<chstate_t>& state,const reg_t &qubits, const std::string& pauli, uint_t rank);
 
   // Measure qubits and return a list of outcomes [q0, q1, ...]
   // If a state subclass supports this function then "measure" 
   // should be contained in the set returned by the 'allowed_ops'
   // method.
-  void apply_measure(const reg_t &qubits,
+  void apply_measure(QuantumState::Registers<chstate_t>& state,const reg_t &qubits,
                      const reg_t &cmemory,
                      const reg_t &cregister,
                      RngEngine &rng);
 
   // Reset the specified qubits to the |0> state by measuring the
   // projectors Id+Z_{i} for each qubit i
-  void apply_reset(const reg_t &qubits, AER::RngEngine &rng);
+  void apply_reset(QuantumState::Registers<chstate_t>& state, const reg_t &qubits, AER::RngEngine &rng);
 
-  void apply_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
+  void apply_snapshot(QuantumState::Registers<chstate_t>& state,const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
   //Convert a decomposition to a state-vector
-  void statevector_snapshot(const Operations::Op &op, ExperimentResult &result);
+  void statevector_snapshot(QuantumState::Registers<chstate_t>& state,const Operations::Op &op, ExperimentResult &result);
   // //Compute probabilities from a stabilizer rank decomposition
-  void probabilities_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
+  void probabilities_snapshot(QuantumState::Registers<chstate_t>& state,const Operations::Op &op, ExperimentResult &result, RngEngine &rng);
   const static stringmap_t<Gates> gateset_;
   const static stringmap_t<Snapshots> snapshotset_;
 
@@ -157,21 +165,21 @@ protected:
   //-----------------------------------------------------------------------
 
   // Compute and save the statevector for the current simulator state
-  void apply_save_statevector(const Operations::Op &op,
+  void apply_save_statevector(QuantumState::Registers<chstate_t>& state,const Operations::Op &op,
                               ExperimentResult &result);
 
   // Compute and save the expval for the current simulator state
-  void apply_save_expval(const Operations::Op &op,
+  void apply_save_expval(QuantumState::Registers<chstate_t>& state,const Operations::Op &op,
                               ExperimentResult &result,
                               RngEngine &rng);
 
    // Helper function for computing expectation value
-   double expval_pauli(const reg_t &qubits,
+   double expval_pauli(QuantumState::Registers<chstate_t>& state,const reg_t &qubits,
                        const std::string& pauli,
                        RngEngine &rng);
 
   // Helper function for computing expectation value
-  virtual double expval_pauli(const reg_t &qubits,
+  virtual double expval_pauli(QuantumState::RegistersBase& state,const reg_t &qubits,
                               const std::string& pauli) override;
 
   //-----------------------------------------------------------------------
@@ -263,13 +271,31 @@ const stringmap_t<Snapshots> State::snapshotset_({
 // Implementation: Initialisation and Config
 //-------------------------------------------------------------------------
 
-void State::initialize_qreg(uint_t num_qubits)
+void State::initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits)
 {
-  BaseState::qreg_.initialize(num_qubits);
-  BaseState::qreg_.initialize_omp(BaseState::threads_, omp_threshold_rank_);
+  QuantumState::Registers<chstate_t>& state = dynamic_cast<QuantumState::Registers<chstate_t>&>(state_in);
+  if(state.qregs().size() == 0)
+    state.allocate(1);
+  state.qreg().initialize(num_qubits);
+  state.qreg().initialize_omp(BaseState::threads_, omp_threshold_rank_);
 }
 
-void State::set_config(const json_t &config)
+void State::initialize_qreg_state(QuantumState::RegistersBase& state_in, const chstate_t &chstate)
+{
+  QuantumState::Registers<chstate_t>& state = dynamic_cast<QuantumState::Registers<chstate_t>&>(state_in);
+  if(state.qregs().size() == 0)
+    state.allocate(1);
+
+  if(state.qreg().get_n_qubits() != BaseState::num_qubits_)
+  {
+    throw std::invalid_argument("CH::State::initialize: initial state does not match qubit number.");
+  }
+
+  state.qreg() = chstate;
+  state.qreg().initialize_omp(BaseState::threads_, omp_threshold_rank_);
+}
+
+void State::set_state_config(QuantumState::RegistersBase& state_in, const json_t &config)
 {
   // Set the error upper bound in the stabilizer rank approximation
   JSON::get_value(approximation_error_, "extended_stabilizer_approximation_error", config);
@@ -382,20 +408,29 @@ bool State::check_measurement_opt(InputIterator first, InputIterator last) const
 //-------------------------------------------------------------------------
 // Implementation: Operations
 //-------------------------------------------------------------------------
-void State::apply_op(const Operations::Op &op, ExperimentResult &result,
-                     RngEngine &rng, bool final_op) {
-  apply_ops(&op, &op+1, result, rng, final_op);
+void State::apply_op(QuantumState::RegistersBase& state_in, const Operations::Op &op, ExperimentResult &result,
+                     RngEngine &rng, bool final_op) 
+{
+  QuantumState::Registers<chstate_t>& state = dynamic_cast<QuantumState::Registers<chstate_t>&>(state_in);
+  apply_ops_state(state, &op, &op+1, result, rng, final_op);
 }
 
 template <typename InputIterator>
 void State::apply_ops(InputIterator first, InputIterator last, ExperimentResult &result,
                       RngEngine &rng, bool final_ops)
 {
+  apply_ops_state(BaseState::state_,first, last, result, rng, final_ops);
+}
+
+template <typename InputIterator>
+void State::apply_ops_state(QuantumState::Registers<chstate_t>& state, InputIterator first, InputIterator last, ExperimentResult &result,
+                      RngEngine &rng, bool final_ops)
+{
   std::pair<bool, size_t> stabilizer_opts = check_stabilizer_opt(first, last);
   bool is_stabilizer = stabilizer_opts.first;
   if(is_stabilizer)
   {
-    apply_stabilizer_circuit(first, last, result, rng);
+    apply_stabilizer_circuit(state, first, last, result, rng);
   }
   else
   {
@@ -405,51 +440,51 @@ void State::apply_ops(InputIterator first, InputIterator last, ExperimentResult 
     {
       //Apply the stabilizer circuit first. This optimisaiton avoids duplicating the application
       //of the initial stabilizer circuit chi times.
-      apply_stabilizer_circuit(first, first+first_non_clifford, result, rng);
+      apply_stabilizer_circuit(state, first, first+first_non_clifford, result, rng);
     }
 
     auto it_nonstab_begin = first+first_non_clifford;
 
     uint_t chi = compute_chi(it_nonstab_begin, last);
     double delta = std::pow(approximation_error_, -2);
-    BaseState::qreg_.initialize_decomposition(chi, delta);
+    state.qreg().initialize_decomposition(chi, delta);
     //Check for measurement optimisaitons
     bool measurement_opt = check_measurement_opt(first, last);
 
     if(measurement_opt)
     {
-      apply_ops_parallel(it_nonstab_begin, last, result, rng);
+      apply_ops_parallel(state, it_nonstab_begin, last, result, rng);
     }
     else
     {
       for (auto it = it_nonstab_begin; it != last; it++)
       {
         const auto op = *it;
-        if(BaseState::creg().check_conditional(op)) {
+        if(state.creg().check_conditional(op)) {
           switch (op.type) {
             case Operations::OpType::gate:
-              apply_gate(op, rng);
+              apply_gate(state, op, rng);
               break;
             case Operations::OpType::reset:
-              apply_reset(op.qubits, rng);
+              apply_reset(state, op.qubits, rng);
               break;
             case Operations::OpType::barrier:
             case Operations::OpType::qerror_loc:
               break;
             case Operations::OpType::measure:
-              apply_measure(op.qubits, op.memory, op.registers, rng);
+              apply_measure(state, op.qubits, op.memory, op.registers, rng);
               break;
             case Operations::OpType::roerror:
-              BaseState::creg().apply_roerror(op, rng);
+              state.creg().apply_roerror(op, rng);
               break;
             case Operations::OpType::bfunc:
-              BaseState::creg().apply_bfunc(op);
+              state.creg().apply_bfunc(op);
               break;
             case Operations::OpType::snapshot:
-              apply_snapshot(op, result, rng);
+              apply_snapshot(state, op, result, rng);
               break;
             case Operations::OpType::save_statevec:
-              apply_save_statevector(op, result);
+              apply_save_statevector(state, op, result);
               break;
             // Disabled until can fix bug in expval
             // case Operations::OpType::save_expval:
@@ -467,20 +502,22 @@ void State::apply_ops(InputIterator first, InputIterator last, ExperimentResult 
   }
 }
 
-std::vector<reg_t> State::sample_measure(const reg_t& qubits,
+std::vector<reg_t> State::sample_measure(QuantumState::RegistersBase& state_in, const reg_t& qubits,
                            uint_t shots,
                            RngEngine &rng)
 {
+  QuantumState::Registers<chstate_t>& state = dynamic_cast<QuantumState::Registers<chstate_t>&>(state_in);
+
   std::vector<uint_t> output_samples;
-  if(BaseState::qreg_.get_num_states() == 1)
+  if(state.qreg().get_num_states() == 1)
   {
-    output_samples = BaseState::qreg_.stabilizer_sampler(shots, rng);
+    output_samples = state.qreg().stabilizer_sampler(shots, rng);
   }
   else
   {
     if (sampling_method_ == SamplingMethod::metropolis)
     {
-        output_samples = BaseState::qreg_.metropolis_estimation(metropolis_mixing_steps_, shots, rng);
+      output_samples = state.qreg().metropolis_estimation(metropolis_mixing_steps_, shots, rng);
     }
     else if (sampling_method_ == SamplingMethod::resampled_metropolis)
     {
@@ -488,7 +525,7 @@ std::vector<reg_t> State::sample_measure(const reg_t& qubits,
       for (uint_t i=0; i<shots; i++)
       {
         output_samples.push_back(
-          BaseState::qreg_.metropolis_estimation(metropolis_mixing_steps_, rng)
+          state.qreg().metropolis_estimation(metropolis_mixing_steps_, rng)
         );
       }
     }
@@ -498,7 +535,7 @@ std::vector<reg_t> State::sample_measure(const reg_t& qubits,
       for(uint_t i=0; i<shots; i++)
       {
         output_samples.push_back(
-          BaseState::qreg_.ne_single_sample(norm_estimation_samples_, norm_estimation_repetitions_, true, qubits, rng)
+          state.qreg().ne_single_sample(norm_estimation_samples_, norm_estimation_repetitions_, true, qubits, rng)
         );
       }
     }
@@ -527,13 +564,13 @@ std::vector<reg_t> State::sample_measure(const reg_t& qubits,
 
 //Method with slighty optimized parallelisation for the case of a sample_measure circuit
 template <typename InputIterator>
-void State::apply_ops_parallel(InputIterator first, InputIterator last, ExperimentResult &result, RngEngine &rng)
+void State::apply_ops_parallel(QuantumState::Registers<chstate_t>& state,InputIterator first, InputIterator last, ExperimentResult &result, RngEngine &rng)
 {
-  const int_t NUM_STATES = BaseState::qreg_.get_num_states();
-  #pragma omp parallel for if(BaseState::qreg_.check_omp_threshold() && BaseState::threads_>1) num_threads(BaseState::threads_)
+  const int_t NUM_STATES = state.qreg().get_num_states();
+  #pragma omp parallel for if(state.qreg().check_omp_threshold() && BaseState::threads_>1) num_threads(BaseState::threads_)
   for(int_t i=0; i < NUM_STATES; i++)
   {
-    if(!BaseState::qreg_.check_eps(i))
+    if(!state.qreg().check_eps(i))
     {
       continue;
     }
@@ -542,7 +579,7 @@ void State::apply_ops_parallel(InputIterator first, InputIterator last, Experime
       switch (it->type)
       {
         case Operations::OpType::gate:
-          apply_gate(*it, rng, i);
+          apply_gate(state, *it, rng, i);
           break;
         case Operations::OpType::barrier:
         case Operations::OpType::qerror_loc:
@@ -557,42 +594,42 @@ void State::apply_ops_parallel(InputIterator first, InputIterator last, Experime
 }
 
 template <typename InputIterator>
-void State::apply_stabilizer_circuit(InputIterator first, InputIterator last,
+void State::apply_stabilizer_circuit(QuantumState::Registers<chstate_t>& state,InputIterator first, InputIterator last,
                                      ExperimentResult &result, RngEngine &rng)
 {
   for (auto it = first; it != last; ++it)
   {
     const Operations::Op op = *it;
-    if(BaseState::creg().check_conditional(op)) {
+    if(state.creg().check_conditional(op)) {
       switch (op.type)
       {
         case Operations::OpType::gate:
-          apply_gate(op, rng, 0);
+          apply_gate(state,op, rng, 0);
           break;
         case Operations::OpType::reset:
-          apply_reset(op.qubits, rng);
+          apply_reset(state,op.qubits, rng);
           break;
         case Operations::OpType::barrier:
         case Operations::OpType::qerror_loc:
           break;
         case Operations::OpType::measure:
-          apply_measure(op.qubits, op.memory, op.registers, rng);
+          apply_measure(state, op.qubits, op.memory, op.registers, rng);
           break;
         case Operations::OpType::roerror:
-          BaseState::creg().apply_roerror(op, rng);
+          state.creg().apply_roerror(op, rng);
           break;
         case Operations::OpType::bfunc:
-          BaseState::creg().apply_bfunc(op);
+          state.creg().apply_bfunc(op);
           break;
         case Operations::OpType::snapshot:
-          apply_snapshot(op, result, rng);
+          apply_snapshot(state, op, result, rng);
           break;
         case Operations::OpType::save_statevec:
-          apply_save_statevector(op, result);
+          apply_save_statevector(state, op, result);
           break;
         case Operations::OpType::save_expval:
         case Operations::OpType::save_expval_var:
-          apply_save_expval(op, result, rng);
+          apply_save_expval(state, op, result, rng);
           break;
         default:
           throw std::invalid_argument("CH::State::apply_stabilizer_circuit does not support operations of the type \'" + 
@@ -603,17 +640,17 @@ void State::apply_stabilizer_circuit(InputIterator first, InputIterator last,
   }
 }
 
-void State::apply_measure(const reg_t &qubits, const reg_t &cmemory, const reg_t &cregister, RngEngine &rng)
+void State::apply_measure(QuantumState::Registers<chstate_t>& state,const reg_t &qubits, const reg_t &cmemory, const reg_t &cregister, RngEngine &rng)
 {
   uint_t out_string;
   // Flag if the Pauli projector is applied already as part of the sampling
   bool do_projector_correction = true;
   // Prepare an output register for the qubits we are measurig
   reg_t outcome(qubits.size(), 0ULL);
-  if(BaseState::qreg_.get_num_states() == 1)
+  if(state.qreg().get_num_states() == 1)
   {
     //For a single state, we use the efficient sampler defined in Sec IV.A ofarxiv:1808.00128
-    out_string = BaseState::qreg_.stabilizer_sampler(rng);
+    out_string = state.qreg().stabilizer_sampler(rng);
   }
   else
   {
@@ -621,7 +658,7 @@ void State::apply_measure(const reg_t &qubits, const reg_t &cmemory, const reg_t
     {
       do_projector_correction = false;
       //Run the norm estimation routine
-      out_string = BaseState::qreg_.ne_single_sample(
+      out_string = state.qreg().ne_single_sample(
         norm_estimation_samples_, norm_estimation_repetitions_, false, qubits, rng
       );
     }
@@ -629,7 +666,7 @@ void State::apply_measure(const reg_t &qubits, const reg_t &cmemory, const reg_t
     {
       // We use the metropolis algorithm to sample an output string non-destructively
       // This is a single measure step so we do the same for metropolis or resampled_metropolis
-      out_string = BaseState::qreg_.metropolis_estimation(metropolis_mixing_steps_, rng);
+      out_string = state.qreg().metropolis_estimation(metropolis_mixing_steps_, rng);
     }
   }
   if (do_projector_correction)
@@ -647,7 +684,7 @@ void State::apply_measure(const reg_t &qubits, const reg_t &cmemory, const reg_t
       }
     }
     //Project the decomposition onto the measurement outcome
-    BaseState::qreg_.apply_pauli_projector(paulis);
+    state.qreg().apply_pauli_projector(paulis);
   }
   for (uint_t i=0; i<qubits.size(); i++)
   {
@@ -659,20 +696,20 @@ void State::apply_measure(const reg_t &qubits, const reg_t &cmemory, const reg_t
     }
   }
   // Convert the output string to a reg_t. and store
-  BaseState::creg().store_measure(outcome, cmemory, cregister);
+  state.creg().store_measure(outcome, cmemory, cregister);
 }
 
-void State::apply_reset(const reg_t &qubits, AER::RngEngine &rng)
+void State::apply_reset(QuantumState::Registers<chstate_t>& state,const reg_t &qubits, AER::RngEngine &rng)
 {
   uint_t measure_string;
-  const int_t NUM_STATES = BaseState::qreg_.get_num_states();
-  if(BaseState::qreg_.get_num_states() == 1)
+  const int_t NUM_STATES = state.qreg().get_num_states();
+  if(state.qreg().get_num_states() == 1)
   {
-    measure_string = BaseState::qreg_.stabilizer_sampler(rng);
+    measure_string = state.qreg().stabilizer_sampler(rng);
   }
   else
   {
-    measure_string = BaseState::qreg_.metropolis_estimation(metropolis_mixing_steps_, rng);
+    measure_string = state.qreg().metropolis_estimation(metropolis_mixing_steps_, rng);
   }
 
   std::vector<chpauli_t> paulis(qubits.size(), chpauli_t());
@@ -686,34 +723,34 @@ void State::apply_reset(const reg_t &qubits, AER::RngEngine &rng)
       paulis[i].e = 2;
     }
   }
-  BaseState::qreg_.apply_pauli_projector(paulis);
-  #pragma omp parallel for if(BaseState::threads_ > 1 && BaseState::qreg_.check_omp_threshold()) num_threads(BaseState::threads_)
+  state.qreg().apply_pauli_projector(paulis);
+  #pragma omp parallel for if(BaseState::threads_ > 1 && state.qreg().check_omp_threshold()) num_threads(BaseState::threads_)
   for(int_t i=0; i< NUM_STATES; i++)
   {
     for (auto qubit: qubits)
     {
       if ((measure_string>>qubit) & 1ULL)
       {
-        BaseState::qreg_.apply_x(qubit, i);
+        state.qreg().apply_x(qubit, i);
       }
     }
   }
 }
 
-void State::apply_gate(const Operations::Op &op, RngEngine &rng)
+void State::apply_gate(QuantumState::Registers<chstate_t>& state,const Operations::Op &op, RngEngine &rng)
 {
-  const int_t NUM_STATES = BaseState::qreg_.get_num_states();
-  #pragma omp parallel for if (BaseState::threads_ > 1 && BaseState::qreg_.check_omp_threshold()) num_threads(BaseState::threads_)
+  const int_t NUM_STATES = state.qreg().get_num_states();
+  #pragma omp parallel for if (BaseState::threads_ > 1 && state.qreg().check_omp_threshold()) num_threads(BaseState::threads_)
   for(int_t i=0; i < NUM_STATES; i++)
   {
-    if(BaseState::qreg_.check_eps(i))
+    if(state.qreg().check_eps(i))
     {
-      apply_gate(op, rng, i);
+      apply_gate(state, op, rng, i);
     }
   }
 }
 
-void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank)
+void State::apply_gate(QuantumState::Registers<chstate_t>& state,const Operations::Op &op, RngEngine &rng, uint_t rank)
 {
   auto it = gateset_.find(op.name);
   if (it == gateset_.end())
@@ -724,64 +761,64 @@ void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank)
   switch(it->second)
   {
     case Gates::x:
-      BaseState::qreg_.apply_x(op.qubits[0], rank);
+      state.qreg().apply_x(op.qubits[0], rank);
       break;
     case Gates::y:
-      BaseState::qreg_.apply_y(op.qubits[0], rank);
+      state.qreg().apply_y(op.qubits[0], rank);
       break;
     case Gates::z:
-      BaseState::qreg_.apply_z(op.qubits[0], rank);
+      state.qreg().apply_z(op.qubits[0], rank);
       break;
     case Gates::s:
-      BaseState::qreg_.apply_s(op.qubits[0], rank);
+      state.qreg().apply_s(op.qubits[0], rank);
       break;
     case Gates::sdg:
-      BaseState::qreg_.apply_sdag(op.qubits[0], rank);
+      state.qreg().apply_sdag(op.qubits[0], rank);
       break;
     case Gates::h:
-      BaseState::qreg_.apply_h(op.qubits[0], rank);
+      state.qreg().apply_h(op.qubits[0], rank);
       break;
     case Gates::sx:
       BaseState::add_global_phase(M_PI / 4.);
-      BaseState::qreg_.apply_sx(op.qubits[0], rank);
+      state.qreg().apply_sx(op.qubits[0], rank);
       break;
     case Gates::sxdg:
       BaseState::add_global_phase(-M_PI / 4.);
-      BaseState::qreg_.apply_sxdg(op.qubits[0], rank);
+      state.qreg().apply_sxdg(op.qubits[0], rank);
       break;
     case Gates::cx:
-      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      state.qreg().apply_cx(op.qubits[0], op.qubits[1], rank);
       break;
     case Gates::cz:
-      BaseState::qreg_.apply_cz(op.qubits[0], op.qubits[1], rank);
+      state.qreg().apply_cz(op.qubits[0], op.qubits[1], rank);
       break;
     case Gates::swap:
-      BaseState::qreg_.apply_swap(op.qubits[0], op.qubits[1], rank);
+      state.qreg().apply_swap(op.qubits[0], op.qubits[1], rank);
       break;
     case Gates::t:
-      BaseState::qreg_.apply_t(op.qubits[0], rng.rand(), rank);
+      state.qreg().apply_t(op.qubits[0], rng.rand(), rank);
       break;
     case Gates::tdg:
-      BaseState::qreg_.apply_tdag(op.qubits[0], rng.rand(), rank);
+      state.qreg().apply_tdag(op.qubits[0], rng.rand(), rank);
       break;
     case Gates::ccx:
-      BaseState::qreg_.apply_ccx(op.qubits[0], op.qubits[1], op.qubits[2], rng.rand_int(zero, toff_branch_max), rank);
+      state.qreg().apply_ccx(op.qubits[0], op.qubits[1], op.qubits[2], rng.rand_int(zero, toff_branch_max), rank);
       break;
     case Gates::ccz:
-      BaseState::qreg_.apply_ccz(op.qubits[0], op.qubits[1], op.qubits[2], rng.rand_int(zero, toff_branch_max), rank);
+      state.qreg().apply_ccz(op.qubits[0], op.qubits[1], op.qubits[2], rng.rand_int(zero, toff_branch_max), rank);
       break;
     case Gates::u1:
-      BaseState::qreg_.apply_u1(op.qubits[0], op.params[0], rng.rand(), rank);
+      state.qreg().apply_u1(op.qubits[0], op.params[0], rng.rand(), rank);
       break;
     case Gates::pauli:
-      apply_pauli(op.qubits, op.string_params[0], rank);
+      apply_pauli(state, op.qubits, op.string_params[0], rank);
       break;
     default: //u0 or Identity
       break;
   }
 }
 
-void State::apply_pauli(const reg_t &qubits, const std::string& pauli, uint_t rank) {
+void State::apply_pauli(QuantumState::Registers<chstate_t>& state, const reg_t &qubits, const std::string& pauli, uint_t rank) {
   const auto size = qubits.size();
   for (size_t i = 0; i < qubits.size(); ++i) {
     const auto qubit = qubits[size - 1 - i];
@@ -789,13 +826,13 @@ void State::apply_pauli(const reg_t &qubits, const std::string& pauli, uint_t ra
       case 'I':
         break;
       case 'X':
-        BaseState::qreg_.apply_x(qubit, rank);
+        state.qreg().apply_x(qubit, rank);
         break;
       case 'Y':
-        BaseState::qreg_.apply_y(qubit, rank);
+        state.qreg().apply_y(qubit, rank);
         break;
       case 'Z':
-        BaseState::qreg_.apply_z(qubit, rank);
+        state.qreg().apply_z(qubit, rank);
         break;
       default:
         throw std::invalid_argument("invalid Pauli \'" + std::to_string(pauli[i]) + "\'.");
@@ -803,26 +840,28 @@ void State::apply_pauli(const reg_t &qubits, const std::string& pauli, uint_t ra
   }
 }
 
-void State::apply_save_statevector(const Operations::Op &op,
-                                   ExperimentResult &result) {
-  if (op.qubits.size() != BaseState::qreg_.get_n_qubits()) {
+void State::apply_save_statevector(QuantumState::Registers<chstate_t>& state,const Operations::Op &op,
+                                   ExperimentResult &result) 
+{
+  if (op.qubits.size() != state.qreg().get_n_qubits()) {
     throw std::invalid_argument(
         "Save statevector was not applied to all qubits."
         " Only the full statevector can be saved.");
   }
-  auto statevec = BaseState::qreg_.statevector();
+  auto statevec = state.qreg().statevector();
   if (BaseState::has_global_phase_) {
     statevec *= BaseState::global_phase_;
   }
   result.save_data_pershot(
-    creg(), op.string_params[0],
+    state.creg(), op.string_params[0],
     std::move(statevec),
     op.type, op.save_type);
 }
 
-void State::apply_save_expval(const Operations::Op &op,
+void State::apply_save_expval(QuantumState::Registers<chstate_t>& state,const Operations::Op &op,
                                 ExperimentResult &result,
-                                RngEngine& rng) {
+                                RngEngine& rng) 
+{
   // Check empty edge case
   if (op.expval_params.empty()) {
     throw std::invalid_argument(
@@ -836,7 +875,7 @@ void State::apply_save_expval(const Operations::Op &op,
 
   for (const auto &param : op.expval_params) {
     // param is tuple (pauli, coeff, sq_coeff)
-    const auto val = expval_pauli(op.qubits, std::get<0>(param), rng);
+    const auto val = expval_pauli(state, op.qubits, std::get<0>(param), rng);
     expval += std::get<1>(param) * val;
     if (variance) {
       sq_expval += std::get<2>(param) * val;
@@ -846,13 +885,13 @@ void State::apply_save_expval(const Operations::Op &op,
     std::vector<double> expval_var(2);
     expval_var[0] = expval;  // mean
     expval_var[1] = sq_expval - expval * expval;  // variance
-    result.save_data_average(creg(), op.string_params[0], expval_var, op.type, op.save_type);
+    result.save_data_average(state.creg(), op.string_params[0], expval_var, op.type, op.save_type);
   } else {
-    result.save_data_average(creg(), op.string_params[0], expval, op.type, op.save_type);
+    result.save_data_average(state.creg(), op.string_params[0], expval, op.type, op.save_type);
   }
 }
 
-void State::apply_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng)
+void State::apply_snapshot(QuantumState::Registers<chstate_t>& state, const Operations::Op &op, ExperimentResult &result, RngEngine &rng)
 {
   auto it = snapshotset_.find(op.name);
   if (it == snapshotset_.end())
@@ -863,16 +902,16 @@ void State::apply_snapshot(const Operations::Op &op, ExperimentResult &result, R
   switch(it->second)
   {
     case Snapshots::cmemory:
-      BaseState::snapshot_creg_memory(op, result);
+      BaseState::snapshot_creg_memory(state, op, result);
       break;
     case Snapshots::cregister:
-      BaseState::snapshot_creg_register(op, result);
+      BaseState::snapshot_creg_register(state, op, result);
       break;
     case Snapshots::statevector:
-      statevector_snapshot(op, result);
+      statevector_snapshot(state, op, result);
       break;
     case Snapshots::probs:
-      probabilities_snapshot(op, result, rng);
+      probabilities_snapshot(state, op, result, rng);
       break;
     default:
       throw std::invalid_argument("CH::State::invlaid snapshot instruction \'"+
@@ -881,17 +920,18 @@ void State::apply_snapshot(const Operations::Op &op, ExperimentResult &result, R
   }
 }
 
-void State::statevector_snapshot(const Operations::Op &op, ExperimentResult &result)
+void State::statevector_snapshot(QuantumState::Registers<chstate_t>& state,const Operations::Op &op, ExperimentResult &result)
 {
   result.legacy_data.add_pershot_snapshot("statevector", op.string_params[0],
-		      BaseState::qreg_.statevector());
+           state.qreg().statevector());
 }
 
-double State::expval_pauli(const reg_t &qubits,
+double State::expval_pauli(QuantumState::Registers<chstate_t>& state, const reg_t &qubits,
                            const std::string& pauli,
-                           RngEngine &rng) {
+                           RngEngine &rng) 
+{
     // Compute expval components
-    auto state_cpy = BaseState::qreg_;
+    auto state_cpy = state.qreg();
     auto phi_norm = state_cpy.norm_estimation(norm_estimation_samples_, norm_estimation_repetitions_, rng);
     std::vector<chpauli_t>paulis(1, chpauli_t());
     for (uint_t pos = 0; pos < qubits.size(); ++pos) {
@@ -920,19 +960,19 @@ double State::expval_pauli(const reg_t &qubits,
     return (2*g_norm - phi_norm);
 }
 
-double State::expval_pauli(const reg_t &qubits,
+double State::expval_pauli(QuantumState::RegistersBase& state, const reg_t &qubits,
                            const std::string& pauli) {
     // empty implementation of base class virtual method
     // since in the extended stabilizer, expval relies on RNG
     return 0;
 }
 
-void State::probabilities_snapshot(const Operations::Op &op, ExperimentResult &result, RngEngine &rng)
+void State::probabilities_snapshot(QuantumState::Registers<chstate_t>& state, const Operations::Op &op, ExperimentResult &result, RngEngine &rng)
 {
   rvector_t probs;
   if (op.qubits.size() == 0)
   {
-    probs.push_back(BaseState::qreg_.norm_estimation(norm_estimation_samples_, norm_estimation_repetitions_, rng));
+    probs.push_back(state.qreg().norm_estimation(norm_estimation_samples_, norm_estimation_repetitions_, rng));
   }
   else
   {
@@ -943,30 +983,30 @@ void State::probabilities_snapshot(const Operations::Op &op, ExperimentResult &r
     {
       mask ^= (1ULL << qubit);
     }
-    if (BaseState::qreg_.get_num_states() == 1 || sampling_method_ != SamplingMethod::norm_estimation)
+    if (state.qreg().get_num_states() == 1 || sampling_method_ != SamplingMethod::norm_estimation)
     {
       std::vector<uint_t> samples;
       samples.reserve(probabilities_snapshot_samples_);
-      if(BaseState::qreg_.get_num_states() == 1)
+      if(state.qreg().get_num_states() == 1)
       {
-        samples = BaseState::qreg_.stabilizer_sampler(probabilities_snapshot_samples_, rng);
+        samples = state.qreg().stabilizer_sampler(probabilities_snapshot_samples_, rng);
       }
       else
       {
         if (sampling_method_ == SamplingMethod::metropolis)
         {
-          samples = BaseState::qreg_.metropolis_estimation(metropolis_mixing_steps_, probabilities_snapshot_samples_,
+          samples = state.qreg().metropolis_estimation(metropolis_mixing_steps_, probabilities_snapshot_samples_,
                                                           rng);
         }
         else{
           for (uint_t s=0; s<probabilities_snapshot_samples_; s++)
           {
-            uint_t sample = BaseState::qreg_.metropolis_estimation(metropolis_mixing_steps_, rng);
+            uint_t sample = state.qreg().metropolis_estimation(metropolis_mixing_steps_, rng);
             samples.push_back(sample);
           }
         }
       }
-      #pragma omp parallel for if(BaseState::qreg_.check_omp_threshold() && BaseState::threads_>1) num_threads(BaseState::threads_)
+      #pragma omp parallel for if(state.qreg().check_omp_threshold() && BaseState::threads_>1) num_threads(BaseState::threads_)
       for(int_t i=0; i < dim; i++)
       {
         uint_t target = 0ULL;
@@ -989,11 +1029,11 @@ void State::probabilities_snapshot(const Operations::Op &op, ExperimentResult &r
     }
     else
     {
-      probs = BaseState::qreg_.ne_probabilities(norm_estimation_samples_, norm_estimation_repetitions_, op.qubits, rng);
+      probs = state.qreg().ne_probabilities(norm_estimation_samples_, norm_estimation_repetitions_, op.qubits, rng);
     }
   }
   result.legacy_data.add_average_snapshot("probabilities", op.string_params[0],
-                            BaseState::creg().memory_hex(),
+                            state.creg().memory_hex(),
                             Utils::vec2ket(probs, snapshot_chop_threshold_, 16),
                             false);
 }
@@ -1056,9 +1096,9 @@ void State::compute_extent(const Operations::Op &op, double &xi) const
 }
 
 size_t State::required_memory_mb(uint_t num_qubits,
-                                 const std::vector<Operations::Op> &ops) const
+                                 QuantumState::OpItr first, QuantumState::OpItr last) const
 {
-  size_t required_chi = compute_chi(ops.cbegin(), ops.cend());
+  size_t required_chi = compute_chi(first, last);
   // 5 vectors of num_qubits*8byte words
   // Plus 2*CHSimulator::scalar_t which has 3 4 byte words
   // Plus 2*CHSimulator::pauli_t which has 2 8 byte words and one 4 byte word;

--- a/src/simulators/registers.hpp
+++ b/src/simulators/registers.hpp
@@ -1,0 +1,269 @@
+/**
+ * This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2018, 2019.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
+#ifndef _aer_base_register_hpp_
+#define _aer_base_register_hpp_
+
+#include "framework/types.hpp"
+#include "framework/creg.hpp"
+
+namespace AER {
+namespace QuantumState {
+
+using OpItr = std::vector<Operations::Op>::const_iterator;
+
+class RegistersBase;
+
+//base class of register storage 
+class RegistersBase {
+protected:
+  ClassicalRegister creg_;
+
+  //qubits map for chunk-distribution
+  reg_t qubit_map_;
+
+public:
+  RegistersBase(){}
+  virtual ~RegistersBase()
+  {
+  }
+
+  // Return the state creg object
+  auto &creg() { return creg_; }
+  const auto &creg() const { return creg_; }
+
+  virtual uint_t num_qregs() = 0;
+  virtual void allocate(const uint_t nqregs = 1) = 0;
+
+
+  void initialize_qubit_map(const uint_t num_qubits);
+  void swap_qubit_map(const uint_t q0,const uint_t q1);
+  uint_t get_mapped_index(const uint_t idx);
+};
+
+void RegistersBase::initialize_qubit_map(const uint_t num_qubits)
+{
+  qubit_map_.resize(num_qubits);
+  for(int_t i=0;i<num_qubits;i++)
+    qubit_map_[i] = i;
+}
+
+void RegistersBase::swap_qubit_map(const uint_t q0,const uint_t q1)
+{
+  std::swap(qubit_map_[q0], qubit_map_[q1]);
+}
+
+uint_t RegistersBase::get_mapped_index(const uint_t idx)
+{
+  uint_t i,ret = 0;
+  uint_t t = idx;
+
+  for(i=0;i<qubit_map_.size();i++){
+    if(t & 1){
+      ret |= (1ull << qubit_map_[i]);
+    }
+    t >>= 1;
+  }
+  return ret;
+}
+
+//object to store branch of shots
+struct ShotBranch {
+  //random generators for each shot
+  std::vector<RngEngine> shots_;
+  //additional opertions 
+  std::vector<Operations::Op> additional_ops_;
+  //creg to be stored to the state
+  ClassicalRegister creg_;
+};
+
+
+//register storage for each state_t object
+template <class state_t>
+class Registers : public RegistersBase {
+protected:
+  std::vector<state_t> qregs_;
+
+  //mark for control flow
+  std::unordered_map<std::string, OpItr> flow_marks_;
+
+  //iterator for restarting after branch
+  OpItr next_iter_;
+
+  //random generators for shots
+  std::vector<RngEngine> shots_;
+  //additional operations applied after shot branching
+  std::vector<Operations::Op> additional_ops_;
+  //array of branched shots
+  std::vector<ShotBranch> branches_;
+public:
+  Registers()
+  {
+
+  }
+  Registers(const Registers<state_t>& src);
+  Registers<state_t> &operator=(const Registers<state_t>& src);
+
+  virtual ~Registers()
+  {
+    qregs_.clear();
+
+    shots_.clear();
+    additional_ops_.clear();
+    branches_.clear();
+  }
+
+  // Return the state qreg object
+  auto& qregs(){return qregs_;}
+  auto &qreg(const uint_t idx = 0) { return qregs_[idx]; }
+  auto &qreg_non_const(const uint_t idx = 0) { return qregs_[idx]; }
+  const auto &qreg(const uint_t idx = 0) const { return qregs_[idx]; }
+
+  uint_t num_qregs()  override
+  {
+    return qregs_.size();
+  }
+
+  void allocate(const uint_t nqregs = 1) override
+  {
+    if(qregs_.size() > 0 && qregs_.size() != nqregs)
+      qregs_.clear();
+    qregs_.resize(nqregs);
+  }
+
+  void copy(const Registers<state_t>& src);
+
+  std::unordered_map<std::string, OpItr>& marks(void)
+  {
+    return flow_marks_;
+  }
+  OpItr& next_iter(void)
+  {
+    return next_iter_;
+  }
+
+  uint_t num_shots(void)
+  {
+    uint_t nshots = shots_.size();
+    if(nshots == 0)
+      nshots = 1;
+    return nshots;
+  }
+  RngEngine& rng_shots(uint_t ishot)
+  {
+    return shots_[ishot];
+  }
+  void set_shots(std::vector<RngEngine>& shots)
+  {
+    shots_ = shots;
+  }
+  void initialize_shots(const uint_t nshots, const uint_t seed);
+
+  //functions for shot branching
+  int_t num_branch(void)
+  {
+    return branches_.size();
+  }
+  ShotBranch& branch(int i)
+  {
+    return branches_[i];
+  }
+
+  //branch shots into nbranch states
+  void branch_shots(reg_t& shots, int_t nbranch);
+  void clear_branch(void)
+  {
+    branches_.clear();
+  }
+
+  void add_op_after_branch(const uint_t ibranch, Operations::Op& op)
+  {
+    if(ibranch >= branches_.size()){
+      branches_.resize(ibranch + 1);
+      //copy all shots
+      branches_[ibranch].shots_ = shots_;
+      branches_[ibranch].creg_ = creg_;
+    }
+    branches_[ibranch].additional_ops_.push_back(op);
+  }
+  void copy_ops_after_branch(const uint_t ibranch, std::vector<Operations::Op>& ops)
+  {
+    branches_[ibranch].additional_ops_ = ops;
+  }
+  void clear_additional_ops(void)
+  {
+    additional_ops_.clear();
+  }
+
+  std::vector<Operations::Op>& additional_ops(void)
+  {
+    return additional_ops_;
+  }
+};
+
+template <class state_t>
+Registers<state_t>::Registers(const Registers<state_t>& src)
+{
+  copy(src);
+}
+template <class state_t>
+Registers<state_t>& Registers<state_t>::operator=(const Registers<state_t>& src)
+{
+  copy(src);
+  return *this;
+}
+
+template <class state_t>
+void Registers<state_t>::copy(const Registers<state_t>& src)
+{
+  qregs_.resize(src.qregs_.size());
+  for(int_t i=0;i<qregs_.size();i++)
+    qregs_[i].initialize(src.qregs_[i]);  //make copy of qregs from src
+
+  this->creg_ = src.creg_;
+  this->qubit_map_ = src.qubit_map_;
+  next_iter_ = src.next_iter_;
+  flow_marks_ = src.flow_marks_;
+}
+
+template <class state_t>
+void Registers<state_t>::initialize_shots(const uint_t nshots, const uint_t seed)
+{
+  shots_.resize(nshots);
+  for(int_t i=0;i<nshots;i++){
+    shots_[i].set_seed(seed + i);
+  }
+}
+
+template <class state_t>
+void Registers<state_t>::branch_shots(reg_t& shots, int_t nbranch)
+{
+  branches_.clear();
+  branches_.resize(nbranch);
+
+  for(int_t i=0;i<nbranch;i++){
+    branches_[i].creg_ = creg_;
+  }
+  for(int_t i=0;i<shots.size();i++){
+    branches_[shots[i]].shots_.push_back(shots_[i]);
+  }
+}
+
+//-------------------------------------------------------------------------
+} // end namespace QuantumState
+//-------------------------------------------------------------------------
+} // end namespace AER
+//-------------------------------------------------------------------------
+#endif
+

--- a/src/simulators/stabilizer/binary_vector.hpp
+++ b/src/simulators/stabilizer/binary_vector.hpp
@@ -36,6 +36,18 @@ public:
 
   BinaryVector() : m_length(0), m_data(0){};
 
+  BinaryVector(const BinaryVector& vec)
+  {
+    m_length = vec.m_length;
+    m_data = vec.m_data;
+  }
+  BinaryVector& operator=(const BinaryVector& vec)
+  {
+    m_length = vec.m_length;
+    m_data = vec.m_data;
+    return *this;
+  }
+
   explicit BinaryVector(uint64_t length)
       : m_length(length), m_data((length - 1) / BLOCK_SIZE + 1, ZERO_){};
 

--- a/src/simulators/stabilizer/clifford.hpp
+++ b/src/simulators/stabilizer/clifford.hpp
@@ -37,6 +37,9 @@ public:
   Clifford() = default;
   explicit Clifford(const uint64_t nqubit);
 
+  //initialize from existing state (copy)
+  void initialize(const Clifford& obj);
+
   //-----------------------------------------------------------------------
   // Utility functions
   //-----------------------------------------------------------------------
@@ -210,6 +213,16 @@ Clifford::Clifford(uint64_t nq) : num_qubits_(nq) {
   }
   // Add phases
   phases_.resize(2 * nq);
+}
+
+void Clifford::initialize(const Clifford& obj)
+{
+  table_ = obj.table_;
+  phases_ = obj.phases_;
+  num_qubits_ = obj.num_qubits_;
+  omp_threads_ = obj.omp_threads_;
+  omp_threshold_ = obj.omp_threshold_;
+  json_chop_threshold_ = obj.json_chop_threshold_;
 }
 
 //------------------------------------------------------------------------------

--- a/src/simulators/stabilizer/pauli.hpp
+++ b/src/simulators/stabilizer/pauli.hpp
@@ -32,6 +32,18 @@ public:
   BV::BinaryVector X;
   BV::BinaryVector Z;
 
+  Pauli(const Pauli& pauli)
+  {
+    X = pauli.X;
+    Z = pauli.Z;
+  }
+  Pauli& operator=(const Pauli& pauli)
+  {
+    X = pauli.X;
+    Z = pauli.Z;
+    return *this;
+  }
+
   // Construct an empty pauli
   Pauli() : X(0), Z(0) {};
 

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -85,30 +85,33 @@ public:
 
   // Apply an operation
   // If the op is not in allowed_ops an exeption will be raised.
-  virtual void apply_op(const Operations::Op &op,
+  void apply_op(QuantumState::RegistersBase& state,
+                        const Operations::Op &op,
                         ExperimentResult &result,
                         RngEngine &rng,
                         bool final_op = false) override;
 
-  // Initializes an n-qubit state to the all |0> state
-  virtual void initialize_qreg(uint_t num_qubits) override;
-
   // TODO: currently returns 0
   // Returns the required memory for storing an n-qubit state in megabytes.
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops)
+                                    QuantumState::OpItr first, QuantumState::OpItr last)
                                     const override;
-
-  // Load any settings for the State class from a config JSON
-  virtual void set_config(const json_t &config) override;
 
   // Sample n-measurement outcomes without applying the measure operation
   // to the system state
-  virtual std::vector<reg_t> sample_measure(const reg_t& qubits,
+  virtual std::vector<reg_t> sample_measure(QuantumState::RegistersBase& state_in, const reg_t& qubits,
                                             uint_t shots,
                                             RngEngine &rng) override;
 
 protected:
+  // Initializes an n-qubit state to the all |0> state
+  void initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits) override;
+
+  // Initializes to a specific n-qubit state
+  void initialize_qreg_state(QuantumState::RegistersBase& state_in, const Clifford::Clifford &state) override;
+
+  // Load any settings for the State class from a config JSON
+  void set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) override;
 
   //-----------------------------------------------------------------------
   // Apply instructions
@@ -116,17 +119,18 @@ protected:
 
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
-  void apply_gate(const Operations::Op &op);
+  void apply_gate(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op);
 
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
-  void apply_pauli(const reg_t &qubits, const std::string& pauli);
+  void apply_pauli(QuantumState::Registers<Clifford::Clifford>& state,const reg_t &qubits, const std::string& pauli);
 
   // Measure qubits and return a list of outcomes [q0, q1, ...]
   // If a state subclass supports this function then "measure"
   // should be contained in the set returned by the 'allowed_ops'
   // method.
-  virtual void apply_measure(const reg_t &qubits,
+  virtual void apply_measure(QuantumState::Registers<Clifford::Clifford>& state,
+                             const reg_t &qubits,
                              const reg_t &cmemory,
                              const reg_t &cregister,
                              RngEngine &rng);
@@ -134,43 +138,45 @@ protected:
   // Reset the specified qubits to the |0> state by simulating
   // a measurement, applying a conditional x-gate if the outcome is 1, and
   // then discarding the outcome.
-  void apply_reset(const reg_t &qubits, RngEngine &rng);
+  void apply_reset(QuantumState::Registers<Clifford::Clifford>& state,const reg_t &qubits, RngEngine &rng);
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const Operations::Op &op, ExperimentResult &result);
+  virtual void apply_snapshot(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op, ExperimentResult &result);
 
   // Set the state of the simulator to a given Clifford
-  void apply_set_stabilizer(const Clifford::Clifford &clifford);
+  void apply_set_stabilizer(QuantumState::Registers<Clifford::Clifford>& state,const Clifford::Clifford &clifford);
 
   //-----------------------------------------------------------------------
   // Save data instructions
   //-----------------------------------------------------------------------
 
   // Save Clifford state of simulator
-  void apply_save_stabilizer(const Operations::Op &op, ExperimentResult &result);
+  void apply_save_stabilizer(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op, ExperimentResult &result);
 
   // Save probabilities
-  void apply_save_probs(const Operations::Op &op, ExperimentResult &result);
+  void apply_save_probs(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op, ExperimentResult &result);
 
   // Helper function for saving amplitudes squared
-  void apply_save_amplitudes_sq(const Operations::Op &op,
+  void apply_save_amplitudes_sq(QuantumState::Registers<Clifford::Clifford>& state,
+                                const Operations::Op &op,
                                 ExperimentResult &result);
 
   // Helper function for computing expectation value
-  virtual double expval_pauli(const reg_t &qubits,
+  virtual double expval_pauli(QuantumState::RegistersBase& state,
+                              const reg_t &qubits,
                               const std::string& pauli) override;
 
   // Return the probability of an outcome bitstring.
-  double get_probability(const reg_t &qubits, const std::string &outcome);
+  double get_probability(QuantumState::Registers<Clifford::Clifford>& state,const reg_t &qubits, const std::string &outcome);
 
   template <typename T>
-  void get_probabilities_auxiliary(const reg_t& qubits,
+  void get_probabilities_auxiliary(QuantumState::Registers<Clifford::Clifford>& state,const reg_t& qubits,
 					std::string outcome,
 					double outcome_prob,
 					T& probs);
 
-  void get_probability_helper(const reg_t& qubits,
+  void get_probability_helper(QuantumState::Registers<Clifford::Clifford>& state,const reg_t& qubits,
 	                            const std::string &outcome,
                               std::string &outcome_carry,
                               double &prob_carry);
@@ -180,7 +186,13 @@ protected:
   //-----------------------------------------------------------------------
 
   // Implement a measurement on all specified qubits and return the outcome
-  reg_t apply_measure_and_update(const reg_t &qubits, RngEngine &rng);
+  reg_t apply_measure_and_update(QuantumState::Registers<Clifford::Clifford>& state,const reg_t &qubits, RngEngine &rng);
+
+  void apply_measure_and_update_shot_branching(QuantumState::Registers<Clifford::Clifford>& state,
+                                               const reg_t &qubits,
+                                               const reg_t &cmemory,
+                                               const reg_t &cregister,
+                                               bool reset_only);
 
   //-----------------------------------------------------------------------
   // Special snapshot types
@@ -192,15 +204,15 @@ protected:
 
   // Snapshot the stabilizer state of the simulator.
   // This returns a list of stabilizer generators
-  void snapshot_stabilizer(const Operations::Op &op, ExperimentResult &result);
+  void snapshot_stabilizer(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op, ExperimentResult &result);
                             
   // Snapshot current qubit probabilities for a measurement (average)
-  void snapshot_probabilities(const Operations::Op &op,
+  void snapshot_probabilities(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op,
                               ExperimentResult &result,
                               bool variance);
 
   // Snapshot the expectation value of a Pauli operator
-  void snapshot_pauli_expval(const Operations::Op &op,
+  void snapshot_pauli_expval(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op,
                              ExperimentResult &result,
                              SnapshotDataType type);
 
@@ -221,6 +233,10 @@ protected:
   // Table of allowed snapshot types to enum class members
   const static stringmap_t<Snapshots> snapshotset_;
 
+  bool shot_branching_supported(void) override
+  {
+    return true;
+  }
 };
 
 
@@ -269,8 +285,24 @@ const stringmap_t<Snapshots> State::snapshotset_({
 // Initialization
 //-------------------------------------------------------------------------
 
-void State::initialize_qreg(uint_t num_qubits) {
-  BaseState::qreg_ = Clifford::Clifford(num_qubits);
+void State::initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits) 
+{
+  QuantumState::Registers<Clifford::Clifford>& state = dynamic_cast<QuantumState::Registers<Clifford::Clifford>&>(state_in);
+  if(state.qregs().size() == 0)
+    state.allocate(1);
+  state.qreg() = Clifford::Clifford(num_qubits);
+}
+
+void State::initialize_qreg_state(QuantumState::RegistersBase& state_in, const Clifford::Clifford &clifford) 
+{
+  // Check dimension of state
+  if (clifford.num_qubits() != BaseState::num_qubits_) {
+    throw std::invalid_argument("Stabilizer::State::initialize: initial state does not match qubit number");
+  }
+  QuantumState::Registers<Clifford::Clifford>& state = dynamic_cast<QuantumState::Registers<Clifford::Clifford>&>(state_in);
+  if(state.qregs().size() == 0)
+    state.allocate(1);
+  state.qreg() = clifford;
 }
 
 //-------------------------------------------------------------------------
@@ -278,9 +310,10 @@ void State::initialize_qreg(uint_t num_qubits) {
 //-------------------------------------------------------------------------
 
 size_t State::required_memory_mb(uint_t num_qubits,
-                                 const std::vector<Operations::Op> &ops)
+                                 QuantumState::OpItr first, QuantumState::OpItr last)
                                  const  {
-  (void)ops; // avoid unused variable compiler warning
+  (void)first; // avoid unused variable compiler warning
+  (void)last;
   // The Clifford object requires very little memory.
   // A Pauli vector consists of 2 binary vectors each with
   // Binary vector = (4 + n // 64) 64-bit ints
@@ -292,7 +325,8 @@ size_t State::required_memory_mb(uint_t num_qubits,
   return mem;
 }
 
-void State::set_config(const json_t &config) {
+void State::set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) 
+{
   // Set threshold for truncating snapshots
   JSON::get_value(json_chop_threshold_, "zero_threshold", config);
 
@@ -305,50 +339,77 @@ void State::set_config(const json_t &config) {
 // Implementation: apply operations
 //=========================================================================
 
-void State::apply_op(const Operations::Op &op,
+void State::apply_op(QuantumState::RegistersBase& state_in,
+                     const Operations::Op &op,
                      ExperimentResult &result,
-                     RngEngine &rng, bool final_op) {
-  if (BaseState::creg().check_conditional(op)) {
+                     RngEngine &rng, bool final_op) 
+{
+  QuantumState::Registers<Clifford::Clifford>& state = dynamic_cast<QuantumState::Registers<Clifford::Clifford>&>(state_in);
+
+  if (state.creg().check_conditional(op)) {
     switch (op.type) {
       case OpType::barrier:
       case OpType::qerror_loc:
         break;
       case OpType::reset:
-        apply_reset(op.qubits, rng);
+        if(BaseState::enable_shot_branching_){  //shot branching
+          if(op.name == "update"){    //for the second call of measure
+            uint_t r = op.int_params[0];   //use saved prob
+            if(state.qreg().measure_and_update(op.qubits[0], r)){
+              //add X to additional list
+              Operations::Op xop;
+              xop.type = OpType::gate;
+              xop.name = "x";
+              xop.qubits.push_back(op.qubits[0]);
+              state.add_op_after_branch(0, xop);
+            }
+            break;
+          }
+        }
+        apply_reset(state, op.qubits, rng);
         break;
       case OpType::measure:
-        apply_measure(op.qubits, op.memory, op.registers, rng);
+        if(BaseState::enable_shot_branching_){  //shot branching
+          if(op.name == "update"){    //for the second call of measure
+            reg_t outcome(1);
+            uint_t r = op.int_params[0];   //use saved prob
+            outcome[0] = state.qreg().measure_and_update(op.qubits[0], r);
+            state.creg().store_measure(outcome, op.memory, op.registers);
+            break;
+          }
+        }
+        apply_measure(state, op.qubits, op.memory, op.registers, rng);
         break;
       case OpType::bfunc:
-        BaseState::creg().apply_bfunc(op);
+        state.creg().apply_bfunc(op);
         break;
       case OpType::roerror:
-        BaseState::creg().apply_roerror(op, rng);
+        state.creg().apply_roerror(op, rng);
         break;
       case OpType::gate:
-        apply_gate(op);
+        apply_gate(state, op);
         break;
       case OpType::snapshot:
-        apply_snapshot(op, result);
+        apply_snapshot(state, op, result);
         break;
       case OpType::set_stabilizer:
-        apply_set_stabilizer(op.clifford);
+        apply_set_stabilizer(state, op.clifford);
         break;
       case OpType::save_expval:
       case OpType::save_expval_var:
-        apply_save_expval(op, result);
+        apply_save_expval(state, op, result);
         break;
       case OpType::save_probs:
       case OpType::save_probs_ket:
-        apply_save_probs(op, result);
+        apply_save_probs(state, op, result);
         break;
       case OpType::save_amps_sq:
-        apply_save_amplitudes_sq(op, result);
+        apply_save_amplitudes_sq(state, op, result);
         break;
       case OpType::save_state:
       case OpType::save_stabilizer:
       case OpType::save_clifford:
-        apply_save_stabilizer(op, result);
+        apply_save_stabilizer(state, op, result);
         break;
       default:
         throw std::invalid_argument("Stabilizer::State::invalid instruction \'" +
@@ -357,7 +418,7 @@ void State::apply_op(const Operations::Op &op,
   }
 }
 
-void State::apply_gate(const Operations::Op &op) {
+void State::apply_gate(QuantumState::Registers<Clifford::Clifford>& state, const Operations::Op &op) {
   // Check Op is supported by State
   auto it = gateset_.find(op.name);
   if (it == gateset_.end())
@@ -367,57 +428,57 @@ void State::apply_gate(const Operations::Op &op) {
     case Gates::id:
       break;
     case Gates::x:
-      BaseState::qreg_.append_x(op.qubits[0]);
+      state.qreg().append_x(op.qubits[0]);
       break;
     case Gates::y:
-      BaseState::qreg_.append_y(op.qubits[0]);
+      state.qreg().append_y(op.qubits[0]);
       break;
     case Gates::z:
-      BaseState::qreg_.append_z(op.qubits[0]);
+      state.qreg().append_z(op.qubits[0]);
       break;
     case Gates::h:
-      BaseState::qreg_.append_h(op.qubits[0]);
+      state.qreg().append_h(op.qubits[0]);
       break;
     case Gates::s:
-      BaseState::qreg_.append_s(op.qubits[0]);
+      state.qreg().append_s(op.qubits[0]);
       break;
     case Gates::sdg:
-      BaseState::qreg_.append_z(op.qubits[0]);
-      BaseState::qreg_.append_s(op.qubits[0]);
+      state.qreg().append_z(op.qubits[0]);
+      state.qreg().append_s(op.qubits[0]);
       break;
     case Gates::sx:
-      BaseState::qreg_.append_z(op.qubits[0]);
-      BaseState::qreg_.append_s(op.qubits[0]);
-      BaseState::qreg_.append_h(op.qubits[0]);
-      BaseState::qreg_.append_z(op.qubits[0]);
-      BaseState::qreg_.append_s(op.qubits[0]);
+      state.qreg().append_z(op.qubits[0]);
+      state.qreg().append_s(op.qubits[0]);
+      state.qreg().append_h(op.qubits[0]);
+      state.qreg().append_z(op.qubits[0]);
+      state.qreg().append_s(op.qubits[0]);
       break;
     case Gates::sxdg:
-      BaseState::qreg_.append_s(op.qubits[0]);
-      BaseState::qreg_.append_h(op.qubits[0]);
-      BaseState::qreg_.append_s(op.qubits[0]);
+      state.qreg().append_s(op.qubits[0]);
+      state.qreg().append_h(op.qubits[0]);
+      state.qreg().append_s(op.qubits[0]);
       break;
     case Gates::cx:
-      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      state.qreg().append_cx(op.qubits[0], op.qubits[1]);
       break;
     case Gates::cz:
-      BaseState::qreg_.append_h(op.qubits[1]);
-      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
-      BaseState::qreg_.append_h(op.qubits[1]);
+      state.qreg().append_h(op.qubits[1]);
+      state.qreg().append_cx(op.qubits[0], op.qubits[1]);
+      state.qreg().append_h(op.qubits[1]);
       break;
     case Gates::cy:
-      BaseState::qreg_.append_z(op.qubits[1]);
-      BaseState::qreg_.append_s(op.qubits[1]);
-      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
-      BaseState::qreg_.append_s(op.qubits[1]);
+      state.qreg().append_z(op.qubits[1]);
+      state.qreg().append_s(op.qubits[1]);
+      state.qreg().append_cx(op.qubits[0], op.qubits[1]);
+      state.qreg().append_s(op.qubits[1]);
       break;
     case Gates::swap:
-      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
-      BaseState::qreg_.append_cx(op.qubits[1], op.qubits[0]);
-      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      state.qreg().append_cx(op.qubits[0], op.qubits[1]);
+      state.qreg().append_cx(op.qubits[1], op.qubits[0]);
+      state.qreg().append_cx(op.qubits[0], op.qubits[1]);
       break;
     case Gates::pauli:
-      apply_pauli(op.qubits, op.string_params[0]);
+      apply_pauli(state, op.qubits, op.string_params[0]);
       break;
     default:
       // We shouldn't reach here unless there is a bug in gateset
@@ -426,7 +487,7 @@ void State::apply_gate(const Operations::Op &op) {
   }
 }
 
-void State::apply_pauli(const reg_t &qubits, const std::string& pauli) {
+void State::apply_pauli(QuantumState::Registers<Clifford::Clifford>& state,const reg_t &qubits, const std::string& pauli) {
   const auto size = qubits.size();
   for (size_t i = 0; i < qubits.size(); ++i) {
     const auto qubit = qubits[size - 1 - i];
@@ -434,13 +495,13 @@ void State::apply_pauli(const reg_t &qubits, const std::string& pauli) {
       case 'I':
         break;
       case 'X':
-        BaseState::qreg_.append_x(qubit);
+        state.qreg().append_x(qubit);
         break;
       case 'Y':
-        BaseState::qreg_.append_y(qubit);
+        state.qreg().append_y(qubit);
         break;
       case 'Z':
-        BaseState::qreg_.append_z(qubit);
+        state.qreg().append_z(qubit);
         break;
       default:
         throw std::invalid_argument("invalid Pauli \'" + std::to_string(pauli[i]) + "\'.");
@@ -453,33 +514,49 @@ void State::apply_pauli(const reg_t &qubits, const std::string& pauli) {
 //=========================================================================
 
 
-void State::apply_measure(const reg_t &qubits,
+void State::apply_measure(QuantumState::Registers<Clifford::Clifford>& state,
+                          const reg_t &qubits,
                           const reg_t &cmemory,
                           const reg_t &cregister,
-                          RngEngine &rng) {
-  // Apply measurement and get classical outcome
-  reg_t outcome = apply_measure_and_update(qubits, rng);
-  // Add measurement outcome to creg
-  BaseState::creg().store_measure(outcome, cmemory, cregister);
+                          RngEngine &rng) 
+{
+  if(BaseState::enable_shot_branching_){  //shot branching
+    apply_measure_and_update_shot_branching(state,qubits,cmemory,cregister,false);
+  }
+  else{
+    // Apply measurement and get classical outcome
+    reg_t outcome = apply_measure_and_update(state, qubits, rng);
+    // Add measurement outcome to creg
+    state.creg().store_measure(outcome, cmemory, cregister);
+  }
 }
 
 
-void State::apply_reset(const reg_t &qubits, RngEngine &rng) {
-
-  // Apply measurement and get classical outcome
-  reg_t outcome = apply_measure_and_update(qubits, rng);
-  // Use the outcome to apply X gate to any qubits left in the
-  // |1> state after measure, then discard outcome.
-  for (size_t j=0; j < qubits.size(); j++) {
-    if (outcome[j] == 1) {
-      qreg_.append_x(qubits[j]);
+void State::apply_reset(QuantumState::Registers<Clifford::Clifford>& state,const reg_t &qubits, RngEngine &rng) 
+{
+  if(BaseState::enable_shot_branching_){  //shot branching
+    reg_t cmem;
+    reg_t creg;
+    apply_measure_and_update_shot_branching(state,qubits,cmem,creg,true);
+  }
+  else{
+    // Apply measurement and get classical outcome
+    reg_t outcome = apply_measure_and_update(state, qubits, rng);
+    // Use the outcome to apply X gate to any qubits left in the
+    // |1> state after measure, then discard outcome.
+    for (size_t j=0; j < qubits.size(); j++) {
+      if (outcome[j] == 1) {
+        state.qreg().append_x(qubits[j]);
+      }
     }
   }
 }
 
 
-reg_t State::apply_measure_and_update(const reg_t &qubits,
-                                      RngEngine &rng) {
+reg_t State::apply_measure_and_update(QuantumState::Registers<Clifford::Clifford>& state,
+                                      const reg_t &qubits,
+                                      RngEngine &rng) 
+{
   // Measurement outcome probabilities in the clifford
   // table are either deterministic or random.
   // We generate the distribution for the random case
@@ -490,42 +567,108 @@ reg_t State::apply_measure_and_update(const reg_t &qubits,
   // Measure each qubit
   for (const auto &q : qubits) {
     uint_t r = rng.rand_int(dist);
-    outcome.push_back(qreg_.measure_and_update(q, r));
+    outcome.push_back(state.qreg().measure_and_update(q, r));
   }
   return outcome;
 }
 
-std::vector<reg_t> State::sample_measure(const reg_t &qubits,
+void State::apply_measure_and_update_shot_branching(QuantumState::Registers<Clifford::Clifford>& state,
+                                               const reg_t &qubits,
+                                               const reg_t &cmemory,
+                                               const reg_t &cregister,
+                                               bool reset_only)
+{
+  const rvector_t dist = {0.5, 0.5};
+  uint_t nshots = state.num_shots();
+  reg_t shot_branch(nshots);
+
+  //only first qubit is measured/reset 
+  for(int_t i=0;i<nshots;i++)
+    shot_branch[i] = state.rng_shots(i).rand_int(dist);
+  //branch shots
+  state.branch_shots(shot_branch, 2);
+
+  //states are updated in additional op call
+  for(uint_t i=0;i<2;i++){
+    Operations::Op op;
+    if(reset_only){
+      op.type = OpType::reset;
+    }
+    else{
+      op.type = OpType::measure;
+      if(cmemory.size() > 0)
+        op.memory.push_back(cmemory[0]);
+      if(cregister.size() > 0)
+        op.registers.push_back(cregister[0]);
+    }
+    op.name = "update";   //name for second call
+    op.qubits.push_back(qubits[0]);
+    op.int_params.push_back(i);
+    state.add_op_after_branch(i, op);
+  }
+
+  //add measure/reset for remaining qubits
+  if(qubits.size() > 1){
+    for(uint_t i=0;i<2;i++){
+      Operations::Op op;
+      if(reset_only){
+        op.type = OpType::reset;
+        op.name = "reset";
+      }
+      else{
+        op.type = OpType::measure;
+        op.name = "measure";
+        if(cmemory.size() > 1)
+          op.memory.insert(op.memory.begin(),cmemory.begin()+1,cmemory.end());
+        if(cregister.size() > 1)
+          op.registers.insert(op.registers.begin(),cregister.begin()+1,cregister.end());
+      }
+      op.qubits.insert(op.qubits.begin(),qubits.begin()+1,qubits.end());
+      state.add_op_after_branch(i, op);
+    }
+  }
+}
+
+
+std::vector<reg_t> State::sample_measure(QuantumState::RegistersBase& state_in, const reg_t &qubits,
                                          uint_t shots,
-                                         RngEngine &rng) {
+                                         RngEngine &rng) 
+{
+  QuantumState::Registers<Clifford::Clifford>& state = dynamic_cast<QuantumState::Registers<Clifford::Clifford>&>(state_in);
+
   // TODO: see if we can improve efficiency by directly sampling from Clifford table
-  auto qreg_cache = BaseState::qreg_;
+  auto qreg_cache = state.qreg();
   std::vector<reg_t> samples;
   samples.reserve(shots);
-  while (shots-- > 0) { // loop over shots
-    samples.push_back(apply_measure_and_update(qubits, rng));
-    BaseState::qreg_ = qreg_cache; // restore pre-measurement data from cache
+  for(int_t i=0;i<shots;i++) { // loop over shots
+    if(BaseState::enable_shot_branching_ && state.num_shots() == shots)  //shot branching
+      samples.push_back(apply_measure_and_update(state, qubits, state.rng_shots(i)));
+    else
+      samples.push_back(apply_measure_and_update(state, qubits, rng));
+    state.qreg() = qreg_cache; // restore pre-measurement data from cache
   }
   return samples;
 }
 
-void State::apply_set_stabilizer(const Clifford::Clifford &clifford) {
-  if (clifford.num_qubits() != BaseState::qreg_.num_qubits()) {
+void State::apply_set_stabilizer(QuantumState::Registers<Clifford::Clifford>& state,const Clifford::Clifford &clifford) 
+{
+  if (clifford.num_qubits() != state.qreg().num_qubits()) {
     throw std::invalid_argument(
       "set stabilizer must be defined on full width of qubits (" +
       std::to_string(clifford.num_qubits()) + " != " +
-      std::to_string(BaseState::qreg_.num_qubits()) + ").");
+      std::to_string(state.qreg().num_qubits()) + ").");
   }
-  BaseState::qreg_.table() = clifford.table();
-  BaseState::qreg_.phases() = clifford.phases();
+  state.qreg().table() = clifford.table();
+  state.qreg().phases() = clifford.phases();
 }
 
 //=========================================================================
 // Implementation: Save data
 //=========================================================================
 
-void State::apply_save_stabilizer(const Operations::Op &op,
-                                ExperimentResult &result) {
+void State::apply_save_stabilizer(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op,
+                                ExperimentResult &result) 
+{
   std::string key = op.string_params[0];
   OpType op_type = op.type;
   switch (op_type) {
@@ -547,12 +690,13 @@ void State::apply_save_stabilizer(const Operations::Op &op,
       // We shouldn't ever reach here...
       throw std::invalid_argument("Invalid save state instruction for stabilizer");
   }
-  json_t clifford = BaseState::qreg_;
-  result.save_data_pershot(creg(), key, std::move(clifford), op_type, op.save_type);
+  json_t clifford = state.qreg();
+  result.save_data_pershot(state.creg(), key, std::move(clifford), op_type, op.save_type);
 }
 
-void State::apply_save_probs(const Operations::Op &op,
-                             ExperimentResult &result) {
+void State::apply_save_probs(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op,
+                             ExperimentResult &result) 
+{
   // Check number of qubits being measured is less than 64.
   // otherwise we cant use 64-bit int logic.
   // Practical limits are much lower. For example:
@@ -569,40 +713,44 @@ void State::apply_save_probs(const Operations::Op &op,
   }
   if (op.type == OpType::save_probs_ket) {
     std::map<std::string, double> probs;
-    get_probabilities_auxiliary(
+    get_probabilities_auxiliary(state,
         op.qubits, std::string(op.qubits.size(), 'X'), 1, probs);
-    result.save_data_average(creg(), op.string_params[0],
+    result.save_data_average(state.creg(), op.string_params[0],
                              std::move(probs), op.type, op.save_type);
   } else {
     std::vector<double> probs(1ULL << op.qubits.size(), 0.);
-    get_probabilities_auxiliary(
+    get_probabilities_auxiliary(state,
       op.qubits, std::string(op.qubits.size(), 'X'), 1, probs); 
-    result.save_data_average(creg(), op.string_params[0],
+    result.save_data_average(state.creg(), op.string_params[0],
                              std::move(probs), op.type, op.save_type);
   }
 }
 
-void State::apply_save_amplitudes_sq(const Operations::Op &op,
-                                     ExperimentResult &result) {
+void State::apply_save_amplitudes_sq(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op,
+                                     ExperimentResult &result) 
+{
   if (op.int_params.empty()) {
     throw std::invalid_argument("Invalid save_amplitudes_sq instructions (empty params).");
   }
   uint_t num_qubits = op.qubits.size();
-  if (num_qubits != BaseState::qreg_.num_qubits()) {
+  if (num_qubits != state.qreg().num_qubits()) {
     throw std::invalid_argument("Save amplitude square must be defined on full width of qubits.");
   }
   rvector_t amps_sq(op.int_params.size(), 1.0); // Must be initialized in 1 for helper func
   for (size_t i = 0; i < op.int_params.size(); i++) {
-    amps_sq[i] = get_probability(op.qubits, Utils::int2bin(op.int_params[i], num_qubits));
+    amps_sq[i] = get_probability(state, op.qubits, Utils::int2bin(op.int_params[i], num_qubits));
   }
-  result.save_data_average(creg(), op.string_params[0],
+  result.save_data_average(state.creg(), op.string_params[0],
                            std::move(amps_sq), op.type, op.save_type);
 }
 
-double State::expval_pauli(const reg_t &qubits,
-                           const std::string& pauli) {
+double State::expval_pauli(QuantumState::RegistersBase& state_in,const reg_t &qubits,
+                           const std::string& pauli) 
+{
+  QuantumState::Registers<Clifford::Clifford>& state = dynamic_cast<QuantumState::Registers<Clifford::Clifford>&>(state_in);
+
   // Construct Pauli on N-qubits
-  const auto num_qubits = BaseState::qreg_.num_qubits();
+  const auto num_qubits = state.qreg().num_qubits();
   Pauli::Pauli P(num_qubits);
   uint_t phase = 0;
   for (size_t i = 0; i < qubits.size(); ++i) {
@@ -626,7 +774,7 @@ double State::expval_pauli(const reg_t &qubits,
   // Check if there is a stabilizer that anti-commutes with an odd number of qubits
   // If so expectation value is 0
   for (size_t i = 0; i < num_qubits; i++) {
-    const auto& stabi = BaseState::qreg_.stabilizer(i);
+    const auto& stabi = state.qreg().stabilizer(i);
     size_t num_anti = 0;
     for (const auto& qubit : qubits) {
       if (P.Z[qubit] & stabi.X[qubit]) {
@@ -646,7 +794,7 @@ double State::expval_pauli(const reg_t &qubits,
   auto PZ = P.Z; // Make a copy of P.Z 
   for (size_t i = 0; i < num_qubits; i++) {
     // Check if destabilizer anti-commutes
-    const auto& destabi = BaseState::qreg_.destabilizer(i);
+    const auto& destabi = state.qreg().destabilizer(i);
     size_t num_anti = 0;
     for (const auto& qubit : qubits) {
       if (P.Z[qubit] & destabi.X[qubit]) {
@@ -659,8 +807,8 @@ double State::expval_pauli(const reg_t &qubits,
     if (num_anti % 2 == 0) continue;
 
     // If anti-commutes multiply Pauli by stabilizer
-    const auto& stabi = BaseState::qreg_.stabilizer(i);
-    phase += 2 * BaseState::qreg_.phases()[i + num_qubits];
+    const auto& stabi = state.qreg().stabilizer(i);
+    phase += 2 * state.qreg().phases()[i + num_qubits];
     for (size_t k = 0; k < num_qubits; k++) {
       phase += stabi.Z[k] & stabi.X[k];
       phase += 2 * (PZ[k] & stabi.X[k]);
@@ -683,7 +831,8 @@ static void set_value_helper(std::vector<double>& probs,
 }
 
 template <typename T>
-void State::get_probabilities_auxiliary(const reg_t &qubits,
+void State::get_probabilities_auxiliary(QuantumState::Registers<Clifford::Clifford>& state,
+                                        const reg_t &qubits,
                                         std::string outcome,
                                         double outcome_prob,
                                         T &probs) {
@@ -691,9 +840,9 @@ void State::get_probabilities_auxiliary(const reg_t &qubits,
   for (uint_t i = 0; i < qubits.size(); ++i) {
     uint_t qubit = qubits[qubits.size() - i - 1];
     if (outcome[i] == 'X') {
-      if (BaseState::qreg_.is_deterministic_outcome(qubit)) {
+      if (state.qreg().is_deterministic_outcome(qubit)) {
         bool single_qubit_outcome =
-            BaseState::qreg_.measure_and_update(qubit, 0);
+        state.qreg().measure_and_update(qubit, 0);
         if (single_qubit_outcome) {
           outcome[i] = '1';
         } else {
@@ -719,32 +868,35 @@ void State::get_probabilities_auxiliary(const reg_t &qubits,
       new_outcome[qubit_for_branching] = '0';
     }
 
-    auto copy_of_qreg = BaseState::qreg_;
-    BaseState::qreg_.measure_and_update(
+    auto copy_of_qreg = state.qreg();
+    state.qreg().measure_and_update(
         qubits[qubits.size() - qubit_for_branching - 1], single_qubit_outcome);
-    get_probabilities_auxiliary(qubits, new_outcome, 0.5 * outcome_prob, probs);
-    BaseState::qreg_ = copy_of_qreg;
+    get_probabilities_auxiliary(state, qubits, new_outcome, 0.5 * outcome_prob, probs);
+    state.qreg() = copy_of_qreg;
   }
 }
 
-double State::get_probability(const reg_t &qubits, const std::string &outcome) {
+double State::get_probability(QuantumState::Registers<Clifford::Clifford>& state,const reg_t &qubits, const std::string &outcome) 
+{
   std::string outcome_carry = std::string(qubits.size(), 'X');
   double prob = 1.0;
-  get_probability_helper(qubits, outcome, outcome_carry, prob);
+  get_probability_helper(state, qubits, outcome, outcome_carry, prob);
   return prob;
 }
 
-void State::get_probability_helper(const reg_t &qubits,
+void State::get_probability_helper(QuantumState::Registers<Clifford::Clifford>& state,
+                                   const reg_t &qubits,
                                    const std::string &outcome,
                                    std::string &outcome_carry,
-                                   double &prob_carry) {
+                                   double &prob_carry) 
+{
   uint_t qubit_for_branching = -1;
   for (uint_t i = 0; i < qubits.size(); ++i) {
     uint_t qubit = qubits[qubits.size() - i - 1];
     if (outcome_carry[i] == 'X') {
-      if (BaseState::qreg_.is_deterministic_outcome(qubit)) {
+      if (state.qreg().is_deterministic_outcome(qubit)) {
         bool single_qubit_outcome =
-            BaseState::qreg_.measure_and_update(qubit, 0);
+          state.qreg().measure_and_update(qubit, 0);
         if (single_qubit_outcome) {
           outcome_carry[i] = '1';
         } else {
@@ -764,21 +916,21 @@ void State::get_probability_helper(const reg_t &qubits,
   }
   outcome_carry[qubit_for_branching] = outcome[qubit_for_branching];
   uint_t single_qubit_outcome = (outcome[qubit_for_branching] == '1') ? 1 : 0;
-  auto cached_qreg = BaseState::qreg_;
-  BaseState::qreg_.measure_and_update(
+  auto cached_qreg = state.qreg();
+  state.qreg().measure_and_update(
       qubits[qubits.size() - qubit_for_branching - 1], single_qubit_outcome);
   prob_carry *= 0.5;
-  get_probability_helper(qubits, outcome, outcome_carry, prob_carry);
-  BaseState::qreg_ = cached_qreg;
+  get_probability_helper(state, qubits, outcome, outcome_carry, prob_carry);
+  state.qreg() = cached_qreg;
 }
 
 //=========================================================================
 // Implementation: Snapshots
 //=========================================================================
 
-void State::apply_snapshot(const Operations::Op &op,
-                           ExperimentResult &result) {
-
+void State::apply_snapshot(QuantumState::Registers<Clifford::Clifford>& state, const Operations::Op &op,
+                           ExperimentResult &result) 
+{
 // Look for snapshot type in snapshotset
   auto it = snapshotset_.find(op.name);
   if (it == snapshotset_.end())
@@ -786,28 +938,28 @@ void State::apply_snapshot(const Operations::Op &op,
                                 op.name + "\'.");
   switch (it->second) {
     case Snapshots::stabilizer:
-      snapshot_stabilizer(op, result);
+      snapshot_stabilizer(state, op, result);
       break;
     case Snapshots::cmemory:
-      BaseState::snapshot_creg_memory(op, result);
+      BaseState::snapshot_creg_memory(state, op, result);
       break;
     case Snapshots::cregister:
-      BaseState::snapshot_creg_register(op, result);
+      BaseState::snapshot_creg_register(state, op, result);
       break;
     case Snapshots::probs: {
-      snapshot_probabilities(op, result, false);
+      snapshot_probabilities(state, op, result, false);
     } break;
     case Snapshots::probs_var: {
-      snapshot_probabilities(op, result, true);
+      snapshot_probabilities(state, op, result, true);
     } break;
     case Snapshots::expval_pauli: {
-      snapshot_pauli_expval(op, result, SnapshotDataType::average);
+      snapshot_pauli_expval(state, op, result, SnapshotDataType::average);
     } break;
     case Snapshots::expval_pauli_var: {
-      snapshot_pauli_expval(op, result, SnapshotDataType::average_var);
+      snapshot_pauli_expval(state, op, result, SnapshotDataType::average_var);
     } break;
     case Snapshots::expval_pauli_shot: {
-      snapshot_pauli_expval(op, result, SnapshotDataType::pershot);
+      snapshot_pauli_expval(state, op, result, SnapshotDataType::pershot);
     } break;
     default:
       // We shouldn't get here unless there is a bug in the snapshotset
@@ -817,10 +969,11 @@ void State::apply_snapshot(const Operations::Op &op,
 }
 
 
-void State::snapshot_stabilizer(const Operations::Op &op, ExperimentResult &result) {
+void State::snapshot_stabilizer(QuantumState::Registers<Clifford::Clifford>& state,const Operations::Op &op, ExperimentResult &result) 
+{
   // We don't want to snapshot the full Clifford table, only the
   // stabilizer part. First Convert simulator clifford table to JSON
-  json_t clifford = BaseState::qreg_;
+  json_t clifford = state.qreg();
   // Then extract the stabilizer generator list
   result.legacy_data.add_pershot_snapshot("stabilizer",
                                op.string_params[0],
@@ -828,9 +981,10 @@ void State::snapshot_stabilizer(const Operations::Op &op, ExperimentResult &resu
 }
 
 
-void State::snapshot_probabilities(const Operations::Op &op,
+void State::snapshot_probabilities(QuantumState::Registers<Clifford::Clifford>& state, const Operations::Op &op,
                                    ExperimentResult &result,
-                                   bool variance) {
+                                   bool variance) 
+{
   // Check number of qubits being measured is less than 64.
   // otherwise we cant use 64-bit int logic.
   // Practical limits are much lower. For example:
@@ -847,17 +1001,18 @@ void State::snapshot_probabilities(const Operations::Op &op,
   }
 
   std::map<std::string, double> probs;
-  get_probabilities_auxiliary(
+  get_probabilities_auxiliary(state, 
       op.qubits, std::string(op.qubits.size(), 'X'), 1, probs);
 
   // Add snapshot to data
   result.legacy_data.add_average_snapshot("probabilities", op.string_params[0],
-                            BaseState::creg().memory_hex(), probs, variance);
+                                        state.creg().memory_hex(), probs, variance);
 }
 
 
-void State::snapshot_pauli_expval(const Operations::Op &op,
-                                  ExperimentResult &result, SnapshotDataType type) {
+void State::snapshot_pauli_expval(QuantumState::Registers<Clifford::Clifford>& state, const Operations::Op &op,
+                                  ExperimentResult &result, SnapshotDataType type) 
+{
   // Check empty edge case
   if (op.params_expval_pauli.empty()) {
     throw std::invalid_argument(
@@ -869,7 +1024,7 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
   for (const auto &param : op.params_expval_pauli) {
     const auto &coeff = param.first;
     const auto &pauli = param.second;
-    expval += coeff * expval_pauli(op.qubits, pauli);
+    expval += coeff * expval_pauli(state, op.qubits, pauli);
   }
 
   // add to snapshot
@@ -877,11 +1032,11 @@ void State::snapshot_pauli_expval(const Operations::Op &op,
   switch (type) {
     case SnapshotDataType::average:
       result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                            BaseState::creg().memory_hex(), expval, false);
+                            state.creg().memory_hex(), expval, false);
       break;
     case SnapshotDataType::average_var:
       result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                            BaseState::creg().memory_hex(), expval, true);
+                            state.creg().memory_hex(), expval, true);
       break;
     case SnapshotDataType::pershot:
       result.legacy_data.add_pershot_snapshot("expectation_values", op.string_params[0], expval);

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -23,9 +23,13 @@
 
 #include "noise/noise_model.hpp"
 
+#include "simulators/registers.hpp"
+
 namespace AER {
 
 namespace QuantumState {
+
+using OpItr = std::vector<Operations::Op>::const_iterator;
 
 //=========================================================================
 // State interface base class for Qiskit-Aer
@@ -36,7 +40,6 @@ public:
   using ignore_argument = void;
   using DataSubType = Operations::DataSubType;
   using OpType = Operations::OpType;
-  using OpItr = std::vector<Operations::Op>::const_iterator;
 
   //-----------------------------------------------------------------------
   // Constructors
@@ -60,8 +63,8 @@ public:
   // For snapshot ops allowed snapshots are specified by a set of string names,
   // For example this could include {"probabilities", "pauli_observable"}
 
-  Base(const Operations::OpSet &opset) : opset_(opset) {
-    cregs_.resize(1);
+  Base(const Operations::OpSet &opset) : opset_(opset) 
+  {
   }
 
   virtual ~Base() = default;
@@ -71,10 +74,8 @@ public:
   //-----------------------------------------------------------------------
 
   // Return the state creg object
-  auto &creg(uint_t idx=0) { return cregs_[idx]; }
-  const auto &creg(uint_t idx=0) const { return cregs_[idx]; }
-  std::vector<ClassicalRegister> &cregs() { return cregs_; }
-  const std::vector<ClassicalRegister> &cregs() const { return cregs_; }
+  virtual ClassicalRegister& creg(void) = 0;
+  virtual const ClassicalRegister& creg(void) const = 0;
 
   // Return the state opset object
   Operations::OpSet &opset() { return opset_; }
@@ -101,7 +102,7 @@ public:
   // Return an estimate of the required memory for implementing the
   // specified sequence of operations on a `num_qubit` sized State.
   virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops)
+                                    OpItr first, OpItr last)
                                     const = 0;
 
   //memory allocation (previously called before inisitalize_qreg)
@@ -115,20 +116,20 @@ public:
 
   // Initializes the State to the default state.
   // Typically this is the n-qubit all |0> state
-  virtual void initialize_qreg(uint_t num_qubits) = 0;
+  virtual void initialize_qreg(const uint_t num_qubits) = 0;
 
   //-----------------------------------------------------------------------
   // ClassicalRegister methods
   //-----------------------------------------------------------------------
 
   // Initialize classical memory and register to default value (all-0)
-  virtual void initialize_creg(uint_t num_memory, uint_t num_register);
+  virtual void initialize_creg(uint_t num_memory, uint_t num_register) = 0;
 
   // Initialize classical memory and register to specific values
   virtual void initialize_creg(uint_t num_memory,
                                uint_t num_register,
                                const std::string &memory_hex,
-                               const std::string &register_hex);
+                               const std::string &register_hex) = 0;
 
   //-----------------------------------------------------------------------
   // Apply circuits and ops
@@ -155,18 +156,7 @@ public:
   // to the state after this sequence, so the state can be modified at the
   // end of the instructions.
   virtual void apply_ops(OpItr first, OpItr last,
-                         ExperimentResult &result, RngEngine &rng, bool final_ops = false);
-
-  //apply ops to multiple shots
-  //this function should be separately defined since apply_ops is called in quantum_error
-  void apply_ops_multi_shots(OpItr first, OpItr last,
-                             const Noise::NoiseModel &noise,
-                             ExperimentResult &result,
-                             uint_t rng_seed,
-                             bool final_ops = false)
-  {
-    throw std::invalid_argument("apply_ops_multi_shots is not supported in State " + name());
-  }
+                         ExperimentResult &result, RngEngine &rng, bool final_ops = false) = 0;
 
   //-----------------------------------------------------------------------
   // Optional: Load config settings
@@ -196,7 +186,7 @@ public:
   // as before sampling
   virtual std::vector<reg_t> sample_measure(const reg_t &qubits,
                                             uint_t shots,
-                                            RngEngine &rng);
+                                            RngEngine &rng) = 0;
 
   //-----------------------------------------------------------------------
   // Config Settings
@@ -213,12 +203,26 @@ public:
   void add_global_phase(double theta);
 
   //set number of processes to be distributed
-  virtual void set_distribution(uint_t nprocs){}
+  virtual void set_distribution(uint_t nprocs) = 0;
 
   //set maximum number of qubits for matrix multiplication
   virtual void set_max_matrix_qubits(int_t bits)
   {
     max_matrix_qubits_ = bits;
+  }
+
+  virtual void set_parallel_shots(int shots)
+  {
+    parallel_shots_ = shots;
+  }
+
+  void enable_shot_branching(bool flg)
+  {
+    enable_shot_branching_ = flg;
+  }
+  void enable_batch_execution(bool flg)
+  {
+    enable_batch_execution_ = flg;
   }
 
   //set max number of shots to execute in a batch (used in StateChunk class)
@@ -230,6 +234,9 @@ public:
   //Does this state support multi-shot parallelization?
   virtual bool multi_shot_parallelization_supported(void){return false;}
 
+  //Does this state support runtime noise sampling?
+  virtual bool runtime_noise_sampling_supported(void){return false;}
+
   //-----------------------------------------------------------------------
   // Common instructions
   //-----------------------------------------------------------------------
@@ -237,23 +244,7 @@ public:
   // Apply a save expectation value instruction
   void apply_save_expval(const Operations::Op &op, ExperimentResult &result);
 
-  //-----------------------------------------------------------------------
-  // Standard snapshots
-  //-----------------------------------------------------------------------
-
-  // Snapshot the classical memory bits state (single-shot)
-  void snapshot_creg_memory(const Operations::Op &op, ExperimentResult &result,
-                            std::string name = "memory") const;
-
-  // Snapshot the classical register bits state (single-shot)
-  void snapshot_creg_register(const Operations::Op &op, ExperimentResult &result,
-                              std::string name = "register") const;
-
 protected:
-
-  // Classical register data
-  std::vector<ClassicalRegister> cregs_;
-
   // Opset of instructions supported by the state
   Operations::OpSet opset_;
 
@@ -261,11 +252,21 @@ protected:
   // Default value is single-threaded unless overridden
   int threads_ = 1;
 
+  // Save counts as memory list
+  bool save_creg_memory_ = false;
+
   // Set a global phase exp(1j * theta) for the state
   bool has_global_phase_ = false;
   complex_t global_phase_ = 1;
 
   int_t max_matrix_qubits_ = 0;
+
+  //OMP parallel shots 
+  int parallel_shots_ = 1;
+
+  //shot branching
+  bool enable_shot_branching_ = false;
+  bool enable_batch_execution_ = false;  //apply the same op to multiple states, if enable_shot_branching_ is false this flag is used for batched execution on GPU
 
   std::string sim_device_name_ = "CPU";
 };
@@ -273,73 +274,38 @@ protected:
 void Base::set_config(const json_t &config) 
 {
   JSON::get_value(sim_device_name_, "device", config);
+
+  // Load config for memory (creg list data)
+  JSON::get_value(save_creg_memory_, "memory", config);
 }
 
-std::vector<reg_t> Base::sample_measure(const reg_t &qubits,
-                                             uint_t shots,
-                                             RngEngine &rng) {
-  (ignore_argument)qubits;
-  (ignore_argument)shots;
-  return std::vector<reg_t>();
-}
-
-void Base::apply_ops(const OpItr first, const OpItr last,
-                          ExperimentResult &result, RngEngine &rng, bool final_ops) {
-
-  std::unordered_map<std::string, OpItr> marks;
-  // Simple loop over vector of input operations
-  for (auto it = first; it != last; ++it) {
-    switch (it->type) {
-    case Operations::OpType::mark: {
-      marks[it->string_params[0]] = it;
-      break;
-    }
-    case Operations::OpType::jump: {
-      if (creg().check_conditional(*it)) {
-        const auto& mark_name = it->string_params[0];
-        auto mark_it = marks.find(mark_name);
-        if (mark_it != marks.end()) {
-          it = mark_it->second;
-        } else {
-          for (++it; it != last; ++it) {
-            if (it->type == Operations::OpType::mark) {
-              marks[it->string_params[0]] = it;
-              if (it->string_params[0] == mark_name) {
-                break;
-              }
-            }
-          }
-          if (it == last) {
-            std::stringstream msg;
-            msg << "Invalid jump destination:\"" << mark_name << "\"." << std::endl;
-            throw std::runtime_error(msg.str());
-          }
-        }
-      }
-      break;
-    }
-    default: {
-      apply_op(*it, result, rng, final_ops && (it + 1 == last));
-    }
-    }
-  }
-};
-
-void Base::initialize_creg(uint_t num_memory, uint_t num_register) 
+void Base::set_global_phase(double theta) 
 {
-  creg().initialize(num_memory, num_register);
+  if (Linalg::almost_equal(theta, 0.0)) {
+    has_global_phase_ = false;
+    global_phase_ = 1;
+  }
+  else {
+    has_global_phase_ = true;
+    global_phase_ = std::exp(complex_t(0.0, theta));
+  }
 }
 
-void Base::initialize_creg(uint_t num_memory,
-                                uint_t num_register,
-                                const std::string &memory_hex,
-                                const std::string &register_hex) {
-  creg().initialize(num_memory, num_register, memory_hex, register_hex);
+void Base::add_global_phase(double theta) 
+{
+  if (Linalg::almost_equal(theta, 0.0)) 
+    return;
+  
+  has_global_phase_ = true;
+  global_phase_ *= std::exp(complex_t(0.0, theta));
 }
+
+//=========================================================================
+// State interface base class for Qiskit-Aer
+//=========================================================================
 
 template <class state_t>
-class State: public Base {
-
+class State : public Base {
 public:
   using ignore_argument = void;
   using DataSubType = Operations::DataSubType;
@@ -367,85 +333,1070 @@ public:
   // For snapshot ops allowed snapshots are specified by a set of string names,
   // For example this could include {"probabilities", "pauli_observable"}
 
-  State(const Operations::OpSet &opset) : Base(opset) {}
+  State(const Operations::OpSet &opset) : Base(opset) 
+  {
+    myrank_ = 0;
+    nprocs_ = 1;
+
+    distributed_procs_ = 1;
+    distributed_rank_ = 0;
+    distributed_group_ = 0;
+    distributed_proc_bits_ = 0;
+#ifdef AER_MPI
+    distributed_comm_ = MPI_COMM_WORLD;
+#endif
+  }
 
   State(const Operations::OpSet::optypeset_t &optypes,
         const stringset_t &gates,
         const stringset_t &snapshots)
-    : State(Operations::OpSet(optypes, gates, snapshots)) {};
+    : State(Operations::OpSet(optypes, gates, snapshots))
+  {
+  }
 
-  virtual ~State() {};
+  virtual ~State();
 
   //-----------------------------------------------------------------------
   // Data accessors
   //-----------------------------------------------------------------------
 
   // Return the state qreg object
-  auto &qreg() { return qreg_; }
-  const auto &qreg() const { return qreg_; }
+  auto &qreg() { return state_.qreg(); }
+  const auto &qreg() const { return state_.qreg(); }
+
+  // Return the state creg object
+  ClassicalRegister& creg() override final { return state_.creg(); }
+  const ClassicalRegister& creg() const override final { return state_.creg(); }
+
+  //=======================================================================
+  // Subclass Override Methods
+  //
+  // The following methods should be implemented by any State subclasses.
+  // Abstract methods are required, while some methods are optional for
+  // State classes that support measurement to be compatible with a general
+  // QasmController.
+  //=======================================================================
+
+  //-----------------------------------------------------------------------
+  // Abstract methods
+  //
+  // The implementation of these methods must be defined in all subclasses
+  //-----------------------------------------------------------------------
+
+  // Initializes the State to the default state.
+  // Typically this is the n-qubit all |0> state
+  void initialize_qreg(const uint_t num_qubits) override;
+
+  // Initializes the State to a specific state.
+  virtual void initialize_qreg(const state_t &state);
+
+  //memory allocation (previously called before inisitalize_qreg)
+  virtual bool allocate(uint_t num_qubits,uint_t block_bits,uint_t num_initial_states = 1);
+
+  virtual bool allocate_state(RegistersBase& state, uint_t num_max_shots = 1){return true;}
+
+  // Return the expectation value of a N-qubit Pauli operator
+  // If the simulator does not support Pauli expectation value this should
+  // raise an exception.
+  double expval_pauli(const reg_t &qubits,
+                              const std::string& pauli) override final
+  {
+    return expval_pauli(state_, qubits, pauli);
+  }
+
+  virtual double expval_pauli(RegistersBase& state, const reg_t &qubits,
+                              const std::string& pauli) = 0;
+
+  //-----------------------------------------------------------------------
+  // ClassicalRegister methods
+  //-----------------------------------------------------------------------
+
+  // Initialize classical memory and register to default value (all-0)
+  virtual void initialize_creg(uint_t num_memory, uint_t num_register);
+
+  // Initialize classical memory and register to specific values
+  virtual void initialize_creg(uint_t num_memory,
+                               uint_t num_register,
+                               const std::string &memory_hex,
+                               const std::string &register_hex);
+
+  //-----------------------------------------------------------------------
+  // Apply circuits and ops
+  //-----------------------------------------------------------------------
+
+  // Apply a single operation
+  // The `final_op` flag indicates no more instructions will be applied
+  // to the state after this sequence, so the state can be modified at the
+  // end of the instructions.
+  void apply_op(
+                        const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine& rng,
+                        bool final_op = false) override final
+  {
+    apply_op(state_, op, result, rng, final_op);
+  }
+
+  virtual void apply_op(RegistersBase& state,
+                        const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine& rng,
+                        bool final_op = false) = 0;
+
+  // Apply a sequence of operations to the current state of the State class.
+  // It is up to the State subclass to decide how this sequence should be
+  // executed (ie in sequence, or some other execution strategy.)
+  // If this sequence contains operations not in the supported opset
+  // an exeption will be thrown.
+  // The `final_ops` flag indicates no more instructions will be applied
+  // to the state after this sequence, so the state can be modified at the
+  // end of the instructions.
+  void apply_ops(OpItr first,
+                 OpItr last,
+                 ExperimentResult &result,
+                 RngEngine &rng,
+                 bool final_ops = false) override;
+
+  //run multiple shots
+  void run_shots(OpItr first,
+                 OpItr last,
+                 const json_t &config,
+                 const Noise::NoiseModel &noise,
+                 ExperimentResult &result,
+                 const uint_t rng_seed,
+                 const uint_t num_shots);
+
+  //-----------------------------------------------------------------------
+  // Config Settings
+  //-----------------------------------------------------------------------
+
+  // Load any settings for the State class from a config JSON
+  void set_config(const json_t &config) override;
+
+  //set number of processes to be distributed
+  void set_distribution(uint_t nprocs) override final;
+
+
+  //-----------------------------------------------------------------------
+  // Common instructions
+  //-----------------------------------------------------------------------
+ 
+  // Apply a save expectation value instruction
+  void apply_save_expval(Registers<state_t>& state, const Operations::Op &op, ExperimentResult &result);
+
+  //-----------------------------------------------------------------------
+  // Optional: measurement sampling
+  //
+  // This method is only required for a State subclass to be compatible with
+  // the measurement sampling optimization of a general the QasmController
+  //-----------------------------------------------------------------------
+
+  // Sample n-measurement outcomes without applying the measure operation
+  // to the system state. Even though this method is not marked as const
+  // at the end of sample the system should be left in the same state
+  // as before sampling
+  std::vector<reg_t> sample_measure(const reg_t &qubits,
+                                            uint_t shots,
+                                            RngEngine &rng) override final
+  {
+    return sample_measure(state_, qubits, shots, rng);
+  }
+  virtual std::vector<reg_t> sample_measure(RegistersBase& state, const reg_t &qubits,
+                                            uint_t shots,
+                                            RngEngine &rng);
+
+  void measure_sampler(OpItr first_meas, OpItr last_meas, uint_t num_shots, 
+                       ExperimentResult &result, RngEngine& rng)
+  {
+    std::vector<ClassicalRegister> cregs(1);  //this is not used for this call
+    measure_sampler(state_, first_meas, last_meas, num_shots, result, rng, true, cregs.begin());
+  }
+
+  void measure_sampler(Registers<state_t>& state, OpItr first_meas, OpItr last_meas, uint_t num_shots, 
+                       ExperimentResult &result, RngEngine& rng, bool save_results, std::vector<ClassicalRegister>::iterator creg_save);
 
   //-----------------------------------------------------------------------
   // Standard snapshots
   //-----------------------------------------------------------------------
 
+  // Snapshot the classical memory bits state (single-shot)
+  void snapshot_creg_memory(Registers<state_t>& state, const Operations::Op &op, ExperimentResult &result,
+                            std::string name = "memory") const;
+
+  // Snapshot the classical register bits state (single-shot)
+  void snapshot_creg_register(Registers<state_t>& state, const Operations::Op &op, ExperimentResult &result,
+                              std::string name = "register") const;
   // Snapshot the current statevector (single-shot)
   // if type_label is the empty string the operation type will be used for the type
-  virtual void snapshot_state(const Operations::Op &op, ExperimentResult &result,
+  virtual void snapshot_state(Registers<state_t>& state, const Operations::Op &op, ExperimentResult &result,
                       std::string name = "") const;
 
 protected:
-  // The quantum state data structure
-  state_t qreg_;
+  // Initializes the State to the default state.
+  // Typically this is the n-qubit all |0> state
+  virtual void initialize_qreg_state(RegistersBase& state, const uint_t num_qubits) = 0;
+
+  // Initializes the State to a specific state.
+  virtual void initialize_qreg_state(RegistersBase& state, const state_t &src_state) = 0;
+
+  // Initialize classical memory and register to default value (all-0)
+  virtual void initialize_creg_state(RegistersBase& state, uint_t num_memory, uint_t num_register);
+
+  // Initialize classical memory and register to specific values
+  virtual void initialize_creg_state(RegistersBase& state, 
+                       uint_t num_memory,
+                       uint_t num_register,
+                       const std::string &memory_hex,
+                       const std::string &register_hex);
+
+  virtual void initialize_creg_state(RegistersBase& state, const ClassicalRegister& creg);
+
+  // Load any settings for the State class from a config JSON
+  virtual void set_state_config(RegistersBase& state, const json_t &config){}
+
+  virtual void apply_ops(RegistersBase& state,
+                 OpItr first,
+                 OpItr last,
+                 const Noise::NoiseModel &noise,
+                 ExperimentResult &result,
+                 RngEngine &rng,
+                 const bool final_ops = false);
+
+  void run_shots_with_branching(OpItr first,
+                 OpItr last,
+                 const json_t &config,
+                 const Noise::NoiseModel &noise,
+                 ExperimentResult &result,
+                 const uint_t rng_seed,
+                 const uint_t num_shots);
+
+  virtual bool run_shots_with_batched_execution(
+                 OpItr first,
+                 OpItr last,
+                 const Noise::NoiseModel &noise,
+                 ExperimentResult &result,
+                 const uint_t rng_seed,
+                 const uint_t num_shots)
+  {
+    return false;   //return true if this method is supported
+  }
+
+  //sample noise function, this is used to avoid compile error for Superoperator::State referred from noise/quantum_error.h
+  virtual std::vector<Operations::Op> sample_noise(const Noise::NoiseModel &noise, const Operations::Op &op, RngEngine &rng)
+  {
+    return std::vector<Operations::Op>();
+  }
+
+  //runtime noise sampling for shot branching
+  void apply_runtime_noise_sampling(RegistersBase& state, const Operations::Op &op, const Noise::NoiseModel &noise);
+
+  // The quantum state and Classical register data structure for single shot execution
+  Registers<state_t> state_;
+
+  //max allocatable shots
+  uint_t num_max_shots_ = 1;
+
+  //number of places for shot distribution
+  uint_t num_distributed_places_ = 1;
+
+  //MPI settings
+  uint_t myrank_;               //process ID
+  uint_t nprocs_;               //number of processes
+  uint_t distributed_rank_;     //process ID in communicator group
+  uint_t distributed_procs_;    //number of processes in communicator group
+  uint_t distributed_group_;    //group id of distribution
+  int_t distributed_proc_bits_; //distributed_procs_=2^distributed_proc_bits_  (if nprocs != power of 2, set -1)
+#ifdef AER_MPI
+  //communicator group to simulate a circuit (for multi-experiments)
+  MPI_Comm distributed_comm_;
+#endif
+
+  //number of qubits for the circuit
+  uint_t num_qubits_;
+
+  //creg initialization
+  uint_t num_creg_memory_;
+  uint_t num_creg_registers_;
+
+  bool runtime_noise_sampled_ = false;  //true when runtime noise sampling is done
+
+  virtual bool shot_branching_supported(void)
+  {
+    return false;   //return true if simulation method supports
+  }
+
+  uint_t get_max_allocatable_shots(const uint_t num_qubits, OpItr first, OpItr last);
+
+  //gather cregs 
+  void gather_creg_memory(std::vector<ClassicalRegister>& cregs, uint_t num_local);
 };
 
 
+//=========================================================================
+// Implementations
+//=========================================================================
 template <class state_t>
-void State<state_t>::snapshot_state(const Operations::Op &op,
+State<state_t>::~State(void)
+{
+
+#ifdef AER_MPI
+  if(distributed_comm_ != MPI_COMM_WORLD){
+    MPI_Comm_free(&distributed_comm_);
+  }
+#endif
+}
+
+template <class state_t>
+void State<state_t>::set_config(const json_t &config) 
+{
+  Base::set_config(config);
+
+  set_state_config(state_, config);
+}
+
+template <class state_t>
+uint_t State<state_t>::get_max_allocatable_shots(const uint_t num_qubits,  OpItr first, OpItr last)
+{
+  state_t t;
+  uint_t size_per_shot_mb = required_memory_mb(num_qubits, first, last);
+  uint_t free_mem_mb = 0;
+
+  if(size_per_shot_mb == 0)
+    size_per_shot_mb = 1;
+
+  if(sim_device_name_ == "GPU"){
+#ifdef AER_THRUST_CUDA
+    int nDev;
+    if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
+      cudaGetLastError();
+      nDev = 0;
+    }
+    
+    for(int iDev=0;iDev<nDev;iDev++){
+      size_t freeMem, totalMem;
+      cudaSetDevice(iDev);
+      cudaMemGetInfo(&freeMem, &totalMem);
+      free_mem_mb += freeMem;
+    }
+    free_mem_mb >>= 20;
+#endif
+  }
+  else{
+    free_mem_mb = Utils::get_free_memory_mb();
+  }
+
+  free_mem_mb = free_mem_mb*8/10;
+  if(free_mem_mb < size_per_shot_mb)
+    return 1;
+  return free_mem_mb/size_per_shot_mb;
+}
+
+template <class state_t>
+void State<state_t>::set_distribution(uint_t nprocs)
+{
+  myrank_ = 0;
+  nprocs_ = 1;
+
+#ifdef AER_MPI
+  int t;
+  MPI_Comm_size(MPI_COMM_WORLD,&t);
+  nprocs_ = t;
+  MPI_Comm_rank(MPI_COMM_WORLD,&t);
+  myrank_ = t;
+#endif
+
+  distributed_procs_ = nprocs;
+  distributed_rank_ = myrank_ % nprocs;
+  distributed_group_ = myrank_ / nprocs;
+
+  distributed_proc_bits_ = 0;
+  int proc_bits = 0;
+  uint_t p = distributed_procs_;
+  while(p > 1){
+    if((p & 1) != 0){   //procs is not power of 2
+      distributed_proc_bits_ = -1;
+      break;
+    }
+    distributed_proc_bits_++;
+    p >>= 1;
+  }
+
+#ifdef AER_MPI
+  if(nprocs != nprocs_){
+    MPI_Comm_split(MPI_COMM_WORLD,(int)distributed_group_,(int)distributed_rank_,&distributed_comm_);
+  }
+  else{
+    distributed_comm_ = MPI_COMM_WORLD;
+  }
+#endif
+
+#ifdef AER_THRUST_CUDA
+  int nDev;
+  if (cudaGetDeviceCount(&nDev) != cudaSuccess) {
+    cudaGetLastError();
+    nDev = 0;
+  }
+  num_distributed_places_ = nDev;
+#else
+  num_distributed_places_ = 1;
+#endif
+}
+
+template <class state_t>
+bool State<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t num_initial_states)
+{
+  num_qubits_ = num_qubits;
+
+  state_.allocate(num_initial_states);
+  return true;
+}
+
+template <class state_t>
+void State<state_t>::initialize_qreg(const uint_t num_qubits)
+{
+  initialize_qreg_state(state_, num_qubits);
+}
+
+template <class state_t>
+void State<state_t>::initialize_qreg(const state_t &state)
+{
+  initialize_qreg_state(state_, state);
+}
+
+template <class state_t>
+void State<state_t>::apply_ops(OpItr first, OpItr last,
+                               ExperimentResult &result,
+                               RngEngine &rng,
+                               bool final_ops) 
+{
+  // Simple loop over vector of input operations
+  for (auto it = first; it != last; ++it) {
+    switch (it->type) {
+      case Operations::OpType::mark: {
+        state_.marks()[it->string_params[0]] = it;
+        break;
+      }
+      case Operations::OpType::jump: {
+        if (state_.creg().check_conditional(*it)) {
+          const auto& mark_name = it->string_params[0];
+          auto mark_it = state_.marks().find(mark_name);
+          if (mark_it != state_.marks().end()) {
+            it = mark_it->second;
+          } else {
+            for (++it; it != last; ++it) {
+              if (it->type == Operations::OpType::mark) {
+                state_.marks()[it->string_params[0]] = it;
+                if (it->string_params[0] == mark_name) {
+                  break;
+                }
+              }
+            }
+            if (it == last) {
+              std::stringstream msg;
+              msg << "Invalid jump destination:\"" << mark_name << "\"." << std::endl;
+              throw std::runtime_error(msg.str());
+            }
+          }
+        }
+        break;
+      }
+      default: {
+        apply_op(state_, *it, result, rng, final_ops && (it + 1 == last));
+      }
+    }
+  }
+}
+
+template <class state_t>
+std::vector<reg_t> State<state_t>::sample_measure(RegistersBase& state, const reg_t &qubits,
+                                             uint_t shots,
+                                             RngEngine &rng) {
+  (ignore_argument)qubits;
+  (ignore_argument)shots;
+  return std::vector<reg_t>();
+}
+
+template <class state_t>
+void State<state_t>::apply_ops(RegistersBase& state_in,
+                               OpItr first, OpItr last,
+                               const Noise::NoiseModel &noise,
+                               ExperimentResult &result,
+                               RngEngine &rng,
+                               const bool final_ops) 
+{
+  Registers<state_t>& state = dynamic_cast<Registers<state_t>&>(state_in);
+
+  // Simple loop over vector of input operations
+  for (auto it = first; it != last; ++it) {
+    switch (it->type) {
+      case Operations::OpType::mark: {
+        state.marks()[it->string_params[0]] = it;
+        break;
+      }
+      case Operations::OpType::jump: {
+        if (state.creg().check_conditional(*it)) {
+          const auto& mark_name = it->string_params[0];
+          auto mark_it = state.marks().find(mark_name);
+          if (mark_it != state.marks().end()) {
+            it = mark_it->second;
+          } else {
+            for (++it; it != last; ++it) {
+              if (it->type == Operations::OpType::mark) {
+                state.marks()[it->string_params[0]] = it;
+                if (it->string_params[0] == mark_name) {
+                  break;
+                }
+              }
+            }
+            if (it == last) {
+              std::stringstream msg;
+              msg << "Invalid jump destination:\"" << mark_name << "\"." << std::endl;
+              throw std::runtime_error(msg.str());
+            }
+          }
+        }
+        break;
+      }
+      case Operations::OpType::sample_noise: {
+        //runtime noise sampling
+        apply_runtime_noise_sampling(state, *it, noise);
+        state.next_iter() = it + 1;
+        return;
+      }
+      default: {
+        apply_op(state, *it, result, rng, final_ops && (it + 1 == last));
+        if(Base::enable_shot_branching_ && state.num_branch() > 0){
+          state.next_iter() = it + 1;
+          return;
+        }
+      }
+    }
+  }
+  state.next_iter() = last;
+}
+
+template <class state_t>
+void State<state_t>::run_shots(OpItr first,
+               OpItr last,
+               const json_t &config,
+               const Noise::NoiseModel &noise,
+               ExperimentResult &result,
+               const uint_t rng_seed,
+               const uint_t num_shots)
+{
+  num_max_shots_ = get_max_allocatable_shots(num_qubits_, first, last);
+
+  Base::enable_shot_branching_ &= shot_branching_supported();
+  if(Base::enable_shot_branching_ && num_max_shots_ > 1){
+    return run_shots_with_branching(first, last, config, noise, result, rng_seed, num_shots);
+  }
+  else if(Base::enable_batch_execution_ && multi_shot_parallelization_supported()){
+    if(run_shots_with_batched_execution(first, last, noise, result, rng_seed, num_shots))
+      return;
+  }
+
+  bool batch_shots_tmp = Base::enable_batch_execution_; //save this option and disable for single shot execution
+  Base::enable_batch_execution_ = false;
+
+  uint_t shot_index = num_shots*distributed_rank_/distributed_procs_;
+  uint_t num_local_shots = (num_shots*(distributed_rank_+1)/distributed_procs_) - shot_index;
+  std::vector<ClassicalRegister> cregs;   //storage for cregs for shots
+  if(num_shots != num_local_shots){
+    cregs.resize(num_local_shots);
+  }
+
+  int_t par_shots = Base::parallel_shots_;
+  if(par_shots > num_max_shots_)
+    par_shots = num_max_shots_;
+
+  std::vector<ExperimentResult> par_results(par_shots);
+  std::vector<Registers<state_t>> states(par_shots);
+
+  for(int_t i=0;i<par_shots;i++){
+    states[i].allocate(1);  //allocate single chunk
+
+    // allocate qubit register
+    allocate_state(states[i], 1);
+  }
+
+  auto run_single_shot = [this,&par_results,config,shot_index, num_shots, num_local_shots,par_shots,rng_seed, first, last, &states, &noise, &cregs](int_t i){
+    uint_t i_shot,shot_end;
+    i_shot = num_local_shots*i/par_shots;
+    shot_end = num_local_shots*(i+1)/par_shots;
+
+    // Set state config
+    set_state_config(states[i], config);
+
+    for(;i_shot<shot_end;i_shot++){
+      RngEngine rng;
+      rng.set_seed(rng_seed + shot_index + i_shot);
+
+      initialize_qreg_state(states[i], num_qubits_);
+      initialize_creg_state(states[i], num_creg_memory_, num_creg_registers_);
+
+      apply_ops(states[i], first,last,noise, par_results[i], rng, true);
+
+      if(num_shots != num_local_shots){
+        //store cregs into array if shots are distributed on MPI processes
+        cregs[i_shot] = states[i].creg();
+      }
+      else{
+        //otherwise save to result
+        if(states[i].creg().memory_size() > 0) {
+          std::string memory_hex = states[i].creg().memory_hex();
+          par_results[i].data.add_accum(static_cast<uint_t>(1ULL), "counts", memory_hex);
+          if (Base::save_creg_memory_) {
+            par_results[i].data.add_list(std::move(memory_hex), "memory");
+          }
+        }
+      }
+    }
+  };
+  Utils::apply_omp_parallel_for((par_shots > 1), 0, par_shots, run_single_shot, par_shots);
+
+  if(num_shots != num_local_shots){
+    //gather cregs among MPI processes
+    gather_creg_memory(cregs, num_local_shots);
+
+    //save cregs to result
+    auto save_cregs = [this,&par_results, &cregs, num_shots, par_shots](int_t i){
+      uint_t i_shot,shot_end;
+      i_shot = num_shots*i/par_shots;
+      shot_end = num_shots*(i+1)/par_shots;
+
+      for(;i_shot<shot_end;i_shot++){
+        if(cregs[i_shot].memory_size() > 0) {
+          std::string memory_hex = cregs[i_shot].memory_hex();
+          par_results[i].data.add_accum(static_cast<uint_t>(1ULL), "counts", memory_hex);
+          if (Base::save_creg_memory_) {
+            par_results[i].data.add_list(std::move(memory_hex), "memory");
+          }
+        }
+      }
+    };
+    Utils::apply_omp_parallel_for((par_shots > 1),0,par_shots,save_cregs, par_shots);
+  }
+
+  for (auto &res : par_results) {
+    result.combine(std::move(res));
+  }
+  add_metadata(result);
+
+  Base::enable_batch_execution_ = batch_shots_tmp;
+
+  result.metadata.add(false, "shot_branching_enabled");
+  result.metadata.add(false, "runtime_noise_sampling_enabled");
+}
+
+template <class state_t>
+void State<state_t>::run_shots_with_branching(OpItr first,
+                 OpItr last,
+                 const json_t &config,
+                 const Noise::NoiseModel &noise,
+                 ExperimentResult &result,
+                 const uint_t rng_seed,
+                 const uint_t num_shots)
+{
+  RngEngine rng;
+  rng.set_seed(rng_seed);   //this is not used actually
+
+  //check if there is sequence of measure at the end of operations
+  bool can_sample = false;
+  OpItr measure_seq = last;
+  OpItr it = last - 1;
+  int_t num_measure = 0;
+
+  do{
+    if(it->type != OpType::measure){
+      measure_seq = it + 1;
+      break;
+    }
+    num_measure += it->qubits.size();
+    it--;
+  }while(it != first);
+
+  if(num_measure >= num_qubits_ && measure_seq != last){
+    can_sample = true;
+  }
+  else{
+    measure_seq = last;
+  }
+
+  uint_t shot_index = num_shots*distributed_rank_/distributed_procs_;
+  uint_t num_local_shots = (num_shots*(distributed_rank_+1)/distributed_procs_) - shot_index;
+
+  std::vector<ClassicalRegister> cregs(num_local_shots);   //storage for cregs for local shots
+
+  std::vector<RngEngine> reserved_shots(num_local_shots);
+  for(int_t i=0;i<num_local_shots;i++){
+    reserved_shots[i].set_seed(rng_seed + shot_index + i);
+  }
+
+  uint_t num_shots_saved = 0;
+
+  std::vector<ExperimentResult> par_results(Base::parallel_shots_);
+
+  while(reserved_shots.size() > 0){
+    std::vector<std::shared_ptr<Registers<state_t>>> states;
+    std::shared_ptr<Registers<state_t>> initial_state = std::make_shared<Registers<state_t>>();
+
+    allocate_state(*initial_state, std::min((uint_t)reserved_shots.size(),num_max_shots_) );
+    initial_state->set_shots(reserved_shots);
+    reserved_shots.clear();
+
+    set_state_config(*initial_state, config);
+    initialize_qreg_state(*initial_state, num_qubits_);
+    initialize_creg_state(*initial_state, num_creg_memory_, num_creg_registers_);
+
+    states.push_back(initial_state);
+
+    //functor for ops execution
+    auto apply_ops_func = [this, &states, &rng, &noise, &par_results, measure_seq](int_t i)
+    {
+      uint_t istate,state_end;
+      istate = states.size()*i/Base::parallel_shots_;
+      state_end = states.size()*(i+1)/Base::parallel_shots_;
+      uint_t nbranch = 0;
+
+      for(;istate<state_end;istate++){
+        apply_ops(*states[istate], states[istate]->next_iter(),measure_seq ,noise,par_results[i], rng, true);
+        nbranch += states[istate]->num_branch();
+      }
+      return nbranch;
+    };
+
+    initial_state->next_iter() = first;
+    uint_t nactive = 1;
+    while(nactive > 0){   //loop until all states execute all ops
+      uint_t nbranch = 0;
+
+      //apply ops until a branch operation comes (reset, measure, kraus, initialize, noises)
+      nbranch = Utils::apply_omp_parallel_for_reduction_int((Base::parallel_shots_ > 1 && states.size() > 1), 0, Base::parallel_shots_, apply_ops_func, Base::parallel_shots_);
+
+      while(nbranch > 0){
+        uint_t num_states_prev = states.size();
+
+        for(int_t i=0;i<num_states_prev;i++){
+          if(states[i]->num_branch() > 0){
+            int_t istart = 1;
+            if(states[i]->branch(0).shots_.size() == 0){   //if first state has no shots after branch, copy other shots to the first
+              for(int_t j=1;j<states[i]->num_branch();j++){
+                if(states[i]->branch(j).shots_.size() > 0){
+                  states[i]->set_shots(states[i]->branch(j).shots_);
+                  states[i]->additional_ops() = states[i]->branch(j).additional_ops_;
+                  initialize_creg_state(*states[i], states[i]->branch(j).creg_);
+                  istart = j+1;
+                  break;
+                }
+              }
+            }
+            else{ //otherwise set branched shots 
+              states[i]->set_shots(states[i]->branch(0).shots_);
+              states[i]->additional_ops() = states[i]->branch(0).additional_ops_;
+              initialize_creg_state(*states[i], states[i]->branch(0).creg_);
+            }
+            for(int_t j=istart;j<states[i]->num_branch();j++){
+              if(states[i]->branch(j).shots_.size() > 0){  //copy state and set branched shots
+                uint_t pos = states.size();
+                if(pos >= num_max_shots_){  //if there is not enough memory to allocate copied state, shots are reserved to the next iteration
+                  //reset seed to reproduce same results
+                  for(int_t k=0;k<states[i]->branch(j).shots_.size();k++){
+                    states[i]->branch(j).shots_[k].set_seed(states[i]->branch(j).shots_[k].initial_seed());
+                  }
+                  reserved_shots.insert(reserved_shots.end(), states[i]->branch(j).shots_.begin(), states[i]->branch(j).shots_.end());
+                }
+                else{
+                  states.push_back(std::make_shared<Registers<state_t>>(*states[i]));
+                  states[pos]->set_shots(states[i]->branch(j).shots_);
+                  states[pos]->additional_ops() = states[i]->branch(j).additional_ops_;
+                  initialize_creg_state(*states[pos], states[i]->branch(j).creg_);
+                }
+              }
+            }
+          }
+        }
+
+        //then execute ops applied after branching (reset, Kraus, noises, etc.)
+        auto apply_additional_ops_func = [this, &states, &rng, &noise, &par_results](int_t i)
+        {
+          uint_t istate,state_end;
+          istate = states.size()*i/Base::parallel_shots_;
+          state_end = states.size()*(i+1)/Base::parallel_shots_;
+          uint_t nbranch = 0;
+
+          for(;istate<state_end;istate++){
+            states[istate]->clear_branch();
+            for(int_t j=0;j<states[istate]->additional_ops().size();j++){
+              apply_op(*states[istate], states[istate]->additional_ops()[j], par_results[i], rng, false );
+
+              if(states[istate]->num_branch() > 0){  //check if there are new branches
+                //if there are additional ops remaining, queue them on new branches
+                for(int_t k=j+1;k<states[istate]->additional_ops().size();k++){
+                  for(int_t l=0;l<states[istate]->num_branch();l++)
+                    states[istate]->add_op_after_branch(l,states[istate]->additional_ops()[k]);
+                }
+                nbranch += states[istate]->num_branch();
+                break;
+              }
+            }
+            states[istate]->clear_additional_ops();
+          }
+          return nbranch;
+        };
+        nbranch = Utils::apply_omp_parallel_for_reduction_int((Base::parallel_shots_ > 1 && states.size() > 1), 0, Base::parallel_shots_, apply_additional_ops_func, Base::parallel_shots_);
+      }
+
+      nactive = 0;
+      for(int_t i=0;i<states.size();i++){
+        if(states[i]->next_iter() != measure_seq)
+          nactive++;
+      }
+    }
+
+    reg_t creg_pos(states.size());
+    for(int_t i=0;i<states.size();i++){
+      creg_pos[i] = num_shots_saved;
+      num_shots_saved += states[i]->num_shots();
+    }
+
+    //save cregs to array
+    auto save_creg_func = [this, &states, &cregs, &creg_pos](int_t i)
+    {
+      for(int_t j=0;j<states[i]->num_shots();j++){
+        cregs[creg_pos[i] + j] = states[i]->creg();
+      }
+    };
+    Utils::apply_omp_parallel_for((Base::parallel_shots_ > 1 && states.size() > 1), 0, states.size(), save_creg_func, Base::parallel_shots_);
+
+    //apply sampling measure for each branch
+    if(can_sample){
+      auto sampling_measure_func = [this, &states, &cregs, &creg_pos, &par_results, &rng, measure_seq, last](int_t i)
+      {
+        uint_t istate,state_end;
+        istate = states.size()*i/Base::parallel_shots_;
+        state_end = states.size()*(i+1)/Base::parallel_shots_;
+
+        for(;istate<state_end;istate++)
+          measure_sampler(*states[istate], measure_seq, last, states[istate]->num_shots(), par_results[i], rng, false, cregs.begin() + creg_pos[istate]);
+      };
+      Utils::apply_omp_parallel_for((Base::parallel_shots_ > 1 && states.size() > 1), 0, Base::parallel_shots_, sampling_measure_func, Base::parallel_shots_);
+    }
+
+    //clear
+    for(int_t i=0;i<states.size();i++){
+      states[i].reset();
+    }
+    states.clear();
+    initial_state.reset();
+  }
+
+  gather_creg_memory(cregs, num_local_shots);
+
+  //save cregs to result
+  auto save_cregs = [this,&par_results, &cregs, num_shots](int_t i){
+    uint_t i_shot,shot_end;
+    i_shot = num_shots*i/Base::parallel_shots_;
+    shot_end = num_shots*(i+1)/Base::parallel_shots_;
+
+    for(;i_shot<shot_end;i_shot++){
+      if(cregs[i_shot].memory_size() > 0) {
+        std::string memory_hex = cregs[i_shot].memory_hex();
+        par_results[i].data.add_accum(static_cast<uint_t>(1ULL), "counts", memory_hex);
+        if (Base::save_creg_memory_) {
+          par_results[i].data.add_list(std::move(memory_hex), "memory");
+        }
+      }
+    }
+  };
+  Utils::apply_omp_parallel_for((Base::parallel_shots_ > 1),0,Base::parallel_shots_,save_cregs, Base::parallel_shots_);
+
+  for (auto &res : par_results) {
+    result.combine(std::move(res));
+  }
+
+  result.metadata.add(true, "shot_branching_enabled");
+  result.metadata.add(runtime_noise_sampled_, "runtime_noise_sampling_enabled");
+}
+
+
+template <class state_t>
+void State<state_t>::apply_runtime_noise_sampling(RegistersBase& state_in, const Operations::Op &op, const Noise::NoiseModel &noise)
+{
+  Registers<state_t>& state = dynamic_cast<Registers<state_t>&>(state_in);
+  uint_t nshots = state.num_shots();
+  reg_t shot_map(nshots);
+  std::vector<std::vector<Operations::Op>> noises;
+
+  for(int_t i=0;i<nshots;i++){
+    std::vector<Operations::Op> noise_ops = sample_noise(noise, op, state.rng_shots(i));
+
+    //search same noise ops 
+    int_t pos = -1;
+    for(int_t j=0;j<noises.size();j++){
+      if(noise_ops.size() != noises[j].size())
+        continue;
+      bool same = true;
+      for(int_t k=0;k<noise_ops.size();k++){
+        if(noise_ops[k].type != noises[j][k].type || noise_ops[k].name != noises[j][k].name)
+          same = false;
+        else if(noise_ops[k].qubits.size() != noises[j][k].qubits.size())
+          same = false;
+        else{
+          for(int_t l=0;l<noise_ops[k].qubits.size();l++){
+            if(noise_ops[k].qubits[l] != noises[j][k].qubits[l]){
+              same = false;
+              break;
+            }
+          }
+        }
+        if(!same)
+          break;
+        if(noise_ops[k].type == OpType::gate){
+          if(noise_ops[k].name == "pauli"){
+            if(noise_ops[k].string_params[0] != noises[j][k].string_params[0])
+              same = false;
+          }
+          else if(noise_ops[k].params.size() != noises[j][k].params.size())
+            same = false;
+          else{
+            for(int_t l=0;l<noise_ops[k].params.size();l++){
+              if(noise_ops[k].params[l] != noises[j][k].params[l]){
+                same = false;
+                break;
+              }
+            }
+          }
+        }
+        else if(noise_ops[k].type == OpType::matrix || noise_ops[k].type == OpType::diagonal_matrix){
+          if(noise_ops[k].mats.size() != noises[j][k].mats.size())
+            same = false;
+          else{
+            for(int_t l=0;l<noise_ops[k].mats.size();l++){
+              if(noise_ops[k].mats[l].size() != noises[j][k].mats[l].size()){
+                same = false;
+                break;
+              }
+              for(int_t m=0;m<noise_ops[k].mats[l].size();m++){
+                if(noise_ops[k].mats[l][m] != noises[j][k].mats[l][m]){
+                  same = false;
+                  break;
+                }
+              }
+              if(!same)
+                break;
+            }
+          }
+        }
+        if(!same)
+          break;
+      }
+      if(same){
+        pos = j;
+        break;
+      }
+    }
+
+    if(pos < 0){  //if not found, add noise ops to the list
+      shot_map[i] = noises.size();
+      noises.push_back(noise_ops);
+    }
+    else{   //if found, add shot
+      shot_map[i] = pos;
+    }
+  }
+
+  state.branch_shots(shot_map, noises.size());
+  for(int_t i=0;i<noises.size();i++){
+    state.copy_ops_after_branch(i,noises[i]);
+  }
+  runtime_noise_sampled_ = true;
+}
+
+template <class state_t>
+void State<state_t>::initialize_creg(uint_t num_memory, uint_t num_register) 
+{
+  num_creg_memory_ = num_memory;
+  num_creg_registers_ = num_register;
+
+  initialize_creg_state(state_, num_memory, num_register);
+}
+template <class state_t>
+void State<state_t>::initialize_creg(uint_t num_memory,
+                                     uint_t num_register,
+                                     const std::string &memory_hex,
+                                     const std::string &register_hex) 
+{
+  num_creg_memory_ = num_memory;
+  num_creg_registers_ = num_register;
+
+  initialize_creg_state(state_, num_memory, num_register, memory_hex, register_hex);
+}
+
+template <class state_t>
+void State<state_t>::initialize_creg_state(RegistersBase& state, uint_t num_memory, uint_t num_register) 
+{
+  num_creg_memory_ = num_memory;
+  num_creg_registers_ = num_register;
+
+  state.creg().initialize(num_memory, num_register);
+}
+
+template <class state_t>
+void State<state_t>::initialize_creg_state(RegistersBase& state, 
+                                     uint_t num_memory,
+                                     uint_t num_register,
+                                     const std::string &memory_hex,
+                                     const std::string &register_hex) 
+{
+  num_creg_memory_ = num_memory;
+  num_creg_registers_ = num_register;
+  state.creg().initialize(num_memory, num_register, memory_hex, register_hex);
+}
+
+template <class state_t>
+void State<state_t>::initialize_creg_state(RegistersBase& state, const ClassicalRegister& creg)
+{
+  state.creg() = creg;
+}
+
+
+template <class state_t>
+void State<state_t>::snapshot_state(Registers<state_t>& state, const Operations::Op &op,
                                     ExperimentResult &result,
-                                    std::string name) const {
+                                    std::string name) const 
+{
   name = (name.empty()) ? op.name : name;
-  result.legacy_data.add_pershot_snapshot(name, op.string_params[0], qreg());
+  result.legacy_data.add_pershot_snapshot(name, op.string_params[0], state.qreg());
 }
 
-void Base::set_global_phase(double theta) {
-  if (Linalg::almost_equal(theta, 0.0)) {
-    has_global_phase_ = false;
-    global_phase_ = 1;
-  }
-  else {
-    has_global_phase_ = true;
-    global_phase_ = std::exp(complex_t(0.0, theta));
-  }
-}
 
-void Base::add_global_phase(double theta) {
-  if (Linalg::almost_equal(theta, 0.0)) 
-    return;
-  
-  has_global_phase_ = true;
-  global_phase_ *= std::exp(complex_t(0.0, theta));
-}
-
-void Base::snapshot_creg_memory(const Operations::Op &op,
+template <class state_t>
+void State<state_t>::snapshot_creg_memory(Registers<state_t>& state,const Operations::Op &op,
                                           ExperimentResult &result,
-                                          std::string name) const {
+                                          std::string name) const 
+{
   result.legacy_data.add_pershot_snapshot(name,
                                op.string_params[0],
-                               creg().memory_hex());
+                               state.creg().memory_hex());
 }
 
 
-void Base::snapshot_creg_register(const Operations::Op &op,
+template <class state_t>
+void State<state_t>::snapshot_creg_register(Registers<state_t>& state, const Operations::Op &op,
                                             ExperimentResult &result,
-                                            std::string name) const {
+                                            std::string name) const 
+{
   result.legacy_data.add_pershot_snapshot(name,
                                op.string_params[0],
-                               creg().register_hex());
+                               state.creg().register_hex());
 }
 
 
-void Base::apply_save_expval(const Operations::Op &op,
-                                       ExperimentResult &result){
+template <class state_t>
+void State<state_t>::apply_save_expval(Registers<state_t>& state, 
+                                       const Operations::Op &op,
+                                       ExperimentResult &result)
+{
   // Check empty edge case
   if (op.expval_params.empty()) {
     throw std::invalid_argument(
@@ -459,7 +1410,7 @@ void Base::apply_save_expval(const Operations::Op &op,
 
   for (const auto &param : op.expval_params) {
     // param is tuple (pauli, coeff, sq_coeff)
-    const auto val = expval_pauli(op.qubits, std::get<0>(param));
+    const auto val = expval_pauli(state, op.qubits, std::get<0>(param));
     expval += std::get<1>(param) * val;
     if (variance) {
       sq_expval += std::get<2>(param) * val;
@@ -469,9 +1420,195 @@ void Base::apply_save_expval(const Operations::Op &op,
     std::vector<double> expval_var(2);
     expval_var[0] = expval;  // mean
     expval_var[1] = sq_expval - expval * expval;  // variance
-    result.save_data_average(creg(), op.string_params[0], expval_var, op.type, op.save_type);
+    result.save_data_average(state.creg(), op.string_params[0], expval_var, op.type, op.save_type);
   } else {
-    result.save_data_average(creg(), op.string_params[0], expval, op.type, op.save_type);
+    result.save_data_average(state.creg(), op.string_params[0], expval, op.type, op.save_type);
+  }
+}
+
+template <class state_t>
+void State<state_t>::gather_creg_memory(std::vector<ClassicalRegister>& cregs, uint_t num_local)
+{
+#ifdef AER_MPI
+  int_t i,j;
+  uint_t n64,i64,ibit,mem_size;
+  uint_t num_global = 0;
+
+  if(distributed_procs_ == 1)
+    return;
+  mem_size = cregs[0].memory_size();
+  if(mem_size == 0)
+    return;
+
+  std::vector<int> recv_counts(distributed_procs_);
+  std::vector<int> recv_offset(distributed_procs_);
+  std::vector<int> tmp(distributed_procs_);
+
+  for(i=0;i<distributed_procs_;i++){
+    recv_counts[i] = num_local;
+  }
+
+  tmp = recv_counts;
+  MPI_Alltoall(&tmp[0],1,MPI_INTEGER,&recv_counts[0],1,MPI_INTEGER,distributed_comm_);
+
+  for(i=0;i<distributed_procs_;i++){
+    recv_offset[i] = num_global;
+    num_global += recv_counts[i];
+  }
+  uint_t global_id = recv_offset[distributed_rank_];
+
+  //number of 64-bit integers per memory
+  n64 = (mem_size + 63) >> 6;
+
+  reg_t bin_memory(n64*num_local,0);
+  //compress memory string to binary
+#pragma omp parallel for private(i,j,i64,ibit)
+  for(i=0;i<num_local;i++){
+    for(j=0;j<mem_size;j++){
+      i64 = j >> 6;
+      ibit = j & 63;
+      if(cregs[i].creg_memory()[j] == '1'){
+        bin_memory[i*n64 + i64] |= (1ull << ibit);
+      }
+    }
+  }
+
+  reg_t recv(n64*num_global);
+
+  MPI_Allgatherv(&bin_memory[0],n64*num_local,MPI_UINT64_T,
+                 &recv[0],&recv_counts[0],&recv_offset[0],MPI_UINT64_T, distributed_comm_);
+
+  cregs.clear();
+  cregs.resize(num_global);
+
+  //store gathered memory
+#pragma omp parallel for private(i,j,i64,ibit)
+  for(i=0;i<num_global;i++){
+    cregs[i].initialize(mem_size,mem_size);
+    for(j=0;j<mem_size;j++){
+      i64 = j >> 6;
+      ibit = j & 63;
+      if(((recv[i*n64 + i64] >> ibit) & 1) == 1)
+        cregs[i].creg_memory()[j] = '1';
+      else
+        cregs[i].creg_memory()[j] = '0';
+    }
+  }
+#endif
+}
+
+template <class state_t>
+void State<state_t>::measure_sampler(Registers<state_t>& state, OpItr first_meas, OpItr last_meas, uint_t num_shots, 
+                       ExperimentResult &result, RngEngine& rng, bool save_results, std::vector<ClassicalRegister>::iterator creg_save)
+{
+    using myclock_t = std::chrono::high_resolution_clock;
+
+  // Check if meas_circ is empty, and if so return initial creg
+  if (first_meas == last_meas) {
+    if(save_results){
+      while (num_shots-- > 0) {
+        result.save_count_data(state.creg(), Base::save_creg_memory_);
+      }
+    }
+    return;
+  }
+
+  std::vector<Operations::Op> meas_ops;
+  std::vector<Operations::Op> roerror_ops;
+  for (auto op = first_meas; op != last_meas; op++) {
+    if (op->type == Operations::OpType::roerror) {
+      roerror_ops.push_back(*op);
+    } else { /*(op.type == Operations::OpType::measure) */
+      meas_ops.push_back(*op);
+    }
+  }
+
+  // Get measured qubits from circuit sort and delete duplicates
+  std::vector<uint_t> meas_qubits; // measured qubits
+  for (const auto &op : meas_ops) {
+    for (size_t j = 0; j < op.qubits.size(); ++j)
+      meas_qubits.push_back(op.qubits[j]);
+  }
+  sort(meas_qubits.begin(), meas_qubits.end());
+  meas_qubits.erase(unique(meas_qubits.begin(), meas_qubits.end()),
+                    meas_qubits.end());
+
+  // Generate the samples
+  auto timer_start = myclock_t::now();
+  auto all_samples = sample_measure(state, meas_qubits, num_shots, rng);
+  auto time_taken =
+      std::chrono::duration<double>(myclock_t::now() - timer_start).count();
+  result.metadata.add(time_taken, "sample_measure_time");
+
+  // Make qubit map of position in vector of measured qubits
+  std::unordered_map<uint_t, uint_t> qubit_map;
+  for (uint_t j = 0; j < meas_qubits.size(); ++j) {
+    qubit_map[meas_qubits[j]] = j;
+  }
+
+  // Maps of memory and register to qubit position
+  std::map<uint_t, uint_t> memory_map;
+  std::map<uint_t, uint_t> register_map;
+  for (const auto &op : meas_ops) {
+    for (size_t j = 0; j < op.qubits.size(); ++j) {
+      auto pos = qubit_map[op.qubits[j]];
+      if (!op.memory.empty())
+        memory_map[op.memory[j]] = pos;
+      if (!op.registers.empty())
+        register_map[op.registers[j]] = pos;
+    }
+  }
+
+  // Process samples
+  if(save_results){
+    uint_t num_memory = (memory_map.empty()) ? 0ULL : 1 + memory_map.rbegin()->first;
+    uint_t num_registers = (register_map.empty()) ? 0ULL : 1 + register_map.rbegin()->first;
+    ClassicalRegister creg;
+    while (!all_samples.empty()) {
+      auto sample = all_samples.back();
+      creg.initialize(num_memory, num_registers);
+
+      // process memory bit measurements
+      for (const auto &pair : memory_map) {
+        creg.store_measure(reg_t({sample[pair.second]}), reg_t({pair.first}),
+                           reg_t());
+      }
+      // process register bit measurements
+      for (const auto &pair : register_map) {
+        creg.store_measure(reg_t({sample[pair.second]}), reg_t(),
+                           reg_t({pair.first}));
+      }
+
+      // process read out errors for memory and registers
+      for (const Operations::Op &roerror : roerror_ops) {
+        creg.apply_roerror(roerror, rng);
+      }
+
+      // Save count data
+        result.save_count_data(creg, Base::save_creg_memory_);
+
+      // pop off processed sample
+      all_samples.pop_back();
+    }
+  }
+  else{
+    for(int_t i=0;i<all_samples.size();i++){
+      // process memory bit measurements
+      for (const auto &pair : memory_map) {
+        (creg_save + i)->store_measure(reg_t({all_samples[i][pair.second]}), reg_t({pair.first}),
+                           reg_t());
+      }
+      // process register bit measurements
+      for (const auto &pair : register_map) {
+        (creg_save + i)->store_measure(reg_t({all_samples[i][pair.second]}), reg_t(),
+                           reg_t({pair.first}));
+      }
+
+      // process read out errors for memory and registers
+      for (const Operations::Op &roerror : roerror_ops) {
+        (creg_save + i)->apply_roerror(roerror, rng);
+      }
+    }
   }
 }
 

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -79,20 +79,9 @@ public:
     num_global_chunks_ = 0;
     num_local_chunks_ = 0;
 
-    myrank_ = 0;
-    nprocs_ = 1;
-
-    distributed_procs_ = 1;
-    distributed_rank_ = 0;
-    distributed_group_ = 0;
-    distributed_proc_bits_ = 0;
-
     chunk_omp_parallel_ = false;
     global_chunk_indexing_ = false;
 
-#ifdef AER_MPI
-    distributed_comm_ = MPI_COMM_WORLD;
-#endif
   }
 
   virtual ~StateChunk();
@@ -100,14 +89,6 @@ public:
   //-----------------------------------------------------------------------
   // Data accessors
   //-----------------------------------------------------------------------
-
-  // Return the state qreg object
-  auto &qreg(int_t idx=0) { return qregs_[idx]; }
-  const auto &qreg(int_t idx=0) const { return qregs_[idx]; }
-
-  // Return the creg object
-  auto &chunk_creg(uint_t iChunk) { return BaseState::creg(get_global_shot_index(iChunk)); }
-  const auto &chunk_creg(uint_t iChunk) const { return BaseState::creg(get_global_shot_index(iChunk)); }
 
   //=======================================================================
   // Subclass Override Methods
@@ -127,25 +108,15 @@ public:
   // Return a string name for the StateChunk type
   virtual std::string name() const = 0;
 
-  // Initializes the StateChunk to the default state.
-  // Typically this is the n-qubit all |0> state
-  virtual void initialize_qreg(uint_t num_qubits) = 0;
-
-  // Return an estimate of the required memory for implementing the
-  // specified sequence of operations on a `num_qubit` sized StateChunk.
-  virtual size_t required_memory_mb(uint_t num_qubits,
-                                    const std::vector<Operations::Op> &ops)
-                                    const = 0;
-
   //memory allocation (previously called before inisitalize_qreg)
   virtual bool allocate(uint_t num_qubits,uint_t block_bits,uint_t num_parallel_shots = 1);
+
+  bool allocate_state(RegistersBase& state, uint_t num_max_shots = 1) override;
 
   // Return the expectation value of a N-qubit Pauli operator
   // If the simulator does not support Pauli expectation value this should
   // raise an exception.
-  double expval_pauli(const reg_t &qubits,const std::string& pauli) override final {return 0.0;}
-
-  virtual double expval_pauli(const int_t iChunk, const reg_t &qubits,
+  virtual double expval_pauli(RegistersBase& state, const reg_t &qubits,
                               const std::string& pauli) = 0;
 
   //-----------------------------------------------------------------------
@@ -153,7 +124,7 @@ public:
   //-----------------------------------------------------------------------
 
   // Load any settings for the StateChunk class from a config JSON
-  virtual void set_config(const json_t &config);
+  void set_config(const json_t &config) override final;
 
   //=======================================================================
   // Standard non-virtual methods
@@ -164,24 +135,6 @@ public:
   //-----------------------------------------------------------------------
   // Apply circuits and ops
   //-----------------------------------------------------------------------
-
-  // Apply a single operation
-  // The `final_op` flag indicates no more instructions will be applied
-  // to the state after this sequence, so the state can be modified at the
-  // end of the instructions.
-
-  //this is not used for StateChunk
-  void apply_op(const Operations::Op &op,
-                      ExperimentResult &result,
-                      RngEngine& rng,
-                      bool final_op = false) override final { apply_op(0, op, result, rng, final_op); }
-
-  //so this one is used
-  virtual void apply_op(const int_t iChunk, const Operations::Op &op,
-                        ExperimentResult &result,
-                        RngEngine& rng,
-                        bool final_op = false) = 0;
-
 
   // Apply a sequence of operations to the current state of the StateChunk class.
   // It is up to the StateChunk subclass to decide how this sequence should be
@@ -197,70 +150,30 @@ public:
                  RngEngine &rng,
                  bool final_ops = false) override;
 
-  //apply ops to multiple shots
-  //this function should be separately defined since apply_ops is called in quantum_error
-  template <typename InputIterator>
-  void apply_ops_multi_shots(InputIterator first,
-                 InputIterator last,
-                 const Noise::NoiseModel &noise,
-                 ExperimentResult &result,
-                 uint_t rng_seed,
-                 bool final_ops = false);
+  //apply_op for specific chunk
+  virtual void apply_op_chunk(uint_t iChunk, RegistersBase& state, 
+                        const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine& rng,
+                        bool final_op = false) = 0;
 
   //-----------------------------------------------------------------------
   // Initialization
   //-----------------------------------------------------------------------
   template <typename list_t>
-  void initialize_from_vector(const int_t iChunk, const list_t &vec);
+  void initialize_from_vector(Registers<state_t>& state, const list_t &vec);
 
   template <typename list_t>
-  void initialize_from_matrix(const int_t iChunk, const list_t &mat);
-
-  //-----------------------------------------------------------------------
-  // ClassicalRegister methods
-  //-----------------------------------------------------------------------
-
-  // Initialize classical memory and register to default value (all-0)
-  virtual void initialize_creg(uint_t num_memory, uint_t num_register);
-
-  // Initialize classical memory and register to specific values
-  virtual void initialize_creg(uint_t num_memory,
-                       uint_t num_register,
-                       const std::string &memory_hex,
-                       const std::string &register_hex);
+  void initialize_from_matrix(Registers<state_t>& state, const list_t &mat);
 
   //-----------------------------------------------------------------------
   // Common instructions
   //-----------------------------------------------------------------------
  
-  // Apply a save expectation value instruction
-  void apply_save_expval(const int_t iChunk, const Operations::Op &op, ExperimentResult &result);
-
-  //-----------------------------------------------------------------------
-  // Standard snapshots
-  //-----------------------------------------------------------------------
-
-  // Snapshot the current statevector (single-shot)
-  // if type_label is the empty string the operation type will be used for the type
-  virtual void snapshot_state(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
-                      std::string name = "") const;
-
-  // Snapshot the classical memory bits state (single-shot)
-  void snapshot_creg_memory(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
-                            std::string name = "memory") const;
-
-  // Snapshot the classical register bits state (single-shot)
-  void snapshot_creg_register(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
-                              std::string name = "register") const;
-
 
   //-----------------------------------------------------------------------
   // Config Settings
   //-----------------------------------------------------------------------
-
-
-  //set number of processes to be distributed
-  virtual void set_distribution(uint_t nprocs);
 
   //set max number of shots to execute in a batch
   void set_max_bached_shots(uint_t shots)
@@ -269,17 +182,15 @@ public:
   }
 
   //Does this state support multi-chunk distribution?
-  virtual bool multi_chunk_distribution_supported(void){return true;}
+  bool multi_chunk_distribution_supported(void) override
+  {return true;}
   //Does this state support multi-shot parallelization?
-  virtual bool multi_shot_parallelization_supported(void){return true;}
+  virtual bool multi_shot_parallelization_supported(void)
+  {
+    return true;
+  }
 
 protected:
-
-  // The array of the quantum state data structure
-  std::vector<state_t> qregs_;
-
-  //number of qubits for the circuit
-  uint_t num_qubits_;
 
   //extra parameters for parallel simulations
   uint_t num_global_chunks_;    //number of total chunks 
@@ -292,12 +203,6 @@ protected:
   reg_t chunk_index_end_;       //ending chunk index for each process
   uint_t local_shot_index_;    //local shot ID of current batch loop
 
-  uint_t myrank_;               //process ID
-  uint_t nprocs_;               //number of processes
-  uint_t distributed_rank_;     //process ID in communicator group
-  uint_t distributed_procs_;    //number of processes in communicator group
-  uint_t distributed_group_;    //group id of distribution
-  int_t distributed_proc_bits_; //distributed_procs_=2^distributed_proc_bits_  (if nprocs != power of 2, set -1)
 
   bool chunk_omp_parallel_;     //using thread parallel to process loop of chunks or not
   bool global_chunk_indexing_;  //using global index for control qubits and diagonal matrix
@@ -326,42 +231,59 @@ protected:
   // Apply circuits and ops
   //-----------------------------------------------------------------------
   //apply ops for multi-chunk distribution
-  template <typename InputIterator>
-  void apply_ops_chunks(InputIterator first,
-                 InputIterator last,
+  void apply_ops_chunks(Registers<state_t>& state, 
+                 OpItr first,
+                 OpItr last,
                  ExperimentResult &result,
                  RngEngine &rng,
                  bool final_ops = false);
 
+  void apply_ops(RegistersBase& state,
+                 OpItr first,
+                 OpItr last,
+                 const Noise::NoiseModel &noise,
+                 ExperimentResult &result,
+                 RngEngine &rng,
+                 const bool final_ops = false) override;
+
   //apply cache blocked ops in each chunk
-  template <typename InputIterator>
-  void apply_cache_blocking_ops(const int_t iGroup, InputIterator first,
-                 InputIterator last,
+  void apply_cache_blocking_ops(Registers<state_t>& state, const int_t iGroup,
+                 OpItr first,
+                 OpItr last,
                  ExperimentResult &result,
                  RngEngine &rng);
 
+
+  //apply ops to multiple shots
+  //this function should be separately defined since apply_ops is called in quantum_error
+  bool run_shots_with_batched_execution(OpItr first,
+                 OpItr last,
+                 const Noise::NoiseModel &noise,
+                 ExperimentResult &result,
+                 const uint_t rng_seed,
+                 const uint_t num_shots) override;
+
   //apply ops for multi-shots to one group
-  template <typename InputIterator>
-  void apply_ops_multi_shots_for_group(int_t i_group, 
-                               InputIterator first, InputIterator last,
+  void apply_ops_multi_shots_for_group(Registers<state_t>& state, int_t i_group, 
+                               OpItr first, OpItr last,
                                const Noise::NoiseModel &noise,
                                ExperimentResult &result,
-                               uint_t rng_seed,
+                               const uint_t rng_seed,
                                bool final_ops);
 
   //apply op to multiple shots , return flase if op is not supported to execute in a batch
-  virtual bool apply_batched_op(const int_t iChunk, const Operations::Op &op,
+  virtual bool apply_batched_op(const int_t iChunk, RegistersBase& state, const Operations::Op &op,
                                 ExperimentResult &result,
                                 std::vector<RngEngine> &rng,
                                 bool final_op = false){return false;}
 
   //apply sampled noise to multiple-shots (this is used for ops contains non-Pauli operators)
-  void apply_batched_noise_ops(const int_t i_group, const std::vector<std::vector<Operations::Op>> &ops, 
+  void apply_batched_noise_ops(Registers<state_t>& state,const int_t i_group, const std::vector<std::vector<Operations::Op>> &ops, 
                                ExperimentResult &result,
                                std::vector<RngEngine> &rng);
 
   //check conditional
-  bool check_conditional(const int_t iChunk, const Operations::Op &op);
+  bool check_conditional(Registers<state_t>& state, const Operations::Op &op);
 
   //this function is used to scale chunk qubits for multi-chunk distribution
   virtual int qubit_scale(void)
@@ -371,24 +293,24 @@ protected:
   uint_t get_process_by_chunk(uint_t cid);
 
   //allocate qregs
-  bool allocate_qregs(uint_t num_chunks);
+  bool allocate_qregs(Registers<state_t>& state, uint_t num_chunks);
 
 
   //-----------------------------------------------------------------------
   //Functions for multi-chunk distribution
   //-----------------------------------------------------------------------
   //swap between chunks
-  virtual void apply_chunk_swap(const reg_t &qubits);
+  virtual void apply_chunk_swap(RegistersBase& state, const reg_t &qubits);
 
   //apply multiple swaps between chunks
-  virtual void apply_multi_chunk_swap(const reg_t &qubits);
+  virtual void apply_multi_chunk_swap(RegistersBase& state, const reg_t &qubits);
 
   //apply X gate over chunks
-  virtual void apply_chunk_x(const uint_t qubit);
+  virtual void apply_chunk_x(RegistersBase& state, const uint_t qubit);
 
   //send/receive chunk in receive buffer
-  void send_chunk(uint_t local_chunk_index, uint_t global_chunk_index);
-  void recv_chunk(uint_t local_chunk_index, uint_t global_chunk_index);
+  void send_chunk(Registers<state_t>& state, uint_t local_chunk_index, uint_t global_chunk_index);
+  void recv_chunk(Registers<state_t>& state, uint_t local_chunk_index, uint_t global_chunk_index);
 
   template <class data_t>
   void send_data(data_t* pSend, uint_t size, uint_t myid,uint_t pairid);
@@ -403,9 +325,6 @@ protected:
 
   //gather values on each process
   void gather_value(rvector_t& val) const;
-
-  //gather cregs 
-  void gather_creg_memory(void);
 
   //barrier all processes
   void sync_process(void) const;
@@ -422,10 +341,10 @@ protected:
   void qubits_inout(const reg_t& qubits, reg_t& qubits_in,reg_t& qubits_out) const;
 
   //collect matrix over multiple chunks
-  auto apply_to_matrix(bool copy = false);
+  auto apply_to_matrix(Registers<state_t>& state, bool copy = false);
 
   // Apply the global phase
-  virtual void apply_global_phase() override {}
+  virtual void apply_global_phase(RegistersBase& state){}
 
   //check if the operator should be applied to each chunk
   virtual bool is_applied_to_each_chunk(const Operations::Op &op);
@@ -439,15 +358,13 @@ protected:
   //separate inside and outside qubits for (multi) control gates
   void get_inout_ctrl_qubits(const Operations::Op &op, reg_t& qubits_out, reg_t& qubits_in);
 
+  std::vector<Operations::Op> sample_noise(const Noise::NoiseModel &noise, const Operations::Op &op, RngEngine &rng) override
+  {
+    return noise.sample_noise_loc(op, rng);
+  }
+
   //remake gate operation by qubits inside chunk
   Operations::Op remake_gate_in_chunk_qubits(const Operations::Op &op, reg_t& qubits_in);
-
-#ifdef AER_MPI
-  //communicator group to simulate a circuit (for multi-experiments)
-  MPI_Comm distributed_comm_;
-#endif
-
-  uint_t mapped_index(const uint_t idx);
 };
 
 
@@ -458,11 +375,6 @@ protected:
 template <class state_t>
 StateChunk<state_t>::~StateChunk(void)
 {
-#ifdef AER_MPI
-  if(distributed_comm_ != MPI_COMM_WORLD){
-    MPI_Comm_free(&distributed_comm_);
-  }
-#endif
 }
 
 template <class state_t>
@@ -487,99 +399,56 @@ void StateChunk<state_t>::set_config(const json_t &config)
 #endif
 }
 
-template <class state_t>
-void StateChunk<state_t>::set_distribution(uint_t nprocs)
-{
-  myrank_ = 0;
-  nprocs_ = 1;
-#ifdef AER_MPI
-  int t;
-  MPI_Comm_size(MPI_COMM_WORLD,&t);
-  nprocs_ = t;
-  MPI_Comm_rank(MPI_COMM_WORLD,&t);
-  myrank_ = t;
-#endif
-
-  distributed_procs_ = nprocs;
-  distributed_rank_ = myrank_ % nprocs;
-  distributed_group_ = myrank_ / nprocs;
-
-  distributed_proc_bits_ = 0;
-  int proc_bits = 0;
-  uint_t p = distributed_procs_;
-  while(p > 1){
-    if((p & 1) != 0){   //procs is not power of 2
-      distributed_proc_bits_ = -1;
-      break;
-    }
-    distributed_proc_bits_++;
-    p >>= 1;
-  }
-
-#ifdef AER_MPI
-  if(nprocs != nprocs_){
-    MPI_Comm_split(MPI_COMM_WORLD,(int)distributed_group_,(int)distributed_rank_,&distributed_comm_);
-  }
-  else{
-    distributed_comm_ = MPI_COMM_WORLD;
-  }
-#endif
-}
 
 template <class state_t>
 bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t num_parallel_shots)
 {
   int_t i;
-  num_qubits_ = num_qubits;
+  BaseState::num_qubits_ = num_qubits;
   block_bits_ = block_bits;
 
   if(block_bits_ > 0){
     chunk_bits_ = block_bits_;
-    if(chunk_bits_ > num_qubits_){
-      chunk_bits_ = num_qubits_;
+    if(chunk_bits_ > BaseState::num_qubits_){
+      chunk_bits_ = BaseState::num_qubits_;
     }
   }
   else{
-    chunk_bits_ = num_qubits_;
+    chunk_bits_ = BaseState::num_qubits_;
   }
 
-  if(chunk_bits_ < num_qubits_){
+  if(chunk_bits_ < BaseState::num_qubits_){
     //multi-chunk distribution with cache blocking transpiler
     multi_chunk_distribution_ = true;
     multi_shots_parallelization_ = false;
-    num_global_chunks_ = 1ull << ((num_qubits_ - chunk_bits_)*qubit_scale());
-
-    BaseState::cregs_.resize(1);
+    num_global_chunks_ = 1ull << ((BaseState::num_qubits_ - chunk_bits_)*qubit_scale());
   }
   else{
-    //multi-shots parallelization
+    //single-shot or multi-shots parallelization
     multi_chunk_distribution_ = false;
     if(num_parallel_shots > 1)
       multi_shots_parallelization_ = true;
     else
       multi_shots_parallelization_ = false;
     num_global_chunks_ = num_parallel_shots;
-
-    //classical registers for all shots
-    BaseState::cregs_.resize(num_parallel_shots);
   }
 
-  chunk_index_begin_.resize(distributed_procs_);
-  chunk_index_end_.resize(distributed_procs_);
-  for(i=0;i<distributed_procs_;i++){
-    chunk_index_begin_[i] = num_global_chunks_*i / distributed_procs_;
-    chunk_index_end_[i] = num_global_chunks_*(i+1) / distributed_procs_;
+  chunk_index_begin_.resize(BaseState::distributed_procs_);
+  chunk_index_end_.resize(BaseState::distributed_procs_);
+  for(i=0;i<BaseState::distributed_procs_;i++){
+    chunk_index_begin_[i] = num_global_chunks_*i / BaseState::distributed_procs_;
+    chunk_index_end_[i] = num_global_chunks_*(i+1) / BaseState::distributed_procs_;
   }
 
-  num_local_chunks_ = chunk_index_end_[distributed_rank_] - chunk_index_begin_[distributed_rank_];
-  global_chunk_index_ = chunk_index_begin_[distributed_rank_];
+  num_local_chunks_ = chunk_index_end_[BaseState::distributed_rank_] - chunk_index_begin_[BaseState::distributed_rank_];
+  global_chunk_index_ = chunk_index_begin_[BaseState::distributed_rank_];
   local_shot_index_ = 0;
 
   global_chunk_indexing_ = false;
   chunk_omp_parallel_ = false;
   if(BaseState::sim_device_name_ == "GPU"){
 #ifdef _OPENMP
-    if(omp_get_num_threads() == 1)
+    if(omp_get_num_threads() == 1 && multi_chunk_distribution_)
       chunk_omp_parallel_ = true;
 #endif
 
@@ -597,19 +466,7 @@ bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t nu
     chunk_omp_parallel_ = false;
   }
 
-  if(multi_shots_parallelization_){
-    allocate_qregs(std::min(num_local_chunks_,max_batched_shots_));
-  }
-  else{
-    allocate_qregs(num_local_chunks_);
-  }
-
-
-  //initialize qubit map
-  qubit_map_.resize(num_qubits_);
-  for(i=0;i<num_qubits_;i++){
-    qubit_map_[i] = i;
-  }
+  allocate_state(BaseState::state_, num_local_chunks_);
 
   if(chunk_bits_ <= chunk_swap_buffer_qubits_ + 1)
     multi_chunk_swap_enable_ = false;
@@ -620,42 +477,54 @@ bool StateChunk<state_t>::allocate(uint_t num_qubits,uint_t block_bits,uint_t nu
 }
 
 template <class state_t>
-bool StateChunk<state_t>::allocate_qregs(uint_t num_chunks)
+bool StateChunk<state_t>::allocate_state(RegistersBase& state, uint_t num_max_shots)
+{
+  allocate_qregs(dynamic_cast<Registers<state_t>&>(state), std::max(num_local_chunks_, num_max_shots));
+
+  state.initialize_qubit_map(BaseState::num_qubits_);
+
+  return true;
+}
+
+
+template <class state_t>
+bool StateChunk<state_t>::allocate_qregs(Registers<state_t>& state, uint_t num_chunks)
 {
   int_t i;
+
   //deallocate qregs before reallocation
-  if(qregs_.size() > 0){
-    if(qregs_.size() == num_chunks)
+  if(state.qregs().size() > 0 && num_local_chunks_ > 1){
+    if(state.qregs().size() == num_local_chunks_)
       return true;  //can reuse allocated chunks
 
-    qregs_.clear();
+    state.qregs().clear();
   }
-
-  qregs_.resize(num_chunks);
+  state.allocate(num_local_chunks_);   //for multi-shot + multi-chunk, allocate 1st set of chunks only (=num_local_chunks_)
 
   //allocate qregs
   uint_t chunk_id = multi_chunk_distribution_ ? global_chunk_index_ : 0;
   bool ret = true;
-  qregs_[0].set_max_matrix_bits(BaseState::max_matrix_qubits_);
-  qregs_[0].set_num_threads_per_group(num_threads_per_group_);
-  qregs_[0].cuStateVec_enable(cuStateVec_enable_);
-  ret &= qregs_[0].chunk_setup(chunk_bits_*qubit_scale(), num_qubits_*qubit_scale(), chunk_id, num_chunks);
-  for(i=1;i<num_chunks;i++){
+  state.qreg(0).set_max_matrix_bits(BaseState::max_matrix_qubits_);
+  state.qreg(0).set_num_threads_per_group(num_threads_per_group_);
+  state.qreg(0).cuStateVec_enable(cuStateVec_enable_);
+  //reserve num_chunk chunks memory space for multi-shot (num_chunks == num_local_chunks_ for single shot)
+  ret &= state.qreg(0).chunk_setup(chunk_bits_*qubit_scale(), BaseState::num_qubits_*qubit_scale(), chunk_id, num_chunks);
+  for(i=1;i<num_local_chunks_;i++){
     uint_t gid = i + chunk_id;
-    ret &= qregs_[i].chunk_setup(qregs_[0],gid);
-    qregs_[i].set_num_threads_per_group(num_threads_per_group_);
+    ret &= state.qreg(i).chunk_setup(state.qreg(0),gid);
+    state.qreg(i).set_num_threads_per_group(num_threads_per_group_);
   }
 
   //initialize groups
   top_chunk_of_group_.clear();
   num_groups_ = 0;
-  for(i=0;i<qregs_.size();i++){
-    if(qregs_[i].top_of_group()){
+  for(i=0;i<state.num_qregs();i++){
+    if(state.qreg(i).top_of_group()){
       top_chunk_of_group_.push_back(i);
       num_groups_++;
     }
   }
-  top_chunk_of_group_.push_back(qregs_.size());
+  top_chunk_of_group_.push_back(state.qregs().size());
   num_chunks_in_group_.resize(num_groups_);
   for(i=0;i<num_groups_;i++){
     num_chunks_in_group_[i] = top_chunk_of_group_[i+1] - top_chunk_of_group_[i];
@@ -668,12 +537,12 @@ template <class state_t>
 uint_t StateChunk<state_t>::get_process_by_chunk(uint_t cid)
 {
   uint_t i;
-  for(i=0;i<distributed_procs_;i++){
+  for(i=0;i<BaseState::distributed_procs_;i++){
     if(cid >= chunk_index_begin_[i] && cid < chunk_index_end_[i]){
       return i;
     }
   }
-  return distributed_procs_;
+  return BaseState::distributed_procs_;
 }
 
 template <class state_t>
@@ -683,13 +552,12 @@ void StateChunk<state_t>::apply_ops(OpItr first, OpItr last,
                                bool final_ops) 
 {
   if(multi_chunk_distribution_){
-    apply_ops_chunks(first,last,result,rng,final_ops);
+    apply_ops_chunks(BaseState::state_, first,last,result,rng, final_ops);
+    return;
   }
-  else{
-    Base::apply_ops(first, last, result, rng,final_ops);
-  }
+  BaseState::apply_ops(first, last, result, rng, final_ops);
 
-  qregs_[0].synchronize();
+  BaseState::state_.qreg().synchronize();
 
 #ifdef AER_CUSTATEVEC
   result.metadata.add(cuStateVec_enable_, "cuStateVec_enable");
@@ -697,8 +565,77 @@ void StateChunk<state_t>::apply_ops(OpItr first, OpItr last,
 }
 
 template <class state_t>
-template <typename InputIterator>
-void StateChunk<state_t>::apply_ops_chunks(InputIterator first, InputIterator last,
+void StateChunk<state_t>::apply_ops(RegistersBase& state_in,
+               OpItr first,
+               OpItr last,
+               const Noise::NoiseModel &noise,
+               ExperimentResult &result,
+               RngEngine &rng,
+               const bool final_ops)
+{
+  Registers<state_t>& state = dynamic_cast<Registers<state_t>&>(state_in);
+  if(multi_chunk_distribution_){
+    return apply_ops_chunks(state, first,last,result,rng, final_ops);
+  }
+
+  // Simple loop over vector of input operations
+  for (auto it = first; it != last; ++it) {
+    switch (it->type) {
+      case Operations::OpType::mark: {
+        state.marks()[it->string_params[0]] = it;
+        break;
+      }
+      case Operations::OpType::jump: {
+        if(state.creg().check_conditional(*it)) {
+          const auto& mark_name = it->string_params[0];
+          auto mark_it = state.marks().find(mark_name);
+          if (mark_it != state.marks().end()) {
+            it = mark_it->second;
+          } else {
+            for (++it; it != last; ++it) {
+              if (it->type == Operations::OpType::mark) {
+                state.marks()[it->string_params[0]] = it;
+                if (it->string_params[0] == mark_name) {
+                  break;
+                }
+              }
+            }
+            if (it == last) {
+              std::stringstream msg;
+              msg << "Invalid jump destination:\"" << mark_name << "\"." << std::endl;
+              throw std::runtime_error(msg.str());
+            }
+          }
+        }
+        break;
+      }
+      case Operations::OpType::sample_noise: {
+        //runtime noise sampling
+        BaseState::apply_runtime_noise_sampling(state, *it, noise);
+        state.next_iter() = it + 1;
+        return;
+      }
+      default: {
+        this->apply_op(state, *it, result, rng, final_ops && (it + 1 == last) );
+        if(BaseState::enable_shot_branching_ && state.num_branch() > 0){
+          //break loop to branch states
+          state.next_iter() = it + 1;
+          return;
+        }
+      }
+    }
+  }
+  state.next_iter() = last;
+
+#ifdef AER_CUSTATEVEC
+  result.metadata.add(cuStateVec_enable_, "cuStateVec_enable");
+#endif
+}
+
+
+template <class state_t>
+void StateChunk<state_t>::apply_ops_chunks(Registers<state_t>& state, 
+                               OpItr first, OpItr last,
                                ExperimentResult &result,
                                RngEngine &rng,
                                bool final_ops) 
@@ -715,35 +652,35 @@ void StateChunk<state_t>::apply_ops_chunks(InputIterator first, InputIterator la
     if(op_iOp.type == Operations::OpType::gate && op_iOp.name == "swap_chunk"){
       //apply swap between chunks
       if(multi_chunk_swap_enable_ && op_iOp.qubits[0] < chunk_bits_ && op_iOp.qubits[1] >= chunk_bits_){
-        if(distributed_proc_bits_ < 0 || (op_iOp.qubits[1] >= (num_qubits_*qubit_scale() - distributed_proc_bits_))){   //apply multi-swap when swap is cross qubits
+        if(BaseState::distributed_proc_bits_ < 0 || (op_iOp.qubits[1] >= (BaseState::num_qubits_*qubit_scale() - BaseState::distributed_proc_bits_))){   //apply multi-swap when swap is cross qubits
           multi_swap.push_back(op_iOp.qubits[0]);
           multi_swap.push_back(op_iOp.qubits[1]);
           if(multi_swap.size() >= max_multi_swap_*2){
-            apply_multi_chunk_swap(multi_swap);
+            apply_multi_chunk_swap(state, multi_swap);
             multi_swap.clear();
           }
         }
         else
-          apply_chunk_swap(op_iOp.qubits);
+          apply_chunk_swap(state, op_iOp.qubits);
       }
       else{
         if(multi_swap.size() > 0){
-          apply_multi_chunk_swap(multi_swap);
+          apply_multi_chunk_swap(state, multi_swap);
           multi_swap.clear();
         }
-        apply_chunk_swap(op_iOp.qubits);
+        apply_chunk_swap(state, op_iOp.qubits);
       }
       iOp++;
       continue;
     }
-    else if(multi_swap.size() > 0){
-      apply_multi_chunk_swap(multi_swap);
+
+    if(multi_swap.size() > 0){
+      apply_multi_chunk_swap(state, multi_swap);
       multi_swap.clear();
     }
 
     if(op_iOp.type == Operations::OpType::sim_op && op_iOp.name == "begin_blocking"){
       //applying sequence of gates inside each chunk
-
       uint_t iOpEnd = iOp;
       while(iOpEnd < nOp){
         const Operations::Op op_iOpEnd = *(first + iOpEnd);
@@ -757,11 +694,11 @@ void StateChunk<state_t>::apply_ops_chunks(InputIterator first, InputIterator la
       if(num_groups_ > 1 && chunk_omp_parallel_){
 #pragma omp parallel for  num_threads(num_groups_)
         for(int_t ig=0;ig<num_groups_;ig++)
-          apply_cache_blocking_ops(ig, first + iOpBegin, first + iOpEnd, result, rng);
+          apply_cache_blocking_ops(state, ig, first + iOpBegin, first + iOpEnd, result, rng);
       }
       else{
         for(int_t ig=0;ig<num_groups_;ig++)
-          apply_cache_blocking_ops(ig, first + iOpBegin, first + iOpEnd, result, rng);
+          apply_cache_blocking_ops(state, ig, first + iOpBegin, first + iOpEnd, result, rng);
       }
       iOp = iOpEnd;
     }
@@ -769,31 +706,36 @@ void StateChunk<state_t>::apply_ops_chunks(InputIterator first, InputIterator la
       if(num_groups_ > 1 && chunk_omp_parallel_){
 #pragma omp parallel for num_threads(num_groups_)
         for(int_t ig=0;ig<num_groups_;ig++)
-          apply_cache_blocking_ops(ig, first + iOp, first + iOp+1, result, rng);
+          apply_cache_blocking_ops(state, ig, first + iOp, first + iOp+1, result, rng);
       }
       else{
         for(int_t ig=0;ig<num_groups_;ig++)
-          apply_cache_blocking_ops(ig, first + iOp, first + iOp+1, result, rng);
+          apply_cache_blocking_ops(state, ig, first + iOp, first + iOp+1, result, rng);
       }
     }
     else{
       //parallelize inside state implementations
-      apply_op(STATE_APPLY_TO_ALL_CHUNKS, op_iOp,result,rng,final_ops && nOp == iOp + 1);
+      this->apply_op(state, op_iOp,result,rng,final_ops && nOp == iOp + 1);
     }
     iOp++;
+
+    if(BaseState::enable_shot_branching_ && state.num_branch() > 0){
+      state.next_iter() = (first + iOp);
+      return;
+    }
   }
 
   if(multi_swap.size() > 0)
-    apply_multi_chunk_swap(multi_swap);
+    apply_multi_chunk_swap(state, multi_swap);
 
   if(num_groups_ > 1 && chunk_omp_parallel_){
 #pragma omp parallel for  num_threads(num_groups_)
     for(int_t ig=0;ig<num_groups_;ig++)
-      qregs_[top_chunk_of_group_[ig]].synchronize();
+      state.qreg(top_chunk_of_group_[ig]).synchronize();
   }
   else{
     for(int_t ig=0;ig<num_groups_;ig++)
-      qregs_[top_chunk_of_group_[ig]].synchronize();
+      state.qreg(top_chunk_of_group_[ig]).synchronize();
   }
 
   if(BaseState::sim_device_name_ == "GPU"){
@@ -820,24 +762,26 @@ void StateChunk<state_t>::apply_ops_chunks(InputIterator first, InputIterator la
     result.metadata.add(max_multi_swap_,"cacheblocking", "max_multiple_chunk_swaps");
   }
 #endif
+
+  state.next_iter() = last;
 }
 
 template <class state_t>
-template <typename InputIterator>
-void StateChunk<state_t>::apply_cache_blocking_ops(const int_t iGroup, InputIterator first,
-               InputIterator last,
+void StateChunk<state_t>::apply_cache_blocking_ops(Registers<state_t>& state, const int_t iGroup, 
+               OpItr first,
+               OpItr last,
                ExperimentResult &result,
                RngEngine &rng)
 {
   //for each chunk in group
   for(int_t iChunk = top_chunk_of_group_[iGroup];iChunk < top_chunk_of_group_[iGroup + 1];iChunk++){
     //fecth chunk in cache
-    if(qregs_[iChunk].fetch_chunk()){
+    if(state.qreg(iChunk).fetch_chunk()){
       for (auto it = first; it != last; ++it) {
-        apply_op(iChunk, *it, result, rng, false);
+        apply_op_chunk(iChunk, state, *it, result, rng, false);
       }
       //release chunk from cache
-      qregs_[iChunk].release_chunk();
+      state.qreg(iChunk).release_chunk();
     }
   }
 }
@@ -893,84 +837,102 @@ bool StateChunk<state_t>::is_applied_to_each_chunk(const Operations::Op &op)
 }
 
 template <class state_t>
-bool StateChunk<state_t>::check_conditional(const int_t iChunk, const Operations::Op &op)
+bool StateChunk<state_t>::check_conditional(Registers<state_t>& state, const Operations::Op &op)
 {
   if(multi_shots_parallelization_){
     //multi-shots parallelization
     if(op.conditional){
-      qregs_[iChunk].set_conditional(op.conditional_reg);
+      state.qreg().set_conditional(op.conditional_reg);
     }
     return true;
   }
   else{
-    return BaseState::cregs_[0].check_conditional(op);
+    return state.creg().check_conditional(op);
   }
 }
 
 template <class state_t>
-template <typename InputIterator>
-void StateChunk<state_t>::apply_ops_multi_shots(InputIterator first, InputIterator last,
+bool StateChunk<state_t>::run_shots_with_batched_execution(
+                               OpItr first, OpItr last,
                                const Noise::NoiseModel &noise,
                                ExperimentResult &result,
-                               uint_t rng_seed,
-                               bool final_ops) 
+                               const uint_t rng_seed,
+                               const uint_t num_shots)
 {
+  if(!multi_shots_parallelization_ || BaseState::sim_device_name_ != "GPU" || multi_chunk_distribution_){
+    return false;
+  }
+
+  Registers<state_t> state;
   int_t i;
   int_t i_begin,n_shots;
+
+  std::vector<ClassicalRegister> cregs(num_local_chunks_);
+
+  if(num_shots != num_global_chunks_)
+    allocate(BaseState::num_qubits_, BaseState::num_qubits_, num_shots);
+
+  allocate_state(state, std::min(max_batched_shots_, num_local_chunks_));
+
+  state.creg().initialize(BaseState::num_creg_memory_, BaseState::num_creg_registers_);
+  for(int_t i=0;i<cregs.size();i++){
+    cregs[i].initialize(BaseState::num_creg_memory_, BaseState::num_creg_registers_);
+  }
 
   i_begin = 0;
   while(i_begin<num_local_chunks_){
     local_shot_index_ = i_begin;
 
     //loop for states can be stored in available memory
-    n_shots = qregs_.size();
+    n_shots = state.qregs().size();
     if(i_begin+n_shots > num_local_chunks_){
       n_shots = num_local_chunks_ - i_begin;
       //resize qregs
-      allocate_qregs(n_shots);
+      allocate_qregs(state, n_shots);
     }
     //initialization (equivalent to initialize_qreg + initialize_creg)
-    auto init_group = [this](int_t ig){
+    auto init_group = [this, &state](int_t ig){
       for(uint_t j=top_chunk_of_group_[ig];j<top_chunk_of_group_[ig+1];j++){
         //enabling batch shots optimization
-        qregs_[j].enable_batch(true);
+        state.qreg(j).enable_batch(true);
 
         //initialize qreg here
-        qregs_[j].set_num_qubits(chunk_bits_);
-        qregs_[j].initialize();
+        state.qreg(j).set_num_qubits(chunk_bits_);
+        state.qreg(j).initialize();
 
         //initialize creg here
-        qregs_[j].initialize_creg(this->creg(0).memory_size(), this->creg(0).register_size());
+        state.qreg(j).initialize_creg(state.creg().memory_size(), state.creg().register_size());
       }
     };
     Utils::apply_omp_parallel_for((num_groups_ > 1 && chunk_omp_parallel_),0,num_groups_,init_group);
 
-    apply_global_phase(); //this is parallelized in StateChunk sub-classes
+    this->apply_global_phase(state); //this is parallelized in StateChunk sub-classes
 
     //apply ops to multiple-shots
     if(num_groups_ > 1 && chunk_omp_parallel_){
       std::vector<ExperimentResult> par_results(num_groups_);
 #pragma omp parallel for num_threads(num_groups_)
       for(i=0;i<num_groups_;i++)
-        apply_ops_multi_shots_for_group(i, first, last, noise, par_results[i], rng_seed, final_ops);
+        apply_ops_multi_shots_for_group(state, i, first, last, noise, par_results[i], rng_seed, true);
 
       for (auto &res : par_results)
         result.combine(std::move(res));
     }
     else{
       for(i=0;i<num_groups_;i++)
-        apply_ops_multi_shots_for_group(i, first, last, noise, result, rng_seed, final_ops);
+        apply_ops_multi_shots_for_group(state, i, first, last, noise, result, rng_seed, true);
     }
 
     //collect measured bits and copy memory
     for(i=0;i<n_shots;i++){
-      qregs_[i].read_measured_data(this->creg(global_chunk_index_ + i_begin + i));
+      state.qreg(i).read_measured_data(cregs[i_begin + i]);
     }
-
     i_begin += n_shots;
   }
 
-  gather_creg_memory();
+  BaseState::gather_creg_memory(cregs, num_local_chunks_);
+
+  result.save_count_data(cregs, BaseState::save_creg_memory_);
 
 #ifdef AER_THRUST_CUDA
   if(BaseState::sim_device_name_ == "GPU"){
@@ -984,15 +946,19 @@ void StateChunk<state_t>::apply_ops_multi_shots(InputIterator first, InputIterat
     result.metadata.add(nDev,"batched_shots_optimization_parallel_gpus");
   }
 #endif
+
+  result.metadata.add(true, "batched_shots_optimization");
+
+  return true;
 }
 
 template <class state_t>
-template <typename InputIterator>
-void StateChunk<state_t>::apply_ops_multi_shots_for_group(int_t i_group, 
-                               InputIterator first, InputIterator last,
+void StateChunk<state_t>::apply_ops_multi_shots_for_group(Registers<state_t>& state,
+                               int_t i_group,
+                               OpItr first, OpItr last,
                                const Noise::NoiseModel &noise,
                                ExperimentResult &result,
-                               uint_t rng_seed,
+                               const uint_t rng_seed,
                                bool final_ops)
 {
   uint_t istate = top_chunk_of_group_[i_group];
@@ -1007,7 +973,7 @@ void StateChunk<state_t>::apply_ops_multi_shots_for_group(int_t i_group,
     rng[j-top_chunk_of_group_[i_group]].set_seed(rng_seed + global_chunk_index_ + local_shot_index_ + j);
 
   for (auto op = first; op != last; ++op) {
-    if(op->type == Operations::OpType::qerror_loc){
+    if(op->type == Operations::OpType::sample_noise){
       //sample error here
       uint_t count = num_chunks_in_group_[i_group];
       std::vector<std::vector<Operations::Op>> noise_ops(count);
@@ -1045,33 +1011,35 @@ void StateChunk<state_t>::apply_ops_multi_shots_for_group(int_t i_group,
           }
         }
       }
-
       if(count_ops == 0){
         continue;   //do nothing
       }
       if(non_pauli_gate_count == 0){   //ptimization for Pauli error
-        qregs_[istate].apply_batched_pauli_ops(noise_ops);
+        state.qreg(istate).apply_batched_pauli_ops(noise_ops);
       }
       else{
         //otherwise execute each circuit
-        apply_batched_noise_ops(i_group, noise_ops,result, rng);
+        apply_batched_noise_ops(state, i_group, noise_ops,result, rng);
       }
     }
     else{
-      if(!apply_batched_op(istate, *op, result, rng, final_ops && (op + 1 == last))){
+      if(!apply_batched_op(istate, state, *op, result, rng, final_ops && (op + 1 == last))){
         //call apply_op for each state
-        for(uint_t j=top_chunk_of_group_[i_group];j<top_chunk_of_group_[i_group+1];j++){
-          qregs_[j].enable_batch(false);
-          apply_op(j, *op, result, rng[j-top_chunk_of_group_[i_group]], final_ops && (op + 1 == last) );
-          qregs_[j].enable_batch(true);
-        }
+        for(uint_t j=top_chunk_of_group_[i_group];j<top_chunk_of_group_[i_group+1];j++)
+          state.qreg(j).enable_batch(false);
+
+        this->apply_op(state, *op, result, rng[0], final_ops && (op + 1 == last) );
+
+        for(uint_t j=top_chunk_of_group_[i_group];j<top_chunk_of_group_[i_group+1];j++)
+          state.qreg(j).enable_batch(true);
       }
     }
   }
+
 }
 
 template <class state_t>
-void StateChunk<state_t>::apply_batched_noise_ops(const int_t i_group, const std::vector<std::vector<Operations::Op>> &ops, 
+void StateChunk<state_t>::apply_batched_noise_ops(Registers<state_t>& state, const int_t i_group, const std::vector<std::vector<Operations::Op>> &ops, 
                              ExperimentResult &result,
                              std::vector<RngEngine> &rng)
 {
@@ -1124,7 +1092,7 @@ void StateChunk<state_t>::apply_batched_noise_ops(const int_t i_group, const std
     }
 
     //mask conditional register
-    int_t sys_reg = qregs_[istate].set_batched_system_conditional(cond_reg, mask);
+    int_t sys_reg = state.qreg(istate).set_batched_system_conditional(cond_reg, mask);
 
     //batched execution on same ops
     for(k=0;k<ops[i].size();k++){
@@ -1134,112 +1102,27 @@ void StateChunk<state_t>::apply_batched_noise_ops(const int_t i_group, const std
       cop.conditional = true;
       cop.conditional_reg = sys_reg;
 
-      if(!apply_batched_op(istate, cop, result,rng, false)){
+      if(!apply_batched_op(istate, state, cop, result,rng, false)){
         //call apply_op for each state
-        for(uint_t j=top_chunk_of_group_[i_group];j<top_chunk_of_group_[i_group+1];j++){
-          qregs_[j].enable_batch(false);
-          apply_op(j, cop, result ,rng[j-top_chunk_of_group_[i_group]],false);
-          qregs_[j].enable_batch(true);
-        }
+        for(uint_t j=top_chunk_of_group_[i_group];j<top_chunk_of_group_[i_group+1];j++)
+          state.qreg(j).enable_batch(false);
+        this->apply_op(state, cop, result ,rng[0],false);
+        for(uint_t j=top_chunk_of_group_[i_group];j<top_chunk_of_group_[i_group+1];j++)
+          state.qreg(j).enable_batch(true);
       }
     }
     mask[i] = 0;
     finished[i] = true;
   }
-}
 
-template <class state_t>
-void StateChunk<state_t>::initialize_creg(uint_t num_memory, uint_t num_register) 
-{
-  for(int_t i=0;i<BaseState::cregs_.size();i++){
-    BaseState::cregs_[i].initialize(num_memory, num_register);
-  }
-}
-
-
-template <class state_t>
-void StateChunk<state_t>::initialize_creg(uint_t num_memory,
-                                     uint_t num_register,
-                                     const std::string &memory_hex,
-                                     const std::string &register_hex) {
-  for(int_t i=0;i<BaseState::cregs_.size();i++){
-    BaseState::cregs_[i].initialize(num_memory, num_register, memory_hex, register_hex);
-  }
-}
-
-template <class state_t>
-void StateChunk<state_t>::snapshot_state(const int_t iChunk, const Operations::Op &op,
-                                    ExperimentResult &result,
-                                    std::string name) const 
-{
-  name = (name.empty()) ? op.name : name;
-  result.legacy_data.add_pershot_snapshot(name, op.string_params[0], qregs_[iChunk]);
-}
-
-
-template <class state_t>
-void StateChunk<state_t>::snapshot_creg_memory(const int_t iChunk, const Operations::Op &op,
-                                          ExperimentResult &result,
-                                          std::string name) const 
-{
-  int_t ishot = get_global_shot_index(iChunk);
-  result.legacy_data.add_pershot_snapshot(name,
-                               op.string_params[0],
-                               BaseState::cregs_[ishot].memory_hex());
-}
-
-
-template <class state_t>
-void StateChunk<state_t>::snapshot_creg_register(const int_t iChunk, const Operations::Op &op,
-                                            ExperimentResult &result,
-                                            std::string name) const 
-{
-  int_t ishot = get_global_shot_index(iChunk);
-  result.legacy_data.add_pershot_snapshot(name,
-                               op.string_params[0],
-                               BaseState::cregs_[ishot].register_hex());
-}
-
-
-template <class state_t>
-void StateChunk<state_t>::apply_save_expval(const int_t iChunk, const Operations::Op &op,
-                                       ExperimentResult &result){
-  // Check empty edge case
-  if (op.expval_params.empty()) {
-    throw std::invalid_argument(
-        "Invalid save expval instruction (Pauli components are empty).");
-  }
-  bool variance = (op.type == Operations::OpType::save_expval_var);
-
-  // Accumulate expval components
-  double expval(0.);
-  double sq_expval(0.);
-
-  for (const auto &param : op.expval_params) {
-    // param is tuple (pauli, coeff, sq_coeff)
-    const auto val = expval_pauli(iChunk, op.qubits, std::get<0>(param));
-    expval += std::get<1>(param) * val;
-    if (variance) {
-      sq_expval += std::get<2>(param) * val;
-    }
-  }
-  if (variance) {
-    std::vector<double> expval_var(2);
-    expval_var[0] = expval;  // mean
-    expval_var[1] = sq_expval - expval * expval;  // variance
-    result.save_data_average(BaseState::cregs_[get_global_shot_index(iChunk)], op.string_params[0], expval_var, op.type, op.save_type);
-  } else {
-    result.save_data_average(BaseState::cregs_[get_global_shot_index(iChunk)], op.string_params[0], expval, op.type, op.save_type);
-  }
 }
 
 //-------------------------------------------------------------------------
 // functions for multi-chunk distribution
 //-------------------------------------------------------------------------
 template <class state_t>
-void StateChunk<state_t>::block_diagonal_matrix(const int_t iChunk, reg_t &qubits, cvector_t &diag)
+void StateChunk<state_t>::block_diagonal_matrix(const int_t gid, reg_t &qubits, cvector_t &diag)
 {
-  uint_t gid = global_chunk_index_ + iChunk;
   uint_t i;
   uint_t mask_out = 0;
   uint_t mask_id = 0;
@@ -1293,7 +1176,7 @@ void StateChunk<state_t>::qubits_inout(const reg_t& qubits, reg_t& qubits_in,reg
 
 template <class state_t>
 template <typename list_t>
-void StateChunk<state_t>::initialize_from_vector(const int_t iChunkIn, const list_t &vec)
+void StateChunk<state_t>::initialize_from_vector(Registers<state_t>& state, const list_t &vec)
 {
   int_t iChunk;
 
@@ -1306,7 +1189,7 @@ void StateChunk<state_t>::initialize_from_vector(const int_t iChunkIn, const lis
           for(int_t i=0;i<(1ull << (chunk_bits_*qubit_scale()));i++){
             tmp[i] = vec[((global_chunk_index_ + iChunk) << (chunk_bits_*qubit_scale())) + i];
           }
-          qregs_[iChunk].initialize_from_vector(tmp);
+          state.qreg(iChunk).initialize_from_vector(tmp);
         }
       }
     }
@@ -1316,24 +1199,20 @@ void StateChunk<state_t>::initialize_from_vector(const int_t iChunkIn, const lis
         for(int_t i=0;i<(1ull << (chunk_bits_*qubit_scale()));i++){
           tmp[i] = vec[((global_chunk_index_ + iChunk) << (chunk_bits_*qubit_scale())) + i];
         }
-        qregs_[iChunk].initialize_from_vector(tmp);
+        state.qreg(iChunk).initialize_from_vector(tmp);
       }
     }
   }
   else{
-    if(iChunkIn == STATE_APPLY_TO_ALL_CHUNKS){
-      for(iChunk=0;iChunk<num_local_chunks_;iChunk++){
-        qregs_[iChunk].initialize_from_vector(vec);
-      }
+    for(iChunk=0;iChunk<num_local_chunks_;iChunk++){
+      state.qreg(iChunk).initialize_from_vector(vec);
     }
-    else
-      qregs_[iChunkIn].initialize_from_vector(vec);
   }
 }
 
 template <class state_t>
 template <typename list_t>
-void StateChunk<state_t>::initialize_from_matrix(const int_t iChunkIn, const list_t &mat)
+void StateChunk<state_t>::initialize_from_matrix(Registers<state_t>& state, const list_t &mat)
 {
   int_t iChunk;
   if(multi_chunk_distribution_){
@@ -1342,78 +1221,74 @@ void StateChunk<state_t>::initialize_from_matrix(const int_t iChunkIn, const lis
       for(int_t ig=0;ig<num_groups_;ig++){
         for(iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++){
           list_t tmp(1ull << (chunk_bits_),1ull << (chunk_bits_));
-          uint_t irow_chunk = ((iChunk + global_chunk_index_) >> ((num_qubits_ - chunk_bits_))) << (chunk_bits_);
-          uint_t icol_chunk = ((iChunk + global_chunk_index_) & ((1ull << ((num_qubits_ - chunk_bits_)))-1)) << (chunk_bits_);
+          uint_t irow_chunk = ((iChunk + global_chunk_index_) >> ((BaseState::num_qubits_ - chunk_bits_))) << (chunk_bits_);
+          uint_t icol_chunk = ((iChunk + global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - chunk_bits_)))-1)) << (chunk_bits_);
 
           //copy part of state for this chunk
           uint_t i,row,col;
           for(i=0;i<(1ull << (chunk_bits_*qubit_scale()));i++){
             uint_t icol = i & ((1ull << chunk_bits_)-1);
             uint_t irow = i >> chunk_bits_;
-            tmp[i] = mat[icol_chunk + icol + ((irow_chunk + irow) << num_qubits_)];
+            tmp[i] = mat[icol_chunk + icol + ((irow_chunk + irow) << BaseState::num_qubits_)];
           }
-          qregs_[iChunk].initialize_from_matrix(tmp);
+          state.qreg(iChunk).initialize_from_matrix(tmp);
         }
       }
     }
     else{
       for(iChunk=0;iChunk<num_local_chunks_;iChunk++){
         list_t tmp(1ull << (chunk_bits_),1ull << (chunk_bits_));
-        uint_t irow_chunk = ((iChunk + global_chunk_index_) >> ((num_qubits_ - chunk_bits_))) << (chunk_bits_);
-        uint_t icol_chunk = ((iChunk + global_chunk_index_) & ((1ull << ((num_qubits_ - chunk_bits_)))-1)) << (chunk_bits_);
+        uint_t irow_chunk = ((iChunk + global_chunk_index_) >> ((BaseState::num_qubits_ - chunk_bits_))) << (chunk_bits_);
+        uint_t icol_chunk = ((iChunk + global_chunk_index_) & ((1ull << ((BaseState::num_qubits_ - chunk_bits_)))-1)) << (chunk_bits_);
 
         //copy part of state for this chunk
         uint_t i,row,col;
         for(i=0;i<(1ull << (chunk_bits_*qubit_scale()));i++){
           uint_t icol = i & ((1ull << chunk_bits_)-1);
           uint_t irow = i >> chunk_bits_;
-          tmp[i] = mat[icol_chunk + icol + ((irow_chunk + irow) << num_qubits_)];
+          tmp[i] = mat[icol_chunk + icol + ((irow_chunk + irow) << BaseState::num_qubits_)];
         }
-        qregs_[iChunk].initialize_from_matrix(tmp);
+        state.qreg(iChunk).initialize_from_matrix(tmp);
       }
     }
   }
   else{
-    if(iChunkIn == STATE_APPLY_TO_ALL_CHUNKS){
-      for(iChunk=0;iChunk<num_local_chunks_;iChunk++){
-        qregs_[iChunk].initialize_from_matrix(mat);
-      }
+    for(iChunk=0;iChunk<num_local_chunks_;iChunk++){
+      state.qreg(iChunk).initialize_from_matrix(mat);
     }
-    else
-      qregs_[iChunkIn].initialize_from_matrix(mat);
   }
 }
 
 template <class state_t>
-auto StateChunk<state_t>::apply_to_matrix(bool copy)
+auto StateChunk<state_t>::apply_to_matrix(Registers<state_t>& state, bool copy)
 {
   //this function is used to collect states over chunks
   int_t iChunk;
   uint_t size = 1ull << (chunk_bits_*qubit_scale());
   uint_t mask = (1ull << (chunk_bits_)) - 1;
-  uint_t num_threads = qregs_[0].get_omp_threads();
+  uint_t num_threads = state.qreg().get_omp_threads();
 
-  size_t size_required = 2*(sizeof(std::complex<double>) << (num_qubits_*2)) + (sizeof(std::complex<double>) << (chunk_bits_*2))*num_local_chunks_;
+  size_t size_required = 2*(sizeof(std::complex<double>) << (BaseState::num_qubits_*2)) + (sizeof(std::complex<double>) << (chunk_bits_*2))*num_local_chunks_;
   if((size_required>>20) > Utils::get_system_memory_mb()){
     throw std::runtime_error(std::string("There is not enough memory to store states as matrix"));
   }
 
-  auto matrix = qregs_[0].copy_to_matrix();
+  auto matrix = state.qreg(0).copy_to_matrix();
 
-  if(distributed_rank_ == 0){
-    matrix.resize(1ull << (num_qubits_),1ull << (num_qubits_));
+  if(BaseState::distributed_rank_ == 0){
+    matrix.resize(1ull << (BaseState::num_qubits_),1ull << (BaseState::num_qubits_));
 
-    auto tmp = qregs_[0].copy_to_matrix();
+    auto tmp = state.qreg(0).copy_to_matrix();
     for(iChunk=0;iChunk<num_global_chunks_;iChunk++){
       int_t i;
-      uint_t irow_chunk = (iChunk >> ((num_qubits_ - chunk_bits_))) << chunk_bits_;
-      uint_t icol_chunk = (iChunk & ((1ull << ((num_qubits_ - chunk_bits_)))-1)) << chunk_bits_;
+      uint_t irow_chunk = (iChunk >> ((BaseState::num_qubits_ - chunk_bits_))) << chunk_bits_;
+      uint_t icol_chunk = (iChunk & ((1ull << ((BaseState::num_qubits_ - chunk_bits_)))-1)) << chunk_bits_;
 
       if(iChunk < num_local_chunks_){
         if(copy)
-          tmp = qregs_[iChunk].copy_to_matrix();
+          tmp = state.qreg(iChunk).copy_to_matrix();
         else
-          tmp = qregs_[iChunk].move_to_matrix();
+          tmp = state.qreg(iChunk).move_to_matrix();
       }
 #ifdef AER_MPI
       else
@@ -1423,7 +1298,7 @@ auto StateChunk<state_t>::apply_to_matrix(bool copy)
       for(i=0;i<size;i++){
         uint_t irow = i >> (chunk_bits_);
         uint_t icol = i & mask;
-        uint_t idx = ((irow+irow_chunk) << (num_qubits_)) + icol_chunk + icol;
+        uint_t idx = ((irow+irow_chunk) << (BaseState::num_qubits_)) + icol_chunk + icol;
         matrix[idx] = tmp[i];
       }
     }
@@ -1433,13 +1308,13 @@ auto StateChunk<state_t>::apply_to_matrix(bool copy)
     //send matrices to process 0
     for(iChunk=0;iChunk<num_global_chunks_;iChunk++){
       uint_t iProc = get_process_by_chunk(iChunk);
-      if(iProc == distributed_rank_){
+      if(iProc == BaseState::distributed_rank_){
         if(copy){
-          auto tmp = qregs_[iChunk-global_chunk_index_].copy_to_matrix();
+          auto tmp = state.qreg(iChunk-global_chunk_index_).copy_to_matrix();
           send_data(tmp.data(),size,iChunk,0);
         }
         else{
-          auto tmp = qregs_[iChunk-global_chunk_index_].move_to_matrix();
+          auto tmp = state.qreg(iChunk-global_chunk_index_).move_to_matrix();
           send_data(tmp.data(),size,iChunk,0);
         }
       }
@@ -1450,34 +1325,20 @@ auto StateChunk<state_t>::apply_to_matrix(bool copy)
   return matrix;
 }
 
-
 template <class state_t>
-uint_t StateChunk<state_t>::mapped_index(const uint_t idx)
-{
-  uint_t i,ret = 0;
-  uint_t t = idx;
-
-  for(i=0;i<num_qubits_;i++){
-    if(t & 1){
-      ret |= (1ull << qubit_map_[i]);
-    }
-    t >>= 1;
-  }
-  return ret;
-}
-
-template <class state_t>
-void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
+void StateChunk<state_t>::apply_chunk_swap(RegistersBase& state_in, const reg_t &qubits)
 {
   uint_t nLarge = 1;
   uint_t q0,q1;
   int_t iChunk;
 
+  Registers<state_t>& state = dynamic_cast<Registers<state_t>&>(state_in);
+
   q0 = qubits[qubits.size() - 2];
   q1 = qubits[qubits.size() - 1];
 
   if(qubit_scale() == 1){
-    std::swap(qubit_map_[q0],qubit_map_[q1]);
+    state.swap_qubit_map(q0,q1);
   }
 
   if(q0 > q1){
@@ -1490,13 +1351,13 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
 #pragma omp parallel for num_threads(num_groups_) 
       for(int_t ig=0;ig<num_groups_;ig++){
         for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
-          qregs_[iChunk].apply_mcswap(qubits);
+          state.qreg(iChunk).apply_mcswap(qubits);
       }
     }
     else{
       for(int_t ig=0;ig<num_groups_;ig++){
         for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
-          qregs_[iChunk].apply_mcswap(qubits);
+          state.qreg(iChunk).apply_mcswap(qubits);
       }
     }
   }
@@ -1508,17 +1369,17 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
     mask0 >>= (chunk_bits_*qubit_scale());
     mask1 >>= (chunk_bits_*qubit_scale());
 
-    if(distributed_procs_ == 1 || (distributed_proc_bits_ >= 0 && q1 < (num_qubits_*qubit_scale() - distributed_proc_bits_))){   //no data transfer between processes is needed
-      auto apply_chunk_swap_1qubit = [this, mask1, qubits](int_t iGroup)
+    if(BaseState::distributed_procs_ == 1 || (BaseState::distributed_proc_bits_ >= 0 && q1 < (BaseState::num_qubits_*qubit_scale() - BaseState::distributed_proc_bits_))){   //no data transfer between processes is needed
+      auto apply_chunk_swap_1qubit = [this, mask1, &qubits, &state](int_t iGroup)
       {
         for(int_t ic = top_chunk_of_group_[iGroup];ic < top_chunk_of_group_[iGroup + 1];ic++){
           uint_t baseChunk;
           baseChunk = ic & (~mask1);
           if(ic == baseChunk)
-            qregs_[ic].apply_chunk_swap(qubits,qregs_[ic | mask1],true);
+            state.qreg(ic).apply_chunk_swap(qubits,state.qreg(ic | mask1),true);
         }
       };
-      auto apply_chunk_swap_2qubits = [this, mask0, mask1, qubits](int_t iGroup)
+      auto apply_chunk_swap_2qubits = [this, mask0, mask1, &qubits, &state](int_t iGroup)
       {
         for(int_t ic = top_chunk_of_group_[iGroup];ic < top_chunk_of_group_[iGroup + 1];ic++){
           uint_t baseChunk;
@@ -1526,7 +1387,7 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
           uint_t iChunk1 = baseChunk | mask0;
           uint_t iChunk2 = baseChunk | mask1;
           if(ic == iChunk1)
-            qregs_[iChunk1].apply_chunk_swap(qubits,qregs_[iChunk2],true);
+            state.qreg(iChunk1).apply_chunk_swap(qubits,state.qreg(iChunk2),true);
         }
       };
       if(q0 < chunk_bits_*qubit_scale())
@@ -1559,7 +1420,7 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
         ub[0] = 0;
         iu[0] = 0;
 
-        nu[1] = 1ull << (num_qubits_*qubit_scale() - q1 - 1);
+        nu[1] = 1ull << (BaseState::num_qubits_*qubit_scale() - q1 - 1);
         ub[1] = (q1 - chunk_bits_*qubit_scale()) + 1;
         iu[1] = 0;
       }
@@ -1573,11 +1434,11 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
         ub[1] = (q0 - chunk_bits_*qubit_scale()) + 1;
         iu[1] = 0;
 
-        nu[2] = 1ull << (num_qubits_*qubit_scale() - q1 - 1);
+        nu[2] = 1ull << (BaseState::num_qubits_*qubit_scale() - q1 - 1);
         ub[2] = (q1 - chunk_bits_*qubit_scale()) + 1;
         iu[2] = 0;
       }
-      nPair = 1ull << (num_qubits_*qubit_scale() - chunk_bits_*qubit_scale() - nLarge);
+      nPair = 1ull << (BaseState::num_qubits_*qubit_scale() - chunk_bits_*qubit_scale() - nLarge);
 
       for(iPair=0;iPair<nPair;iPair++){
         //calculate index of pair of chunks
@@ -1597,9 +1458,9 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
         iChunk1 = baseChunk | mask0;
         iChunk2 = baseChunk | mask1;
 
-        if(iChunk1 >= chunk_index_begin_[distributed_rank_] && iChunk1 < chunk_index_end_[distributed_rank_]){    //chunk1 is on this process
-          if(iChunk2 >= chunk_index_begin_[distributed_rank_] && iChunk2 < chunk_index_end_[distributed_rank_]){    //chunk2 is on this process
-            qregs_[iChunk1 - global_chunk_index_].apply_chunk_swap(qubits,qregs_[iChunk2 - global_chunk_index_],true);
+        if(iChunk1 >= chunk_index_begin_[BaseState::distributed_rank_] && iChunk1 < chunk_index_end_[BaseState::distributed_rank_]){    //chunk1 is on this process
+          if(iChunk2 >= chunk_index_begin_[BaseState::distributed_rank_] && iChunk2 < chunk_index_end_[BaseState::distributed_rank_]){    //chunk2 is on this process
+            state.qreg(iChunk1 - global_chunk_index_).apply_chunk_swap(qubits,state.qreg(iChunk2 - global_chunk_index_),true);
             continue;
           }
           else{
@@ -1609,7 +1470,7 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
           }
         }
         else{
-          if(iChunk2 >= chunk_index_begin_[distributed_rank_] && iChunk2 < chunk_index_end_[distributed_rank_]){    //chunk2 is on this process
+          if(iChunk2 >= chunk_index_begin_[BaseState::distributed_rank_] && iChunk2 < chunk_index_end_[BaseState::distributed_rank_]){    //chunk2 is on this process
             iLocalChunk = iChunk2;
             iRemoteChunk = iChunk1;
             iProc = get_process_by_chunk(iChunk1);
@@ -1623,16 +1484,16 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
         MPI_Status st;
         uint_t sizeRecv,sizeSend;
 
-        auto pRecv = qregs_[iLocalChunk - global_chunk_index_].recv_buffer(sizeRecv);
-        MPI_Irecv(pRecv,sizeRecv,MPI_BYTE,iProc,iPair,distributed_comm_,&reqRecv);
+        auto pRecv = state.qreg(iLocalChunk - global_chunk_index_).recv_buffer(sizeRecv);
+        MPI_Irecv(pRecv,sizeRecv,MPI_BYTE,iProc,iPair,BaseState::distributed_comm_,&reqRecv);
 
-        auto pSend = qregs_[iLocalChunk - global_chunk_index_].send_buffer(sizeSend);
-        MPI_Isend(pSend,sizeSend,MPI_BYTE,iProc,iPair,distributed_comm_,&reqSend);
+        auto pSend = state.qreg(iLocalChunk - global_chunk_index_).send_buffer(sizeSend);
+        MPI_Isend(pSend,sizeSend,MPI_BYTE,iProc,iPair,BaseState::distributed_comm_,&reqSend);
 
         MPI_Wait(&reqSend,&st);
         MPI_Wait(&reqRecv,&st);
 
-        qregs_[iLocalChunk - global_chunk_index_].apply_chunk_swap(qubits,iRemoteChunk);
+        state.qreg(iLocalChunk - global_chunk_index_).apply_chunk_swap(qubits,iRemoteChunk);
       }
     }
 #endif
@@ -1640,7 +1501,7 @@ void StateChunk<state_t>::apply_chunk_swap(const reg_t &qubits)
 }
 
 template <class state_t>
-void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
+void StateChunk<state_t>::apply_multi_chunk_swap(RegistersBase& state_in, const reg_t &qubits)
 {
   int_t nswap = qubits.size()/2;
   reg_t chunk_shuffle_qubits(nswap,0);
@@ -1650,9 +1511,11 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
   reg_t chunk_procs(nchunk);
   reg_t chunk_offset(nchunk);
 
+  Registers<state_t>& state = dynamic_cast<Registers<state_t>&>(state_in);
+
   if(qubit_scale() == 1){
     for(int_t i=0;i<nswap;i++)
-      std::swap(qubit_map_[qubits[i*2]],qubit_map_[qubits[i*2]+1]);
+      state.swap_qubit_map(qubits[i*2],qubits[i*2+1]);
   }
 
   //define local swaps
@@ -1684,13 +1547,13 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
 #pragma omp parallel for 
     for(int_t ig=0;ig<num_groups_;ig++){
       for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
-        qregs_[iChunk].apply_multi_swaps(local_swaps);
+        state.qreg(iChunk).apply_multi_swaps(local_swaps);
     }
   }
   else{
     for(int_t ig=0;ig<num_groups_;ig++){
       for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
-        qregs_[iChunk].apply_multi_swaps(local_swaps);
+        state.qreg(iChunk).apply_multi_swaps(local_swaps);
     }
   }
 
@@ -1741,7 +1604,7 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
 
         uint_t iProc1 = chunk_procs[i1];
         uint_t iProc2 = chunk_procs[i2];
-        if(iProc1 != distributed_rank_ && iProc2 != distributed_rank_)
+        if(iProc1 != BaseState::distributed_rank_ && iProc2 != BaseState::distributed_rank_)
           continue;
         if(iProc1 == iProc2){  //on the same process
           num_local_swap++;
@@ -1755,19 +1618,19 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
 
         int_t tid = (iPair << nswap) + iswap;
 
-        if(iProc1 == distributed_rank_){
-          auto pRecv = qregs_[iChunk1].recv_buffer(sizeRecv);
-          MPI_Irecv(pRecv + offset2,(sizeRecv >> nswap),MPI_BYTE,iProc2,tid,distributed_comm_,&reqRecv[i2]);
+        if(iProc1 == BaseState::distributed_rank_){
+          auto pRecv = state.qreg(iChunk1).recv_buffer(sizeRecv);
+          MPI_Irecv(pRecv + offset2,(sizeRecv >> nswap),MPI_BYTE,iProc2,tid,BaseState::distributed_comm_,&reqRecv[i2]);
 
-          auto pSend = qregs_[iChunk1].send_buffer(sizeSend);
-          MPI_Isend(pSend + offset2,(sizeSend >> nswap),MPI_BYTE,iProc2,tid,distributed_comm_,&reqSend[i2]);
+          auto pSend = state.qreg(iChunk1).send_buffer(sizeSend);
+          MPI_Isend(pSend + offset2,(sizeSend >> nswap),MPI_BYTE,iProc2,tid,BaseState::distributed_comm_,&reqSend[i2]);
         }
         else{
-          auto pRecv = qregs_[iChunk2].recv_buffer(sizeRecv);
-          MPI_Irecv(pRecv + offset1,(sizeRecv >> nswap),MPI_BYTE,iProc1,tid,distributed_comm_,&reqRecv[i1]);
+          auto pRecv = state.qreg(iChunk2).recv_buffer(sizeRecv);
+          MPI_Irecv(pRecv + offset1,(sizeRecv >> nswap),MPI_BYTE,iProc1,tid,BaseState::distributed_comm_,&reqRecv[i1]);
 
-          auto pSend = qregs_[iChunk2].send_buffer(sizeSend);
-          MPI_Isend(pSend + offset1,(sizeSend >> nswap),MPI_BYTE,iProc1,tid,distributed_comm_,&reqSend[i1]);
+          auto pSend = state.qreg(iChunk2).send_buffer(sizeSend);
+          MPI_Isend(pSend + offset1,(sizeSend >> nswap),MPI_BYTE,iProc1,tid,BaseState::distributed_comm_,&reqSend[i1]);
         }
 #endif
       }
@@ -1781,14 +1644,14 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
 
           uint_t iProc1 = chunk_procs[i1];
           uint_t iProc2 = chunk_procs[i2];
-          if(iProc1 != distributed_rank_ && iProc2 != distributed_rank_)
+          if(iProc1 != BaseState::distributed_rank_ && iProc2 != BaseState::distributed_rank_)
             continue;
           if(iProc1 == iProc2){  //on the same process
             uint_t offset1 = i1 << (chunk_bits_*qubit_scale() - nswap);
             uint_t offset2 = i2 << (chunk_bits_*qubit_scale() - nswap);
             uint_t iChunk1 = baseChunk + chunk_offset[i1] - global_chunk_index_;
             uint_t iChunk2 = baseChunk + chunk_offset[i2] - global_chunk_index_;
-            qregs_[iChunk1].apply_chunk_swap(qregs_[iChunk2],offset2,offset1,(1ull << (chunk_bits_*qubit_scale() - nswap)) );
+            state.qreg(iChunk1).apply_chunk_swap(state.qreg(iChunk2),offset2,offset1,(1ull << (chunk_bits_*qubit_scale() - nswap)) );
           }
         }
       }
@@ -1800,7 +1663,7 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
 
         uint_t iProc1 = chunk_procs[i1];
         uint_t iProc2 = chunk_procs[i2];
-        if(iProc1 != distributed_rank_)
+        if(iProc1 != BaseState::distributed_rank_)
           continue;
         if(iProc1 == iProc2){  //on the same process
           continue;
@@ -1813,7 +1676,7 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
         MPI_Wait(&reqRecv[i2],&st);
 
         //copy states from recv buffer to chunk
-        qregs_[iChunk1].apply_chunk_swap(qregs_[iChunk1],offset2,offset2,(1ull << (chunk_bits_*qubit_scale() - nswap)) );
+        state.qreg(iChunk1).apply_chunk_swap(state.qreg(iChunk1),offset2,offset2,(1ull << (chunk_bits_*qubit_scale() - nswap)) );
       }
 #endif
     }
@@ -1824,33 +1687,34 @@ void StateChunk<state_t>::apply_multi_chunk_swap(const reg_t &qubits)
 #pragma omp parallel for 
     for(int_t ig=0;ig<num_groups_;ig++){
       for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
-        qregs_[iChunk].apply_multi_swaps(local_swaps);
+        state.qreg(iChunk).apply_multi_swaps(local_swaps);
     }
   }
   else{
     for(int_t ig=0;ig<num_groups_;ig++){
       for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
-        qregs_[iChunk].apply_multi_swaps(local_swaps);
+        state.qreg(iChunk).apply_multi_swaps(local_swaps);
     }
   }
 }
 
 
 template <class state_t>
-void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
+void StateChunk<state_t>::apply_chunk_x(RegistersBase& state_in, const uint_t qubit)
 {
   int_t iChunk;
   uint_t nLarge = 1;
 
+  Registers<state_t>& state = dynamic_cast<Registers<state_t>&>(state_in);
 
   if(qubit < chunk_bits_*qubit_scale()){
-    auto apply_mcx = [this, qubit](int_t ig)
+    auto apply_par_mcx = [this, qubit, &state](int_t ig)
     {
       reg_t qubits(1,qubit);
       for(int_t iChunk = top_chunk_of_group_[ig];iChunk < top_chunk_of_group_[ig + 1];iChunk++)
-        qregs_[iChunk].apply_mcx(qubits);
+        state.qreg(iChunk).apply_mcx(qubits);
     };
-    Utils::apply_omp_parallel_for((chunk_omp_parallel_ && num_groups_ > 1),0,num_groups_,apply_mcx);
+    Utils::apply_omp_parallel_for((chunk_omp_parallel_ && num_groups_ > 1),0,num_groups_,apply_par_mcx);
   }
   else{ //exchange over chunks
     int_t iPair;
@@ -1863,19 +1727,19 @@ void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
     mask = (1ull << qubit);
     mask >>= (chunk_bits_*qubit_scale());
 
-    if(distributed_procs_ == 1 || (distributed_proc_bits_ >= 0 && qubit < (num_qubits_*qubit_scale() - distributed_proc_bits_))){   //no data transfer between processes is needed
+    if(BaseState::distributed_procs_ == 1 || (BaseState::distributed_proc_bits_ >= 0 && qubit < (BaseState::num_qubits_*qubit_scale() - BaseState::distributed_proc_bits_))){   //no data transfer between processes is needed
       nPair = num_local_chunks_ >> 1;
 
-      auto apply_chunk_swap = [this, mask, qubits](int_t iGroup)
+      auto apply_par_chunk_swap = [this, mask, &qubits,&state](int_t iGroup)
       {
         for(int_t ic = top_chunk_of_group_[iGroup];ic < top_chunk_of_group_[iGroup + 1];ic++){
           uint_t pairChunk;
           pairChunk = ic ^ mask;
           if(ic < pairChunk)
-            qregs_[ic].apply_chunk_swap(qubits,qregs_[pairChunk],true);
+            state.qreg(ic).apply_chunk_swap(qubits,state.qreg(pairChunk),true);
         }
       };
-      Utils::apply_omp_parallel_for((chunk_omp_parallel_ && num_groups_ > 1),0, nPair, apply_chunk_swap);
+      Utils::apply_omp_parallel_for((chunk_omp_parallel_ && num_groups_ > 1),0, nPair, apply_par_chunk_swap);
     }
 #ifdef AER_MPI
     else{
@@ -1892,10 +1756,10 @@ void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
       ub[0] = 0;
       iu[0] = 0;
 
-      nu[1] = 1ull << (num_qubits_*qubit_scale() - qubit - 1);
+      nu[1] = 1ull << (BaseState::num_qubits_*qubit_scale() - qubit - 1);
       ub[1] = (qubit - chunk_bits_*qubit_scale()) + 1;
       iu[1] = 0;
-      nPair = 1ull << (num_qubits_*qubit_scale() - chunk_bits_*qubit_scale() - 1);
+      nPair = 1ull << (BaseState::num_qubits_*qubit_scale() - chunk_bits_*qubit_scale() - 1);
 
       for(iPair=0;iPair<nPair;iPair++){
         //calculate index of pair of chunks
@@ -1915,9 +1779,9 @@ void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
         iChunk1 = baseChunk;
         iChunk2 = baseChunk | mask;
 
-        if(iChunk1 >= chunk_index_begin_[distributed_rank_] && iChunk1 < chunk_index_end_[distributed_rank_]){    //chunk1 is on this process
-          if(iChunk2 >= chunk_index_begin_[distributed_rank_] && iChunk2 < chunk_index_end_[distributed_rank_]){    //chunk2 is on this process
-            qregs_[iChunk1 - global_chunk_index_].apply_chunk_swap(qubits,qregs_[iChunk2 - global_chunk_index_],true);
+        if(iChunk1 >= chunk_index_begin_[BaseState::distributed_rank_] && iChunk1 < chunk_index_end_[BaseState::distributed_rank_]){    //chunk1 is on this process
+          if(iChunk2 >= chunk_index_begin_[BaseState::distributed_rank_] && iChunk2 < chunk_index_end_[BaseState::distributed_rank_]){    //chunk2 is on this process
+            state.qreg(iChunk1 - global_chunk_index_).apply_chunk_swap(qubits,state.qreg(iChunk2 - global_chunk_index_),true);
             continue;
           }
           else{
@@ -1927,7 +1791,7 @@ void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
           }
         }
         else{
-          if(iChunk2 >= chunk_index_begin_[distributed_rank_] && iChunk2 < chunk_index_end_[distributed_rank_]){    //chunk2 is on this process
+          if(iChunk2 >= chunk_index_begin_[BaseState::distributed_rank_] && iChunk2 < chunk_index_end_[BaseState::distributed_rank_]){    //chunk2 is on this process
             iLocalChunk = iChunk2;
             iRemoteChunk = iChunk1;
             iProc = get_process_by_chunk(iChunk1);
@@ -1941,16 +1805,16 @@ void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
         MPI_Status st;
         uint_t sizeRecv,sizeSend;
 
-        auto pSend = qregs_[iLocalChunk - global_chunk_index_].send_buffer(sizeSend);
-        MPI_Isend(pSend,sizeSend,MPI_BYTE,iProc,iPair,distributed_comm_,&reqSend);
+        auto pSend = state.qreg(iLocalChunk - global_chunk_index_).send_buffer(sizeSend);
+        MPI_Isend(pSend,sizeSend,MPI_BYTE,iProc,iPair,BaseState::distributed_comm_,&reqSend);
 
-        auto pRecv = qregs_[iLocalChunk - global_chunk_index_].recv_buffer(sizeRecv);
-        MPI_Irecv(pRecv,sizeRecv,MPI_BYTE,iProc,iPair,distributed_comm_,&reqRecv);
+        auto pRecv = state.qreg(iLocalChunk - global_chunk_index_).recv_buffer(sizeRecv);
+        MPI_Irecv(pRecv,sizeRecv,MPI_BYTE,iProc,iPair,BaseState::distributed_comm_,&reqRecv);
 
         MPI_Wait(&reqSend,&st);
         MPI_Wait(&reqRecv,&st);
 
-        qregs_[iLocalChunk - global_chunk_index_].apply_chunk_swap(qubits,iRemoteChunk);
+        state.qreg(iLocalChunk - global_chunk_index_).apply_chunk_swap(qubits,iRemoteChunk);
       }
     }
 #endif
@@ -1959,7 +1823,7 @@ void StateChunk<state_t>::apply_chunk_x(const uint_t qubit)
 }
 
 template <class state_t>
-void StateChunk<state_t>::send_chunk(uint_t local_chunk_index, uint_t global_pair_index)
+void StateChunk<state_t>::send_chunk(Registers<state_t>& state, uint_t local_chunk_index, uint_t global_pair_index)
 {
 #ifdef AER_MPI
   MPI_Request reqSend;
@@ -1969,17 +1833,17 @@ void StateChunk<state_t>::send_chunk(uint_t local_chunk_index, uint_t global_pai
 
   iProc = get_process_by_chunk(global_pair_index);
 
-  auto pSend = qregs_[local_chunk_index].send_buffer(sizeSend);
-  MPI_Isend(pSend,sizeSend,MPI_BYTE,iProc,local_chunk_index + global_chunk_index_,distributed_comm_,&reqSend);
+  auto pSend = state.qreg(local_chunk_index).send_buffer(sizeSend);
+  MPI_Isend(pSend,sizeSend,MPI_BYTE,iProc,local_chunk_index + global_chunk_index_,BaseState::distributed_comm_,&reqSend);
 
   MPI_Wait(&reqSend,&st);
 
-  qregs_[local_chunk_index].release_send_buffer();
+  state.qreg(local_chunk_index).release_send_buffer();
 #endif
 }
 
 template <class state_t>
-void StateChunk<state_t>::recv_chunk(uint_t local_chunk_index, uint_t global_pair_index)
+void StateChunk<state_t>::recv_chunk(Registers<state_t>& state, uint_t local_chunk_index, uint_t global_pair_index)
 {
 #ifdef AER_MPI
   MPI_Request reqRecv;
@@ -1989,8 +1853,8 @@ void StateChunk<state_t>::recv_chunk(uint_t local_chunk_index, uint_t global_pai
 
   iProc = get_process_by_chunk(global_pair_index);
 
-  auto pRecv = qregs_[local_chunk_index].recv_buffer(sizeRecv);
-  MPI_Irecv(pRecv,sizeRecv,MPI_BYTE,iProc,global_pair_index,distributed_comm_,&reqRecv);
+  auto pRecv = state.qreg(local_chunk_index).recv_buffer(sizeRecv);
+  MPI_Irecv(pRecv,sizeRecv,MPI_BYTE,iProc,global_pair_index,BaseState::distributed_comm_,&reqRecv);
 
   MPI_Wait(&reqRecv,&st);
 #endif
@@ -2007,7 +1871,7 @@ void StateChunk<state_t>::send_data(data_t* pSend, uint_t size, uint_t myid,uint
 
   iProc = get_process_by_chunk(pairid);
 
-  MPI_Isend(pSend,size*sizeof(data_t),MPI_BYTE,iProc,myid,distributed_comm_,&reqSend);
+  MPI_Isend(pSend,size*sizeof(data_t),MPI_BYTE,iProc,myid,BaseState::distributed_comm_,&reqSend);
 
   MPI_Wait(&reqSend,&st);
 #endif
@@ -2024,7 +1888,7 @@ void StateChunk<state_t>::recv_data(data_t* pRecv, uint_t size, uint_t myid,uint
 
   iProc = get_process_by_chunk(pairid);
 
-  MPI_Irecv(pRecv,size*sizeof(data_t),MPI_BYTE,iProc,pairid,distributed_comm_,&reqRecv);
+  MPI_Irecv(pRecv,size*sizeof(data_t),MPI_BYTE,iProc,pairid,BaseState::distributed_comm_,&reqRecv);
 
   MPI_Wait(&reqRecv,&st);
 #endif
@@ -2034,10 +1898,10 @@ template <class state_t>
 void StateChunk<state_t>::reduce_sum(reg_t& sum) const
 {
 #ifdef AER_MPI
-  if(distributed_procs_ > 1){
+  if(BaseState::distributed_procs_ > 1){
     uint_t i,n = sum.size();
     reg_t tmp(n);
-    MPI_Allreduce(&sum[0],&tmp[0],n,MPI_UINT64_T,MPI_SUM,distributed_comm_);
+    MPI_Allreduce(&sum[0],&tmp[0],n,MPI_UINT64_T,MPI_SUM,BaseState::distributed_comm_);
     for(i=0;i<n;i++){
       sum[i] = tmp[i];
     }
@@ -2049,10 +1913,10 @@ template <class state_t>
 void StateChunk<state_t>::reduce_sum(rvector_t& sum) const
 {
 #ifdef AER_MPI
-  if(distributed_procs_ > 1){
+  if(BaseState::distributed_procs_ > 1){
     uint_t i,n = sum.size();
     rvector_t tmp(n);
-    MPI_Allreduce(&sum[0],&tmp[0],n,MPI_DOUBLE_PRECISION,MPI_SUM,distributed_comm_);
+    MPI_Allreduce(&sum[0],&tmp[0],n,MPI_DOUBLE_PRECISION,MPI_SUM,BaseState::distributed_comm_);
     for(i=0;i<n;i++){
       sum[i] = tmp[i];
     }
@@ -2064,9 +1928,9 @@ template <class state_t>
 void StateChunk<state_t>::reduce_sum(complex_t& sum) const
 {
 #ifdef AER_MPI
-  if(distributed_procs_ > 1){
+  if(BaseState::distributed_procs_ > 1){
     complex_t tmp;
-    MPI_Allreduce(&sum,&tmp,2,MPI_DOUBLE_PRECISION,MPI_SUM,distributed_comm_);
+    MPI_Allreduce(&sum,&tmp,2,MPI_DOUBLE_PRECISION,MPI_SUM,BaseState::distributed_comm_);
     sum = tmp;
   }
 #endif
@@ -2076,9 +1940,9 @@ template <class state_t>
 void StateChunk<state_t>::reduce_sum(double& sum) const
 {
 #ifdef AER_MPI
-  if(distributed_procs_ > 1){
+  if(BaseState::distributed_procs_ > 1){
     double tmp;
-    MPI_Allreduce(&sum,&tmp,1,MPI_DOUBLE_PRECISION,MPI_SUM,distributed_comm_);
+    MPI_Allreduce(&sum,&tmp,1,MPI_DOUBLE_PRECISION,MPI_SUM,BaseState::distributed_comm_);
     sum = tmp;
   }
 #endif
@@ -2088,9 +1952,9 @@ template <class state_t>
 void StateChunk<state_t>::gather_value(rvector_t& val) const
 {
 #ifdef AER_MPI
-  if(distributed_procs_ > 1){
+  if(BaseState::distributed_procs_ > 1){
     rvector_t tmp = val;
-    MPI_Alltoall(&tmp[0],1,MPI_DOUBLE_PRECISION,&val[0],1,MPI_DOUBLE_PRECISION,distributed_comm_);
+    MPI_Alltoall(&tmp[0],1,MPI_DOUBLE_PRECISION,&val[0],1,MPI_DOUBLE_PRECISION,BaseState::distributed_comm_);
   }
 #endif
 }
@@ -2099,8 +1963,8 @@ template <class state_t>
 void StateChunk<state_t>::sync_process(void) const
 {
 #ifdef AER_MPI
-  if(distributed_procs_ > 1){
-    MPI_Barrier(distributed_comm_);
+  if(BaseState::distributed_procs_ > 1){
+    MPI_Barrier(BaseState::distributed_comm_);
   }
 #endif
 }
@@ -2111,14 +1975,14 @@ template <class data_t>
 void StateChunk<state_t>::gather_state(std::vector<std::complex<data_t>>& state)
 {
 #ifdef AER_MPI
-  if(distributed_procs_ > 1){
+  if(BaseState::distributed_procs_ > 1){
     uint_t size,local_size,global_size,offset;
     int i;
-    std::vector<int> recv_counts(distributed_procs_);
-    std::vector<int> recv_offset(distributed_procs_);
+    std::vector<int> recv_counts(BaseState::distributed_procs_);
+    std::vector<int> recv_offset(BaseState::distributed_procs_);
 
     global_size = 0;
-    for(i=0;i<distributed_procs_;i++){
+    for(i=0;i<BaseState::distributed_procs_;i++){
       recv_offset[i] = (int)(chunk_index_begin_[i] << (chunk_bits_*qubit_scale()))*2;
       recv_counts[i] = (int)((chunk_index_end_[i] - chunk_index_begin_[i]) << (chunk_bits_*qubit_scale()));
       global_size += recv_counts[i];
@@ -2131,12 +1995,12 @@ void StateChunk<state_t>::gather_state(std::vector<std::complex<data_t>>& state)
     state.resize(global_size);
 
     if(sizeof(std::complex<data_t>) == 16){
-      MPI_Allgatherv(local_state.data(),recv_counts[distributed_rank_],MPI_DOUBLE_PRECISION,
-                     state.data(),&recv_counts[0],&recv_offset[0],MPI_DOUBLE_PRECISION,distributed_comm_);
+      MPI_Allgatherv(local_state.data(),recv_counts[BaseState::distributed_rank_],MPI_DOUBLE_PRECISION,
+                     state.data(),&recv_counts[0],&recv_offset[0],MPI_DOUBLE_PRECISION,BaseState::distributed_comm_);
     }
     else{
-      MPI_Allgatherv(local_state.data(),recv_counts[distributed_rank_],MPI_FLOAT,
-                     state.data(),&recv_counts[0],&recv_offset[0],MPI_FLOAT,distributed_comm_);
+      MPI_Allgatherv(local_state.data(),recv_counts[BaseState::distributed_rank_],MPI_FLOAT,
+                     state.data(),&recv_counts[0],&recv_offset[0],MPI_FLOAT,BaseState::distributed_comm_);
     }
   }
 #endif
@@ -2147,15 +2011,15 @@ template <class data_t>
 void StateChunk<state_t>::gather_state(AER::Vector<std::complex<data_t>>& state)
 {
 #ifdef AER_MPI
-  if(distributed_procs_ > 1){
+  if(BaseState::distributed_procs_ > 1){
     uint_t size,local_size,global_size,offset;
     int i;
 
-    std::vector<int> recv_counts(distributed_procs_);
-    std::vector<int> recv_offset(distributed_procs_);
+    std::vector<int> recv_counts(BaseState::distributed_procs_);
+    std::vector<int> recv_offset(BaseState::distributed_procs_);
 
     global_size = 0;
-    for(i=0;i<distributed_procs_;i++){
+    for(i=0;i<BaseState::distributed_procs_;i++){
       recv_offset[i] = (int)(chunk_index_begin_[i] << (chunk_bits_*qubit_scale()))*2;
       recv_counts[i] = (int)((chunk_index_end_[i] - chunk_index_begin_[i]) << (chunk_bits_*qubit_scale()));
       global_size += recv_counts[i];
@@ -2168,67 +2032,12 @@ void StateChunk<state_t>::gather_state(AER::Vector<std::complex<data_t>>& state)
     state.resize(global_size);
 
     if(sizeof(std::complex<data_t>) == 16){
-      MPI_Allgatherv(local_state.data(),recv_counts[distributed_rank_],MPI_DOUBLE_PRECISION,
-                     state.data(),&recv_counts[0],&recv_offset[0],MPI_DOUBLE_PRECISION,distributed_comm_);
+      MPI_Allgatherv(local_state.data(),recv_counts[BaseState::distributed_rank_],MPI_DOUBLE_PRECISION,
+                     state.data(),&recv_counts[0],&recv_offset[0],MPI_DOUBLE_PRECISION,BaseState::distributed_comm_);
     }
     else{
-      MPI_Allgatherv(local_state.data(),recv_counts[distributed_rank_],MPI_FLOAT,
-                     state.data(),&recv_counts[0],&recv_offset[0],MPI_FLOAT,distributed_comm_);
-    }
-  }
-#endif
-}
-
-template <class state_t>
-void StateChunk<state_t>::gather_creg_memory(void)
-{
-#ifdef AER_MPI
-  int_t i,j;
-  uint_t n64,i64,ibit;
-
-  if(distributed_procs_ == 1)
-    return;
-  if(BaseState::cregs_[0].memory_size() == 0)
-    return;
-
-  //number of 64-bit integers per memory
-  n64 = (BaseState::cregs_[0].memory_size() + 63) >> 6;
-
-  reg_t bin_memory(n64*num_local_chunks_,0);
-  //compress memory string to binary
-#pragma omp parallel for private(i,j,i64,ibit)
-  for(i=0;i<num_local_chunks_;i++){
-    for(j=0;j<BaseState::cregs_[0].memory_size();j++){
-      i64 = j >> 6;
-      ibit = j & 63;
-      if(BaseState::cregs_[global_chunk_index_ + i].creg_memory()[j] == '1'){
-        bin_memory[i*n64 + i64] |= (1ull << ibit);
-      }
-    }
-  }
-
-  reg_t recv(n64*num_global_chunks_);
-  std::vector<int> recv_counts(distributed_procs_);
-  std::vector<int> recv_offset(distributed_procs_);
-
-  for(i=0;i<distributed_procs_;i++){
-    recv_offset[i] = num_global_chunks_ * i / distributed_procs_;
-    recv_counts[i] = (num_global_chunks_ * (i+1) / distributed_procs_) - recv_offset[i];
-  }
-
-  MPI_Allgatherv(&bin_memory[0],n64*num_local_chunks_,MPI_UINT64_T,
-                 &recv[0],&recv_counts[0],&recv_offset[0],MPI_UINT64_T,distributed_comm_);
-
-  //store gathered memory
-#pragma omp parallel for private(i,j,i64,ibit)
-  for(i=0;i<num_global_chunks_;i++){
-    for(j=0;j<BaseState::cregs_[0].memory_size();j++){
-      i64 = j >> 6;
-      ibit = j & 63;
-      if(((recv[i*n64 + i64] >> ibit) & 1) == 1)
-        BaseState::cregs_[i].creg_memory()[j] = '1';
-      else
-        BaseState::cregs_[i].creg_memory()[j] = '0';
+      MPI_Allgatherv(local_state.data(),recv_counts[BaseState::distributed_rank_],MPI_FLOAT,
+                     state.data(),&recv_counts[0],&recv_offset[0],MPI_FLOAT,BaseState::distributed_comm_);
     }
   }
 #endif

--- a/src/simulators/statevector/chunk/chunk.hpp
+++ b/src/simulators/statevector/chunk/chunk.hpp
@@ -356,6 +356,14 @@ public:
   {
     return chunk_container_.lock()->measured_cbit(chunk_pos_,qubit);
   }
+  void write_cbit(int qubit, int val)
+  {
+    chunk_container_.lock()->write_cbit(chunk_pos_,qubit,val);
+  }
+  void store_cbits(void)
+  {
+    chunk_container_.lock()->store_cbits();
+  }
 
 
   void set_conditional(int_t bit)

--- a/src/simulators/statevector/chunk/chunk_container.hpp
+++ b/src/simulators/statevector/chunk/chunk_container.hpp
@@ -318,6 +318,9 @@ public:
   {
     return 0;
   }
+  virtual void write_cbit(uint_t iChunk,int qubit,int val){}
+  virtual void store_cbits(void){}
+
 
   virtual uint_t* creg_buffer(uint_t iChunk) const
   {
@@ -435,6 +438,7 @@ void ChunkContainer<data_t>::Execute(Function func,uint_t iChunk,const uint_t gi
   func.set_cregs_(creg_buffer(iChunk),num_creg_bits_);
 
   if(iChunk == 0 && conditional_bit_ >= 0){
+    store_cbits();  //update creg on device
     func.set_conditional(conditional_bit_);
     if(!keep_conditional_bit_)
       conditional_bit_ = -1;  //reset conditional

--- a/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
@@ -120,7 +120,7 @@ uint_t cuStateVecChunkContainer<data_t>::Allocate(int idev,int chunk_bits,int nu
     throw std::runtime_error(str.str());
   }
 
-  err = custatevecSetStream(custatevec_handle_,BaseContainer::stream_);
+  err = custatevecSetStream(custatevec_handle_,BaseContainer::stream_[0]);
   if(err != CUSTATEVEC_STATUS_SUCCESS){
     std::stringstream str;
     str << "cuStateVecChunkContainer::allocate::custatevecSetStream : " << custatevecGetErrorString(err);
@@ -182,13 +182,13 @@ reg_t cuStateVecChunkContainer<data_t>::sample_measure(uint_t iChunk,const std::
     reg_t samples(SHOTS,0);
 
     BaseContainer::set_device();
-    custatevecSetStream(custatevec_handle_,BaseContainer::stream_);
+    custatevecSetStream(custatevec_handle_,BaseContainer::stream_[0]);
 
     custatevecStatus_t err;
     custatevecSamplerDescriptor_t sampler;
     size_t extSize;
 
-    cudaStreamSynchronize(BaseContainer::stream_);
+    cudaStreamSynchronize(BaseContainer::stream_[0]);
 
     cudaDataType_t state_type;
     if(sizeof(data_t) == sizeof(double))

--- a/src/simulators/statevector/chunk/device_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/device_chunk_container.hpp
@@ -48,6 +48,7 @@ protected:
   bool multi_shots_;                  //multi-shot parallelization
 
   bool creg_host_update_;
+  bool creg_dev_update_;
 
   //for register blocking
   thrust::host_vector<uint_t>               blocked_qubits_holder_;
@@ -57,8 +58,7 @@ protected:
   reg_t num_blocked_qubits_;
 
 #ifdef AER_THRUST_CUDA
-  cudaStream_t stream_;    //asynchronous execution
-  cudaStream_t stream_cache_;    //asynchronous execution
+  std::vector<cudaStream_t> stream_;    //asynchronous execution
 #endif
 
 public:
@@ -70,10 +70,7 @@ public:
     num_matrices_ = 1;
     multi_shots_ = false;
     creg_host_update_ = true;
-#ifdef AER_THRUST_CUDA
-    stream_ = nullptr;
-    stream_cache_ = nullptr;
-#endif
+    creg_dev_update_ = false;
   }
   ~DeviceChunkContainer();
 
@@ -128,8 +125,10 @@ public:
   cudaStream_t stream(uint_t iChunk) const
   {
     if(iChunk >= this->num_chunks_)
-      return stream_cache_;
-    return stream_;
+      return stream_[(num_matrices_ + iChunk - this->num_chunks_)];
+    if(num_matrices_ == 1)
+      return stream_[0];
+    return stream_[iChunk];
   }
 #endif
 
@@ -214,14 +213,50 @@ public:
     if(iChunk == 0 && creg_host_update_){
       creg_host_update_ = false;
 #ifdef AER_THRUST_CUDA
-      cudaMemcpyAsync(thrust::raw_pointer_cast(cregs_host_.data()),thrust::raw_pointer_cast(cregs_.data()),sizeof(uint_t)*this->num_chunks_*n64,cudaMemcpyDeviceToHost,stream_);
-      cudaStreamSynchronize(stream_);
+      cudaMemcpyAsync(thrust::raw_pointer_cast(cregs_host_.data()),thrust::raw_pointer_cast(cregs_.data()),sizeof(uint_t)*num_matrices_*n64,cudaMemcpyDeviceToHost,stream_[0]);
+      cudaStreamSynchronize(stream_[0]);
 #else
       thrust::copy_n(cregs_.begin(),this->num_chunks_*n64,cregs_host_.begin());
 #endif
     }
 
     return (cregs_host_[iChunk*n64 + i64] >> ibit) & 1;
+  }
+
+  void write_cbit(uint_t iChunk, int qubit, int val)
+  {
+    uint_t n64,i64,ibit;
+    if(qubit >= this->num_creg_bits_)
+      return;
+    n64 = (this->num_creg_bits_ + 63) >> 6;
+    i64 = qubit >> 6;
+    ibit = qubit & 63;
+    if(iChunk == 0 && creg_host_update_){
+      creg_host_update_ = false;
+#ifdef AER_THRUST_CUDA
+      cudaMemcpyAsync(thrust::raw_pointer_cast(cregs_host_.data()),thrust::raw_pointer_cast(cregs_.data()),sizeof(uint_t)*num_matrices_*n64,cudaMemcpyDeviceToHost,stream_[0]);
+      cudaStreamSynchronize(stream_[0]);
+#else
+      thrust::copy_n(cregs_.begin(),this->num_chunks_*n64,cregs_host_.begin());
+#endif
+    }
+
+    cregs_host_[iChunk*n64 + i64] = (cregs_host_[iChunk*n64 + i64] & (~(1ull << ibit)) ) | (((uint_t)val & 1) << ibit);
+    creg_dev_update_ = true;
+  }
+  void store_cbits(void)
+  {
+    if(creg_dev_update_){
+      uint_t n64;
+      n64 = (this->num_creg_bits_ + 63) >> 6;
+      creg_dev_update_ = false;
+      creg_host_update_ = false;
+#ifdef AER_THRUST_CUDA
+      cudaMemcpyAsync(thrust::raw_pointer_cast(cregs_.data()),thrust::raw_pointer_cast(cregs_host_.data()),sizeof(uint_t)*num_matrices_*n64,cudaMemcpyHostToDevice,stream_[0]);
+#else
+      thrust::copy_n(cregs_host_.begin(), this->num_chunks_*n64,cregs_.begin());
+#endif
+    }
   }
 
   uint_t* creg_buffer(uint_t iChunk) const
@@ -239,10 +274,7 @@ public:
   {
 #ifdef AER_THRUST_CUDA
     set_device();
-    if(iChunk >= this->num_chunks_)
-      cudaStreamSynchronize(stream_cache_);
-    else
-      cudaStreamSynchronize(stream_);
+    cudaStreamSynchronize(stream(iChunk));
 #endif
   }
 
@@ -353,9 +385,12 @@ uint_t DeviceChunkContainer<data_t>::Allocate(int idev,int chunk_bits,int num_qu
     nc_tmp >>= 1;
   }
 
+  uint_t size = num_matrices_ + this->num_buffers_;
+
 #ifdef AER_THRUST_CUDA
-  cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
-  cudaStreamCreateWithFlags(&stream_cache_, cudaStreamNonBlocking);
+  stream_.resize(size);
+  for(int i=0;i<size;i++)
+    cudaStreamCreateWithFlags(&stream_[i], cudaStreamNonBlocking);
 
   if(chunk_bits < 10){
     reduce_buffer_size_ = 1;
@@ -374,7 +409,6 @@ uint_t DeviceChunkContainer<data_t>::Allocate(int idev,int chunk_bits,int num_qu
   creg_host_update_ = false;
   this->num_creg_bits_ = num_qubits;
 
-  uint_t size = num_matrices_ + this->num_buffers_;
   num_blocked_gates_.resize(size);
   num_blocked_matrix_.resize(size);
   num_blocked_qubits_.resize(size);
@@ -399,8 +433,10 @@ void DeviceChunkContainer<data_t>::allocate_creg(uint_t num_mem,uint_t num_reg)
   this->num_cmemory_ = num_mem;
 
   uint_t n64 = (this->num_creg_bits_ + 63) >> 6;
-  cregs_.resize(num_matrices_*n64);
-  cregs_host_.resize(num_matrices_*n64);
+  if(cregs_.size() != num_matrices_*n64){
+    cregs_.resize(num_matrices_*n64);
+    cregs_host_.resize(num_matrices_*n64);
+  }
 }
   
 template <typename data_t>
@@ -430,14 +466,9 @@ void DeviceChunkContainer<data_t>::Deallocate(void)
   blocked_qubits_holder_.clear();
 
 #ifdef AER_THRUST_CUDA
-  if(stream_){
-    cudaStreamDestroy(stream_);
-    stream_ = nullptr;
-  }
-  if(stream_cache_){
-    cudaStreamDestroy(stream_cache_);
-    stream_cache_ = nullptr;
-  }
+  for(int i=0;i<stream_.size();i++)
+    cudaStreamDestroy(stream_[i]);
+  stream_.clear();
 #endif
   ChunkContainer<data_t>::deallocate_chunks();
 }
@@ -579,10 +610,10 @@ void DeviceChunkContainer<data_t>::CopyIn(Chunk<data_t>& src,uint_t iChunk)
 #ifdef AER_THRUST_CUDA
   if(src.device() >= 0){
     if(peer_access(src.device())){
-      cudaMemcpyAsync(chunk_pointer(iChunk),src.pointer(),size*sizeof(thrust::complex<data_t>),cudaMemcpyDeviceToDevice,stream_);
+      cudaMemcpyAsync(chunk_pointer(iChunk),src.pointer(),size*sizeof(thrust::complex<data_t>),cudaMemcpyDeviceToDevice,stream(iChunk));
     }
     else{
-      cudaMemcpyPeerAsync(chunk_pointer(iChunk),device_id_,src.pointer(),src.device(),size,stream_);
+      cudaMemcpyPeerAsync(chunk_pointer(iChunk),device_id_,src.pointer(),src.device(),size,stream(iChunk));
     }
   }
   else{
@@ -608,10 +639,10 @@ void DeviceChunkContainer<data_t>::CopyOut(Chunk<data_t>& dest,uint_t iChunk)
 #ifdef AER_THRUST_CUDA
   if(dest.device() >= 0){
     if(peer_access(dest.device())){
-      cudaMemcpyAsync(dest.pointer(),chunk_pointer(iChunk),size*sizeof(thrust::complex<data_t>),cudaMemcpyDeviceToDevice,stream_);
+      cudaMemcpyAsync(dest.pointer(),chunk_pointer(iChunk),size*sizeof(thrust::complex<data_t>),cudaMemcpyDeviceToDevice,stream(iChunk));
     }
     else{
-      cudaMemcpyPeerAsync(dest.pointer(),dest.device(),chunk_pointer(iChunk),device_id_,size,stream_);
+      cudaMemcpyPeerAsync(dest.pointer(),dest.device(),chunk_pointer(iChunk),device_id_,size,stream(iChunk));
     }
   }
   else{
@@ -633,7 +664,11 @@ template <typename data_t>
 void DeviceChunkContainer<data_t>::CopyIn(thrust::complex<data_t>* src,uint_t iChunk, uint_t size)
 {
   uint_t this_size = 1ull << this->chunk_bits_;
-  if(this_size < size) throw std::runtime_error("CopyIn chunk size is less than provided size");
+  if(this_size < size){
+    std::stringstream str;
+    str << "DeviceChunkContainer::CopyIn chunk size " << this_size << " is less than " << size;
+    throw std::runtime_error(str.str());
+  }
 
   synchronize(iChunk);
   thrust::copy_n(src,size,data_.begin() + (iChunk << this->chunk_bits_));
@@ -643,8 +678,11 @@ template <typename data_t>
 void DeviceChunkContainer<data_t>::CopyOut(thrust::complex<data_t>* dest,uint_t iChunk, uint_t size)
 {
   uint_t this_size = 1ull << this->chunk_bits_;
-  if(this_size < size) throw std::runtime_error("CopyOut chunk size is less than provided size");
-
+  if(this_size < size){
+    std::stringstream str;
+    str << "DeviceChunkContainer::CopyOut chunk size " << this_size << " is less than " << size;
+    throw std::runtime_error(str.str());
+  }
   synchronize(iChunk);
   thrust::copy_n(data_.begin() + (iChunk << this->chunk_bits_),size,dest);
 }
@@ -665,17 +703,17 @@ void DeviceChunkContainer<data_t>::Swap(Chunk<data_t>& src,uint_t iChunk, uint_t
     else{
       thrust::complex<data_t>* pBuffer = buffer_pointer();
       thrust::complex<data_t>* pSrc = src.pointer();
-      cudaMemcpyPeerAsync(pBuffer + dest_offset,device_id_,pSrc + src_offset,src.device(),size*sizeof(thrust::complex<data_t>),stream_);
+      cudaMemcpyPeerAsync(pBuffer + dest_offset,device_id_,pSrc + src_offset,src.device(),size*sizeof(thrust::complex<data_t>),stream(iChunk));
       this->Execute(BufferSwap_func<data_t>(chunk_pointer(iChunk) + dest_offset,pBuffer + dest_offset, size, true), iChunk, 0, 1);
-      cudaMemcpyPeerAsync(pSrc + src_offset,src.device(),pBuffer + dest_offset,device_id_,size*sizeof(thrust::complex<data_t>),stream_);
+      cudaMemcpyPeerAsync(pSrc + src_offset,src.device(),pBuffer + dest_offset,device_id_,size*sizeof(thrust::complex<data_t>),stream(iChunk));
     }
   }
   else{
     thrust::complex<data_t>* pBuffer = buffer_pointer();
     thrust::complex<data_t>* pSrc = src.pointer();
-    cudaMemcpyAsync(pBuffer + dest_offset,pSrc + src_offset,size*sizeof(thrust::complex<data_t>),cudaMemcpyHostToDevice,stream_cache_);
+    cudaMemcpyAsync(pBuffer + dest_offset,pSrc + src_offset,size*sizeof(thrust::complex<data_t>),cudaMemcpyHostToDevice,stream(this->num_chunks_));
     this->Execute(BufferSwap_func<data_t>(chunk_pointer(iChunk) + dest_offset,pBuffer + dest_offset, size, true), iChunk, 0, 1);
-    cudaMemcpyAsync(pSrc + src_offset,pBuffer + dest_offset,size*sizeof(thrust::complex<data_t>),cudaMemcpyDeviceToHost,stream_cache_);
+    cudaMemcpyAsync(pSrc + src_offset,pBuffer + dest_offset,size*sizeof(thrust::complex<data_t>),cudaMemcpyDeviceToHost,stream(this->num_chunks_));
   }
   cudaError_t err = cudaGetLastError();
   if(err != cudaSuccess){
@@ -696,7 +734,7 @@ void DeviceChunkContainer<data_t>::Zero(uint_t iChunk,uint_t count)
 {
   set_device();
 #ifdef AER_THRUST_CUDA
-  thrust::fill_n(thrust::cuda::par.on(stream_),data_.begin() + (iChunk << this->chunk_bits_),count,0.0);
+  thrust::fill_n(thrust::cuda::par.on(stream(iChunk)),data_.begin() + (iChunk << this->chunk_bits_),count,0.0);
 #else
   if(this->omp_threads_ > 1)
     thrust::fill_n(thrust::device,data_.begin() + (iChunk << this->chunk_bits_),count,0.0);
@@ -719,33 +757,40 @@ reg_t DeviceChunkContainer<data_t>::sample_measure(uint_t iChunk,const std::vect
 #ifdef AER_THRUST_CUDA
 
   if(dot)
-    thrust::transform_inclusive_scan(thrust::cuda::par.on(stream_),iter.begin(),iter.end(),iter.begin(),complex_dot_scan<data_t>(),thrust::plus<thrust::complex<data_t>>());
+    thrust::transform_inclusive_scan(thrust::cuda::par.on(stream(iChunk)),iter.begin(),iter.end(),iter.begin(),complex_dot_scan<data_t>(),thrust::plus<thrust::complex<data_t>>());
   else
-    thrust::inclusive_scan(thrust::cuda::par.on(stream_),iter.begin(),iter.end(),iter.begin(),thrust::plus<thrust::complex<data_t>>());
+    thrust::inclusive_scan(thrust::cuda::par.on(stream(iChunk)),iter.begin(),iter.end(),iter.begin(),thrust::plus<thrust::complex<data_t>>());
 
+  uint_t i,nshots,size;
   uint_t iBuf = 0;
-  if(multi_shots_)
+  if(multi_shots_){
     iBuf = iChunk;
+    size = matrix_buffer_size_*2;
+    if(size > params_buffer_size_)
+      size = params_buffer_size_;
+  }
+  else{
+    size = matrix_.size()*2;
+    if(size > params_.size())
+    size = params_.size();
+  }
 
   double* pRnd = (double*)matrix_pointer(iBuf);
   uint_t* pSmp = param_pointer(iBuf);
   thrust::device_ptr<double> rnd_dev_ptr = thrust::device_pointer_cast(pRnd);
-  uint_t i,nshots,size = matrix_.size()*2;
-  if(size > params_.size())
-    size = params_.size();
 
   for(i=0;i<SHOTS;i+=size){
     nshots = size;
     if(i + nshots > SHOTS)
       nshots = SHOTS - i;
 
-    cudaMemcpyAsync(pRnd,&rnds[i],nshots*sizeof(double),cudaMemcpyHostToDevice,stream_);
+    cudaMemcpyAsync(pRnd,&rnds[i],nshots*sizeof(double),cudaMemcpyHostToDevice,stream(iChunk));
 
-    thrust::lower_bound(thrust::cuda::par.on(stream_), iter.begin(), iter.end(), rnd_dev_ptr, rnd_dev_ptr + nshots, params_.begin() + (iBuf * params_buffer_size_),complex_less<data_t>());
+    thrust::lower_bound(thrust::cuda::par.on(stream(iChunk)), iter.begin(), iter.end(), rnd_dev_ptr, rnd_dev_ptr + nshots, params_.begin() + (iBuf * params_buffer_size_),complex_less<data_t>());
 
-    cudaMemcpyAsync(&samples[i],pSmp,nshots*sizeof(uint_t),cudaMemcpyDeviceToHost,stream_);
+    cudaMemcpyAsync(&samples[i],pSmp,nshots*sizeof(uint_t),cudaMemcpyDeviceToHost,stream(iChunk));
   }
-  cudaStreamSynchronize(stream_);
+  cudaStreamSynchronize(stream(iChunk));
 
 #else
   if(this->omp_threads_ > 1){
@@ -801,7 +846,7 @@ void DeviceChunkContainer<data_t>::set_blocked_qubits(uint_t iChunk,const reg_t&
   set_device();
   cudaMemcpyAsync(param_pointer(iChunk),
                   (uint_t*)&qubits_sorted[0],
-                  qubits.size()*sizeof(uint_t),cudaMemcpyHostToDevice,stream_);
+                  qubits.size()*sizeof(uint_t),cudaMemcpyHostToDevice,stream(iChunk));
 #endif
 
   num_blocked_gates_[iBlock] = 0;
@@ -896,7 +941,7 @@ void DeviceChunkContainer<data_t>::queue_blocked_gate(uint_t iChunk,char gate,ui
   set_device();
   cudaMemcpyAsync((BlockedGateParams*)(param_pointer(iChunk) + num_blocked_qubits_[iBlock]) + num_blocked_gates_[iBlock],
                   &params,
-                  sizeof(BlockedGateParams),cudaMemcpyHostToDevice,stream_);
+                  sizeof(BlockedGateParams),cudaMemcpyHostToDevice,stream(iChunk));
 
   if(pMat != NULL){
     if(gate == 'd'){  //diagonal matrix
@@ -904,14 +949,14 @@ void DeviceChunkContainer<data_t>::queue_blocked_gate(uint_t iChunk,char gate,ui
       mat[1] = pMat[1];
       cudaMemcpyAsync(matrix_pointer(iChunk) + num_blocked_matrix_[iBlock],
                       (thrust::complex<double>*)&mat[0],
-                      2*sizeof(thrust::complex<double>),cudaMemcpyHostToDevice,stream_);
+                      2*sizeof(thrust::complex<double>),cudaMemcpyHostToDevice,stream(iChunk));
       num_blocked_matrix_[iBlock] += 2;
     }
     else if(gate == 'p'){ //phase
       mat[0]   = pMat[0];
       cudaMemcpyAsync(matrix_pointer(iChunk) + num_blocked_matrix_[iBlock],
                       (thrust::complex<double>*)&mat[0],
-                      1*sizeof(thrust::complex<double>),cudaMemcpyHostToDevice,stream_);
+                      1*sizeof(thrust::complex<double>),cudaMemcpyHostToDevice,stream(iChunk));
       num_blocked_matrix_[iBlock] += 1;
     }
     else{ //otherwise, 2x2 matrix
@@ -921,7 +966,7 @@ void DeviceChunkContainer<data_t>::queue_blocked_gate(uint_t iChunk,char gate,ui
       mat[3] = pMat[1];
       cudaMemcpyAsync(matrix_pointer(iChunk) + num_blocked_matrix_[iBlock],
                       (thrust::complex<double>*)&mat[0],
-                      4*sizeof(thrust::complex<double>),cudaMemcpyHostToDevice,stream_);
+                      4*sizeof(thrust::complex<double>),cudaMemcpyHostToDevice,stream(iChunk));
       num_blocked_matrix_[iBlock] += 4;
     }
   }
@@ -1211,7 +1256,7 @@ void DeviceChunkContainer<data_t>::apply_blocked_gates(uint_t iChunk)
 
   if(num_blocked_qubits_[iBlock] < 6){
     //using register blocking (<=5 qubits)
-    dev_apply_register_blocked_gates<data_t><<<nb,nt,num_blocked_matrix_[iChunk]*sizeof(thrust::complex<double>),stream_>>>(
+    dev_apply_register_blocked_gates<data_t><<<nb,nt,num_blocked_matrix_[iChunk]*sizeof(thrust::complex<double>),stream(iChunk)>>>(
                                                                           chunk_pointer(iChunk),
                                                                           num_blocked_gates_[iBlock],
                                                                           num_blocked_qubits_[iBlock],
@@ -1220,7 +1265,7 @@ void DeviceChunkContainer<data_t>::apply_blocked_gates(uint_t iChunk)
   }
   else{
     //using shared memory blocking (<=10 qubits)
-    dev_apply_shared_memory_blocked_gates<data_t><<<nb,nt,1024*sizeof(thrust::complex<data_t>),stream_>>>(
+    dev_apply_shared_memory_blocked_gates<data_t><<<nb,nt,1024*sizeof(thrust::complex<data_t>),stream(iChunk)>>>(
                                                                           chunk_pointer(iChunk),
                                                                           num_blocked_gates_[iBlock],
                                                                           num_blocked_qubits_[iBlock],
@@ -1239,7 +1284,7 @@ void DeviceChunkContainer<data_t>::copy_to_probability_buffer(std::vector<double
 {
 #ifdef AER_THRUST_CUDA
   set_device();
-  cudaMemcpyAsync(probability_buffer(0) + pos*this->num_chunks_,&buf[0],buf.size()*sizeof(double),cudaMemcpyHostToDevice,stream_);
+  cudaMemcpyAsync(probability_buffer(0) + pos*this->num_chunks_,&buf[0],buf.size()*sizeof(double),cudaMemcpyHostToDevice,stream_[0]);
 #else
   thrust::copy_n(buf.begin(),buf.size(),probability_buffer_.begin());
 #endif

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -68,9 +68,9 @@ public:
   virtual ~QubitVectorThrust();
 
   //copy constructor for std::vector
-  QubitVectorThrust(const QubitVectorThrust<data_t>& qv)
+  QubitVectorThrust(const QubitVectorThrust<data_t>& obj) : QubitVectorThrust(0)
   {
-    
+    copy_qv(obj);
   }
 
   //-----------------------------------------------------------------------
@@ -148,7 +148,12 @@ public:
 
   //chunk setup
   bool chunk_setup(int chunk_bits,int num_qubits,uint_t chunk_index,uint_t num_local_chunks);
-  bool chunk_setup(QubitVectorThrust<data_t>& base,const uint_t chunk_index);
+  bool chunk_setup(const QubitVectorThrust<data_t>& base,const uint_t chunk_index);
+
+  uint_t chunk_index(void)
+  {
+    return chunk_index_;
+  }
 
   //cache control for chunks on host
   bool fetch_chunk(void) const;
@@ -191,6 +196,12 @@ public:
 
   // Initializes the current vector so that all qubits are in the |0> state.
   void initialize();
+
+  //initialize from existing state (copy)
+  void initialize(const QubitVectorThrust<data_t>& obj)
+  {
+    copy_qv(obj);
+  }
 
   // Initializes the vector to a custom initial state.
   // If the length of the data vector does not match the number of qubits
@@ -322,7 +333,7 @@ public:
   virtual bool batched_optimization_supported(void)
   {
 #ifdef AER_THRUST_CUDA
-    if(multi_shots_ && enable_batch_)
+    if(enable_batch_)
       return true;
     else
       return false;
@@ -462,6 +473,7 @@ public:
   int get_sample_measure_index_size() {return sample_measure_index_size_;}
 
 protected:
+  void copy_qv(const QubitVectorThrust<data_t>& obj);
 
   //-----------------------------------------------------------------------
   // Protected data members
@@ -479,7 +491,6 @@ protected:
 
   uint_t chunk_index_;
   bool multi_chunk_distribution_;
-  bool multi_shots_;
   mutable bool enable_batch_;
   bool cuStateVec_enable_ = false;
 
@@ -639,7 +650,6 @@ QubitVectorThrust<data_t>::QubitVectorThrust(size_t num_qubits) : num_qubits_(0)
 {
   chunk_index_ = 0;
   multi_chunk_distribution_ = false;
-  multi_shots_ = false;
   enable_batch_ = false;
 
   max_matrix_bits_ = 0;
@@ -671,6 +681,27 @@ QubitVectorThrust<data_t>::~QubitVectorThrust()
     chunk_manager_.reset();
   }
   checkpoint_.clear();
+}
+
+
+template <typename data_t>
+void QubitVectorThrust<data_t>::copy_qv(const QubitVectorThrust<data_t>& obj)
+{
+  omp_threads_ = obj.omp_threads_;
+  omp_threshold_ = obj.omp_threshold_;
+  sample_measure_index_size_ = obj.sample_measure_index_size_;
+  json_chop_threshold_ = obj.json_chop_threshold_;
+  chunk_index_ = obj.chunk_index_;
+  num_threads_per_group_ = obj.num_threads_per_group_;
+  max_matrix_bits_ = obj.max_matrix_bits_;
+
+  if(!chunk_setup(obj, obj.chunk_index_)){
+    throw std::runtime_error("QubitVectorThrust: can not allocate chunk for copy");
+  }
+  set_num_qubits(obj.num_qubits());
+
+  chunk_.CopyIn(obj.chunk_);
+
 }
 
 //------------------------------------------------------------------------------
@@ -870,17 +901,11 @@ bool QubitVectorThrust<data_t>::chunk_setup(int chunk_bits,int num_qubits,uint_t
 }
 
 template <typename data_t>
-bool QubitVectorThrust<data_t>::chunk_setup(QubitVectorThrust<data_t>& base,const uint_t chunk_index)
+bool QubitVectorThrust<data_t>::chunk_setup(const QubitVectorThrust<data_t>& base,const uint_t chunk_index)
 {
   chunk_manager_ = base.chunk_manager_;
 
   multi_chunk_distribution_ = base.multi_chunk_distribution_;
-  if(!multi_chunk_distribution_){
-    if(chunk_manager_->chunk_bits() == chunk_manager_->num_qubits()){
-      multi_shots_ = true;
-      base.multi_shots_ = true;
-    }
-  }
   cuStateVec_enable_ = base.cuStateVec_enable_;
 
   //set global chunk ID / shot ID
@@ -1167,10 +1192,12 @@ uint_t QubitVectorThrust<data_t>::get_chunk_count(void)
       return 0;   //first chunk execute all in batch
   }
   else{   //multi-shots
-    if(enable_batch_ && chunk_.pos() != 0)
+    if(!enable_batch_)
+      return 1;
+    else if(chunk_.pos() != 0)
       return 0;   //first chunk execute all in batch
   }
-  return chunk_.container()->num_chunks();
+  return chunk_.container()->num_chunk_mapped();
 }
 
 //------------------------------------------------------------------------------
@@ -1276,29 +1303,30 @@ void QubitVectorThrust<data_t>::initialize_creg(uint_t num_memory,
   if(chunk_manager_){
     num_creg_bits_ = num_register;
     num_cmem_bits_ = num_memory;
-    if(chunk_.pos() == 0){
+    if(chunk_.pos() == 0)
       chunk_.container()->allocate_creg(num_cmem_bits_,num_creg_bits_);
 
-      int_t i;
-      for(i=0;i<num_register;i++){
-        if(register_hex[register_hex.size() - 1 - i] == '0'){
-          store_cregister(i,0);
-        }
-        else{
-          store_cregister(i,1);
-        }
+    //write bits to host buffer, they are copied to device at first execution
+    int_t i;
+    for(i=0;i<num_register;i++){
+      if(register_hex[register_hex.size() - 1 - i] == '0'){
+        chunk_.write_cbit(i,0);
       }
-      for(i=0;i<num_memory;i++){
-        if(memory_hex[memory_hex.size() - 1 - i] == '0'){
-          store_cregister(i+num_creg_bits_,0);
-        }
-        else{
-          store_cregister(i+num_creg_bits_,1);
-        }
+      else{
+        chunk_.write_cbit(i,1);
+      }
+    }
+    for(i=0;i<num_memory;i++){
+      if(memory_hex[memory_hex.size() - 1 - i] == '0'){
+        chunk_.write_cbit(i+num_creg_bits_,0);
+      }
+      else{
+        chunk_.write_cbit(i+num_creg_bits_,1);
       }
     }
   }
 }
+
 //--------------------------------------------------------------------------------------
 //  gate kernel execution
 //--------------------------------------------------------------------------------------
@@ -1311,7 +1339,7 @@ void QubitVectorThrust<data_t>::apply_function(Function func, uint_t count) cons
   if(chunk_count == 0){
     if(!cuStateVec_enable_ && func.batch_enable() && ((multi_chunk_distribution_ && chunk_.device() >= 0) || enable_batch_)){
       if(chunk_.pos() == 0)        //only first chunk on device calculates all the chunks
-        chunk_count = chunk_.container()->num_chunks();
+        chunk_count = chunk_.container()->num_chunk_mapped();
       else
         return;
     }
@@ -1338,7 +1366,7 @@ void QubitVectorThrust<data_t>::apply_function(Function func, const std::vector<
   if(chunk_count == 0){
     if(!cuStateVec_enable_ && func.batch_enable() && ((multi_chunk_distribution_ && chunk_.device() >= 0) || enable_batch_)){
       if(chunk_.pos() == 0)        //only first chunk on device calculates all the chunks
-        chunk_count = chunk_.container()->num_chunks();
+        chunk_count = chunk_.container()->num_chunk_mapped();
       else
         return;
     }
@@ -1371,7 +1399,7 @@ void QubitVectorThrust<data_t>::apply_function_sum(double* pSum,Function func,bo
         *pSum = 0.0;
       return;
     }
-    count = chunk_.container()->num_chunks();
+    count = chunk_.container()->num_chunk_mapped();
   }
 #endif
 
@@ -1400,7 +1428,7 @@ void QubitVectorThrust<data_t>::apply_function_sum2(double* pSum,Function func,b
       }
       return;
     }
-    count = chunk_.container()->num_chunks();
+    count = chunk_.container()->num_chunk_mapped();
   }
 #endif
 
@@ -1597,7 +1625,7 @@ void QubitVectorThrust<data_t>::apply_multi_swaps(const reg_t &qubits)
   if(count == 0)
     return;
 
-  chunk_.apply_multi_swaps(qubits,chunk_.container()->num_chunks());
+  chunk_.apply_multi_swaps(qubits,chunk_.container()->num_chunk_mapped());
 }
 
 template <typename data_t>
@@ -1913,7 +1941,7 @@ double QubitVectorThrust<data_t>::norm() const
   if(enable_batch_ && ((multi_chunk_distribution_ && chunk_.device() >= 0) || !multi_chunk_distribution_)){
     if(chunk_.pos() != 0)
       return 0.0;   //first chunk execute all in batch
-    count = chunk_.container()->num_chunks();
+    count = chunk_.container()->num_chunk_mapped();
   }
 #endif
 
@@ -2262,7 +2290,7 @@ void QubitVectorThrust<data_t>::apply_batched_measure(const reg_t& qubits,std::v
       return;   //first chunk execute all in batch
     }
   }
-  count = chunk_.container()->num_chunks();
+  count = chunk_.container()->num_chunk_mapped();
 
   //set system register[0] to 1 used for conditional register
   uint_t system_reg = num_creg_bits_ + num_cmem_bits_;
@@ -2284,7 +2312,7 @@ void QubitVectorThrust<data_t>::apply_batched_measure(const reg_t& qubits,std::v
 
   //total probability
   apply_function_sum(nullptr,Chunk::norm_func<data_t>(),true);
-  apply_function(set_probability_buffer_for_reset_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunks(),
+  apply_function(set_probability_buffer_for_reset_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),
                                                                chunk_.reduce_buffer(),chunk_.reduce_buffer_size()) );
 
   reg_t params(qubits.size() + cmemory.size() + cregs.size());
@@ -2311,18 +2339,18 @@ void QubitVectorThrust<data_t>::apply_batched_measure(const reg_t& qubits,std::v
     chunk_.set_conditional(system_reg);
     apply_function_sum(nullptr,Chunk::probability_func<data_t>(qubits,i),true);
 
-    apply_function(check_measure_probability_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunks(),
+    apply_function(check_measure_probability_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),
                                                                         chunk_.reduce_buffer(),chunk_.reduce_buffer_size(),
                                                                         i,cmemory.size(),cregs.size()) );
 
     chunk_.set_conditional(system_reg+1);
-    apply_function(reset_after_measure_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunks(),i ));
+    apply_function(reset_after_measure_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),i ));
     store_cregister(system_reg+1,0);
   }
   //for last case
   chunk_.keep_conditional(false);
   chunk_.set_conditional(system_reg);
-  apply_function(reset_after_measure_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunks(),DIM-1 ));
+  apply_function(reset_after_measure_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),DIM-1 ));
 
   chunk_.container()->request_creg_update();
 }
@@ -2400,7 +2428,7 @@ void QubitVectorThrust<data_t>::apply_batched_reset(const reg_t& qubits,std::vec
       return;   //first chunk execute all in batch
     }
   }
-  count = chunk_.container()->num_chunks();
+  count = chunk_.container()->num_chunk_mapped();
 
   //set system register[0] to 1 used for conditional register
   uint_t system_reg = num_creg_bits_ + num_cmem_bits_;
@@ -2417,12 +2445,13 @@ void QubitVectorThrust<data_t>::apply_batched_reset(const reg_t& qubits,std::vec
     //can be applied to all states
     store_cregister(system_reg,1);
   }
+
   chunk_.set_conditional(system_reg);
   chunk_.keep_conditional(true);
 
   //total probability
   apply_function_sum(nullptr,Chunk::norm_func<data_t>(),true);
-  apply_function(set_probability_buffer_for_reset_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunks(),
+  apply_function(set_probability_buffer_for_reset_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),
                                                                chunk_.reduce_buffer(),chunk_.reduce_buffer_size()) );
 
   //probability
@@ -2437,17 +2466,17 @@ void QubitVectorThrust<data_t>::apply_batched_reset(const reg_t& qubits,std::vec
     chunk_.set_conditional(system_reg);
     apply_function_sum(nullptr,Chunk::probability_func<data_t>(qubits,i),true);
 
-    apply_function(check_measure_probability_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunks(),
+    apply_function(check_measure_probability_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),
                                                                         chunk_.reduce_buffer(),chunk_.reduce_buffer_size(),
                                                                         i,0,0) );
 
     chunk_.set_conditional(system_reg+1);
-    apply_function(reset_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunks(),i ) );
+    apply_function(reset_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),i ) );
     store_cregister(system_reg+1,0);
   }
   chunk_.keep_conditional(false);
   chunk_.set_conditional(system_reg);
-  apply_function(reset_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunks(),DIM-1 ) );
+  apply_function(reset_func<data_t>(qubits.size(),chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),DIM-1 ) );
 }
 
 
@@ -2662,7 +2691,7 @@ reg_t QubitVectorThrust<data_t>::sample_measure(const std::vector<double> &rnds)
   if((multi_chunk_distribution_ && chunk_.device() >= 0) || enable_batch_){
     if(chunk_.pos() != 0)
       return reg_t();   //first chunk execute all in batch
-    count = chunk_.container()->num_chunks();
+    count = chunk_.container()->num_chunk_mapped();
   }
 #endif
 
@@ -3133,7 +3162,7 @@ void QubitVectorThrust<data_t>::apply_batched_kraus(const reg_t &qubits,
   uint_t i,count;
   double ret;
 
-  count = chunk_.container()->num_chunks();
+  count = chunk_.container()->num_chunk_mapped();
 
   //set system register[0] to 1 used for conditional register
   uint_t system_reg = num_creg_bits_ + num_cmem_bits_;
@@ -3154,7 +3183,7 @@ void QubitVectorThrust<data_t>::apply_batched_kraus(const reg_t &qubits,
   chunk_.keep_conditional(true);
 
   //total probability
-  apply_function(set_probability_buffer_for_reset_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunks(),
+  apply_function(set_probability_buffer_for_reset_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),
                                                                nullptr,0) );
 
   std::vector<double> r(count);
@@ -3170,12 +3199,12 @@ void QubitVectorThrust<data_t>::apply_batched_kraus(const reg_t &qubits,
       chunk_.set_conditional(system_reg);
       apply_function_sum(nullptr,Chunk::NormMatrixMult2x2<data_t>(vmat,qubits[0]),true);
 
-      apply_function(check_kraus_probability_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunks(),
+      apply_function(check_kraus_probability_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),
                                                           chunk_.reduce_buffer(),chunk_.reduce_buffer_size() ) );
 
       //multiply only when system reg[1] is 1
       chunk_.set_conditional(system_reg+1);
-      apply_function(MatrixMult2x2_conditional<data_t>(vmat,qubits[0],chunk_.probability_buffer(),chunk_.container()->num_chunks()) );
+      apply_function(MatrixMult2x2_conditional<data_t>(vmat,qubits[0],chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped()) );
       store_cregister(system_reg+1,0);
     }
   }
@@ -3192,12 +3221,12 @@ void QubitVectorThrust<data_t>::apply_batched_kraus(const reg_t &qubits,
       chunk_.StoreMatrix(Utils::vectorize_matrix(kmats[i]));
       apply_function_sum(nullptr,Chunk::NormMatrixMultNxN<data_t>(N),true);
 
-      apply_function(check_kraus_probability_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunks(),
+      apply_function(check_kraus_probability_func<data_t>(chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped(),
                                                           chunk_.reduce_buffer(),chunk_.reduce_buffer_size() ) );
 
       //multiply only when system reg[1] is 1
       chunk_.set_conditional(system_reg+1);
-      apply_function(MatrixMultNxN_conditional<data_t>(N,chunk_.probability_buffer(),chunk_.container()->num_chunks()) );
+      apply_function(MatrixMultNxN_conditional<data_t>(N,chunk_.probability_buffer(),chunk_.container()->num_chunk_mapped()) );
       store_cregister(system_reg+1,0);
     }
   }
@@ -3423,8 +3452,8 @@ void QubitVectorThrust<data_t>::apply_roerror(const Operations::Op &op, std::vec
   }
   params.push_back(offset);
 
-  std::vector<double> r(chunk_.container()->num_chunks());
-  for(i=0;i<chunk_.container()->num_chunks();i++){
+  std::vector<double> r(chunk_.container()->num_chunk_mapped());
+  for(i=0;i<chunk_.container()->num_chunk_mapped();i++){
     r[i] = rng[i].rand(0., 1.);
   }
   chunk_.container()->copy_to_probability_buffer(r,0);

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -49,7 +49,8 @@ const Operations::OpSet StateOpSet(
      OpType::save_amps, OpType::save_amps_sq,
      OpType::save_state, OpType::save_statevec,
      OpType::save_statevec_dict, OpType::save_densmat,
-     OpType::jump, OpType::mark
+     OpType::jump, OpType::mark,
+     OpType::sample_noise
      },
     // Gates
     {"u1",     "u2",      "u3",  "u",    "U",    "CX",   "cx",   "cz",
@@ -116,50 +117,73 @@ public:
 
   // Apply an operation
   // If the op is not in allowed_ops an exeption will be raised.
-  void apply_op(const int_t iChunk, const Operations::Op &op,
+  void apply_op(QuantumState::RegistersBase& state, 
+                const Operations::Op &op,
+                ExperimentResult &result,
+                RngEngine& rng,
+                bool final_op = false) override;
+
+  //apply_op for specific chunk
+  void apply_op_chunk(uint_t iChunk, QuantumState::RegistersBase& state, 
+                        const Operations::Op &op,
                         ExperimentResult &result,
                         RngEngine& rng,
                         bool final_op = false) override;
-
-  // Initializes an n-qubit state to the all |0> state
-  virtual void initialize_qreg(uint_t num_qubits) override;
-
-  // Initializes to a specific n-qubit state
-  virtual void initialize_statevector(uint_t num_qubits,
-                                      statevec_t &&state);
 
   // Returns the required memory for storing an n-qubit state in megabytes.
   // For this state the memory is independent of the number of ops
   // and is approximately 16 * 1 << num_qubits bytes
   virtual size_t
   required_memory_mb(uint_t num_qubits,
-                     const std::vector<Operations::Op> &ops) const override;
-
-  // Load the threshold for applying OpenMP parallelization
-  // if the controller/engine allows threads for it
-  virtual void set_config(const json_t &config) override;
+                     QuantumState::OpItr first, QuantumState::OpItr last) const override;
 
   // Sample n-measurement outcomes without applying the measure operation
   // to the system state
-  virtual std::vector<reg_t> sample_measure(const reg_t &qubits, uint_t shots,
+  virtual std::vector<reg_t> sample_measure(QuantumState::RegistersBase& state, const reg_t &qubits, uint_t shots,
                                             RngEngine &rng) override;
 
   //-----------------------------------------------------------------------
   // Additional methods
   //-----------------------------------------------------------------------
+  // Initializes to a specific n-qubit state given as a complex std::vector
+  void initialize_qreg_from_data(uint_t num_qubits, const cvector_t &state);
 
   // Initialize OpenMP settings for the underlying QubitVector class
-  void initialize_omp();
+  void initialize_omp(QuantumState::Registers<statevec_t>& state);
 
-  auto move_to_vector(const int_t iChunk);
-  auto copy_to_vector(const int_t iChunk);
+  auto move_to_vector(QuantumState::Registers<statevec_t>& state);
+  auto copy_to_vector(QuantumState::Registers<statevec_t>& state);
+
+  //Does this state support runtime noise sampling?
+  bool runtime_noise_sampling_supported(void) override {return true;}
 
 protected:
+  // Initialize classical memory and register to default value (all-0)
+  void initialize_creg_state(QuantumState::RegistersBase& state, uint_t num_memory, uint_t num_register) override;
+
+  // Initialize classical memory and register to specific values
+  void initialize_creg_state(QuantumState::RegistersBase& state, 
+                       uint_t num_memory,
+                       uint_t num_register,
+                       const std::string &memory_hex,
+                       const std::string &register_hex) override;
+  void initialize_creg_state(QuantumState::RegistersBase& state, const ClassicalRegister& creg) override;
+
+  // Initializes an n-qubit state to the all |0> state
+  void initialize_qreg_state(QuantumState::RegistersBase& state, const uint_t num_qubits) override;
+
+  // Initializes to a specific n-qubit state
+  void initialize_qreg_state(QuantumState::RegistersBase& state, const statevec_t &vector) override;
+
+  // Load the threshold for applying OpenMP parallelization
+  // if the controller/engine allows threads for it
+  void set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) override;
+
   //-----------------------------------------------------------------------
   // Apply instructions
   //-----------------------------------------------------------------------
   //apply op to multiple shots , return flase if op is not supported to execute in a batch
-  bool apply_batched_op(const int_t iChunk, const Operations::Op &op,
+  bool apply_batched_op(const int_t iChunk, QuantumState::RegistersBase& state, const Operations::Op &op,
                                 ExperimentResult &result,
                                 std::vector<RngEngine> &rng,
                                 bool final_op = false) override;
@@ -167,55 +191,55 @@ protected:
 
   // Applies a sypported Gate operation to the state class.
   // If the input is not in allowed_gates an exeption will be raised.
-  void apply_gate(const int_t iChunk, const Operations::Op &op);
+  void apply_gate(statevec_t& qreg, const Operations::Op &op);
 
   // Measure qubits and return a list of outcomes [q0, q1, ...]
   // If a state subclass supports this function it then "measure"
   // should be contained in the set returned by the 'allowed_ops'
   // method.
-  virtual void apply_measure(const int_t iChunk, const reg_t &qubits, const reg_t &cmemory,
+  virtual void apply_measure(QuantumState::Registers<statevec_t>& state, const reg_t &qubits, const reg_t &cmemory,
                              const reg_t &cregister, RngEngine &rng);
 
   // Reset the specified qubits to the |0> state by simulating
   // a measurement, applying a conditional x-gate if the outcome is 1, and
   // then discarding the outcome.
-  void apply_reset(const int_t iChunk, const reg_t &qubits, RngEngine &rng);
+  void apply_reset(QuantumState::Registers<statevec_t>& state, const reg_t &qubits, RngEngine &rng);
 
   // Initialize the specified qubits to a given state |psi>
   // by applying a reset to the these qubits and then
   // computing the tensor product with the new state |psi>
   // /psi> is given in params
-  void apply_initialize(const int_t iChunk, const reg_t &qubits, const cvector_t &params,
+  void apply_initialize(QuantumState::Registers<statevec_t>& state, const reg_t &qubits, const cvector_t &params,
                         RngEngine &rng);
 
-  void initialize_from_vector(const int_t iChunk, const cvector_t &params);
+  void initialize_from_vector(QuantumState::Registers<statevec_t>& state, const cvector_t &params);
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const int_t iChunk, const Operations::Op &op, ExperimentResult &result, bool last_op = false);
+  virtual void apply_snapshot(QuantumState::Registers<statevec_t>& state, const Operations::Op &op, ExperimentResult &result, bool last_op = false);
 
   // Apply a matrix to given qubits (identity on all other qubits)
-  void apply_matrix(const int_t iChunk, const Operations::Op &op);
+  void apply_matrix(statevec_t& qreg, const Operations::Op &op);
 
   // Apply a vectorized matrix to given qubits (identity on all other qubits)
-  void apply_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t &vmat);
+  void apply_matrix(statevec_t& qreg, const reg_t &qubits, const cvector_t &vmat);
 
   //apply diagonal matrix
-  void apply_diagonal_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t & diag); 
+  void apply_diagonal_matrix(statevec_t& qreg, const reg_t &qubits, const cvector_t & diag); 
 
   // Apply a vector of control matrices to given qubits (identity on all other
   // qubits)
-  void apply_multiplexer(const int_t iChunk, const reg_t &control_qubits,
+  void apply_multiplexer(statevec_t& qreg, const reg_t &control_qubits,
                          const reg_t &target_qubits,
                          const std::vector<cmatrix_t> &mmat);
 
   // Apply stacked (flat) version of multiplexer matrix to target qubits (using
   // control qubits to select matrix instance)
-  void apply_multiplexer(const int_t iChunk, const reg_t &control_qubits,
+  void apply_multiplexer(statevec_t& qreg, const reg_t &control_qubits,
                          const reg_t &target_qubits, const cmatrix_t &mat);
 
   // Apply a Kraus error operation
-  void apply_kraus(const int_t iChunk, const reg_t &qubits, const std::vector<cmatrix_t> &krausops,
+  void apply_kraus(QuantumState::Registers<statevec_t>& state, const reg_t &qubits, const std::vector<cmatrix_t> &krausops,
                    RngEngine &rng);
 
   //-----------------------------------------------------------------------
@@ -226,28 +250,31 @@ protected:
   // If `last_op` is True this will use move semantics to move the simulator
   // state to the results, otherwise it will use copy semantics to leave
   // the current simulator state unchanged.
-  void apply_save_statevector(const int_t iChunk, const Operations::Op &op,
+  void apply_save_statevector(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                               ExperimentResult &result,
                               bool last_op);
 
   // Save the current state of the statevector simulator as a ket-form map.
-  void apply_save_statevector_dict(const int_t iChunk, const Operations::Op &op,
+  void apply_save_statevector_dict(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                   ExperimentResult &result);
 
   // Save the current density matrix or reduced density matrix
-  void apply_save_density_matrix(const int_t iChunk, const Operations::Op &op,
+  void apply_save_density_matrix(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                  ExperimentResult &result);
 
   // Helper function for computing expectation value
-  void apply_save_probs(const int_t iChunk, const Operations::Op &op,
+  void apply_save_probs(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                         ExperimentResult &result);
 
   // Helper function for saving amplitudes and amplitudes squared
-  void apply_save_amplitudes(const int_t iChunk, const Operations::Op &op,
+  void apply_save_amplitudes(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                              ExperimentResult &result);
 
+  // Apply a save expectation value instruction
+  void apply_save_expval(QuantumState::Registers<statevec_t>& state, const Operations::Op &op, ExperimentResult &result);
+
   // Helper function for computing expectation value
-  virtual double expval_pauli(const int_t iChunk, const reg_t &qubits,
+  double expval_pauli(QuantumState::RegistersBase& state, const reg_t &qubits,
                               const std::string& pauli) override;
   //-----------------------------------------------------------------------
   // Measurement Helpers
@@ -258,7 +285,7 @@ protected:
   // should be contained in the set returned by the 'allowed_ops'
   // method.
   // TODO: move to private (no longer part of base class)
-  rvector_t measure_probs(const int_t iChunk, const reg_t &qubits) const;
+  rvector_t measure_probs(QuantumState::Registers<statevec_t>& state, const reg_t &qubits) const;
 
   // Sample the measurement outcome for qubits
   // return a pair (m, p) of the outcome m, and its corresponding
@@ -268,12 +295,17 @@ protected:
   // 1 -> |q1 = 0, q0 = 1> state
   // 2 -> |q1 = 1, q0 = 0> state
   // 3 -> |q1 = 1, q0 = 1> state
-  std::pair<uint_t, double> sample_measure_with_prob(const int_t iChunk, const reg_t &qubits,
+  std::pair<uint_t, double> sample_measure_with_prob(QuantumState::Registers<statevec_t>& state, const reg_t &qubits,
                                                      RngEngine &rng);
+  rvector_t sample_measure_with_prob_shot_branching(QuantumState::Registers<statevec_t>& state, const reg_t &qubits);
 
-  void measure_reset_update(const int_t iChunk, const std::vector<uint_t> &qubits,
+  void measure_reset_update(QuantumState::Registers<statevec_t>& state, const std::vector<uint_t> &qubits,
                             const uint_t final_state, const uint_t meas_state,
                             const double meas_prob);
+  void measure_reset_update_shot_branching(
+                             QuantumState::Registers<statevec_t>& state, const std::vector<uint_t> &qubits,
+                             const int_t final_state,
+                             const rvector_t& meas_probs);
 
   //-----------------------------------------------------------------------
   // Special snapshot types
@@ -285,23 +317,23 @@ protected:
   //-----------------------------------------------------------------------
 
   // Snapshot current qubit probabilities for a measurement (average)
-  void snapshot_probabilities(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
+  void snapshot_probabilities(QuantumState::Registers<statevec_t>& state, const Operations::Op &op, ExperimentResult &result,
                               SnapshotDataType type);
 
   // Snapshot the expectation value of a Pauli operator
-  void snapshot_pauli_expval(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
+  void snapshot_pauli_expval(QuantumState::Registers<statevec_t>& state, const Operations::Op &op, ExperimentResult &result,
                              SnapshotDataType type);
 
   // Snapshot the expectation value of a matrix operator
-  void snapshot_matrix_expval(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
+  void snapshot_matrix_expval(QuantumState::Registers<statevec_t>& state, const Operations::Op &op, ExperimentResult &result,
                               SnapshotDataType type);
 
   // Snapshot reduced density matrix
-  void snapshot_density_matrix(const int_t iChunk, const Operations::Op &op, ExperimentResult &result,
+  void snapshot_density_matrix(QuantumState::Registers<statevec_t>& state, const Operations::Op &op, ExperimentResult &result,
                                SnapshotDataType type);
 
   // Return the reduced density matrix for the simulator
-  cmatrix_t density_matrix(const int_t iChunk, const reg_t &qubits);
+  cmatrix_t density_matrix(QuantumState::Registers<statevec_t>& state, const reg_t &qubits);
 
   // Helper function to convert a vector to a reduced density matrix
   template <class T> cmatrix_t vec2density(const reg_t &qubits, const T &vec);
@@ -311,7 +343,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Optimize phase gate with diagonal [1, phase]
-  void apply_gate_phase(const int_t iChunk, const uint_t qubit, const complex_t phase);
+  void apply_gate_phase(statevec_t& qreg, const uint_t qubit, const complex_t phase);
 
   //-----------------------------------------------------------------------
   // Multi-controlled u3
@@ -320,7 +352,7 @@ protected:
   // Apply N-qubit multi-controlled single qubit gate specified by
   // 4 parameters u4(theta, phi, lambda, gamma)
   // NOTE: if N=1 this is just a regular u4 gate.
-  void apply_gate_mcu(const int_t iChunk, const reg_t &qubits, const double theta,
+  void apply_gate_mcu(statevec_t& qreg, const reg_t &qubits, const double theta,
                       const double phi, const double lambda,
                       const double gamma);
 
@@ -329,7 +361,7 @@ protected:
   //-----------------------------------------------------------------------
 
   // Apply the global phase
-  void apply_global_phase();
+  void apply_global_phase(QuantumState::RegistersBase& state) override;
 
   // OpenMP qubit threshold
   int omp_qubit_threshold_ = 14;
@@ -345,6 +377,13 @@ protected:
 
   // Table of allowed snapshot types to enum class members
   const static stringmap_t<Snapshots> snapshotset_;
+
+  bool shot_branching_supported(void) override
+  {
+    if(BaseState::multi_chunk_distribution_)
+      return false;   //disable shot branching if multi-chunk distribution is used
+    return true;
+  }
 
 };
 
@@ -446,16 +485,18 @@ const stringmap_t<Snapshots> State<statevec_t>::snapshotset_(
 //-------------------------------------------------------------------------
 
 template <class statevec_t>
-void State<statevec_t>::initialize_qreg(uint_t num_qubits) 
+void State<statevec_t>::initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits) 
 {
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
   int_t i;
-  if(BaseState::qregs_.size() == 0)
-    BaseState::allocate(num_qubits,num_qubits,1);
+  if(state.qregs().size() == 0)
+    BaseState::allocate(num_qubits,BaseState::chunk_bits_,1);
 
-  initialize_omp();
+  initialize_omp(state);
 
-  for(i=0;i<BaseState::qregs_.size();i++){
-    BaseState::qregs_[i].set_num_qubits(BaseState::chunk_bits_);
+  for(i=0;i<state.qregs().size();i++){
+    state.qregs()[i].set_num_qubits(BaseState::chunk_bits_);
   }
 
   if(BaseState::multi_chunk_distribution_){
@@ -464,147 +505,206 @@ void State<statevec_t>::initialize_qreg(uint_t num_qubits)
       for(int_t ig=0;ig<BaseState::num_groups_;ig++){
         for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++){
           if(BaseState::global_chunk_index_ + iChunk == 0 || this->num_qubits_ == this->chunk_bits_){
-            BaseState::qregs_[iChunk].initialize();
+            state.qregs()[iChunk].initialize();
           }
           else{
-            BaseState::qregs_[iChunk].zero();
+            state.qregs()[iChunk].zero();
           }
         }
       }
     }
     else{
-      for(i=0;i<BaseState::qregs_.size();i++){
+      for(i=0;i<state.qregs().size();i++){
         if(BaseState::global_chunk_index_ + i == 0 || this->num_qubits_ == this->chunk_bits_){
-          BaseState::qregs_[i].initialize();
+          state.qregs()[i].initialize();
         }
         else{
-          BaseState::qregs_[i].zero();
+          state.qregs()[i].zero();
         }
       }
     }
   }
   else{
-    for(i=0;i<BaseState::qregs_.size();i++){
-      BaseState::qregs_[i].initialize();
+    for(i=0;i<state.qregs().size();i++){
+      state.qregs()[i].initialize();
     }
   }
-  apply_global_phase();
+  apply_global_phase(state);
 }
 
 template <class statevec_t>
-void State<statevec_t>::initialize_statevector(uint_t num_qubits,
-                                               statevec_t &&state) 
+void State<statevec_t>::initialize_qreg_state(QuantumState::RegistersBase& state_in, const statevec_t &vector) 
 {
-  if (state.num_qubits() != num_qubits) {
+  if (vector.num_qubits() != BaseState::num_qubits_) {
     throw std::invalid_argument("QubitVector::State::initialize: initial state does not match qubit number");
   }
 
-  if (BaseState::qregs_.size() == 1) {
-    BaseState::qregs_[0] = std::move(state);
-  } else {
-    if(BaseState::qregs_.size() == 0)
-      BaseState::allocate(num_qubits,num_qubits,1);
-    initialize_omp();
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
 
-    int_t iChunk;
-    for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-      BaseState::qregs_[iChunk].set_num_qubits(BaseState::chunk_bits_);
-    }
+  if(state.qregs().size() == 0)
+    BaseState::allocate(BaseState::num_qubits_,BaseState::chunk_bits_,1);
+  initialize_omp(state);
 
-    if(BaseState::multi_chunk_distribution_){
-      uint_t local_offset = BaseState::global_chunk_index_ << BaseState::chunk_bits_;
-      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
+  int_t iChunk;
+  for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+    state.qregs()[iChunk].set_num_qubits(BaseState::chunk_bits_);
+  }
+
+  if(BaseState::multi_chunk_distribution_){
+    uint_t local_offset = BaseState::global_chunk_index_ << BaseState::chunk_bits_;
+    if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for private(iChunk)
-        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          for(iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++)
-            BaseState::qregs_[iChunk].initialize_from_data(state.data() + local_offset + (iChunk << BaseState::chunk_bits_), 1ull << BaseState::chunk_bits_);
-        }
-      }
-      else{
-        for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++)
-          BaseState::qregs_[iChunk].initialize_from_data(state.data() + local_offset + (iChunk << BaseState::chunk_bits_), 1ull << BaseState::chunk_bits_);
+      for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+        for(iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++)
+          state.qregs()[iChunk].initialize_from_data(vector.data() + local_offset + (iChunk << BaseState::chunk_bits_), 1ull << BaseState::chunk_bits_);
       }
     }
     else{
-      for(iChunk=0;iChunk<BaseState::qregs_.size();iChunk++){
-        BaseState::qregs_[iChunk].initialize_from_data(state.data(), 1ull << BaseState::chunk_bits_);
-      }
+      for(iChunk=0;iChunk<state.qregs().size();iChunk++)
+        state.qregs()[iChunk].initialize_from_data(vector.data() + local_offset + (iChunk << BaseState::chunk_bits_), 1ull << BaseState::chunk_bits_);
     }
   }
-
-  apply_global_phase();
+  else{
+    for(iChunk=0;iChunk<state.qregs().size();iChunk++){
+      state.qregs()[iChunk].initialize_from_data(vector.data(), 1ull << BaseState::chunk_bits_);
+    }
+  }
+  apply_global_phase(state);
 }
 
-template <class statevec_t> void State<statevec_t>::initialize_omp() 
+template <class statevec_t>
+void State<statevec_t>::initialize_qreg_from_data(uint_t num_qubits,
+                                        const cvector_t &vector) 
+{
+  if (vector.size() != 1ULL << num_qubits) {
+    throw std::invalid_argument("QubitVector::State::initialize: initial state does not match qubit number");
+  }
+
+  QuantumState::Registers<statevec_t>& state = BaseState::state_;
+
+  if(BaseState::state_.qregs().size() == 0)
+    BaseState::allocate(num_qubits,BaseState::chunk_bits_,1);
+
+  initialize_omp(BaseState::state_);
+
+  int_t iChunk;
+  for(iChunk=0;iChunk<BaseState::state_.qregs().size();iChunk++){
+    BaseState::state_.qregs()[iChunk].set_num_qubits(BaseState::chunk_bits_);
+  }
+
+  initialize_from_vector(BaseState::state_, vector);
+  apply_global_phase(BaseState::state_);
+}
+
+template <class statevec_t> void State<statevec_t>::initialize_omp(QuantumState::Registers<statevec_t>& state) 
 {
   uint_t i;
 
-  for(i=0;i<BaseState::qregs_.size();i++){
-    BaseState::qregs_[i].set_omp_threshold(omp_qubit_threshold_);
+  for(i=0;i<state.qregs().size();i++){
+    state.qregs()[i].set_omp_threshold(omp_qubit_threshold_);
     if (BaseState::threads_ > 0)
-      BaseState::qregs_[i].set_omp_threads(BaseState::threads_); // set allowed OMP threads in qubitvector
+      state.qregs()[i].set_omp_threads(BaseState::threads_); // set allowed OMP threads in qubitvector
   }
 }
 
+template <class statevec_t>
+void State<statevec_t>::initialize_creg_state(QuantumState::RegistersBase& state_in, uint_t num_memory, uint_t num_register) 
+{
+  BaseState::initialize_creg_state(state_in, num_memory, num_register);
+
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
+  for(int_t i=0;i<state.qregs().size();i++)
+    state.qreg(i).initialize_creg(num_memory, num_register);
+}
+
+
+template <class statevec_t>
+void State<statevec_t>::initialize_creg_state(QuantumState::RegistersBase& state_in, 
+                                     uint_t num_memory,
+                                     uint_t num_register,
+                                     const std::string &memory_hex,
+                                     const std::string &register_hex) 
+{
+  BaseState::initialize_creg_state(state_in, num_memory, num_register, memory_hex, register_hex);
+
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
+  for(int_t i=0;i<state.qregs().size();i++)
+    state.qreg(i).initialize_creg(num_memory, num_register, memory_hex, register_hex);
+}
+
+template <class statevec_t>
+void State<statevec_t>::initialize_creg_state(QuantumState::RegistersBase& state_in, const ClassicalRegister& creg)
+{
+  BaseState::initialize_creg_state(state_in, creg);
+
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
+  for(int_t i=0;i<state.qregs().size();i++)
+    state.qreg(i).initialize_creg(creg.memory_size(), creg.register_size(), creg.memory_hex(), creg.register_hex());
+}
 
 //-------------------------------------------------------------------------
 // Utility
 //-------------------------------------------------------------------------
 
 template <class statevec_t>
-void State<statevec_t>::apply_global_phase() 
+void State<statevec_t>::apply_global_phase(QuantumState::RegistersBase& state_in) 
 {
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
   if (BaseState::has_global_phase_) {
     int_t i;
     if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 0){
 #pragma omp parallel for 
       for(int_t ig=0;ig<BaseState::num_groups_;ig++){
         for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++)
-          BaseState::qregs_[iChunk].apply_diagonal_matrix({0}, {BaseState::global_phase_, BaseState::global_phase_});
+          state.qreg(iChunk).apply_diagonal_matrix({0}, {BaseState::global_phase_, BaseState::global_phase_});
       }
     }
     else{
-      for(i=0;i<BaseState::qregs_.size();i++)
-        BaseState::qregs_[i].apply_diagonal_matrix({0}, {BaseState::global_phase_, BaseState::global_phase_});
+      for(i=0;i<state.qregs().size();i++)
+        state.qreg(i).apply_diagonal_matrix({0}, {BaseState::global_phase_, BaseState::global_phase_});
     }
   }
 }
 
 template <class statevec_t>
 size_t State<statevec_t>::required_memory_mb(uint_t num_qubits,
-                                             const std::vector<Operations::Op> &ops)
+                                             QuantumState::OpItr first, QuantumState::OpItr last)
                                              const 
 {
-  (void)ops; // avoid unused variable compiler warning
+  (void)first; // avoid unused variable compiler warning
+  (void)last;
   statevec_t tmp;
   return tmp.required_memory_mb(num_qubits);
 }
 
 template <class statevec_t>
-void State<statevec_t>::set_config(const json_t &config) {
-  BaseState::set_config(config);
-
-  // Set threshold for truncating snapshots
-  JSON::get_value(json_chop_threshold_, "zero_threshold", config);
-  for(int_t i=0;i<BaseState::qregs_.size();i++){
-    BaseState::qregs_[i].set_json_chop_threshold(json_chop_threshold_);
-  }
+void State<statevec_t>::set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) 
+{
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+  double thresh;
 
   // Set OMP threshold for state update functions
+  // Set threshold for truncating snapshots
+  JSON::get_value(json_chop_threshold_, "zero_threshold", config);
   JSON::get_value(omp_qubit_threshold_, "statevector_parallel_threshold", config);
+  thresh = json_chop_threshold_;
 
   // Set the sample measure indexing size
   int index_size;
-  if (JSON::get_value(index_size, "statevector_sample_measure_opt", config)) {
-    for(int_t i=0;i<BaseState::qregs_.size();i++){
-      BaseState::qregs_[i].set_sample_measure_index_size(index_size);
-    }
+  JSON::get_value(index_size, "statevector_sample_measure_opt", config);
+  for(int_t i=0;i<state.qregs().size();i++){
+    state.qregs()[i].set_json_chop_threshold(thresh);
+    state.qregs()[i].set_sample_measure_index_size(index_size);
   }
 }
 
 
 template <class statevec_t>
-auto State<statevec_t>::move_to_vector(const int_t iChunkIn)
+auto State<statevec_t>::move_to_vector(QuantumState::Registers<statevec_t>& state)
 {
   if(BaseState::multi_chunk_distribution_){
     size_t size_required = 2*(sizeof(std::complex<double>) << BaseState::num_qubits_) + (sizeof(std::complex<double>) << BaseState::chunk_bits_)*BaseState::num_local_chunks_;
@@ -612,56 +712,55 @@ auto State<statevec_t>::move_to_vector(const int_t iChunkIn)
       throw std::runtime_error(std::string("There is not enough memory to store states"));
     }
     int_t iChunk;
-    auto state = BaseState::qregs_[0].move_to_vector();
-    state.resize(BaseState::num_local_chunks_ << BaseState::chunk_bits_);
+    auto out = state.qreg(0).move_to_vector();
+    out.resize(BaseState::num_local_chunks_ << BaseState::chunk_bits_);
 
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(iChunk)
-    for(iChunk=1;iChunk<BaseState::qregs_.size();iChunk++){
-      auto tmp = BaseState::qregs_[iChunk].move_to_vector();
+    for(iChunk=1;iChunk<state.qregs().size();iChunk++){
+      auto tmp = state.qreg(iChunk).move_to_vector();
       uint_t j,offset = iChunk << BaseState::chunk_bits_;
       for(j=0;j<tmp.size();j++){
-        state[offset + j] = tmp[j];
+        out[offset + j] = tmp[j];
       }
     }
 
 #ifdef AER_MPI
-    BaseState::gather_state(state);
+    BaseState::gather_state(out);
 #endif
-    return state;
-  }
-  else {
-    return std::move(BaseState::qregs_[iChunkIn].move_to_vector());
-  }
-}
-
-template <class statevec_t>
-auto State<statevec_t>::copy_to_vector(const int_t iChunkIn)
-{
-  if(BaseState::multi_chunk_distribution_){
-    size_t size_required = 2*(sizeof(std::complex<double>) << BaseState::num_qubits_) + (sizeof(std::complex<double>) << BaseState::chunk_bits_)*BaseState::num_local_chunks_;
-    if((size_required >> 20) > Utils::get_system_memory_mb()){
-      throw std::runtime_error(std::string("There is not enough memory to store states"));
-    }
-    int_t iChunk;
-    auto state = BaseState::qregs_[0].copy_to_vector();
-    state.resize(BaseState::num_local_chunks_ << BaseState::chunk_bits_);
-
-#pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(iChunk)
-    for(iChunk=1;iChunk<BaseState::qregs_.size();iChunk++){
-      auto tmp = BaseState::qregs_[iChunk].copy_to_vector();
-      uint_t j,offset = iChunk << BaseState::chunk_bits_;
-      for(j=0;j<tmp.size();j++){
-        state[offset + j] = tmp[j];
-      }
-    }
-
-#ifdef AER_MPI
-    BaseState::gather_state(state);
-#endif
-    return state;
+    return out;
   }
   else
-    return BaseState::qregs_[iChunkIn].copy_to_vector();
+    return state.qreg().move_to_vector();
+}
+
+template <class statevec_t>
+auto State<statevec_t>::copy_to_vector(QuantumState::Registers<statevec_t>& state)
+{
+  if(BaseState::multi_chunk_distribution_){
+    size_t size_required = 2*(sizeof(std::complex<double>) << BaseState::num_qubits_) + (sizeof(std::complex<double>) << BaseState::chunk_bits_)*BaseState::num_local_chunks_;
+    if((size_required >> 20) > Utils::get_system_memory_mb()){
+      throw std::runtime_error(std::string("There is not enough memory to store states"));
+    }
+    int_t iChunk;
+    auto out = state.qreg(0).copy_to_vector();
+    out.resize(BaseState::num_local_chunks_ << BaseState::chunk_bits_);
+
+#pragma omp parallel for if(BaseState::chunk_omp_parallel_) private(iChunk)
+    for(iChunk=1;iChunk<state.qregs().size();iChunk++){
+      auto tmp = state.qreg(iChunk).copy_to_vector();
+      uint_t j,offset = iChunk << BaseState::chunk_bits_;
+      for(j=0;j<tmp.size();j++){
+        out[offset + j] = tmp[j];
+      }
+    }
+
+#ifdef AER_MPI
+    BaseState::gather_state(out);
+#endif
+    return out;
+  }
+  else
+  return state.qreg().copy_to_vector();
 }
 
 
@@ -669,83 +768,150 @@ auto State<statevec_t>::copy_to_vector(const int_t iChunkIn)
 // Implementation: apply operations
 //=========================================================================
 template <class statevec_t>
-void State<statevec_t>::apply_op(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::apply_op(QuantumState::RegistersBase& state_in,
+                        const Operations::Op &op,
                         ExperimentResult &result,
                         RngEngine& rng,
                         bool final_op)
 {
-  if(BaseState::check_conditional(iChunk, op)) {
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
+  if(BaseState::enable_batch_execution_ && state.qreg().batched_optimization_supported()){
+    if(op.conditional){
+      state.qreg().set_conditional(op.conditional_reg);
+    }
+    if(state.additional_ops().size() == 0)
+      state.qreg().enable_batch(true);
+    else
+      state.qreg().enable_batch(false);
+  }
+  else if(!state.creg().check_conditional(op))
+    return;
+
+  switch (op.type) {
+    case OpType::barrier:
+    case OpType::nop:
+    case OpType::qerror_loc:
+      break;
+    case OpType::reset:
+      apply_reset(state, op.qubits, rng);
+      break;
+    case OpType::initialize:
+      apply_initialize(state, op.qubits, op.params, rng);
+      break;
+    case OpType::measure:
+      apply_measure(state, op.qubits, op.memory, op.registers, rng);
+      break;
+    case OpType::bfunc:
+      state.creg().apply_bfunc(op);
+      break;
+    case OpType::roerror:
+      state.creg().apply_roerror(op, rng);
+      break;
+    case OpType::gate:
+      for(int_t i=0;i<state.qregs().size();i++)
+        apply_gate(state.qreg(i), op);
+      break;
+    case OpType::snapshot:
+      apply_snapshot(state, op, result, final_op);
+      break;
+    case OpType::matrix:
+      for(int_t i=0;i<state.qregs().size();i++)
+        apply_matrix(state.qreg(i), op);
+      break;
+    case OpType::diagonal_matrix:
+      for(int_t i=0;i<state.qregs().size();i++)
+        apply_diagonal_matrix(state.qreg(i), op.qubits, op.params);
+      break;
+    case OpType::multiplexer:
+      for(int_t i=0;i<state.qregs().size();i++){
+        apply_multiplexer(state.qreg(i), op.regs[0], op.regs[1],
+                        op.mats); // control qubits ([0]) & target qubits([1])
+      }
+      break;
+    case OpType::kraus:
+      apply_kraus(state, op.qubits, op.mats, rng);
+      break;
+    case OpType::sim_op:
+      if(op.name == "begin_register_blocking"){
+        state.qreg().enter_register_blocking(op.qubits);
+      }
+      else if(op.name == "end_register_blocking"){
+        state.qreg().leave_register_blocking();
+      }
+      break;
+    case OpType::set_statevec:
+      initialize_from_vector(state, op.params);
+      break;
+    case OpType::save_expval:
+    case OpType::save_expval_var:
+      apply_save_expval(state, op, result);
+      break;
+    case OpType::save_densmat:
+      apply_save_density_matrix(state, op, result);
+      break;
+    case OpType::save_state:
+    case OpType::save_statevec:
+      apply_save_statevector(state, op, result, final_op);
+      break;
+    case OpType::save_statevec_dict:
+      apply_save_statevector_dict(state, op, result);
+      break;
+    case OpType::save_probs:
+    case OpType::save_probs_ket:
+      apply_save_probs(state, op, result);
+      break;
+    case OpType::save_amps:
+    case OpType::save_amps_sq:
+      apply_save_amplitudes(state, op, result);
+      break;
+    default:
+      throw std::invalid_argument(
+          "QubitVector::State::invalid instruction \'" + op.name + "\'.");
+  }
+}
+
+template <class statevec_t>
+void State<statevec_t>::apply_op_chunk(uint_t iChunk, QuantumState::RegistersBase& state_in, 
+                        const Operations::Op &op,
+                        ExperimentResult &result,
+                        RngEngine& rng,
+                        bool final_op)
+{
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
+  if(state.creg().check_conditional(op)) {
     switch (op.type) {
       case OpType::barrier:
       case OpType::nop:
       case OpType::qerror_loc:
         break;
-      case OpType::reset:
-        apply_reset(iChunk, op.qubits, rng);
-        break;
-      case OpType::initialize:
-        apply_initialize(iChunk, op.qubits, op.params, rng);
-        break;
-      case OpType::measure:
-        apply_measure(iChunk, op.qubits, op.memory, op.registers, rng);
-        break;
       case OpType::bfunc:
-        BaseState::cregs_[0].apply_bfunc(op);
+        state.creg().apply_bfunc(op);
         break;
       case OpType::roerror:
-        BaseState::cregs_[0].apply_roerror(op, rng);
+        state.creg().apply_roerror(op, rng);
         break;
       case OpType::gate:
-        apply_gate(iChunk, op);
-        break;
-      case OpType::snapshot:
-        apply_snapshot(iChunk, op, result, final_op);
+        apply_gate(state.qreg(iChunk), op);
         break;
       case OpType::matrix:
-        apply_matrix(iChunk, op);
+        apply_matrix(state.qreg(iChunk), op);
         break;
       case OpType::diagonal_matrix:
-        apply_diagonal_matrix(iChunk, op.qubits, op.params);
+        apply_diagonal_matrix(state.qreg(iChunk), op.qubits, op.params);
         break;
       case OpType::multiplexer:
-        apply_multiplexer(iChunk, op.regs[0], op.regs[1],
+        apply_multiplexer(state.qreg(iChunk), op.regs[0], op.regs[1],
                           op.mats); // control qubits ([0]) & target qubits([1])
-        break;
-      case OpType::kraus:
-        apply_kraus(iChunk, op.qubits, op.mats, rng);
         break;
       case OpType::sim_op:
         if(op.name == "begin_register_blocking"){
-          BaseState::qregs_[iChunk].enter_register_blocking(op.qubits);
+          state.qreg(iChunk).enter_register_blocking(op.qubits);
         }
         else if(op.name == "end_register_blocking"){
-          BaseState::qregs_[iChunk].leave_register_blocking();
+          state.qreg(iChunk).leave_register_blocking();
         }
-        break;
-      case OpType::set_statevec:
-        initialize_from_vector(iChunk, op.params);
-        break;
-      case OpType::save_expval:
-      case OpType::save_expval_var:
-        BaseState::apply_save_expval(iChunk, op, result);
-        break;
-      case OpType::save_densmat:
-        apply_save_density_matrix(iChunk, op, result);
-        break;
-      case OpType::save_state:
-      case OpType::save_statevec:
-        apply_save_statevector(iChunk, op, result, final_op);
-        break;
-      case OpType::save_statevec_dict:
-        apply_save_statevector_dict(iChunk, op, result);
-        break;
-      case OpType::save_probs:
-      case OpType::save_probs_ket:
-        apply_save_probs(iChunk, op, result);
-        break;
-      case OpType::save_amps:
-      case OpType::save_amps_sq:
-        apply_save_amplitudes(iChunk, op, result);
         break;
       default:
         throw std::invalid_argument(
@@ -755,14 +921,16 @@ void State<statevec_t>::apply_op(const int_t iChunk, const Operations::Op &op,
 }
 
 template <class statevec_t>
-bool State<statevec_t>::apply_batched_op(const int_t iChunk, 
+bool State<statevec_t>::apply_batched_op(const int_t iChunk, QuantumState::RegistersBase& state_in, 
                                   const Operations::Op &op,
                                   ExperimentResult &result,
                                   std::vector<RngEngine> &rng,
                                   bool final_op) 
 {
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
   if(op.conditional){
-    BaseState::qregs_[iChunk].set_conditional(op.conditional_reg);
+    state.qreg(iChunk).set_conditional(op.conditional_reg);
   }
 
   switch (op.type) {
@@ -771,55 +939,56 @@ bool State<statevec_t>::apply_batched_op(const int_t iChunk,
     case OpType::qerror_loc:
       break;
     case OpType::reset:
-      BaseState::qregs_[iChunk].apply_batched_reset(op.qubits,rng);
+      state.qreg(iChunk).apply_batched_reset(op.qubits,rng);
       break;
     case OpType::initialize:
-      BaseState::qregs_[iChunk].apply_batched_reset(op.qubits,rng);
-      BaseState::qregs_[iChunk].initialize_component(op.qubits, op.params);
+      state.qreg(iChunk).apply_batched_reset(op.qubits,rng);
+      state.qreg(iChunk).initialize_component(op.qubits, op.params);
       break;
     case OpType::measure:
-      BaseState::qregs_[iChunk].apply_batched_measure(op.qubits,rng,op.memory,op.registers);
+      state.qreg(iChunk).apply_batched_measure(op.qubits,rng,op.memory,op.registers);
       break;
     case OpType::bfunc:
-      BaseState::qregs_[iChunk].apply_bfunc(op);
+      state.qreg(iChunk).apply_bfunc(op);
       break;
     case OpType::roerror:
-      BaseState::qregs_[iChunk].apply_roerror(op, rng);
+      state.qreg(iChunk).apply_roerror(op, rng);
       break;
     case OpType::gate:
-      apply_gate(iChunk, op);
+      apply_gate(state.qreg(iChunk), op);
       break;
     case OpType::matrix:
-      apply_matrix(iChunk, op);
+      apply_matrix(state.qreg(iChunk), op);
       break;
     case OpType::diagonal_matrix:
-      BaseState::qregs_[iChunk].apply_diagonal_matrix(op.qubits, op.params);
+      state.qreg(iChunk).apply_diagonal_matrix(op.qubits, op.params);
       break;
     case OpType::multiplexer:
-      apply_multiplexer(iChunk, op.regs[0], op.regs[1],
+      apply_multiplexer(state.qreg(iChunk), op.regs[0], op.regs[1],
                         op.mats); // control qubits ([0]) & target qubits([1])
       break;
     case OpType::kraus:
-      BaseState::qregs_[iChunk].apply_batched_kraus(op.qubits, op.mats,rng);
+      state.qreg(iChunk).apply_batched_kraus(op.qubits, op.mats,rng);
       break;
     case OpType::sim_op:
       if(op.name == "begin_register_blocking"){
-        BaseState::qregs_[iChunk].enter_register_blocking(op.qubits);
+        state.qreg(iChunk).enter_register_blocking(op.qubits);
       }
       else if(op.name == "end_register_blocking"){
-        BaseState::qregs_[iChunk].leave_register_blocking();
+        state.qreg(iChunk).leave_register_blocking();
       }
       else{
         return false;
       }
       break;
     case OpType::set_statevec:
-      BaseState::qregs_[iChunk].initialize_from_vector(op.params);
+      state.qreg(iChunk).initialize_from_vector(op.params);
       break;
     default:
       //other operations should be called to indivisual chunks by apply_op
       return false;
   }
+
   return true;
 }
 
@@ -829,29 +998,31 @@ bool State<statevec_t>::apply_batched_op(const int_t iChunk,
 //=========================================================================
 
 template <class statevec_t>
-void State<statevec_t>::apply_save_probs(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::apply_save_probs(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                          ExperimentResult &result) 
 {
   // get probs as hexadecimal
-  auto probs = measure_probs(iChunk, op.qubits);
+  auto probs = measure_probs(state, op.qubits);
   if (op.type == Operations::OpType::save_probs_ket) {
     // Convert to ket dict
-    result.save_data_average(BaseState::chunk_creg(iChunk), op.string_params[0],
+    result.save_data_average(state.creg(), op.string_params[0],
                              Utils::vec2ket(probs, json_chop_threshold_, 16),
                              op.type, op.save_type);
   } else {
-    result.save_data_average(BaseState::chunk_creg(iChunk), op.string_params[0],
+    result.save_data_average(state.creg(), op.string_params[0],
                              std::move(probs), op.type, op.save_type);
   }
 }
 
 
 template <class statevec_t>
-double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
+double State<statevec_t>::expval_pauli(QuantumState::RegistersBase& state_in, const reg_t &qubits,
                                        const std::string& pauli) 
 {
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
   if(!BaseState::multi_chunk_distribution_)
-    return BaseState::qregs_[iChunk].expval_pauli(qubits, pauli);
+    return state.qreg().expval_pauli(qubits, pauli);
 
   //multi-chunk distribution
   reg_t qubits_in_chunk;
@@ -910,7 +1081,7 @@ double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
       const uint_t mask_u = ~((1ull << (x_max + 1)) - 1);
       const uint_t mask_l = (1ull << x_max) - 1;
       if(on_same_process){
-        auto apply_expval_pauli_chunk = [this, x_mask, z_mask, x_max,mask_u,mask_l, qubits_in_chunk, pauli_in_chunk, phase](int_t iGroup)
+        auto apply_expval_pauli_chunk = [this, x_mask, z_mask, x_max,mask_u,mask_l, qubits_in_chunk, pauli_in_chunk, phase, state](int_t iGroup)
         {
           double expval = 0.0;
           for(int_t iChunk = BaseState::top_chunk_of_group_[iGroup];iChunk < BaseState::top_chunk_of_group_[iGroup + 1];iChunk++){
@@ -920,7 +1091,7 @@ double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
               z_count = AER::Utils::popcount(iChunk & z_mask);
               z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
 
-              expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk],z_count,z_count_pair,phase);
+              expval += state.qreg(iChunk-BaseState::global_chunk_index_).expval_pauli(qubits_in_chunk, pauli_in_chunk,state.qreg(pair_chunk),z_count,z_count_pair,phase);
             }
           }
           return expval;
@@ -938,16 +1109,16 @@ double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
             z_count_pair = AER::Utils::popcount(pair_chunk & z_mask);
 
             if(iProc == BaseState::distributed_rank_){  //pair is on the same process
-              expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[pair_chunk - BaseState::global_chunk_index_],z_count,z_count_pair,phase);
+              expval += state.qreg(iChunk-BaseState::global_chunk_index_).expval_pauli(qubits_in_chunk, pauli_in_chunk,state.qreg(pair_chunk - BaseState::global_chunk_index_),z_count,z_count_pair,phase);
             }
             else{
-              BaseState::recv_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+              BaseState::recv_chunk(state, iChunk-BaseState::global_chunk_index_,pair_chunk);
               //refer receive buffer to calculate expectation value
-              expval += BaseState::qregs_[iChunk-BaseState::global_chunk_index_].expval_pauli(qubits_in_chunk, pauli_in_chunk,BaseState::qregs_[iChunk-BaseState::global_chunk_index_],z_count,z_count_pair,phase);
+              expval += state.qreg(iChunk-BaseState::global_chunk_index_).expval_pauli(qubits_in_chunk, pauli_in_chunk,state.qreg(iChunk-BaseState::global_chunk_index_),z_count,z_count_pair,phase);
             }
           }
           else if(iProc == BaseState::distributed_rank_){  //pair is on this process
-            BaseState::send_chunk(iChunk-BaseState::global_chunk_index_,pair_chunk);
+            BaseState::send_chunk(state, iChunk-BaseState::global_chunk_index_,pair_chunk);
           }
         }
       }
@@ -962,17 +1133,17 @@ double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
             double sign = 1.0;
             if (z_mask && (AER::Utils::popcount((iChunk + BaseState::global_chunk_index_) & z_mask) & 1))
               sign = -1.0;
-            e_tmp += sign * BaseState::qregs_[iChunk].expval_pauli(qubits_in_chunk, pauli_in_chunk);
+            e_tmp += sign * state.qreg(iChunk).expval_pauli(qubits_in_chunk, pauli_in_chunk);
           }
           expval += e_tmp;
         }
       }
       else{
-        for(i=0;i<BaseState::qregs_.size();i++){
+        for(i=0;i<state.qregs().size();i++){
           double sign = 1.0;
           if (z_mask && (AER::Utils::popcount((i + BaseState::global_chunk_index_) & z_mask) & 1))
             sign = -1.0;
-          expval += sign * BaseState::qregs_[i].expval_pauli(qubits_in_chunk, pauli_in_chunk);
+          expval += sign * state.qreg(i).expval_pauli(qubits_in_chunk, pauli_in_chunk);
         }
       }
     }
@@ -983,13 +1154,13 @@ double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
       for(int_t ig=0;ig<BaseState::num_groups_;ig++){
         double e_tmp = 0.0;
         for(int_t iChunk = BaseState::top_chunk_of_group_[ig];iChunk < BaseState::top_chunk_of_group_[ig + 1];iChunk++)
-          e_tmp += BaseState::qregs_[iChunk].expval_pauli(qubits, pauli);
+          e_tmp += state.qreg(iChunk).expval_pauli(qubits, pauli);
         expval += e_tmp;
       }
     }
     else{
-      for(i=0;i<BaseState::qregs_.size();i++)
-        expval += BaseState::qregs_[i].expval_pauli(qubits, pauli);
+      for(i=0;i<state.qregs().size();i++)
+        expval += state.qreg(i).expval_pauli(qubits, pauli);
     }
   }
 
@@ -1000,7 +1171,7 @@ double State<statevec_t>::expval_pauli(const int_t iChunk, const reg_t &qubits,
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_save_statevector(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::apply_save_statevector(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                                ExperimentResult &result,
                                                bool last_op) 
 {
@@ -1013,18 +1184,31 @@ void State<statevec_t>::apply_save_statevector(const int_t iChunk, const Operati
                       ? "statevector"
                       : op.string_params[0];
 
-  if (last_op) {
-    auto v = move_to_vector(iChunk);
-    result.save_data_pershot(BaseState::chunk_creg(iChunk), key, std::move(v),
-                                  OpType::save_statevec, op.save_type);
-  } else {
-    result.save_data_pershot(BaseState::chunk_creg(iChunk), key, copy_to_vector(iChunk),
-                                OpType::save_statevec, op.save_type);
+  if(BaseState::multi_chunk_distribution_ || state.num_shots() > 1){
+    if (last_op) {
+      result.save_data_pershot(state.creg(), key, move_to_vector(state),
+                               OpType::save_statevec, op.save_type, state.num_shots());
+    } else {
+      result.save_data_pershot(state.creg(), key, copy_to_vector(state),
+                                  OpType::save_statevec, op.save_type, state.num_shots());
+    }
+  }
+  else{
+    //for batched multi-shot, save each qreg
+    for(int_t i=0;i<state.num_qregs();i++){
+      if (last_op) {
+        result.save_data_pershot(state.creg(), key, state.qreg(i).move_to_vector(),
+                                 OpType::save_statevec, op.save_type, 1);
+      } else {
+        result.save_data_pershot(state.creg(), key, state.qreg(i).copy_to_vector(),
+                                    OpType::save_statevec, op.save_type, 1);
+      }
+    }
   }
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_save_statevector_dict(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::apply_save_statevector_dict(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                                    ExperimentResult &result) 
 {
   if (op.qubits.size() != BaseState::num_qubits_) {
@@ -1033,7 +1217,7 @@ void State<statevec_t>::apply_save_statevector_dict(const int_t iChunk, const Op
         " Only the full statevector can be saved.");
   }
   if(BaseState::multi_chunk_distribution_){
-    auto vec = copy_to_vector(iChunk);
+    auto vec = copy_to_vector(state);
     std::map<std::string, complex_t> result_state_ket;
     for (size_t k = 0; k < vec.size(); ++k) {
       if (std::abs(vec[k]) >= json_chop_threshold_){
@@ -1041,22 +1225,24 @@ void State<statevec_t>::apply_save_statevector_dict(const int_t iChunk, const Op
         result_state_ket.insert({key, vec[k]});
       }
     }
-    result.save_data_pershot(BaseState::chunk_creg(iChunk), op.string_params[0],
-                                 std::move(result_state_ket), op.type, op.save_type);
+    result.save_data_pershot(state.creg(), op.string_params[0],
+                                 std::move(result_state_ket), op.type, op.save_type, state.num_shots());
   }
   else{
-    auto state_ket = BaseState::qregs_[iChunk].vector_ket(json_chop_threshold_);
-    std::map<std::string, complex_t> result_state_ket;
-    for (auto const& it : state_ket){
-      result_state_ket[it.first] = it.second;
+    for(int_t i=0;i<state.num_qregs();i++){
+      auto state_ket = state.qreg().vector_ket(json_chop_threshold_);
+      std::map<std::string, complex_t> result_state_ket;
+      for (auto const& it : state_ket){
+        result_state_ket[it.first] = it.second;
+      }
+      result.save_data_pershot(state.creg(), op.string_params[0],
+                                   std::move(result_state_ket), op.type, op.save_type, state.num_shots());
     }
-    result.save_data_pershot(BaseState::chunk_creg(iChunk), op.string_params[0],
-                                 std::move(result_state_ket), op.type, op.save_type);
   }
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_save_density_matrix(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::apply_save_density_matrix(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                                   ExperimentResult &result) 
 {
   cmatrix_t reduced_state;
@@ -1065,35 +1251,52 @@ void State<statevec_t>::apply_save_density_matrix(const int_t iChunk, const Oper
   if (op.qubits.empty()) {
     reduced_state = cmatrix_t(1, 1);
 
-    if(!BaseState::multi_chunk_distribution_){
-      reduced_state[0] = BaseState::qregs_[iChunk].norm();
-    }
-    else{
+    if(BaseState::multi_chunk_distribution_){
       double sum = 0.0;
       if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for reduction(+:sum)
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          sum += BaseState::qregs_[i].norm();
+        for(int_t i=0;i<state.qregs().size();i++)
+          sum += state.qreg(i).norm();
       }
       else{
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          sum += BaseState::qregs_[i].norm();
+        for(int_t i=0;i<state.qregs().size();i++)
+          sum += state.qreg(i).norm();
       }
 #ifdef AER_MPI
       BaseState::reduce_sum(sum);
 #endif
       reduced_state[0] = sum;
+
+      result.save_data_average(state.creg(), op.string_params[0],
+                               std::move(reduced_state), op.type, op.save_type);
     }
-  } else {
-    reduced_state = density_matrix(iChunk, op.qubits);
+    else{
+      for(int_t i=0;i<state.num_qregs();i++){
+        reduced_state[0] = state.qreg().norm();
+        result.save_data_average(state.creg(), op.string_params[0],
+                                 reduced_state, op.type, op.save_type);
+      }
+    }
+  }
+  else {
+    if(BaseState::multi_chunk_distribution_){
+      reduced_state = density_matrix(state, op.qubits);
+      result.save_data_average(state.creg(), op.string_params[0],
+                               std::move(reduced_state), op.type, op.save_type);
+    }
+    else{
+      for(int_t i=0;i<state.num_qregs();i++){
+        reduced_state = vec2density(op.qubits, state.qreg(i).copy_to_vector());
+        result.save_data_average(state.creg(), op.string_params[0],
+                                 std::move(reduced_state), op.type, op.save_type);
+      }
+    }
   }
 
-  result.save_data_average(BaseState::chunk_creg(iChunk), op.string_params[0],
-                           std::move(reduced_state), op.type, op.save_type);
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_save_amplitudes(const int_t iChunkIn, const Operations::Op &op,
+void State<statevec_t>::apply_save_amplitudes(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                               ExperimentResult &result) 
 {
   if (op.int_params.empty()) {
@@ -1101,19 +1304,14 @@ void State<statevec_t>::apply_save_amplitudes(const int_t iChunkIn, const Operat
   }
   const int_t size = op.int_params.size();
   if (op.type == Operations::OpType::save_amps) {
-    Vector<complex_t> amps(size, false);
-    if(!BaseState::multi_chunk_distribution_){
+    if(BaseState::multi_chunk_distribution_){
+      Vector<complex_t> amps(size, false);
       for (int_t i = 0; i < size; ++i) {
-        amps[i] = BaseState::qregs_[iChunkIn].get_state(op.int_params[i]);
-      }
-    }
-    else{
-      for (int_t i = 0; i < size; ++i) {
-        uint_t idx = BaseState::mapped_index(op.int_params[i]);
+        uint_t idx = state.get_mapped_index(op.int_params[i]);
         uint_t iChunk = idx >> BaseState::chunk_bits_;
         amps[i] = 0.0;
-        if(iChunk >= BaseState::global_chunk_index_ && iChunk < BaseState::global_chunk_index_ + BaseState::qregs_.size()){
-          amps[i] = BaseState::qregs_[iChunk - BaseState::global_chunk_index_].get_state(idx - (iChunk << BaseState::chunk_bits_));
+        if(iChunk >= BaseState::global_chunk_index_ && iChunk < BaseState::global_chunk_index_ + state.qregs().size()){
+          amps[i] = state.qreg(iChunk - BaseState::global_chunk_index_).get_state(idx - (iChunk << BaseState::chunk_bits_));
         }
 #ifdef AER_MPI
         complex_t amp = amps[i];
@@ -1121,31 +1319,86 @@ void State<statevec_t>::apply_save_amplitudes(const int_t iChunkIn, const Operat
         amps[i] = amp;
 #endif
       }
-    }
-    result.save_data_pershot(BaseState::chunk_creg(iChunkIn), op.string_params[0],
-                                 std::move(amps), op.type, op.save_type);
-  }
-  else{
-    rvector_t amps_sq(size,0);
-    if(!BaseState::multi_chunk_distribution_){
-      for (int_t i = 0; i < size; ++i) {
-        amps_sq[i] = BaseState::qregs_[iChunkIn].probability(op.int_params[i]);
-      }
+      result.save_data_pershot(state.creg(), op.string_params[0],
+                                   std::move(amps), op.type, op.save_type, state.num_shots());
     }
     else{
+      for(int_t j=0;j<state.num_qregs();j++){
+        Vector<complex_t> amps(size, false);
+        for (int_t i = 0; i < size; ++i) {
+          amps[i] = state.qreg(j).get_state(op.int_params[i]);
+        }
+        result.save_data_pershot(state.creg(), op.string_params[0],
+                                     std::move(amps), op.type, op.save_type, state.num_shots());
+      }
+    }
+  }
+  else{
+    if(BaseState::multi_chunk_distribution_){
+      rvector_t amps_sq(size,0);
       for (int_t i = 0; i < size; ++i) {
-        uint_t idx = BaseState::mapped_index(op.int_params[i]);
+        uint_t idx = state.get_mapped_index(op.int_params[i]);
         uint_t iChunk = idx >> BaseState::chunk_bits_;
-        if(iChunk >= BaseState::global_chunk_index_ && iChunk < BaseState::global_chunk_index_ + BaseState::qregs_.size()){
-          amps_sq[i] = BaseState::qregs_[iChunk - BaseState::global_chunk_index_].probability(idx - (iChunk << BaseState::chunk_bits_));
+        if(iChunk >= BaseState::global_chunk_index_ && iChunk < BaseState::global_chunk_index_ + state.qregs().size()){
+          amps_sq[i] = state.qreg(iChunk - BaseState::global_chunk_index_).probability(idx - (iChunk << BaseState::chunk_bits_));
         }
       }
 #ifdef AER_MPI
       BaseState::reduce_sum(amps_sq);
 #endif
+     result.save_data_average(state.creg(), op.string_params[0],
+                              std::move(amps_sq), op.type, op.save_type);
     }
-   result.save_data_average(BaseState::chunk_creg(iChunkIn), op.string_params[0],
-                            std::move(amps_sq), op.type, op.save_type);
+    else{
+      for(int_t j=0;j<state.num_qregs();j++){
+        rvector_t amps_sq(size,0);
+        for (int_t i = 0; i < size; ++i) {
+          amps_sq[i] = state.qreg(j).probability(op.int_params[i]);
+        }
+        result.save_data_average(state.creg(), op.string_params[0],
+                                  std::move(amps_sq), op.type, op.save_type);
+      }
+    }
+  }
+}
+
+template <class statevec_t>
+void State<statevec_t>::apply_save_expval(QuantumState::Registers<statevec_t>& state, 
+                                       const Operations::Op &op,
+                                       ExperimentResult &result)
+{
+  if(BaseState::multi_chunk_distribution_){
+    BaseState::apply_save_expval(state,op,result);
+    return;
+  }
+
+  // Check empty edge case
+  if (op.expval_params.empty()) {
+    throw std::invalid_argument(
+        "Invalid save expval instruction (Pauli components are empty).");
+  }
+  bool variance = (op.type == OpType::save_expval_var);
+
+  for(int_t i=0;i<state.num_qregs();i++){
+    // Accumulate expval components
+    double expval(0.);
+    double sq_expval(0.);
+    for (const auto &param : op.expval_params) {
+      // param is tuple (pauli, coeff, sq_coeff)
+      const auto val =   state.qreg(i).expval_pauli(op.qubits, std::get<0>(param));
+      expval += std::get<1>(param) * val;
+      if (variance) {
+        sq_expval += std::get<2>(param) * val;
+      }
+    }
+    if (variance) {
+      std::vector<double> expval_var(2);
+      expval_var[0] = expval;  // mean
+      expval_var[1] = sq_expval - expval * expval;  // variance
+      result.save_data_average(state.creg(), op.string_params[0], expval_var, op.type, op.save_type);
+    } else {
+      result.save_data_average(state.creg(), op.string_params[0], expval, op.type, op.save_type);
+    }
   }
 }
 
@@ -1154,7 +1407,7 @@ void State<statevec_t>::apply_save_amplitudes(const int_t iChunkIn, const Operat
 //=========================================================================
 
 template <class statevec_t>
-void State<statevec_t>::apply_snapshot(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::apply_snapshot(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                        ExperimentResult &result,
                                        bool last_op) {
 
@@ -1167,49 +1420,49 @@ void State<statevec_t>::apply_snapshot(const int_t iChunk, const Operations::Op 
     case Snapshots::statevector:
       if (last_op) {
         result.legacy_data.add_pershot_snapshot("statevector", op.string_params[0],
-                                         move_to_vector(iChunk));
+                                         move_to_vector(state));
       } else {
         result.legacy_data.add_pershot_snapshot("statevector", op.string_params[0],
-                                         copy_to_vector(iChunk));
+                                         copy_to_vector(state));
       }
       break;
     case Snapshots::cmemory:
-      BaseState::snapshot_creg_memory(iChunk, op, result);
+      BaseState::snapshot_creg_memory(state, op, result);
       break;
     case Snapshots::cregister:
-      BaseState::snapshot_creg_register(iChunk, op, result);
+      BaseState::snapshot_creg_register(state, op, result);
       break;
     case Snapshots::probs: {
       // get probs as hexadecimal
-      snapshot_probabilities(iChunk, op, result, SnapshotDataType::average);
+      snapshot_probabilities(state, op, result, SnapshotDataType::average);
     } break;
     case Snapshots::densmat: {
-      snapshot_density_matrix(iChunk, op, result, SnapshotDataType::average);
+      snapshot_density_matrix(state, op, result, SnapshotDataType::average);
     } break;
     case Snapshots::expval_pauli: {
-      snapshot_pauli_expval(iChunk, op, result, SnapshotDataType::average);
+      snapshot_pauli_expval(state, op, result, SnapshotDataType::average);
     } break;
     case Snapshots::expval_matrix: {
-      snapshot_matrix_expval(iChunk, op, result, SnapshotDataType::average);
+      snapshot_matrix_expval(state, op, result, SnapshotDataType::average);
     } break;
     case Snapshots::probs_var: {
       // get probs as hexadecimal
-      snapshot_probabilities(iChunk, op, result, SnapshotDataType::average_var);
+      snapshot_probabilities(state, op, result, SnapshotDataType::average_var);
     } break;
     case Snapshots::densmat_var: {
-      snapshot_density_matrix(iChunk, op, result, SnapshotDataType::average_var);
+      snapshot_density_matrix(state, op, result, SnapshotDataType::average_var);
     } break;
     case Snapshots::expval_pauli_var: {
-      snapshot_pauli_expval(iChunk, op, result, SnapshotDataType::average_var);
+      snapshot_pauli_expval(state, op, result, SnapshotDataType::average_var);
     } break;
     case Snapshots::expval_matrix_var: {
-      snapshot_matrix_expval(iChunk, op, result, SnapshotDataType::average_var);
+      snapshot_matrix_expval(state, op, result, SnapshotDataType::average_var);
     } break;
     case Snapshots::expval_pauli_shot: {
-      snapshot_pauli_expval(iChunk, op, result, SnapshotDataType::pershot);
+      snapshot_pauli_expval(state, op, result, SnapshotDataType::pershot);
     } break;
     case Snapshots::expval_matrix_shot: {
-      snapshot_matrix_expval(iChunk, op, result, SnapshotDataType::pershot);
+      snapshot_matrix_expval(state, op, result, SnapshotDataType::pershot);
     } break;
     default:
       // We shouldn't get here unless there is a bug in the snapshotset
@@ -1220,23 +1473,21 @@ void State<statevec_t>::apply_snapshot(const int_t iChunk, const Operations::Op 
 }
 
 template <class statevec_t>
-void State<statevec_t>::snapshot_probabilities(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::snapshot_probabilities(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                                ExperimentResult &result,
                                                SnapshotDataType type) 
 {
   // get probs as hexadecimal
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
-
   auto probs =
-      Utils::vec2ket(measure_probs(iChunk, op.qubits), json_chop_threshold_, 16);
+      Utils::vec2ket(measure_probs(state, op.qubits), json_chop_threshold_, 16);
   bool variance = type == SnapshotDataType::average_var;
   result.legacy_data.add_average_snapshot("probabilities", op.string_params[0],
-                                   BaseState::cregs_[ishot].memory_hex(),
+                                   state.creg().memory_hex(),
                                    std::move(probs), variance);
 }
 
 template <class statevec_t>
-void State<statevec_t>::snapshot_pauli_expval(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::snapshot_pauli_expval(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                               ExperimentResult &result,
                                               SnapshotDataType type) 
 {
@@ -1245,14 +1496,13 @@ void State<statevec_t>::snapshot_pauli_expval(const int_t iChunk, const Operatio
     throw std::invalid_argument(
         "Invalid expval snapshot (Pauli components are empty).");
   }
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
 
   // Accumulate expval components
   complex_t expval(0., 0.);
   for (const auto &param : op.params_expval_pauli) {
     const auto &coeff = param.first;
     const auto &pauli = param.second;
-    expval += coeff * expval_pauli(iChunk, op.qubits, pauli);
+    expval += coeff * expval_pauli(state, op.qubits, pauli);
   }
 
   // Add to snapshot
@@ -1260,11 +1510,11 @@ void State<statevec_t>::snapshot_pauli_expval(const int_t iChunk, const Operatio
   switch (type) {
   case SnapshotDataType::average:
     result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                              BaseState::cregs_[ishot].memory_hex(), expval, false);
+                                            state.creg().memory_hex(), expval, false);
     break;
   case SnapshotDataType::average_var:
     result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                              BaseState::cregs_[ishot].memory_hex(), expval, true);
+                                            state.creg().memory_hex(), expval, true);
     break;
   case SnapshotDataType::pershot:
     result.legacy_data.add_pershot_snapshot("expectation_values", op.string_params[0],
@@ -1274,7 +1524,7 @@ void State<statevec_t>::snapshot_pauli_expval(const int_t iChunk, const Operatio
 }
 
 template <class statevec_t>
-void State<statevec_t>::snapshot_matrix_expval(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::snapshot_matrix_expval(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                                ExperimentResult &result,
                                                SnapshotDataType type) 
 {
@@ -1283,21 +1533,20 @@ void State<statevec_t>::snapshot_matrix_expval(const int_t iChunk, const Operati
     throw std::invalid_argument(
         "Invalid matrix snapshot (components are empty).");
   }
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
 
   reg_t qubits = op.qubits;
   // Cache the current quantum state
   if(!BaseState::multi_chunk_distribution_)
-    BaseState::qregs_[iChunk].checkpoint();
+    state.qreg().checkpoint();
   else{
     if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for 
-      for(int_t i=0;i<BaseState::qregs_.size();i++)
-        BaseState::qregs_[i].checkpoint();
+      for(int_t i=0;i<state.qregs().size();i++)
+        state.qreg(i).checkpoint();
     }
     else{
-      for(int_t i=0;i<BaseState::qregs_.size();i++)
-        BaseState::qregs_[i].checkpoint();
+      for(int_t i=0;i<state.qregs().size();i++)
+        state.qreg(i).checkpoint();
     }
   }
 
@@ -1313,16 +1562,16 @@ void State<statevec_t>::snapshot_matrix_expval(const int_t iChunk, const Operati
       first = false;
     else{
       if(!BaseState::multi_chunk_distribution_)
-        BaseState::qregs_[iChunk].revert(true);
+        state.qreg().revert(true);
       else{
         if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for 
-          for(int_t i=0;i<BaseState::qregs_.size();i++)
-            BaseState::qregs_[i].revert(true);
+          for(int_t i=0;i<state.qregs().size();i++)
+            state.qreg(i).revert(true);
         }
         else{
-          for(int_t i=0;i<BaseState::qregs_.size();i++)
-            BaseState::qregs_[i].revert(true);
+          for(int_t i=0;i<state.qregs().size();i++)
+            state.qreg(i).revert(true);
         }
       }
     }
@@ -1341,30 +1590,30 @@ void State<statevec_t>::snapshot_matrix_expval(const int_t iChunk, const Operati
 
       if (vmat.size() == 1ULL << qubits.size()) {
         if(!BaseState::multi_chunk_distribution_)
-          apply_diagonal_matrix(iChunk, sub_qubits, vmat);
+          apply_diagonal_matrix(state.qreg(), sub_qubits, vmat);
         else{
           if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for
-            for(int_t i=0;i<BaseState::qregs_.size();i++)
-              apply_diagonal_matrix(i, sub_qubits, vmat);
+            for(int_t i=0;i<state.qregs().size();i++)
+              apply_diagonal_matrix(state.qreg(i), sub_qubits, vmat);
           }
           else{
-            for(int_t i=0;i<BaseState::qregs_.size();i++)
-              apply_diagonal_matrix(i, sub_qubits, vmat);
+            for(int_t i=0;i<state.qregs().size();i++)
+              apply_diagonal_matrix(state.qreg(i), sub_qubits, vmat);
           }
         }
       } else {
         if(!BaseState::multi_chunk_distribution_)
-          BaseState::qregs_[iChunk].apply_matrix(sub_qubits, vmat);
+          state.qreg().apply_matrix(sub_qubits, vmat);
         else{
           if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for 
-            for(int_t i=0;i<BaseState::qregs_.size();i++)
-              BaseState::qregs_[i].apply_matrix(sub_qubits, vmat);
+            for(int_t i=0;i<state.qregs().size();i++)
+              state.qreg(i).apply_matrix(sub_qubits, vmat);
           }
           else{
-            for(int_t i=0;i<BaseState::qregs_.size();i++)
-              BaseState::qregs_[i].apply_matrix(sub_qubits, vmat);
+            for(int_t i=0;i<state.qregs().size();i++)
+              state.qreg(i).apply_matrix(sub_qubits, vmat);
           }
         }
       }
@@ -1372,22 +1621,22 @@ void State<statevec_t>::snapshot_matrix_expval(const int_t iChunk, const Operati
     double exp_re = 0.0;
     double exp_im = 0.0;
     if(!BaseState::multi_chunk_distribution_){
-      auto exp_tmp = coeff*BaseState::qregs_[iChunk].inner_product();
+      auto exp_tmp = coeff*state.qreg().inner_product();
       exp_re += exp_tmp.real();
       exp_im += exp_tmp.imag();
     }
     else{
       if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for reduction(+:exp_re,exp_im)
-        for(int_t i=0;i<BaseState::qregs_.size();i++){
-          auto exp_tmp = coeff*BaseState::qregs_[i].inner_product();
+        for(int_t i=0;i<state.qregs().size();i++){
+          auto exp_tmp = coeff*state.qreg(i).inner_product();
           exp_re += exp_tmp.real();
           exp_im += exp_tmp.imag();
         }
       }
       else{
-        for(int_t i=0;i<BaseState::qregs_.size();i++){
-          auto exp_tmp = coeff*BaseState::qregs_[i].inner_product();
+        for(int_t i=0;i<state.qregs().size();i++){
+          auto exp_tmp = coeff*state.qreg(i).inner_product();
           exp_re += exp_tmp.real();
           exp_im += exp_tmp.imag();
         }
@@ -1406,11 +1655,11 @@ void State<statevec_t>::snapshot_matrix_expval(const int_t iChunk, const Operati
   switch (type) {
   case SnapshotDataType::average:
     result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                              BaseState::cregs_[ishot].memory_hex(), expval, false);
+                              state.creg().memory_hex(), expval, false);
     break;
   case SnapshotDataType::average_var:
     result.legacy_data.add_average_snapshot("expectation_value", op.string_params[0],
-                              BaseState::cregs_[ishot].memory_hex(), expval, true);
+                              state.creg().memory_hex(), expval, true);
     break;
   case SnapshotDataType::pershot:
     result.legacy_data.add_pershot_snapshot("expectation_values", op.string_params[0],
@@ -1419,43 +1668,42 @@ void State<statevec_t>::snapshot_matrix_expval(const int_t iChunk, const Operati
   }
   // Revert to original state
   if(!BaseState::multi_chunk_distribution_)
-    BaseState::qregs_[iChunk].revert(false);
+    state.qreg().revert(false);
   else{
     if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for 
-      for(int_t i=0;i<BaseState::qregs_.size();i++)
-        BaseState::qregs_[i].revert(false);
+      for(int_t i=0;i<state.qregs().size();i++)
+        state.qreg(i).revert(false);
     }
     else{
-      for(int_t i=0;i<BaseState::qregs_.size();i++)
-        BaseState::qregs_[i].revert(false);
+      for(int_t i=0;i<state.qregs().size();i++)
+        state.qreg(i).revert(false);
     }
   }
 }
 
 template <class statevec_t>
-void State<statevec_t>::snapshot_density_matrix(const int_t iChunk, const Operations::Op &op,
+void State<statevec_t>::snapshot_density_matrix(QuantumState::Registers<statevec_t>& state, const Operations::Op &op,
                                                 ExperimentResult &result,
                                                 SnapshotDataType type) {
   cmatrix_t reduced_state;
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
 
   // Check if tracing over all qubits
   if (op.qubits.empty()) {
     reduced_state = cmatrix_t(1, 1);
 
     if(!BaseState::multi_chunk_distribution_)
-      reduced_state[0] = BaseState::qregs_[iChunk].norm();
+      reduced_state[0] = state.qreg().norm();
     else{
       double sum = 0.0;
       if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for reduction(+:sum)
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          sum += BaseState::qregs_[i].norm();
+        for(int_t i=0;i<state.qregs().size();i++)
+          sum += state.qreg(i).norm();
       }
       else{
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          sum += BaseState::qregs_[i].norm();
+        for(int_t i=0;i<state.qregs().size();i++)
+          sum += state.qreg(i).norm();
       }
 #ifdef AER_MPI
       BaseState::reduce_sum(sum);
@@ -1463,19 +1711,19 @@ void State<statevec_t>::snapshot_density_matrix(const int_t iChunk, const Operat
       reduced_state[0] = sum;
     }
   } else {
-    reduced_state = density_matrix(iChunk, op.qubits);
+    reduced_state = density_matrix(state, op.qubits);
   }
 
   // Add density matrix to result data
   switch (type) {
   case SnapshotDataType::average:
     result.legacy_data.add_average_snapshot("density_matrix", op.string_params[0],
-                              BaseState::cregs_[ishot].memory_hex(),
+                              state.creg().memory_hex(),
                               std::move(reduced_state), false);
     break;
   case SnapshotDataType::average_var:
     result.legacy_data.add_average_snapshot("density_matrix", op.string_params[0],
-                              BaseState::cregs_[ishot].memory_hex(),
+                              state.creg().memory_hex(),
                               std::move(reduced_state), true);
     break;
   case SnapshotDataType::pershot:
@@ -1486,9 +1734,9 @@ void State<statevec_t>::snapshot_density_matrix(const int_t iChunk, const Operat
 }
 
 template <class statevec_t>
-cmatrix_t State<statevec_t>::density_matrix(const int_t iChunk, const reg_t &qubits) 
+cmatrix_t State<statevec_t>::density_matrix(QuantumState::Registers<statevec_t>& state, const reg_t &qubits) 
 {
-  return vec2density(qubits, copy_to_vector(iChunk));
+  return vec2density(qubits, copy_to_vector(state));
 }
 
 template <class statevec_t>
@@ -1541,7 +1789,7 @@ cmatrix_t State<statevec_t>::vec2density(const reg_t &qubits, const T &vec) {
 //=========================================================================
 
 template <class statevec_t>
-void State<statevec_t>::apply_gate(const int_t iChunk, const Operations::Op &op) 
+void State<statevec_t>::apply_gate(statevec_t& qreg, const Operations::Op &op) 
 {
   if(!BaseState::global_chunk_indexing_){
     reg_t qubits_in,qubits_out;
@@ -1551,9 +1799,9 @@ void State<statevec_t>::apply_gate(const int_t iChunk, const Operations::Op &op)
       for(int i=0;i<qubits_out.size();i++){
         mask |= (1ull << (qubits_out[i] - BaseState::chunk_bits_));
       }
-      if(((BaseState::global_chunk_index_ + iChunk) & mask) == mask){
+      if((qreg.chunk_index() & mask) == mask){
         Operations::Op new_op = BaseState::remake_gate_in_chunk_qubits(op,qubits_in);
-        apply_gate(iChunk, new_op);
+        apply_gate(qreg, new_op);
       }
       return;
     }
@@ -1567,92 +1815,92 @@ void State<statevec_t>::apply_gate(const int_t iChunk, const Operations::Op &op)
   switch (it->second) {
     case Gates::mcx:
       // Includes X, CX, CCX, etc
-      BaseState::qregs_[iChunk].apply_mcx(op.qubits);
+      qreg.apply_mcx(op.qubits);
       break;
     case Gates::mcy:
       // Includes Y, CY, CCY, etc
-      BaseState::qregs_[iChunk].apply_mcy(op.qubits);
+      qreg.apply_mcy(op.qubits);
       break;
     case Gates::mcz:
       // Includes Z, CZ, CCZ, etc
-      BaseState::qregs_[iChunk].apply_mcphase(op.qubits, -1);
+      qreg.apply_mcphase(op.qubits, -1);
       break;
     case Gates::mcr:
-      BaseState::qregs_[iChunk].apply_mcu(op.qubits, Linalg::VMatrix::r(op.params[0], op.params[1]));
+      qreg.apply_mcu(op.qubits, Linalg::VMatrix::r(op.params[0], op.params[1]));
       break;
     case Gates::mcrx:
-      BaseState::qregs_[iChunk].apply_rotation(op.qubits, QV::Rotation::x, std::real(op.params[0]));
+      qreg.apply_rotation(op.qubits, QV::Rotation::x, std::real(op.params[0]));
       break;
     case Gates::mcry:
-      BaseState::qregs_[iChunk].apply_rotation(op.qubits, QV::Rotation::y, std::real(op.params[0]));
+      qreg.apply_rotation(op.qubits, QV::Rotation::y, std::real(op.params[0]));
       break;
     case Gates::mcrz:
-      BaseState::qregs_[iChunk].apply_rotation(op.qubits, QV::Rotation::z, std::real(op.params[0]));
+      qreg.apply_rotation(op.qubits, QV::Rotation::z, std::real(op.params[0]));
       break;
     case Gates::rxx:
-      BaseState::qregs_[iChunk].apply_rotation(op.qubits, QV::Rotation::xx, std::real(op.params[0]));
+      qreg.apply_rotation(op.qubits, QV::Rotation::xx, std::real(op.params[0]));
       break;
     case Gates::ryy:
-      BaseState::qregs_[iChunk].apply_rotation(op.qubits, QV::Rotation::yy, std::real(op.params[0]));
+      qreg.apply_rotation(op.qubits, QV::Rotation::yy, std::real(op.params[0]));
       break;
     case Gates::rzz:
-      BaseState::qregs_[iChunk].apply_rotation(op.qubits, QV::Rotation::zz, std::real(op.params[0]));
+      qreg.apply_rotation(op.qubits, QV::Rotation::zz, std::real(op.params[0]));
       break;
     case Gates::rzx:
-      BaseState::qregs_[iChunk].apply_rotation(op.qubits, QV::Rotation::zx, std::real(op.params[0]));
+      qreg.apply_rotation(op.qubits, QV::Rotation::zx, std::real(op.params[0]));
       break;
     case Gates::id:
       break;
     case Gates::h:
-      apply_gate_mcu(iChunk, op.qubits, M_PI / 2., 0., M_PI, 0.);
+      apply_gate_mcu(qreg, op.qubits, M_PI / 2., 0., M_PI, 0.);
       break;
     case Gates::s:
-      apply_gate_phase(iChunk, op.qubits[0], complex_t(0., 1.));
+      apply_gate_phase(qreg, op.qubits[0], complex_t(0., 1.));
       break;
     case Gates::sdg:
-      apply_gate_phase(iChunk, op.qubits[0], complex_t(0., -1.));
+      apply_gate_phase(qreg, op.qubits[0], complex_t(0., -1.));
       break;
     case Gates::t: {
       const double isqrt2{1. / std::sqrt(2)};
-      apply_gate_phase(iChunk, op.qubits[0], complex_t(isqrt2, isqrt2));
+      apply_gate_phase(qreg, op.qubits[0], complex_t(isqrt2, isqrt2));
     } break;
     case Gates::tdg: {
       const double isqrt2{1. / std::sqrt(2)};
-      apply_gate_phase(iChunk, op.qubits[0], complex_t(isqrt2, -isqrt2));
+      apply_gate_phase(qreg, op.qubits[0], complex_t(isqrt2, -isqrt2));
     } break;
     case Gates::mcswap:
       // Includes SWAP, CSWAP, etc
-      BaseState::qregs_[iChunk].apply_mcswap(op.qubits);
+      qreg.apply_mcswap(op.qubits);
       break;
     case Gates::mcu3:
       // Includes u3, cu3, etc
-      apply_gate_mcu(iChunk, op.qubits, std::real(op.params[0]), std::real(op.params[1]),
+      apply_gate_mcu(qreg, op.qubits, std::real(op.params[0]), std::real(op.params[1]),
                      std::real(op.params[2]), 0.);
       break;
     case Gates::mcu:
       // Includes u3, cu3, etc
-      apply_gate_mcu(iChunk, op.qubits, std::real(op.params[0]), std::real(op.params[1]),
+      apply_gate_mcu(qreg, op.qubits, std::real(op.params[0]), std::real(op.params[1]),
                       std::real(op.params[2]), std::real(op.params[3]));
       break;
     case Gates::mcu2:
       // Includes u2, cu2, etc
-      apply_gate_mcu(iChunk, op.qubits, M_PI / 2., std::real(op.params[0]),
+      apply_gate_mcu(qreg, op.qubits, M_PI / 2., std::real(op.params[0]),
                      std::real(op.params[1]), 0.);
       break;
     case Gates::mcp:
       // Includes u1, cu1, p, cp, mcp etc
-      BaseState::qregs_[iChunk].apply_mcphase(op.qubits,
+      qreg.apply_mcphase(op.qubits,
                                      std::exp(complex_t(0, 1) * op.params[0]));
       break;
     case Gates::mcsx:
       // Includes sx, csx, mcsx etc
-      BaseState::qregs_[iChunk].apply_mcu(op.qubits, Linalg::VMatrix::SX);
+      qreg.apply_mcu(op.qubits, Linalg::VMatrix::SX);
       break;
     case Gates::mcsxdg:
-      BaseState::qregs_[iChunk].apply_mcu(op.qubits, Linalg::VMatrix::SXDG);
+      qreg.apply_mcu(op.qubits, Linalg::VMatrix::SXDG);
       break;
     case Gates::pauli:
-      BaseState::qregs_[iChunk].apply_pauli(op.qubits, op.string_params[0]);
+      qreg.apply_pauli(op.qubits, op.string_params[0]);
       break;
     default:
       // We shouldn't reach here unless there is a bug in gateset
@@ -1662,70 +1910,70 @@ void State<statevec_t>::apply_gate(const int_t iChunk, const Operations::Op &op)
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_multiplexer(const int_t iChunk, const reg_t &control_qubits,
+void State<statevec_t>::apply_multiplexer(statevec_t& qreg, const reg_t &control_qubits,
                                           const reg_t &target_qubits,
                                           const cmatrix_t &mat) 
 {
   if (control_qubits.empty() == false && target_qubits.empty() == false &&
       mat.size() > 0) {
     cvector_t vmat = Utils::vectorize_matrix(mat);
-    BaseState::qregs_[iChunk].apply_multiplexer(control_qubits, target_qubits, vmat);
+    qreg.apply_multiplexer(control_qubits, target_qubits, vmat);
   }
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_matrix(const int_t iChunk, const Operations::Op &op) 
+void State<statevec_t>::apply_matrix(statevec_t& qreg, const Operations::Op &op) 
 {
   if (op.qubits.empty() == false && op.mats[0].size() > 0) {
     if (Utils::is_diagonal(op.mats[0], .0)) {
-      apply_diagonal_matrix(iChunk, op.qubits, Utils::matrix_diagonal(op.mats[0]));
+      apply_diagonal_matrix(qreg, op.qubits, Utils::matrix_diagonal(op.mats[0]));
     } else {
-      BaseState::qregs_[iChunk].apply_matrix(op.qubits,
+      qreg.apply_matrix(op.qubits,
                                     Utils::vectorize_matrix(op.mats[0]));
     }
   }
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_matrix(const int_t iChunk, const reg_t &qubits,
+void State<statevec_t>::apply_matrix(statevec_t& qreg, const reg_t &qubits,
                                      const cvector_t &vmat) 
 {
   // Check if diagonal matrix
   if (vmat.size() == 1ULL << qubits.size()) {
-    apply_diagonal_matrix(iChunk, qubits, vmat);
+    apply_diagonal_matrix(qreg, qubits, vmat);
   } else {
-    BaseState::qregs_[iChunk].apply_matrix(qubits, vmat);
+    qreg.apply_matrix(qubits, vmat);
   }
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_diagonal_matrix(const int_t iChunk, const reg_t &qubits, const cvector_t & diag)
+void State<statevec_t>::apply_diagonal_matrix(statevec_t& qreg, const reg_t &qubits, const cvector_t & diag)
 {
   if(BaseState::global_chunk_indexing_ || !BaseState::multi_chunk_distribution_){
     //GPU computes all chunks in one kernel, so pass qubits and diagonal matrix as is
-    BaseState::qregs_[iChunk].apply_diagonal_matrix(qubits,diag);
+    qreg.apply_diagonal_matrix(qubits,diag);
   }
   else{
     reg_t qubits_in = qubits;
     cvector_t diag_in = diag;
 
-    BaseState::block_diagonal_matrix(iChunk,qubits_in,diag_in);
-    BaseState::qregs_[iChunk].apply_diagonal_matrix(qubits_in,diag_in);
+    BaseState::block_diagonal_matrix(qreg.chunk_index(),qubits_in,diag_in);
+    qreg.apply_diagonal_matrix(qubits_in,diag_in);
   }
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_gate_mcu(const int_t iChunk, const reg_t &qubits, double theta,
+void State<statevec_t>::apply_gate_mcu(statevec_t& qreg, const reg_t &qubits, double theta,
                                        double phi, double lambda, double gamma) 
 {
-  BaseState::qregs_[iChunk].apply_mcu(qubits, Linalg::VMatrix::u4(theta, phi, lambda, gamma));
+  qreg.apply_mcu(qubits, Linalg::VMatrix::u4(theta, phi, lambda, gamma));
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_gate_phase(const int_t iChunk, uint_t qubit, complex_t phase) 
+void State<statevec_t>::apply_gate_phase(statevec_t& qreg, uint_t qubit, complex_t phase) 
 {
   cvector_t diag = {{1., phase}};
-  apply_diagonal_matrix(iChunk, reg_t({qubit}), diag);
+  apply_diagonal_matrix(qreg, reg_t({qubit}), diag);
 }
 
 //=========================================================================
@@ -1733,23 +1981,10 @@ void State<statevec_t>::apply_gate_phase(const int_t iChunk, uint_t qubit, compl
 //=========================================================================
 
 template <class statevec_t>
-void State<statevec_t>::apply_measure(const int_t iChunk, const reg_t &qubits, const reg_t &cmemory,
-                                      const reg_t &cregister, RngEngine &rng) 
-{
-  int_t ishot = BaseState::get_global_shot_index(iChunk);
-  // Actual measurement outcome
-  const auto meas = sample_measure_with_prob(iChunk, qubits, rng);
-  // Implement measurement update
-  measure_reset_update(iChunk, qubits, meas.first, meas.first, meas.second);
-  const reg_t outcome = Utils::int2reg(meas.first, 2, qubits.size());
-  BaseState::cregs_[ishot].store_measure(outcome, cmemory, cregister);
-}
-
-template <class statevec_t>
-rvector_t State<statevec_t>::measure_probs(const int_t iChunk, const reg_t &qubits) const 
+rvector_t State<statevec_t>::measure_probs(QuantumState::Registers<statevec_t>& state, const reg_t &qubits) const 
 {
   if(!BaseState::multi_chunk_distribution_)
-    return BaseState::qregs_[iChunk].probabilities(qubits);
+    return state.qreg().probabilities(qubits);
 
   uint_t dim = 1ull << qubits.size();
   rvector_t sum(dim,0.0);
@@ -1764,7 +1999,7 @@ rvector_t State<statevec_t>::measure_probs(const int_t iChunk, const reg_t &qubi
 #pragma omp parallel for private(i,j,k) 
       for(int_t ig=0;ig<BaseState::num_groups_;ig++){
         for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++){
-          auto chunkSum = BaseState::qregs_[i].probabilities(qubits_in_chunk);
+          auto chunkSum = state.qreg(i).probabilities(qubits_in_chunk);
 
           if(qubits_in_chunk.size() == qubits.size()){
             for(j=0;j<dim;j++){
@@ -1795,8 +2030,8 @@ rvector_t State<statevec_t>::measure_probs(const int_t iChunk, const reg_t &qubi
       }
     }
     else{
-      for(i=0;i<BaseState::qregs_.size();i++){
-        auto chunkSum = BaseState::qregs_[i].probabilities(qubits_in_chunk);
+      for(i=0;i<state.qregs().size();i++){
+        auto chunkSum = state.qreg(i).probabilities(qubits_in_chunk);
 
         if(qubits_in_chunk.size() == qubits.size()){
           for(j=0;j<dim;j++){
@@ -1829,7 +2064,7 @@ rvector_t State<statevec_t>::measure_probs(const int_t iChunk, const reg_t &qubi
 #pragma omp parallel for private(i,j,k) 
       for(int_t ig=0;ig<BaseState::num_groups_;ig++){
         for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++){
-          auto nr = std::real(BaseState::qregs_[i].norm());
+          auto nr = std::real(state.qreg(i).norm());
           int idx = 0;
           for(k=0;k<qubits_out_chunk.size();k++){
             if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits_out_chunk[k]) & 1){
@@ -1842,8 +2077,8 @@ rvector_t State<statevec_t>::measure_probs(const int_t iChunk, const reg_t &qubi
       }
     }
     else{
-      for(i=0;i<BaseState::qregs_.size();i++){
-        auto nr = std::real(BaseState::qregs_[i].norm());
+      for(i=0;i<state.qregs().size();i++){
+        auto nr = std::real(state.qreg(i).norm());
         int idx = 0;
         for(k=0;k<qubits_out_chunk.size();k++){
           if((((i + BaseState::global_chunk_index_) << (BaseState::chunk_bits_)) >> qubits_out_chunk[k]) & 1){
@@ -1864,25 +2099,79 @@ rvector_t State<statevec_t>::measure_probs(const int_t iChunk, const reg_t &qubi
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_reset(const int_t iChunk, const reg_t &qubits, RngEngine &rng) {
-  // Simulate unobserved measurement
-  const auto meas = sample_measure_with_prob(iChunk, qubits, rng);
-  // Apply update to reset state
-  measure_reset_update(iChunk, qubits, 0, meas.first, meas.second);
+void State<statevec_t>::apply_measure(QuantumState::Registers<statevec_t>& state, const reg_t &qubits, const reg_t &cmemory,
+                                      const reg_t &cregister, RngEngine &rng) 
+{
+  //shot branching
+  if(BaseState::enable_shot_branching_){
+    rvector_t probs = sample_measure_with_prob_shot_branching(state, qubits);
+
+    //save result to cregs
+    for(int_t i=0;i<probs.size();i++){
+      const reg_t outcome = Utils::int2reg(i, 2, qubits.size());
+      state.branch(i).creg_.store_measure(outcome, cmemory, cregister);
+    }
+
+    measure_reset_update_shot_branching(state, qubits, -1, probs);
+  }
+  else{
+    // Actual measurement outcome
+    const auto meas = sample_measure_with_prob(state, qubits, rng);
+    // Implement measurement update
+    measure_reset_update(state, qubits, meas.first, meas.first, meas.second);
+    const reg_t outcome = Utils::int2reg(meas.first, 2, qubits.size());
+    state.creg().store_measure(outcome, cmemory, cregister);
+  }
+}
+
+template <class statevec_t>
+void State<statevec_t>::apply_reset(QuantumState::Registers<statevec_t>& state, const reg_t &qubits, RngEngine &rng) 
+{
+  //shot branching
+  if(BaseState::enable_shot_branching_){
+    rvector_t probs = sample_measure_with_prob_shot_branching(state, qubits);
+
+    measure_reset_update_shot_branching(state, qubits, 0, probs);
+  }
+  else{
+    // Simulate unobserved measurement
+    const auto meas = sample_measure_with_prob(state, qubits, rng);
+    // Apply update to reset state
+    measure_reset_update(state, qubits, 0, meas.first, meas.second);
+  }
 }
 
 template <class statevec_t>
 std::pair<uint_t, double>
-State<statevec_t>::sample_measure_with_prob(const int_t iChunk, const reg_t &qubits,
-                                            RngEngine &rng) {
-  rvector_t probs = measure_probs(iChunk, qubits);
+State<statevec_t>::sample_measure_with_prob(QuantumState::Registers<statevec_t>& state, const reg_t &qubits,
+                                            RngEngine &rng) 
+{
+  rvector_t probs = measure_probs(state, qubits);
+
   // Randomly pick outcome and return pair
   uint_t outcome = rng.rand_int(probs);
   return std::make_pair(outcome, probs[outcome]);
 }
 
 template <class statevec_t>
-void State<statevec_t>::measure_reset_update(const int_t iChunk, const std::vector<uint_t> &qubits,
+rvector_t State<statevec_t>::sample_measure_with_prob_shot_branching(QuantumState::Registers<statevec_t>& state, const reg_t &qubits)
+{
+  rvector_t probs = measure_probs(state, qubits);
+  uint_t nshots = state.num_shots();
+  reg_t shot_branch(nshots);
+
+  for(int_t i=0;i<nshots;i++){
+    shot_branch[i] = state.rng_shots(i).rand_int(probs);
+  }
+
+  //branch shots
+  state.branch_shots(shot_branch, probs.size());
+
+  return probs;
+}
+
+template <class statevec_t>
+void State<statevec_t>::measure_reset_update(QuantumState::Registers<statevec_t>& state, const std::vector<uint_t> &qubits,
                                              const uint_t final_state,
                                              const uint_t meas_state,
                                              const double meas_prob) 
@@ -1898,19 +2187,19 @@ void State<statevec_t>::measure_reset_update(const int_t iChunk, const std::vect
     mdiag[meas_state] = 1. / std::sqrt(meas_prob);
 
     if(!BaseState::multi_chunk_distribution_)
-      BaseState::qregs_[iChunk].apply_diagonal_matrix(qubits, mdiag);
+      state.qreg().apply_diagonal_matrix(qubits, mdiag);
     else{
       if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for  
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
-            apply_diagonal_matrix(ic, qubits, mdiag);
+            apply_diagonal_matrix(state.qreg(ic), qubits, mdiag);
         }
       }
       else{
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
-            apply_diagonal_matrix(ic, qubits, mdiag);
+            apply_diagonal_matrix(state.qreg(ic), qubits, mdiag);
         }
       }
     }
@@ -1918,9 +2207,9 @@ void State<statevec_t>::measure_reset_update(const int_t iChunk, const std::vect
     // If it doesn't agree with the reset state update
     if (final_state != meas_state) {
       if(!BaseState::multi_chunk_distribution_)
-        BaseState::qregs_[iChunk].apply_mcx(qubits);
+        state.qreg().apply_mcx(qubits);
       else
-        BaseState::apply_chunk_x(qubits[0]);
+        BaseState::apply_chunk_x(state, qubits[0]);
     }
   }
   // Multi qubit case
@@ -1931,19 +2220,19 @@ void State<statevec_t>::measure_reset_update(const int_t iChunk, const std::vect
     mdiag[meas_state] = 1. / std::sqrt(meas_prob);
 
     if(!BaseState::multi_chunk_distribution_)
-      BaseState::qregs_[iChunk].apply_diagonal_matrix(qubits, mdiag);
+      state.qreg().apply_diagonal_matrix(qubits, mdiag);
     else{
       if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
-            apply_diagonal_matrix(ic, qubits, mdiag);
+            apply_diagonal_matrix(state.qreg(ic), qubits, mdiag);
         }
       }
       else{
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
-            apply_diagonal_matrix(ic, qubits, mdiag);
+            apply_diagonal_matrix(state.qreg(ic), qubits, mdiag);
         }
       }
     }
@@ -1966,12 +2255,28 @@ void State<statevec_t>::measure_reset_update(const int_t iChunk, const std::vect
             perm[j * dim + j] = 1.;
         }
         // apply permutation to swap state
-        apply_matrix(iChunk, qubits, perm);
+        if(!BaseState::multi_chunk_distribution_)
+          apply_matrix(state.qreg(), qubits, perm);
+        else{
+          if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
+#pragma omp parallel for 
+            for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+              for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+                apply_matrix(state.qreg(ic), qubits, perm);
+            }
+          }
+          else{
+            for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+              for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+                apply_matrix(state.qreg(ic), qubits, perm);
+            }
+          }
+        }
       }
       else{
         for(int_t i=0;i<qubits.size();i++){
           if(((final_state >> i) & 1) != ((meas_state >> i) & 1)){
-            BaseState::apply_chunk_x(qubits[i]);
+            BaseState::apply_chunk_x(state, qubits[i]);
           }
         }
       }
@@ -1980,23 +2285,101 @@ void State<statevec_t>::measure_reset_update(const int_t iChunk, const std::vect
 }
 
 template <class statevec_t>
-std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
+void State<statevec_t>::measure_reset_update_shot_branching(
+                                             QuantumState::Registers<statevec_t>& state, const std::vector<uint_t> &qubits,
+                                             const int_t final_state,
+                                             const rvector_t& meas_probs)
+{
+  // Update a state vector based on an outcome pair [m, p] from
+  // sample_measure_with_prob function, and a desired post-measurement
+  // final_state
+
+  // Single-qubit case
+  if (qubits.size() == 1) {
+    // Diagonal matrix for projecting and renormalizing to measurement outcome
+    for(int_t i=0;i<2;i++){
+      cvector_t mdiag(2, 0.);
+      mdiag[i] = 1. / std::sqrt(meas_probs[i]);
+
+      Operations::Op op;
+      op.type = OpType::diagonal_matrix;
+      op.qubits = qubits;
+      op.params = mdiag;
+      state.add_op_after_branch(i, op);
+
+      if(final_state >= 0 && final_state != i) {
+        Operations::Op op;
+        op.type = OpType::gate;
+        op.name = "mcx";
+        op.qubits = qubits;
+        state.add_op_after_branch(i, op);
+      }
+    }
+  }
+  // Multi qubit case
+  else {
+    // Diagonal matrix for projecting and renormalizing to measurement outcome
+    const size_t dim = 1ULL << qubits.size();
+    for(int_t i=0;i<dim;i++){
+      cvector_t mdiag(dim, 0.);
+      mdiag[i] = 1. / std::sqrt(meas_probs[i]);
+
+      Operations::Op op;
+      op.type = OpType::diagonal_matrix;
+      op.qubits = qubits;
+      op.params = mdiag;
+      state.add_op_after_branch(i, op);
+
+      if(final_state >= 0 && final_state != i) {
+        // build vectorized permutation matrix
+        cvector_t perm(dim * dim, 0.);
+        perm[final_state * dim + i] = 1.;
+        perm[i * dim + final_state] = 1.;
+        for (size_t j = 0; j < dim; j++) {
+          if (j != final_state && j != i)
+            perm[j * dim + j] = 1.;
+        }
+        Operations::Op op;
+        op.type = OpType::matrix;
+        op.qubits = qubits;
+        op.mats.push_back(Utils::devectorize_matrix(perm));
+        state.add_op_after_branch(i, op);
+      }
+    }
+  }
+}
+
+template <class statevec_t>
+std::vector<reg_t> State<statevec_t>::sample_measure(QuantumState::RegistersBase& state_in, const reg_t &qubits,
                                                      uint_t shots,
                                                      RngEngine &rng) 
 {
+  QuantumState::Registers<statevec_t>& state = dynamic_cast<QuantumState::Registers<statevec_t>&>(state_in);
+
   int_t i,j;
   // Generate flat register for storing
-  std::vector<double> rnds;
-  rnds.reserve(shots);
+  std::vector<double> rnds(shots);
   reg_t allbit_samples(shots,0);
 
-  for (i = 0; i < shots; ++i)
-    rnds.push_back(rng.rand(0, 1));
+  if(!BaseState::multi_chunk_distribution_){
+    bool tmp = state.qregs()[0].enable_batch(false);
+    if(state.num_shots() > 1){
+      double norm = state.qregs()[0].norm();
 
-  if(!BaseState::multi_chunk_distribution_)
-    allbit_samples = BaseState::qregs_[0].sample_measure(rnds);
+      //use independent rng for each shot
+      for (i = 0; i < state.num_shots(); ++i)
+        rnds[i] = state.rng_shots(i).rand(0, norm);
+    }
+    else{
+      for (i = 0; i < shots; ++i)
+        rnds[i] = rng.rand(0, 1);
+    }
+
+    allbit_samples = state.qregs()[0].sample_measure(rnds);
+    state.qregs()[0].enable_batch(tmp);
+  }
   else{
-    std::vector<double> chunkSum(BaseState::qregs_.size()+1,0);
+    std::vector<double> chunkSum(state.qregs().size()+1,0);
     double sum,localSum;
 
     //calculate per chunk sum
@@ -2004,29 +2387,29 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
 #pragma omp parallel for 
       for(int_t ig=0;ig<BaseState::num_groups_;ig++){
         for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++){
-          bool batched = BaseState::qregs_[ic].enable_batch(true);   //return sum of all chunks in group
-          chunkSum[ic] = BaseState::qregs_[ic].norm();
-          BaseState::qregs_[ic].enable_batch(batched);
+          bool batched = state.qregs()[ic].enable_batch(true);   //return sum of all chunks in group
+          chunkSum[ic] = state.qregs()[ic].norm();
+          state.qregs()[ic].enable_batch(batched);
         }
       }
     }
     else{
       for(int_t ig=0;ig<BaseState::num_groups_;ig++){
         for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++){
-          bool batched = BaseState::qregs_[ic].enable_batch(true);   //return sum of all chunks in group
-          chunkSum[ic] = BaseState::qregs_[ic].norm();
-          BaseState::qregs_[ic].enable_batch(batched);
+          bool batched = state.qregs()[ic].enable_batch(true);   //return sum of all chunks in group
+          chunkSum[ic] = state.qregs()[ic].norm();
+          state.qregs()[ic].enable_batch(batched);
         }
       }
     }
 
     localSum = 0.0;
-    for(i=0;i<BaseState::qregs_.size();i++){
+    for(i=0;i<state.qregs().size();i++){
       sum = localSum;
       localSum += chunkSum[i];
       chunkSum[i] = sum;
     }
-    chunkSum[BaseState::qregs_.size()] = localSum;
+    chunkSum[state.qregs().size()] = localSum;
 
     double globalSum = 0.0;
     if(BaseState::nprocs_ > 1){
@@ -2043,10 +2426,13 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
       }
     }
 
+    for (i = 0; i < shots; ++i)
+      rnds[i] = rng.rand(0, 1);
+
     reg_t local_samples(shots,0);
 
     //get rnds positions for each chunk
-    for(i=0;i<BaseState::qregs_.size();i++){
+    for(i=0;i<state.qregs().size();i++){
       uint_t nIn;
       std::vector<uint_t> vIdx;
       std::vector<double> vRnd;
@@ -2062,7 +2448,7 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
       }
 
       if(nIn > 0){
-        auto chunkSamples = BaseState::qregs_[i].sample_measure(vRnd);
+        auto chunkSamples = state.qregs()[i].sample_measure(vRnd);
 
         for(j=0;j<chunkSamples.size();j++){
           local_samples[vIdx[j]] = ((BaseState::global_chunk_index_ + i) << BaseState::chunk_bits_) + chunkSamples[j];
@@ -2094,7 +2480,7 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
 }
 
 template <class statevec_t>
-void State<statevec_t>::apply_initialize(const int_t iChunk, const reg_t &qubits,
+void State<statevec_t>::apply_initialize(QuantumState::Registers<statevec_t>& state, const reg_t &qubits,
                                          const cvector_t &params,
                                          RngEngine &rng) 
 {
@@ -2104,16 +2490,35 @@ void State<statevec_t>::apply_initialize(const int_t iChunk, const reg_t &qubits
     // If qubits is all ordered qubits in the statevector
     // we can just initialize the whole state directly
     if (qubits == sorted_qubits) {
-      initialize_from_vector(iChunk, params);
+      initialize_from_vector(state, params);
       return;
     }
   }
-  // Apply reset to qubits
-  apply_reset(iChunk, qubits, rng);
+
+  if(BaseState::enable_shot_branching_){
+    if(state.additional_ops().size() == 0){
+      apply_reset(state, qubits, rng);
+
+      Operations::Op op;
+      op.type = OpType::initialize;
+      op.name = "initialize";
+      op.qubits = qubits;
+      op.params = params;
+      for(int_t i=0;i<state.num_branch();i++){
+        state.add_op_after_branch(i, op);
+      }
+
+      return; //initialize will be done in next call because of shot branching in reset
+    }
+  }
+  else{
+    // Apply reset to qubits
+    apply_reset(state, qubits, rng);
+  }
 
   // Apply initialize_component
   if(!BaseState::multi_chunk_distribution_)
-    BaseState::qregs_[iChunk].initialize_component(qubits, params);
+    state.qreg().initialize_component(qubits, params);
   else{
     reg_t qubits_in_chunk;
     reg_t qubits_out_chunk;
@@ -2124,12 +2529,12 @@ void State<statevec_t>::apply_initialize(const int_t iChunk, const reg_t &qubits
 #pragma omp parallel for 
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
-            BaseState::qregs_[i].initialize_component(qubits, params);
+            state.qreg(i).initialize_component(qubits, params);
         }
       }
       else{
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          BaseState::qregs_[i].initialize_component(qubits, params);
+        for(int_t i=0;i<state.qregs().size();i++)
+          state.qreg(i).initialize_component(qubits, params);
       }
     }
     else{
@@ -2144,12 +2549,12 @@ void State<statevec_t>::apply_initialize(const int_t iChunk, const reg_t &qubits
 
         if(BaseState::chunk_omp_parallel_){
 #pragma omp parallel for 
-          for(int_t i=0;i<BaseState::qregs_.size();i++)
-            apply_matrix(i, qubits_in_chunk, perm );
+          for(int_t i=0;i<state.qregs().size();i++)
+            apply_matrix(state.qreg(i), qubits_in_chunk, perm );
         }
         else{
-          for(int_t i=0;i<BaseState::qregs_.size();i++)
-            apply_matrix(i, qubits_in_chunk, perm );
+          for(int_t i=0;i<state.qregs().size();i++)
+            apply_matrix(state.qreg(i), qubits_in_chunk, perm );
         }
       }
       if(qubits_out_chunk.size() > 0){
@@ -2178,19 +2583,19 @@ void State<statevec_t>::apply_initialize(const int_t iChunk, const reg_t &qubits
 
             if(ic >= BaseState::chunk_index_begin_[BaseState::distributed_rank_] && ic < BaseState::chunk_index_end_[BaseState::distributed_rank_]){    //on this process
               if(baseChunk >= BaseState::chunk_index_begin_[BaseState::distributed_rank_] && baseChunk < BaseState::chunk_index_end_[BaseState::distributed_rank_]){    //base chunk is on this process
-                BaseState::qregs_[ic].initialize_from_data(BaseState::qregs_[baseChunk].data(),1ull << BaseState::chunk_bits_);
+                state.qreg(ic).initialize_from_data(state.qreg(baseChunk).data(),1ull << BaseState::chunk_bits_);
               }
               else{
-                BaseState::recv_chunk(ic,baseChunk);
+                BaseState::recv_chunk(state, ic,baseChunk);
                 //using swap chunk function to release send/recv buffers for Thrust
                 reg_t swap(2);
                 swap[0] = BaseState::chunk_bits_;
                 swap[1] = BaseState::chunk_bits_;
-                BaseState::qregs_[ic].apply_chunk_swap(swap,baseChunk);
+                state.qreg(ic).apply_chunk_swap(swap,baseChunk);
               }
             }
             else if(baseChunk >= BaseState::chunk_index_begin_[BaseState::distributed_rank_] && baseChunk < BaseState::chunk_index_end_[BaseState::distributed_rank_]){    //base chunk is on this process
-              BaseState::send_chunk(baseChunk - BaseState::global_chunk_index_,ic);
+              BaseState::send_chunk(state, baseChunk - BaseState::global_chunk_index_,ic);
             }
           }
         }
@@ -2201,33 +2606,33 @@ void State<statevec_t>::apply_initialize(const int_t iChunk, const reg_t &qubits
 #pragma omp parallel for 
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
-            apply_diagonal_matrix(i, qubits,params );
+            apply_diagonal_matrix(state.qreg(i), qubits,params );
         }
       }
       else{
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          apply_diagonal_matrix(i, qubits,params );
+        for(int_t i=0;i<state.qregs().size();i++)
+          apply_diagonal_matrix(state.qreg(i), qubits,params );
       }
     }
   }
 }
 
 template <class statevec_t>
-void State<statevec_t>::initialize_from_vector(const int_t iChunk, const cvector_t &params)
+void State<statevec_t>::initialize_from_vector(QuantumState::Registers<statevec_t>& state, const cvector_t &params)
 {
   if(!BaseState::multi_chunk_distribution_)
-    BaseState::qregs_[iChunk].initialize_from_vector(params);
+    state.qreg().initialize_from_vector(params);
   else{   //multi-chunk distribution
     uint_t local_offset = BaseState::global_chunk_index_ << BaseState::chunk_bits_;
 
 #pragma omp parallel for if(BaseState::chunk_omp_parallel_)
-    for(int_t i=0;i<BaseState::qregs_.size();i++){
+    for(int_t i=0;i<state.qregs().size();i++){
       //copy part of state for this chunk
       cvector_t tmp(1ull << BaseState::chunk_bits_);
       std::copy(params.begin() + local_offset + (i << BaseState::chunk_bits_),
                 params.begin() + local_offset + ((i+1) << BaseState::chunk_bits_),
                 tmp.begin());
-      BaseState::qregs_[i].initialize_from_vector(tmp);
+      state.qreg(i).initialize_from_vector(tmp);
     }
   }
 }
@@ -2237,7 +2642,7 @@ void State<statevec_t>::initialize_from_vector(const int_t iChunk, const cvector
 //=========================================================================
 
 template <class statevec_t>
-void State<statevec_t>::apply_multiplexer(const int_t iChunk, const reg_t &control_qubits,
+void State<statevec_t>::apply_multiplexer(statevec_t& qreg, const reg_t &control_qubits,
                                           const reg_t &target_qubits,
                                           const std::vector<cmatrix_t> &mmat) {
   // (1) Pack vector of matrices into single (stacked) matrix ... note: matrix
@@ -2245,14 +2650,14 @@ void State<statevec_t>::apply_multiplexer(const int_t iChunk, const reg_t &contr
   cmatrix_t multiplexer_matrix = Utils::stacked_matrix(mmat);
 
   // (2) Treat as single, large(r), chained/batched matrix operator
-  apply_multiplexer(iChunk, control_qubits, target_qubits, multiplexer_matrix);
+  apply_multiplexer(qreg, control_qubits, target_qubits, multiplexer_matrix);
 }
 
 //=========================================================================
 // Implementation: Kraus Noise
 //=========================================================================
 template <class statevec_t>
-void State<statevec_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
+void State<statevec_t>::apply_kraus(QuantumState::Registers<statevec_t>& state, const reg_t &qubits,
                                     const std::vector<cmatrix_t> &kmats,
                                     RngEngine &rng) 
 {
@@ -2266,10 +2671,29 @@ void State<statevec_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
   // So we only compute probabilities for the first N-1 kraus operators
   // and infer the probability of the last one from 1 - sum of the previous
 
-  double r = rng.rand(0., 1.);
+  double r;
   double accum = 0.;
   double p;
   bool complete = false;
+
+  reg_t shot_branch;
+  uint_t nshots;
+  rvector_t rshots,pmats;
+  uint_t nshots_multiplied = 0;
+
+  if(BaseState::enable_shot_branching_){
+    nshots = state.num_shots();
+    shot_branch.resize(nshots);
+    rshots.resize(nshots);
+    for(int_t i=0;i<nshots;i++){
+      shot_branch[i] = kmats.size() - 1;
+      rshots[i] = state.rng_shots(i).rand(0., 1.);
+    }
+    pmats.resize(kmats.size());
+  }
+  else{
+    r = rng.rand(0., 1.);
+  }
 
   // Loop through N-1 kraus operators
   for (size_t j = 0; j < kmats.size() - 1; j++) {
@@ -2278,7 +2702,7 @@ void State<statevec_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
     cvector_t vmat = Utils::vectorize_matrix(kmats[j]);
 
     if(!BaseState::multi_chunk_distribution_){
-      p = BaseState::qregs_[iChunk].norm(qubits, vmat);
+      p = state.qreg().norm(qubits, vmat);
       accum += p;
     }
     else{
@@ -2287,12 +2711,12 @@ void State<statevec_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
 #pragma omp parallel for reduction(+:p)
         for(int_t ig=0;ig<BaseState::num_groups_;ig++){
           for(int_t i = BaseState::top_chunk_of_group_[ig];i < BaseState::top_chunk_of_group_[ig + 1];i++)
-            p += BaseState::qregs_[i].norm(qubits, vmat);
+            p += state.qreg(i).norm(qubits, vmat);
         }
       }
       else{
-        for(int_t i=0;i<BaseState::qregs_.size();i++)
-          p += BaseState::qregs_[i].norm(qubits, vmat);
+        for(int_t i=0;i<state.qregs().size();i++)
+          p += state.qreg(i).norm(qubits, vmat);
       }
 
 #ifdef AER_MPI
@@ -2302,51 +2726,83 @@ void State<statevec_t>::apply_kraus(const int_t iChunk, const reg_t &qubits,
     }
 
     // check if we need to apply this operator
-    if (accum > r) {
-      // rescale vmat so projection is normalized
-      Utils::scalar_multiply_inplace(vmat, 1 / std::sqrt(p));
-      // apply Kraus projection operator
+    if(BaseState::enable_shot_branching_){
+      pmats[j] = p;
+      for(int_t i=0;i<nshots;i++){
+        if(shot_branch[i] >= kmats.size() - 1){
+          if(accum > rshots[i]){
+            shot_branch[i] = j;
+            nshots_multiplied++;
+          }
+        }
+      }
+      if(nshots_multiplied >= nshots){
+        complete = true;
+        break;
+      }
+    }
+    else{
+      if (accum > r) {
+        // rescale vmat so projection is normalized
+        Utils::scalar_multiply_inplace(vmat, 1 / std::sqrt(p));
+        // apply Kraus projection operator
+        if(!BaseState::multi_chunk_distribution_)
+          apply_matrix(state.qreg(), qubits, vmat);
+        else{
+          if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
+#pragma omp parallel for 
+            for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+              for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+                apply_matrix(state.qreg(ic), qubits, vmat);
+            }
+          }
+          else{
+            for(int_t ig=0;ig<BaseState::num_groups_;ig++){
+              for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
+                apply_matrix(state.qreg(ic), qubits, vmat);
+            }
+          }
+        }
+        complete = true;
+        break;
+      }
+    }
+  }
+
+  // check if we haven't applied a kraus operator yet
+  if(BaseState::enable_shot_branching_){
+    pmats[pmats.size()-1] = 1. - accum;
+
+    state.branch_shots(shot_branch, kmats.size());
+    for(int_t i=0;i<kmats.size();i++){
+      Operations::Op op;
+      op.type = OpType::matrix;
+      op.qubits = qubits;
+      op.mats.push_back(kmats[i]);
+      Utils::scalar_multiply_inplace(op.mats[0], 1/std::sqrt(pmats[i]));
+      state.add_op_after_branch(i, op);
+    }
+  }
+  else{
+    if (complete == false) {
+      // Compute probability from accumulated
+      complex_t renorm = 1 / std::sqrt(1. - accum);
+      auto vmat = Utils::vectorize_matrix(renorm * kmats.back());
       if(!BaseState::multi_chunk_distribution_)
-        apply_matrix(iChunk, qubits, vmat);
+        apply_matrix(state.qreg(), qubits, vmat);
       else{
         if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
 #pragma omp parallel for 
           for(int_t ig=0;ig<BaseState::num_groups_;ig++){
             for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
-              apply_matrix(ic, qubits, vmat);
+              apply_matrix(state.qreg(ic), qubits, vmat);
           }
         }
         else{
           for(int_t ig=0;ig<BaseState::num_groups_;ig++){
             for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
-              apply_matrix(ic, qubits, vmat);
+              apply_matrix(state.qreg(ic), qubits, vmat);
           }
-        }
-      }
-      complete = true;
-      break;
-    }
-  }
-
-  // check if we haven't applied a kraus operator yet
-  if (complete == false) {
-    // Compute probability from accumulated
-    complex_t renorm = 1 / std::sqrt(1. - accum);
-    auto vmat = Utils::vectorize_matrix(renorm * kmats.back());
-    if(!BaseState::multi_chunk_distribution_)
-      apply_matrix(iChunk, qubits, vmat);
-    else{
-      if(BaseState::chunk_omp_parallel_ && BaseState::num_groups_ > 1){
-#pragma omp parallel for 
-        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
-            apply_matrix(ic, qubits, vmat);
-        }
-      }
-      else{
-        for(int_t ig=0;ig<BaseState::num_groups_;ig++){
-          for(int_t ic = BaseState::top_chunk_of_group_[ig];ic < BaseState::top_chunk_of_group_[ig + 1];ic++)
-            apply_matrix(ic, qubits, vmat);
         }
       }
     }

--- a/src/simulators/superoperator/superoperator.hpp
+++ b/src/simulators/superoperator/superoperator.hpp
@@ -62,6 +62,13 @@ public:
   // Initialize to the identity superoperator
   void initialize();
 
+  //initialize from existing state (copy)
+  void initialize(const Superoperator<data_t>& obj)
+  {
+    BaseDensity::copy_qv(obj);
+    num_qubits_ = obj.num_qubits_;
+  }
+
   // Initializes the vector to a custom initial state.
   // The matrix can either be superoperator matrix or unitary matrix.
   // The type is inferred by the dimensions of the input matrix.

--- a/src/simulators/superoperator/superoperator_state.hpp
+++ b/src/simulators/superoperator/superoperator_state.hpp
@@ -82,25 +82,17 @@ public:
 
   // Apply an operation
   // If the op is not in allowed_ops an exeption will be raised.
-  virtual void apply_op(const Operations::Op &op,
+  virtual void apply_op(QuantumState::RegistersBase& state, const Operations::Op &op,
                         ExperimentResult &result,
                         RngEngine &rng,
                         bool final_op = false) override;
-
-  // Initializes an n-qubit unitary to the identity matrix
-  virtual void initialize_qreg(uint_t num_qubits) override;
 
   // Returns the required memory for storing an n-qubit state in megabytes.
   // For this state the memory is indepdentent of the number of ops
   // and is approximately 16 * 1 << 4 * num_qubits bytes
   virtual size_t
   required_memory_mb(uint_t num_qubits,
-                     const std::vector<Operations::Op> &ops) const override;
-
-  // Load the threshold for applying OpenMP parallelization
-  // if the controller/engine allows threads for it
-  // Config: {"omp_qubit_threshold": 3}
-  virtual void set_config(const json_t &config) override;
+                     QuantumState::OpItr first, QuantumState::OpItr last) const override;
 
   virtual bool allocate(uint_t num_qubits,uint_t block_bits,uint_t num_parallel_shots = 1) override;
 
@@ -108,14 +100,33 @@ public:
   // Additional methods
   //-----------------------------------------------------------------------
 
+  // Initializes to a specific n-qubit unitary given as a complex matrix
+  void initialize_qreg_from_data(uint_t num_qubits, const cmatrix_t &unitary);
+
   // Initialize OpenMP settings for the underlying QubitVector class
-  void initialize_omp();
+  void initialize_omp(QuantumState::Registers<data_t>& state);
 
   auto move_to_matrix()
   {
-    return BaseState::qreg_.move_to_matrix();
+    return BaseState::state_.qreg().move_to_matrix();
+  }
+
+  auto move_to_matrix(QuantumState::Registers<data_t>& state)
+  {
+    return state.qreg().move_to_matrix();
   }
 protected:
+  // Initializes an n-qubit unitary to the identity matrix
+  void initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits) override;
+
+  // Initializes to a specific n-qubit unitary superop
+  void initialize_qreg_state(QuantumState::RegistersBase& state_in, const data_t &unitary) override;
+
+  // Load the threshold for applying OpenMP parallelization
+  // if the controller/engine allows threads for it
+  // Config: {"omp_qubit_threshold": 3}
+  void set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) override;
+
   //-----------------------------------------------------------------------
   // Apply Instructions
   //-----------------------------------------------------------------------
@@ -123,28 +134,28 @@ protected:
   // Applies a Gate operation to the state class.
   // This should support all and only the operations defined in
   // allowed_operations.
-  void apply_gate(const Operations::Op &op);
+  void apply_gate(QuantumState::Registers<data_t>& state,const Operations::Op &op);
 
   // Apply a supported snapshot instruction
   // If the input is not in allowed_snapshots an exeption will be raised.
-  virtual void apply_snapshot(const Operations::Op &op, ExperimentResult &result);
+  virtual void apply_snapshot(QuantumState::Registers<data_t>& state,const Operations::Op &op, ExperimentResult &result);
 
   // Apply a matrix to given qubits (identity on all other qubits)
-  void apply_matrix(const reg_t &qubits, const cmatrix_t &mat);
+  void apply_matrix(QuantumState::Registers<data_t>& state,const reg_t &qubits, const cmatrix_t &mat);
 
   // Apply a matrix to given qubits (identity on all other qubits)
-  void apply_matrix(const reg_t &qubits, const cvector_t &vmat);
+  void apply_matrix(QuantumState::Registers<data_t>& state,const reg_t &qubits, const cvector_t &vmat);
 
   // Reset the specified qubits to the |0> state by simulating
   // a measurement, applying a conditional x-gate if the outcome is 1, and
   // then discarding the outcome.
-  void apply_reset(const reg_t &qubits);
+  void apply_reset(QuantumState::Registers<data_t>& state,const reg_t &qubits);
 
   // Apply a Kraus error operation
-  void apply_kraus(const reg_t &qubits, const std::vector<cmatrix_t> &krausops);
+  void apply_kraus(QuantumState::Registers<data_t>& state,const reg_t &qubits, const std::vector<cmatrix_t> &krausops);
 
   // Apply an N-qubit Pauli gate
-  void apply_pauli(const reg_t &qubits, const std::string &pauli);
+  void apply_pauli(QuantumState::Registers<data_t>& state,const reg_t &qubits, const std::string &pauli);
 
   //-----------------------------------------------------------------------
   // Multi-controlled u3
@@ -153,7 +164,7 @@ protected:
   // Apply N-qubit multi-controlled single qubit waltz gate specified by
   // parameters u3(theta, phi, lambda)
   // NOTE: if N=1 this is just a regular u3 gate.
-  void apply_gate_u3(const uint_t qubit, const double theta, const double phi,
+  void apply_gate_u3(QuantumState::Registers<data_t>& state,const uint_t qubit, const double theta, const double phi,
                      const double lambda);
 
   //-----------------------------------------------------------------------
@@ -161,12 +172,12 @@ protected:
   //-----------------------------------------------------------------------
 
   // Save the current superop matrix
-  void apply_save_state(const Operations::Op &op,
+  void apply_save_state(QuantumState::Registers<data_t>& state,const Operations::Op &op,
                         ExperimentResult &result,
                         bool last_op = false);
 
   // Helper function for computing expectation value
-  virtual double expval_pauli(const reg_t &qubits,
+  virtual double expval_pauli(QuantumState::RegistersBase& state,const reg_t &qubits,
                               const std::string& pauli) override;
     
   //-----------------------------------------------------------------------
@@ -236,50 +247,54 @@ const stringmap_t<Gates> State<data_t>::gateset_({
 //============================================================================
 
 template <class data_t>
-void State<data_t>::apply_op(const Operations::Op &op,
+void State<data_t>::apply_op(QuantumState::RegistersBase& state_in,
+                             const Operations::Op &op,
                              ExperimentResult &result,
                              RngEngine &rng,
-                             bool final_op) {
-  if (BaseState::creg().check_conditional(op)) {
+                             bool final_op) 
+{
+  QuantumState::Registers<data_t>& state = dynamic_cast<QuantumState::Registers<data_t>&>(state_in);
+
+  if (state.creg().check_conditional(op)) {
     switch (op.type) {
       case Operations::OpType::barrier:
       case Operations::OpType::qerror_loc:
         break;
       case Operations::OpType::gate:
-        apply_gate(op);
+        apply_gate(state, op);
         break;
       case Operations::OpType::bfunc:
-          BaseState::creg().apply_bfunc(op);
+        state.creg().apply_bfunc(op);
         break;
       case Operations::OpType::roerror:
-          BaseState::creg().apply_roerror(op, rng);
+        state.creg().apply_roerror(op, rng);
         break;
       case Operations::OpType::reset:
-        apply_reset(op.qubits);
+        apply_reset(state, op.qubits);
         break;
       case Operations::OpType::matrix:
-        apply_matrix(op.qubits, op.mats[0]);
+        apply_matrix(state, op.qubits, op.mats[0]);
         break;
       case Operations::OpType::diagonal_matrix:
-        BaseState::qreg_.apply_diagonal_matrix(op.qubits, op.params);
+        state.qreg().apply_diagonal_matrix(op.qubits, op.params);
         break;
       case Operations::OpType::kraus:
-        apply_kraus(op.qubits, op.mats);
+        apply_kraus(state, op.qubits, op.mats);
         break;
       case Operations::OpType::superop:
-        BaseState::qreg_.apply_superop_matrix(
+        state.qreg().apply_superop_matrix(
             op.qubits, Utils::vectorize_matrix(op.mats[0]));
         break;
       case Operations::OpType::set_unitary:
       case Operations::OpType::set_superop:
-        BaseState::qreg_.initialize_from_matrix(op.mats[0]);
+        state.qreg().initialize_from_matrix(op.mats[0]);
         break;
       case Operations::OpType::snapshot:
-        apply_snapshot(op, result);
+        apply_snapshot(state, op, result);
         break;
       case Operations::OpType::save_state:
       case Operations::OpType::save_superop:
-        apply_save_state(op, result, final_op);
+        apply_save_state(state, op, result, final_op);
         break;
       default:
         throw std::invalid_argument(
@@ -291,54 +306,105 @@ void State<data_t>::apply_op(const Operations::Op &op,
 
 template <class data_t>
 size_t State<data_t>::required_memory_mb(
-    uint_t num_qubits, const std::vector<Operations::Op> &ops) const {
+    uint_t num_qubits, QuantumState::OpItr first, QuantumState::OpItr last) const {
   // An n-qubit unitary as 2^4n complex doubles
   // where each complex double is 16 bytes
-  (void)ops; // avoid unused variable compiler warning
+  (void)first; // avoid unused variable compiler warning
+      (void)last;
   size_t shift_mb = std::max<int_t>(0, num_qubits + 4 - 20);
   size_t mem_mb = 1ULL << (4 * shift_mb);
   return mem_mb;
 }
 
-template <class data_t> void State<data_t>::set_config(const json_t &config) {
+template <class data_t> void State<data_t>::set_state_config(QuantumState::RegistersBase& state_in, const json_t &config) 
+{
+  double thresh;
   // Set OMP threshold for state update functions
   JSON::get_value(omp_qubit_threshold_, "superoperator_parallel_threshold",
                   config);
 
   // Set threshold for truncating snapshots
   JSON::get_value(json_chop_threshold_, "zero_threshold", config);
-  BaseState::qreg_.set_json_chop_threshold(json_chop_threshold_);
+  thresh = json_chop_threshold_;
+
+  QuantumState::Registers<data_t>& state = dynamic_cast<QuantumState::Registers<data_t>&>(state_in);
+  if(state.qregs().size() == 0)
+    state.allocate(1);
+  state.qreg().set_json_chop_threshold(thresh);
 }
 
-template <class data_t> void State<data_t>::initialize_qreg(uint_t num_qubits) {
-  initialize_omp();
-  BaseState::qreg_.set_num_qubits(num_qubits);
-  BaseState::qreg_.initialize();
+template <class data_t> void State<data_t>::initialize_qreg_state(QuantumState::RegistersBase& state_in, const uint_t num_qubits) 
+{
+  QuantumState::Registers<data_t>& state = dynamic_cast<QuantumState::Registers<data_t>&>(state_in);
+  if(state.qregs().size() == 0)
+    state.allocate(1);
+  initialize_omp(state);
+  state.qreg().set_num_qubits(num_qubits);
+  state.qreg().initialize();
 }
 
-template <class data_t> void State<data_t>::initialize_omp() {
-  BaseState::qreg_.set_omp_threshold(omp_qubit_threshold_);
+template <class data_t>
+void State<data_t>::initialize_qreg_state(QuantumState::RegistersBase& state_in, const data_t &supermat) 
+{
+  // Check dimension of state
+  if (supermat.num_qubits() != BaseState::num_qubits_) {
+    throw std::invalid_argument("QubitSuperoperator::State::initialize: "
+                                "initial state does not match qubit number");
+  }
+  QuantumState::Registers<data_t>& state = dynamic_cast<QuantumState::Registers<data_t>&>(state_in);
+  if(state.qregs().size() == 0)
+    state.allocate(1);
+
+  initialize_omp(state);
+  state.qreg().set_num_qubits(BaseState::num_qubits_);
+  const size_t sz = 1ULL << state.qreg().size();
+  state.qreg().initialize_from_data(supermat.data(), sz);
+}
+
+template <class data_t>
+void State<data_t>::initialize_qreg_from_data(uint_t num_qubits, const cmatrix_t &mat) {
+  // Check dimension of unitary
+  const auto sz_uni = 1ULL << (2 * num_qubits);
+  const auto sz_super = 1ULL << (4 * num_qubits);
+  if (mat.size() != sz_uni && mat.size() != sz_super) {
+    throw std::invalid_argument("QubitSuperoperator::State::initialize: "
+                                "initial state does not match qubit number");
+  }
+  QuantumState::Registers<data_t>& state = BaseState::state_;
+  if(state.qregs().size() == 0)
+    state.allocate(1);
+  initialize_omp(state);
+  state.qreg().set_num_qubits(num_qubits);
+  state.qreg().initialize_from_matrix(mat);
+}
+
+template <class data_t> void State<data_t>::initialize_omp(QuantumState::Registers<data_t>& state) 
+{
+  state.qreg().set_omp_threshold(omp_qubit_threshold_);
   if (BaseState::threads_ > 0)
-    BaseState::qreg_.set_omp_threads(
+    state.qreg().set_omp_threads(
         BaseState::threads_); // set allowed OMP threads in qubitvector
 }
 
 template <class data_t>
 bool State<data_t>::allocate(uint_t num_qubits, uint_t block_bits,uint_t num_parallel_shots)
 {
-  return BaseState::qreg_.chunk_setup(num_qubits * 4, num_qubits * 4, 0, 1);
+  if(BaseState::state_.qregs().size() == 0)
+    BaseState::state_.allocate(1);
+
+  return BaseState::state_.qreg().chunk_setup(num_qubits * 4, num_qubits * 4, 0, 1);
 }
 
 //=========================================================================
 // Implementation: Reset
 //=========================================================================
 
-template <class data_t> void State<data_t>::apply_reset(const reg_t &qubits) {
+template <class data_t> void State<data_t>::apply_reset(QuantumState::Registers<data_t>& state, const reg_t &qubits) {
   // TODO: This can be more efficient by adding reset
   // to base class rather than doing a matrix multiplication
   // where all but 1 row is zeros.
   const auto reset_op = Linalg::SMatrix::reset(1ULL << qubits.size());
-  BaseState::qreg_.apply_superop_matrix(qubits,
+  state.qreg().apply_superop_matrix(qubits,
                                         Utils::vectorize_matrix(reset_op));
 }
 
@@ -346,10 +412,11 @@ template <class data_t> void State<data_t>::apply_reset(const reg_t &qubits) {
 // Implementation: Kraus Noise
 //=========================================================================
 
-template <class statevec_t>
-void State<statevec_t>::apply_kraus(const reg_t &qubits,
-                                    const std::vector<cmatrix_t> &kmats) {
-  BaseState::qreg_.apply_superop_matrix(
+template <class data_t>
+void State<data_t>::apply_kraus(QuantumState::Registers<data_t>& state,const reg_t &qubits,
+                                    const std::vector<cmatrix_t> &kmats) 
+{
+  state.qreg().apply_superop_matrix(
       qubits, Utils::vectorize_matrix(Utils::kraus_superop(kmats)));
 }
 
@@ -358,7 +425,8 @@ void State<statevec_t>::apply_kraus(const reg_t &qubits,
 //=========================================================================
 
 template <class data_t>
-void State<data_t>::apply_gate(const Operations::Op &op) {
+void State<data_t>::apply_gate(QuantumState::Registers<data_t>& state, const Operations::Op &op) 
+{
   // Look for gate name in gateset
   auto it = gateset_.find(op.name);
   if (it == gateset_.end())
@@ -366,95 +434,95 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
                                 op.name + "\'.");
   switch (it->second) {
     case Gates::u3:
-      apply_gate_u3(op.qubits[0], std::real(op.params[0]),
+      apply_gate_u3(state, op.qubits[0], std::real(op.params[0]),
                     std::real(op.params[1]), std::real(op.params[2]));
       break;
     case Gates::u2:
-      apply_gate_u3(op.qubits[0], M_PI / 2., std::real(op.params[0]),
+      apply_gate_u3(state, op.qubits[0], M_PI / 2., std::real(op.params[0]),
                     std::real(op.params[1]));
       break;
     case Gates::u1:
-      BaseState::qreg_.apply_phase(op.qubits[0], std::exp(complex_t(0., 1.) * op.params[0]));
+      state.qreg().apply_phase(op.qubits[0], std::exp(complex_t(0., 1.) * op.params[0]));
       break;
     case Gates::r:
-      apply_matrix(op.qubits, Linalg::VMatrix::r(op.params[0], op.params[1]));
+      apply_matrix(state, op.qubits, Linalg::VMatrix::r(op.params[0], op.params[1]));
       break;
     case Gates::rx:
-      apply_matrix(op.qubits, Linalg::VMatrix::rx(op.params[0]));
+      apply_matrix(state, op.qubits, Linalg::VMatrix::rx(op.params[0]));
       break;
     case Gates::ry:
-      apply_matrix(op.qubits, Linalg::VMatrix::ry(op.params[0]));
+      apply_matrix(state, op.qubits, Linalg::VMatrix::ry(op.params[0]));
       break;
     case Gates::rz:
-      apply_matrix(op.qubits, Linalg::VMatrix::rz_diag(op.params[0]));
+      apply_matrix(state, op.qubits, Linalg::VMatrix::rz_diag(op.params[0]));
       break;
     case Gates::rxx:
-      apply_matrix(op.qubits, Linalg::VMatrix::rxx(op.params[0]));
+      apply_matrix(state, op.qubits, Linalg::VMatrix::rxx(op.params[0]));
       break;
     case Gates::ryy:
-      apply_matrix(op.qubits, Linalg::VMatrix::ryy(op.params[0]));
+      apply_matrix(state, op.qubits, Linalg::VMatrix::ryy(op.params[0]));
       break;
     case Gates::rzz:
-      apply_matrix(op.qubits, Linalg::VMatrix::rzz_diag(op.params[0]));
+      apply_matrix(state, op.qubits, Linalg::VMatrix::rzz_diag(op.params[0]));
       break;
     case Gates::rzx:
-      apply_matrix(op.qubits, Linalg::VMatrix::rzx(op.params[0]));
+      apply_matrix(state, op.qubits, Linalg::VMatrix::rzx(op.params[0]));
       break;
     case Gates::cx:
-      BaseState::qreg_.apply_cnot(op.qubits[0], op.qubits[1]);
+      state.qreg().apply_cnot(op.qubits[0], op.qubits[1]);
       break;
     case Gates::cy:
-      apply_matrix(op.qubits, Linalg::VMatrix::CY);
+      apply_matrix(state, op.qubits, Linalg::VMatrix::CY);
       break;
     case Gates::cz:
-      BaseState::qreg_.apply_cphase(op.qubits[0], op.qubits[1], -1);
+      state.qreg().apply_cphase(op.qubits[0], op.qubits[1], -1);
       break;
     case Gates::cp:
-      BaseState::qreg_.apply_cphase(op.qubits[0], op.qubits[1],
+      state.qreg().apply_cphase(op.qubits[0], op.qubits[1],
                                     std::exp(complex_t(0., 1.) * op.params[0]));
       break;
     case Gates::id:
       break;
     case Gates::x:
-      BaseState::qreg_.apply_x(op.qubits[0]);
+      state.qreg().apply_x(op.qubits[0]);
       break;
     case Gates::y:
-      BaseState::qreg_.apply_y(op.qubits[0]);
+      state.qreg().apply_y(op.qubits[0]);
       break;
     case Gates::z:
-      BaseState::qreg_.apply_phase(op.qubits[0], -1);
+      state.qreg().apply_phase(op.qubits[0], -1);
       break;
     case Gates::h:
-      apply_gate_u3(op.qubits[0], M_PI / 2., 0., M_PI);
+      apply_gate_u3(state, op.qubits[0], M_PI / 2., 0., M_PI);
       break;
     case Gates::s:
-      BaseState::qreg_.apply_phase(op.qubits[0], complex_t(0., 1.));
+      state.qreg().apply_phase(op.qubits[0], complex_t(0., 1.));
       break;
     case Gates::sdg:
-      BaseState::qreg_.apply_phase(op.qubits[0], complex_t(0., -1.));
+      state.qreg().apply_phase(op.qubits[0], complex_t(0., -1.));
       break;
     case Gates::sx:
-      BaseState::qreg_.apply_unitary_matrix(op.qubits, Linalg::VMatrix::SX);
+      state.qreg().apply_unitary_matrix(op.qubits, Linalg::VMatrix::SX);
       break;
     case Gates::sxdg:
-      BaseState::qreg_.apply_unitary_matrix(op.qubits, Linalg::VMatrix::SXDG);
+      state.qreg().apply_unitary_matrix(op.qubits, Linalg::VMatrix::SXDG);
       break;
     case Gates::t: {
       const double isqrt2{1. / std::sqrt(2)};
-      BaseState::qreg_.apply_phase(op.qubits[0], complex_t(isqrt2, isqrt2));
+      state.qreg().apply_phase(op.qubits[0], complex_t(isqrt2, isqrt2));
     } break;
     case Gates::tdg: {
       const double isqrt2{1. / std::sqrt(2)};
-      BaseState::qreg_.apply_phase(op.qubits[0], complex_t(isqrt2, -isqrt2));
+      state.qreg().apply_phase(op.qubits[0], complex_t(isqrt2, -isqrt2));
     } break;
     case Gates::swap: {
-      BaseState::qreg_.apply_swap(op.qubits[0], op.qubits[1]);
+      state.qreg().apply_swap(op.qubits[0], op.qubits[1]);
     } break;
     case Gates::ccx:
-      BaseState::qreg_.apply_toffoli(op.qubits[0], op.qubits[1], op.qubits[2]);
+      state.qreg().apply_toffoli(op.qubits[0], op.qubits[1], op.qubits[2]);
       break;
     case Gates::pauli:
-      apply_pauli(op.qubits, op.string_params[0]);
+      apply_pauli(state, op.qubits, op.string_params[0]);
       break;
     default:
       // We shouldn't reach here unless there is a bug in gateset
@@ -464,35 +532,39 @@ void State<data_t>::apply_gate(const Operations::Op &op) {
 }
 
 template <class data_t>
-void State<data_t>::apply_matrix(const reg_t &qubits, const cmatrix_t &mat) {
+void State<data_t>::apply_matrix(QuantumState::Registers<data_t>& state, const reg_t &qubits, const cmatrix_t &mat) 
+{
   if (qubits.empty() == false && mat.size() > 0) {
-    BaseState::qreg_.apply_unitary_matrix(qubits, Utils::vectorize_matrix(mat));
+    state.qreg().apply_unitary_matrix(qubits, Utils::vectorize_matrix(mat));
   }
 }
 
 template <class data_t>
-void State<data_t>::apply_matrix(const reg_t &qubits, const cvector_t &vmat) {
+void State<data_t>::apply_matrix(QuantumState::Registers<data_t>& state, const reg_t &qubits, const cvector_t &vmat) 
+{
   // Check if diagonal matrix
   if (vmat.size() == 1ULL << qubits.size()) {
-    BaseState::qreg_.apply_diagonal_unitary_matrix(qubits, vmat);
+    state.qreg().apply_diagonal_unitary_matrix(qubits, vmat);
   } else {
-    BaseState::qreg_.apply_unitary_matrix(qubits, vmat);
+    state.qreg().apply_unitary_matrix(qubits, vmat);
   }
 }
 
-template <class statevec_t>
-void State<statevec_t>::apply_gate_u3(const uint_t qubit, double theta,
-                                      double phi, double lambda) {
+template <class data_t>
+void State<data_t>::apply_gate_u3(QuantumState::Registers<data_t>& state, const uint_t qubit, double theta,
+                                      double phi, double lambda) 
+{
   const auto u3 = Linalg::VMatrix::u3(theta, phi, lambda);
-  BaseState::qreg_.apply_unitary_matrix(reg_t({qubit}), u3);
+  state.qreg().apply_unitary_matrix(reg_t({qubit}), u3);
 }
 
 template <class data_t>
-void State<data_t>::apply_snapshot(const Operations::Op &op,
-                                   ExperimentResult &result) {
+void State<data_t>::apply_snapshot(QuantumState::Registers<data_t>& state, const Operations::Op &op,
+                                   ExperimentResult &result) 
+{
   // Look for snapshot type in snapshotset
   if (op.name == "superopertor" || op.name == "state") {
-    BaseState::snapshot_state(op, result, "superop");
+    BaseState::snapshot_state(state, op, result, "superop");
   } else {
     throw std::invalid_argument(
         "QubitSuperoperator::State::invalid snapshot instruction \'" + op.name +
@@ -500,21 +572,23 @@ void State<data_t>::apply_snapshot(const Operations::Op &op,
   }
 }
 
-template <class statevec_t>
-void State<statevec_t>::apply_pauli(const reg_t &qubits,
-                                    const std::string &pauli) {
+template <class data_t>
+void State<data_t>::apply_pauli(QuantumState::Registers<data_t>& state, const reg_t &qubits,
+                                    const std::string &pauli) 
+{
   // Pauli as a superoperator is (-1)^num_y P\otimes P
   complex_t coeff = (std::count(pauli.begin(), pauli.end(), 'Y') % 2) ? -1 : 1;
-  BaseState::qreg_.apply_pauli(
-      BaseState::qreg_.superop_qubits(qubits), pauli + pauli, coeff);
+  state.qreg().apply_pauli(
+      state.qreg().superop_qubits(qubits), pauli + pauli, coeff);
 }
 
 
-template <class statevec_t>
-void State<statevec_t>::apply_save_state(const Operations::Op &op,
+template <class data_t>
+void State<data_t>::apply_save_state(QuantumState::Registers<data_t>& state, const Operations::Op &op,
                                         ExperimentResult &result,
-                                        bool last_op) {
-  if (op.qubits.size() != BaseState::qreg_.num_qubits()) {
+                                        bool last_op) 
+{
+  if (op.qubits.size() != state.qreg().num_qubits()) {
     throw std::invalid_argument(
         op.name + " was not applied to all qubits."
         " Only the full state can be saved.");
@@ -524,21 +598,22 @@ void State<statevec_t>::apply_save_state(const Operations::Op &op,
                       ? "superop"
                       : op.string_params[0];
   if (last_op) {
-    result.save_data_pershot(BaseState::creg(), key,
-                             BaseState::qreg_.move_to_matrix(),
+    result.save_data_pershot(state.creg(), key,
+                             state.qreg().move_to_matrix(),
                              Operations::OpType::save_superop,
                              op.save_type);
   } else {
-    result.save_data_pershot(BaseState::creg(), key,
-                             BaseState::qreg_.copy_to_matrix(),
+    result.save_data_pershot(state.creg(), key,
+                             state.qreg().copy_to_matrix(),
                              Operations::OpType::save_superop,
                              op.save_type);
   }
 }
 
 template <class data_t>
-double  State<data_t>::expval_pauli(const reg_t &qubits,
-                                    const std::string& pauli) {
+double  State<data_t>::expval_pauli(QuantumState::RegistersBase& state,const reg_t &qubits,
+                                    const std::string& pauli) 
+{
   throw std::runtime_error("SuperOp simulator does not support Pauli expectation values.");
 }
 

--- a/src/simulators/superoperator/superoperator_thrust.hpp
+++ b/src/simulators/superoperator/superoperator_thrust.hpp
@@ -62,6 +62,13 @@ public:
   // Initialize to the identity superoperator
   void initialize();
 
+  //initialize from existing state (copy)
+  void initialize(const SuperoperatorThrust<data_t>& obj)
+  {
+    BaseDensity::copy_qv(obj);
+    num_qubits_ = obj.num_qubits_;
+  }
+
   // Initializes the vector to a custom initial state.
   // The matrix can either be superoperator matrix or unitary matrix.
   // The type is inferred by the dimensions of the input matrix.

--- a/src/simulators/unitary/unitarymatrix.hpp
+++ b/src/simulators/unitary/unitarymatrix.hpp
@@ -44,15 +44,20 @@ public:
 
   UnitaryMatrix() : UnitaryMatrix(0) {};
   explicit UnitaryMatrix(size_t num_qubits);
-  UnitaryMatrix(const UnitaryMatrix& obj){}
-  UnitaryMatrix &operator=(const UnitaryMatrix& obj){}
+  UnitaryMatrix(const UnitaryMatrix& obj)
+  {
+  }
+  UnitaryMatrix &operator=(const UnitaryMatrix& obj)
+  {
+    return *this;
+  }
 
   //-----------------------------------------------------------------------
   // Utility functions
   //-----------------------------------------------------------------------
 
   // Set the size of the vector in terms of qubit number
-  void set_num_qubits(size_t num_qubits);
+  void set_num_qubits(size_t num_qubits) override;
 
   // Return the number of rows in the matrix
   size_t num_rows() const {return rows_;}
@@ -74,6 +79,15 @@ public:
 
   // Initializes the current vector so that all qubits are in the |0> state.
   void initialize();
+
+  //initialize from existing state (copy)
+  void initialize(const UnitaryMatrix<data_t>& obj)
+  {
+    BaseVector::initialize(obj);
+    num_qubits_ = obj.num_qubits_;
+    rows_ = obj.rows_;
+    identity_threshold_ = obj.identity_threshold_;
+  }
 
   // Initializes the vector to a custom initial state.
   // If the length of the statevector does not match the number of qubits

--- a/src/simulators/unitary/unitarymatrix_thrust.hpp
+++ b/src/simulators/unitary/unitarymatrix_thrust.hpp
@@ -45,6 +45,13 @@ public:
 
   UnitaryMatrixThrust() : UnitaryMatrixThrust(0) {};
   explicit UnitaryMatrixThrust(size_t num_qubits);
+  UnitaryMatrixThrust(const UnitaryMatrixThrust& obj)
+  {
+  }
+  UnitaryMatrixThrust &operator=(const UnitaryMatrixThrust& obj)
+  {
+    return *this;
+  }
 
   //-----------------------------------------------------------------------
   // Utility functions
@@ -82,6 +89,15 @@ public:
 
   // Initializes the current vector so that all qubits are in the |0> state.
   void initialize();
+
+  //initialize from existing state (copy)
+  void initialize(const UnitaryMatrixThrust<data_t>& obj)
+  {
+    BaseVector::initialize(obj);
+    num_qubits_ = obj.num_qubits_;
+    rows_ = obj.rows_;
+    identity_threshold_ = obj.identity_threshold_;
+  }
 
   // Initializes the vector to a custom initial state.
   // If the length of the statevector does not match the number of qubits

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -123,6 +123,7 @@ public:
 
     // Unitary simulation
     QubitUnitary::State<> unitary_simulator;
+    unitary_simulator.allocate(qubits.size(),qubits.size());
     unitary_simulator.initialize_qreg(qubits.size());
     unitary_simulator.apply_ops(fusioned_ops.cbegin(), fusioned_ops.cend(), dummy_result, dummy_rng);
     return Operations::make_unitary(qubits, unitary_simulator.qreg().move_to_matrix(),

--- a/test/terra/backends/aer_simulator/test_runtime_noise_sampling.py
+++ b/test/terra/backends/aer_simulator/test_runtime_noise_sampling.py
@@ -1,0 +1,148 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+AerSimulator Integration Tests
+"""
+
+from ddt import ddt
+from qiskit_aer import noise
+
+import qiskit.quantum_info as qi
+from qiskit import transpile
+from qiskit.circuit import QuantumCircuit, Reset
+from qiskit.circuit.library import QFT
+from qiskit.circuit.library.standard_gates import IGate, HGate
+from qiskit.quantum_info.states.densitymatrix import DensityMatrix
+from test.terra.backends.simulator_test_case import (
+    SimulatorTestCase, supported_methods)
+from test.terra.reference import ref_kraus_noise
+from test.terra.reference import ref_pauli_noise
+from test.terra.reference import ref_readout_noise
+from test.terra.reference import ref_reset_noise
+
+
+@ddt
+class TestRuntimeNoiseSampling(SimulatorTestCase):
+    """AerSimulator readout error noise model tests."""
+
+    @supported_methods([
+        'statevector'])
+    def test_pauli_gate_noise(self, method, device):
+        """Test simulation with Pauli gate error noise model."""
+        backend = self.backend(method=method, device=device)
+        backend.set_options(runtime_noise_sampling_enable=True)
+        backend.set_options(batched_shots_gpu=False)
+        shots = 1000
+        circuits = ref_pauli_noise.pauli_gate_error_circuits()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_gate_error_noise_models()
+        targets = ref_pauli_noise.pauli_gate_error_counts(shots)
+
+        for circuit, noise_model, target in zip(circuits, noise_models,
+                                                targets):
+            backend.set_options(noise_model=noise_model)
+            result = backend.run(circuit, shots=shots).result()
+            self.assertSuccess(result)
+            self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
+
+    @supported_methods([
+        'statevector'])
+    def test_pauli_reset_noise(self, method, device):
+        """Test simulation with Pauli reset error noise model."""
+        backend = self.backend(method=method, device=device)
+        backend.set_options(runtime_noise_sampling_enable=True)
+        backend.set_options(batched_shots_gpu=False)
+        shots = 1000
+        circuits = ref_pauli_noise.pauli_reset_error_circuits()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_reset_error_noise_models()
+        targets = ref_pauli_noise.pauli_reset_error_counts(shots)
+
+        for circuit, noise_model, target in zip(circuits, noise_models,
+                                                targets):
+            backend.set_options(noise_model=noise_model)
+            result = backend.run(circuit, shots=shots).result()
+            self.assertSuccess(result)
+            self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
+
+    @supported_methods([
+        'statevector'])
+    def test_pauli_measure_noise(self, method, device):
+        """Test simulation with Pauli measure error noise model."""
+        backend = self.backend(method=method, device=device)
+        backend.set_options(runtime_noise_sampling_enable=True)
+        backend.set_options(batched_shots_gpu=False)
+        shots = 1000
+        circuits = ref_pauli_noise.pauli_measure_error_circuits()
+        with self.assertWarns(DeprecationWarning):
+            noise_models = ref_pauli_noise.pauli_measure_error_noise_models()
+        targets = ref_pauli_noise.pauli_measure_error_counts(shots)
+
+        for circuit, noise_model, target in zip(circuits, noise_models,
+                                                targets):
+            backend.set_options(noise_model=noise_model)
+            result = backend.run(circuit, shots=shots).result()
+            self.assertSuccess(result)
+            self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
+
+    @supported_methods([
+        'statevector'])
+    def test_reset_gate_noise(self, method, device):
+        """Test simulation with reset gate error noise model."""
+        backend = self.backend(method=method, device=device)
+        backend.set_options(runtime_noise_sampling_enable=True)
+        backend.set_options(batched_shots_gpu=False)
+        shots = 1000
+        circuits = ref_reset_noise.reset_gate_error_circuits()
+        noise_models = ref_reset_noise.reset_gate_error_noise_models()
+        targets = ref_reset_noise.reset_gate_error_counts(shots)
+
+        for circuit, noise_model, target in zip(circuits, noise_models,
+                                                targets):
+            backend.set_options(noise_model=noise_model)
+            result = backend.run(circuit, shots=shots).result()
+            self.assertSuccess(result)
+            self.compare_counts(result, [circuit], [target], delta=0.05 * shots)
+
+    @supported_methods([
+        'statevector'])
+    def test_clifford_circuit_noise(self, method, device):
+        """Test simulation with mixed Clifford quantum errors in circuit."""
+        backend = self.backend(method=method, device=device)
+        backend.set_options(runtime_noise_sampling_enable=True)
+        backend.set_options(batched_shots_gpu=False)
+        shots = 1000
+        error1 = noise.QuantumError([
+            ([(IGate(), [0])], 0.8),
+            ([(Reset(), [0])], 0.1),
+            ([(HGate(), [0])], 0.1)])
+
+        error2 = noise.QuantumError([
+            ([(IGate(), [0])], 0.75),
+            ([(Reset(), [0])], 0.1),
+            ([(Reset(), [1])], 0.1),
+            ([(Reset(), [0]), (Reset(), [1])], 0.05)])
+
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.append(error1, [0])
+        qc.cx(0, 1)
+        qc.append(error2, [0, 1])
+        target_probs = qi.DensityMatrix(qc).probabilities_dict()
+
+        # Add measurement
+        qc.measure_all()
+        result = backend.run(qc, shots=shots).result()
+        self.assertSuccess(result)
+        probs = {key: val / shots for key, val in result.get_counts(0).items()}
+        self.assertDictAlmostEqual(target_probs, probs, delta=0.1)
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I recreate this PR from PR #1596 because something is wrong to build Docs.
This PR is implementation of optimization for multi-shots simulations with operations with randomness (measure, reset, initialize, kraus or noise sampling)

### Details and comments
Starting from 1 state, the simulation branches state into some states caused by randomness of the operation. Simulation time will be decreased when the number of the final branched states is smaller than number of shots. 
To implement this optimization, I moved `qreg` and `creg `into `Register `class and most of the functions of `State `class takes reference to the `Register `so that each function can handle `Register `class independently to manage multiple branched states.

I implemented `run_shots` function in `State `class that simulates multiple shots with or without shot branching optimization and also batched execution for GPU. 

Here is performance measurements of shot branching using QFT circuits with 1% of Kraus noise (1000 shots)
![image](https://user-images.githubusercontent.com/30102488/189865983-1e1402c1-4362-44a2-b8b4-21bfea3998ee.png)
Since there are so many branches in noise simulation, the effect of this implementation is limited. Smaller noise ratio, larger qubits and larger number of shots will improve performance for this test case.
I think shot branching has more advantage in simulating circuits with intermediate measurements. (smaller number of branches)

