### PR TITLE
Add reno branch configuration

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,0 +1,3 @@
+---
+encoding: utf8
+default_branch: main


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There is currently no reno configuration in Aer, so it defaults to basing release notes off the `master` branch, which doesn't exist.  This updates it to correctly look at `main`.

### Details and comments


