### PR TITLE
Use AerStatevector in unittests

### DIFF
--- a/qiskit_aer/quantum_info/states/aer_statevector.py
+++ b/qiskit_aer/quantum_info/states/aer_statevector.py
@@ -35,7 +35,8 @@ class AerStatevector(Statevector):
     def __init__(self, data, dims=None, **configs):
         """
         Args:
-            data (np.array or list or AerStatevector or QuantumCircuit or qiskit.circuit.Instruction):
+            data (np.array or list or AerStatevector or QuantumCircuit or
+                  qiskit.circuit.Instruction):
                 Data from which the statevector can be constructed. This can be either a complex
                 vector, another statevector or a ``QuantumCircuit`` or ``Instruction``
                 (``Operator`` is not supportted in the current implementation).  If the data is

--- a/qiskit_aer/quantum_info/states/aer_statevector.py
+++ b/qiskit_aer/quantum_info/states/aer_statevector.py
@@ -35,7 +35,7 @@ class AerStatevector(Statevector):
     def __init__(self, data, dims=None, **configs):
         """
         Args:
-            data (np.array or list or Statevector or QuantumCircuit or qiskit.circuit.Instruction):
+            data (np.array or list or AerStatevector or QuantumCircuit or qiskit.circuit.Instruction):
                 Data from which the statevector can be constructed. This can be either a complex
                 vector, another statevector or a ``QuantumCircuit`` or ``Instruction``
                 (``Operator`` is not supportted in the current implementation).  If the data is

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -118,7 +118,7 @@ class TestAerStatevector(common.QiskitAerTestCase):
 
         for pa1, pa2 in zip(state1, state2):
             self.assertAlmostEqual(pa1, pa2)
-        
+
         self.assertNotEqual(id(state1._data), id(state2._data))
 
 
@@ -1040,6 +1040,7 @@ class TestAerStatevector(common.QiskitAerTestCase):
         seed = 1020
         op = Pauli(pauli)
         state = random_statevector(2**op.num_qubits, seed=seed)
+        state = AerStatevector(state.data)
         target = state.expectation_value(op.to_matrix())
         expval = state.expectation_value(op)
         self.assertAlmostEqual(expval, target)
@@ -1050,6 +1051,7 @@ class TestAerStatevector(common.QiskitAerTestCase):
         seed = 1020
         op = random_pauli(2, seed=seed)
         state = random_statevector(2**3, seed=seed)
+        state = AerStatevector(state.data)
         target = state.expectation_value(op.to_matrix(), qubits)
         expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes typos.

### Details and comments

`random_statevector` returns `qiskit.quantum_info.Statevector`. So, an `AerStatevector` instance must be created as the next process.
Also, the documentation has been modified since the current specification is that an `AerStatevector` cannot be created directly from a `Statevector`.

I would like to add that I have already discussed this modification with @hhorii.


