### PR TITLE
Remove lsp files from version control tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,13 @@ rhs*_op.pyx
 build/*
 *libomp.dylib
 
+# Ignore LSP config / files
+compile_commands.json
+.cache/clangd
+.ccls
+.ccls-root
+.ccls-cache/
+
 # Ignore macOS DS_Store
 .DS_Store
 # Ignore other IDE Files


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

### Summary

Using ccls/clangd LSPs generate some temporary files that don't need to be checked in. 


