### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.2
         if: runner.os == 'Windows'
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.2.2
+        run: python -m pip install -U cibuildwheel==2.11.2
       - name: Build Wheels
         env:
           AER_CMAKE_OPENMP_BUILD: 1
@@ -152,7 +152,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.2.2
+        run: python -m pip install -U cibuildwheel==2.11.2
       - name: Build Wheels
         env:
           CIBW_ARCHS_MACOS: arm64

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.7'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.2.2
+          python -m pip install cibuildwheel==2.11.2
       - name: Build wheels
         env:
           AER_CMAKE_OPENMP_BUILD: 1
@@ -55,7 +55,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.2.2 twine
+          python -m pip install cibuildwheel==2.11.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -83,7 +83,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.2.2 twine
+        run: python -m pip install -U cibuildwheel==2.11.2 twine
       - name: Build Wheels
         env:
           CIBW_ARCHS_MACOS: arm64
@@ -133,7 +133,7 @@ jobs:
         if: runner.os == 'Windows'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.2.2
+          python -m pip install cibuildwheel==2.11.2
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget -q https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel6-10-1-local-10.1.243-418.87.00-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 openblas-devel"
@@ -167,7 +167,7 @@ jobs:
         if: runner.os == 'Windows'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.2.2
+          python -m pip install cibuildwheel==2.11.2
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL: "yum install -y yum-utils wget && wget -q https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda-repo-rhel7-10-1-local-10.1.105-418.39-1.0-1.x86_64.rpm && rpm -i cuda-repo-rhel7-10-1-local-10.1.105-418.39-1.0-1.x86_64.rpm && yum clean all && yum -y install cuda-10-1 openblas-devel"
@@ -206,7 +206,7 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_ARCHS_LINUX: s390x
           CIBW_TEST_SKIP: "cp*"
@@ -242,7 +242,7 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_ARCHS_LINUX: ppc64le
           CIBW_TEST_SKIP: "cp*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
     needs: ["lint"]
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", '3.11']
         platform: [
           { os: "ubuntu-latest", python-architecture: "x64" },
         ]
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: ["ubuntu-latest"]
     env:
       AER_THRUST_BACKEND: OMP
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", '3.11']
         os: ["macOS-latest"]
     env:
       AER_THRUST_BACKEND: OMP
@@ -216,7 +216,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: ["windows-2019"]
     env:
       AER_THRUST_BACKEND: OMP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ before-all = "yum install -y openblas-devel"
 environment = { CMAKE_GENERATOR = "Visual Studio 16 2019"}
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3{7,8,9,10}-manylinux_i686"
+select = "cp3{7,8,9,10,11}-manylinux_i686"
 before-all = "yum install -y wget && bash {project}/tools/install_openblas_i686.sh && bash {project}/tools/install_rust.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,4 @@ environment = { CMAKE_GENERATOR = "Visual Studio 16 2019"}
 
 [[tool.cibuildwheel.overrides]]
 select = "cp3{7,8,9,10}-manylinux_i686"
-before-all = "yum install -y openblas-devel wget && bash {project}/tools/install_rust.sh"
+before-all = "yum install -y wget && bash {project}/tools/install_openblas_i686.sh && bash {project}/tools/install_rust.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2010"
+manylinux-i686-image = "manylinux2014"
 skip = "pp* cp36* *musllinux*"
 test-skip = "cp310-win32 cp310-manylinux_i686 cp311-win32 cp311-manylinux_i686"
 test-command = "python {project}/tools/verify_wheels.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "setuptools.build_meta"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2010"
 skip = "pp* cp36* *musllinux*"
-test-skip = "cp310-win32 cp310-manylinux_i686"
+test-skip = "cp310-win32 cp310-manylinux_i686 cp311-win32 cp311-manylinux_i686"
 test-command = "python {project}/tools/verify_wheels.py"
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a
 # tendency to crash if they're installed from source by `pip install`, and since

--- a/releasenotes/notes/add-python-311-support-027047fb389116dd.yaml
+++ b/releasenotes/notes/add-python-311-support-027047fb389116dd.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added support for running Qiskit Aer with Python 3.11 support.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ cmake!=3.17.1,!=3.17.0
 conan>=1.40.0
 scikit-build>=0.11.0
 asv
-cvxpy>=1.0.0,<1.1.15
+cvxpy>=1.0.0,<1.1.15;platform_system != 'Windows' and python_version < '3.11'
 pylint
 pycodestyle
 Sphinx>=1.8.3

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
     ],
     python_requires=">=3.7",

--- a/tools/install_openblas_i686.sh
+++ b/tools/install_openblas_i686.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+wget https://github.com/xianyi/OpenBLAS/releases/download/v0.3.21/OpenBLAS-0.3.21.zip
+unzip OpenBLAS-0.3.21.zip
+cd OpenBLAS-0.3.21
+make TARGET=NORTHWOOD
+make TARGET=NORTHWOOD PREFIX=/usr/ install

--- a/tools/install_openblas_i686.sh
+++ b/tools/install_openblas_i686.sh
@@ -3,5 +3,5 @@
 wget https://github.com/xianyi/OpenBLAS/releases/download/v0.3.21/OpenBLAS-0.3.21.zip
 unzip OpenBLAS-0.3.21.zip
 cd OpenBLAS-0.3.21
-make
-make PREFIX=/usr/ install
+make TARGET=KATMAI
+make TARGET=KATMAI PREFIX=/usr/ install

--- a/tools/install_openblas_i686.sh
+++ b/tools/install_openblas_i686.sh
@@ -3,5 +3,5 @@
 wget https://github.com/xianyi/OpenBLAS/releases/download/v0.3.21/OpenBLAS-0.3.21.zip
 unzip OpenBLAS-0.3.21.zip
 cd OpenBLAS-0.3.21
-make TARGET=NORTHWOOD
-make TARGET=NORTHWOOD PREFIX=/usr/ install
+make
+make PREFIX=/usr/ install

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py37, py38, py39, py310, lint
+envlist = py37, py38, py39, py310, py311, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Python 3.11.0 was released on 10-24-2022, this commit marks the start of support for Python 3.11 in qiskit. It adds the supported Python version in the package metadata and updates the CI configuration to run test jobs on Python 3.11 and build Python 3.11 wheels on release.

### Details and comments