### PR TITLE
Fix tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
   SETUPTOOLS_ENABLE_FEATURES=legacy-editable
+allowlist_externals = mv
 deps =
   -r requirements-dev.txt
 commands =
@@ -17,6 +18,7 @@ commands =
     pip install --find-links={toxinidir}/dist qiskit_aer
     mv qiskit_aer qiskit_aer.bak
     stestr run {posargs}
+commands_post =
     mv qiskit_aer.bak qiskit_aer
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,9 @@ deps =
 commands =
     python setup.py bdist_wheel -- -- -j4
     pip install --find-links={toxinidir}/dist qiskit_aer
+    mv qiskit_aer qiskit_aer.bak
     stestr run {posargs}
+    mv qiskit_aer.bak qiskit_aer
 
 [testenv:coverage]
 basepython = python3
@@ -29,6 +31,7 @@ commands =
 
 [testenv:lint]
 deps =
+  qiskit-terra
   pycodestyle
   pylint
 commands =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary


Hacking of moving `qiskit_aer` is not safe because it cannot be reverted if it is terminated in the middle. If you have other ideas, that must be better, but do you have any suggestion?

### Details and comments


