### PR TITLE
Use more gates for AerState to call state_controller

### DIFF
--- a/contrib/runtime/aer_runtime.cpp
+++ b/contrib/runtime/aer_runtime.cpp
@@ -103,31 +103,31 @@ void aer_apply_z(void* handler, uint_t qubit) {
 // Clifford gate: Hadamard
 void aer_apply_h(void* handler, uint_t qubit) {
   AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
-  state->apply_mcu({qubit}, M_PI / 2.0, 0, M_PI);
+  state->apply_h(qubit);
 };
 
 // Clifford gate: sqrt(Z) or S gate
 void aer_apply_s(void* handler, uint_t qubit) {
   AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
-  state->apply_mcu({qubit}, 0, 0, M_PI / 2.0);
+  state->apply_u(qubit, 0, 0, M_PI / 2.0);
 };
 
 // Clifford gate: inverse of sqrt(Z)
 void aer_apply_sdg(void* handler, uint_t qubit) {
   AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
-  state->apply_mcu({qubit}, 0, 0, - M_PI / 2.0);
+  state->apply_u(qubit, 0, 0, - M_PI / 2.0);
 };
 
 // // sqrt(S) or T gate
 void aer_apply_t(void* handler, uint_t qubit) {
   AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
-  state->apply_mcu({qubit}, 0, 0, M_PI / 4.0);
+  state->apply_u(qubit, 0, 0, M_PI / 4.0);
 };
 
 // inverse of sqrt(S)
 void aer_apply_tdg(void* handler, uint_t qubit) {
   AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
-  state->apply_mcu({qubit}, 0, 0, - M_PI / 4.0);
+  state->apply_u({qubit}, 0, 0, - M_PI / 4.0);
 };
 
 // sqrt(NOT) gate
@@ -199,7 +199,7 @@ void aer_apply_crz(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit, double th
 // controlled-H
 void aer_apply_ch(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit) {
   AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
-  state->apply_mcu({ctrl_qubit, tgt_qubit}, M_PI / 2.0, 0, M_PI);
+  state->apply_mcu({ctrl_qubit, tgt_qubit}, M_PI / 2.0, 0, M_PI, 0);
 };
 
 // swap
@@ -223,7 +223,6 @@ void aer_apply_cswap(void* handler, uint_t ctrl_qubit, uint_t qubit0, uint_t qub
 // four parameter controlled-U gate with relative phase γ
 void aer_apply_cu(void* handler, uint_t ctrl_qubit, uint_t tgt_qubit, double theta, double phi, double lambda, double gamma) {
   AER::AerState* state = reinterpret_cast<AER::AerState*>(handler);
-  state->apply_mcphase({ctrl_qubit}, gamma);
-  state->apply_mcu({ctrl_qubit, tgt_qubit}, theta, phi, lambda);
+  state->apply_mcu({ctrl_qubit, tgt_qubit}, theta, phi, lambda, gamma);
 };
 }

--- a/qiskit_aer/backends/wrappers/bindings.cc
+++ b/qiskit_aer/backends/wrappers/bindings.cc
@@ -132,10 +132,19 @@ PYBIND11_MODULE(controller_wrappers, m) {
     });
 
     aer_state.def("apply_diagonal",  &AER::AerState::apply_diagonal_matrix);
+    aer_state.def("apply_x",  &AER::AerState::apply_x);
+    aer_state.def("apply_cx",  &AER::AerState::apply_cx);
     aer_state.def("apply_mcx",  &AER::AerState::apply_mcx);
+    aer_state.def("apply_y",  &AER::AerState::apply_y);
+    aer_state.def("apply_cy",  &AER::AerState::apply_cy);
     aer_state.def("apply_mcy",  &AER::AerState::apply_mcy);
+    aer_state.def("apply_z",  &AER::AerState::apply_z);
+    aer_state.def("apply_cz",  &AER::AerState::apply_cz);
     aer_state.def("apply_mcz",  &AER::AerState::apply_mcz);
     aer_state.def("apply_mcphase",  &AER::AerState::apply_mcphase);
+    aer_state.def("apply_h",  &AER::AerState::apply_h);
+    aer_state.def("apply_u",  &AER::AerState::apply_u);
+    aer_state.def("apply_cu",  &AER::AerState::apply_cu);
     aer_state.def("apply_mcu",  &AER::AerState::apply_mcu);
     aer_state.def("apply_mcswap",  &AER::AerState::apply_mcswap);
     aer_state.def("apply_measure",  &AER::AerState::apply_measure);

--- a/qiskit_aer/quantum_info/states/aer_state.py
+++ b/qiskit_aer/quantum_info/states/aer_state.py
@@ -358,7 +358,7 @@ class AerState:
         self._native_state.apply_mcphase(control_qubits + [target_qubit], phase)
 
     def apply_h(self, target_qubit):
-        """apply a u operation."""
+        """apply a h operation."""
         self._assert_allocated_or_mapped()
         self._assert_in_allocated_qubits(target_qubit)
         # update state
@@ -371,21 +371,21 @@ class AerState:
         # update state
         self._native_state.apply_u(target_qubit, theta, phi, lamb)
 
-    def apply_cu(self, control_qubit, target_qubit, theta, phi, lamb):
-        """apply a u operation."""
+    def apply_cu(self, control_qubit, target_qubit, theta, phi, lamb, gamma):
+        """apply a cu operation."""
         self._assert_allocated_or_mapped()
         self._assert_in_allocated_qubits(control_qubit)
         self._assert_in_allocated_qubits(target_qubit)
         # update state
-        self._native_state.apply_cu([control_qubit, target_qubit], theta, phi, lamb)
+        self._native_state.apply_cu([control_qubit, target_qubit], theta, phi, lamb, gamma)
 
-    def apply_mcu(self, control_qubits, target_qubit, theta, phi, lamb):
+    def apply_mcu(self, control_qubits, target_qubit, theta, phi, lamb, gamma):
         """apply a mcu operation."""
         self._assert_allocated_or_mapped()
         self._assert_in_allocated_qubits(control_qubits)
         self._assert_in_allocated_qubits(target_qubit)
         # update state
-        self._native_state.apply_mcu(control_qubits + [target_qubit], theta, phi, lamb)
+        self._native_state.apply_mcu(control_qubits + [target_qubit], theta, phi, lamb, gamma)
 
     def apply_mcswap(self, control_qubits, qubit0, qubit1):
         """apply a mcswap operation."""

--- a/qiskit_aer/quantum_info/states/aer_state.py
+++ b/qiskit_aer/quantum_info/states/aer_state.py
@@ -377,7 +377,7 @@ class AerState:
         self._assert_in_allocated_qubits(control_qubit)
         self._assert_in_allocated_qubits(target_qubit)
         # update state
-        self._native_state.apply_cu([target_qubit], theta, phi, lamb)
+        self._native_state.apply_cu([control_qubit, target_qubit], theta, phi, lamb)
 
     def apply_mcu(self, control_qubits, target_qubit, theta, phi, lamb):
         """apply a mcu operation."""

--- a/qiskit_aer/quantum_info/states/aer_state.py
+++ b/qiskit_aer/quantum_info/states/aer_state.py
@@ -280,6 +280,21 @@ class AerState:
         # update state
         self._native_state.apply_diagonal(qubits, diag)
 
+    def apply_x(self, target_qubit):
+        """apply a x operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_x(target_qubit)
+
+    def apply_cx(self, control_qubit, target_qubit):
+        """apply a cx operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(control_qubit)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_cx([control_qubit, target_qubit])
+
     def apply_mcx(self, control_qubits, target_qubit):
         """apply a mcx operation."""
         self._assert_allocated_or_mapped()
@@ -288,6 +303,21 @@ class AerState:
         # update state
         self._native_state.apply_mcx(control_qubits + [target_qubit])
 
+    def apply_y(self, target_qubit):
+        """apply a y operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_y(target_qubit)
+
+    def apply_cy(self, control_qubit, target_qubit):
+        """apply a cy operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(control_qubit)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_cy([control_qubit, target_qubit])
+
     def apply_mcy(self, control_qubits, target_qubit):
         """apply a mcy operation."""
         self._assert_allocated_or_mapped()
@@ -295,6 +325,21 @@ class AerState:
         self._assert_in_allocated_qubits(target_qubit)
         # update state
         self._native_state.apply_mcy(control_qubits + [target_qubit])
+
+    def apply_z(self, target_qubit):
+        """apply a z operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_z(target_qubit)
+
+    def apply_cz(self, control_qubit, target_qubit):
+        """apply a cz operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(control_qubit)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_cz([control_qubit, target_qubit])
 
     def apply_mcz(self, control_qubits, target_qubit):
         """apply a mcz operation."""
@@ -311,6 +356,28 @@ class AerState:
         self._assert_in_allocated_qubits(target_qubit)
         # update state
         self._native_state.apply_mcphase(control_qubits + [target_qubit], phase)
+
+    def apply_h(self, target_qubit):
+        """apply a u operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_h(target_qubit)
+
+    def apply_u(self, target_qubit, theta, phi, lamb):
+        """apply a u operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_u(target_qubit, theta, phi, lamb)
+
+    def apply_cu(self, control_qubit, target_qubit, theta, phi, lamb):
+        """apply a u operation."""
+        self._assert_allocated_or_mapped()
+        self._assert_in_allocated_qubits(control_qubit)
+        self._assert_in_allocated_qubits(target_qubit)
+        # update state
+        self._native_state.apply_cu([target_qubit], theta, phi, lamb)
 
     def apply_mcu(self, control_qubits, target_qubit, theta, phi, lamb):
         """apply a mcu operation."""

--- a/qiskit_aer/quantum_info/states/aer_statevector.py
+++ b/qiskit_aer/quantum_info/states/aer_statevector.py
@@ -24,6 +24,7 @@ from .aer_state import AerState
 from ...backends.aerbackend import AerError
 from ...backends.backend_utils import BASIS_GATES
 
+
 class AerStatevector(Statevector):
     """AerStatevector class
 
@@ -155,7 +156,7 @@ class AerStatevector(Statevector):
             method = 'statevector'
             aer_state.configure('method', method)
 
-        basis_gates = BASIS_GATES[method] 
+        basis_gates = BASIS_GATES[method]
 
         aer_state.allocate_qubits(inst.num_qubits)
         num_qubits = inst.num_qubits
@@ -176,7 +177,7 @@ class AerStatevector(Statevector):
         return aer_state.move_to_ndarray(), aer_state
 
     @staticmethod
-    def _aer_evolve_circuit(aer_state, circuit, qubits, basis_gates=[]):
+    def _aer_evolve_circuit(aer_state, circuit, qubits, basis_gates=None):
         """Apply circuit into aer_state"""
         for instruction in circuit.data:
             if instruction.clbits:
@@ -190,13 +191,13 @@ class AerStatevector(Statevector):
                                                     for qarg in qargs], basis_gates)
 
     @staticmethod
-    def _aer_evolve_instruction(aer_state, inst, qubits, basis_gates=[]):
+    def _aer_evolve_instruction(aer_state, inst, qubits, basis_gates=None):
         """Apply instruction into aer_state"""
 
         params = inst.params
         applied = True
 
-        if inst.name in basis_gates:
+        if basis_gates and inst.name in basis_gates:
             if inst.name in ['u3', 'u']:
                 aer_state.apply_u(qubits[0], params[0], params[1], params[2])
             elif inst.name == 'h':
@@ -221,7 +222,7 @@ class AerStatevector(Statevector):
                 aer_state.apply_cu(qubits[0], qubits[1], params[0], params[1], params[2], params[3])
             elif inst.name == 'mcu':
                 aer_state.apply_mcu(qubits[0:len(qubits) - 1], qubits[len(qubits) - 1],
-                    params[0], params[1], params[2], params[3])
+                                    params[0], params[1], params[2], params[3])
             elif inst.name in 'mcx':
                 aer_state.apply_mcx(qubits[0:len(qubits) - 1], qubits[len(qubits) - 1])
             elif inst.name in 'mcy':

--- a/qiskit_aer/quantum_info/states/aer_statevector.py
+++ b/qiskit_aer/quantum_info/states/aer_statevector.py
@@ -187,40 +187,21 @@ class AerStatevector(Statevector):
 
         params = inst.params
 
-        def _assert_qubits(expected):
-            if len(qubits) != expected:
-                raise AerError(
-                    f"Cannot apply a {expected}-qubit instruction {inst} to qubits {qubits}"
-                )
-
-        def _assert_params(expected):
-            if len(params) < expected:
-                raise AerError(f"Need {expected} parameters, but actually {len(params)}")
-
         if inst.name in ['u', 'u3']:
-            _assert_qubits(1)
-            _assert_params(3)
             aer_state.apply_u(qubits[0], params[0], params[1], params[2])
         elif inst.name == 'h':
-            _assert_qubits(1)
             aer_state.apply_h(qubits[0])
         elif inst.name == 'x':
-            _assert_qubits(1)
             aer_state.apply_x(qubits[0])
         elif inst.name == 'cx':
-            _assert_qubits(2)
             aer_state.apply_cx(qubits[0], qubits[1])
         elif inst.name == 'y':
-            _assert_qubits(1)
             aer_state.apply_y(qubits)
         elif inst.name == 'cy':
-            _assert_qubits(2)
             aer_state.apply_cy(qubits[0], qubits[1])
         elif inst.name == 'z':
-            _assert_qubits(1)
             aer_state.apply_z(qubits)
         elif inst.name == 'cz':
-            _assert_qubits(2)
             aer_state.apply_cz(qubits[0], qubits[1])
         elif inst.name == 'unitary':
             aer_state.apply_unitary(qubits, inst.params[0])
@@ -233,7 +214,6 @@ class AerStatevector(Statevector):
         else:
             definition = inst.definition
             if definition is inst or definition is None:
-                print(inst.definition)
                 raise AerError('cannot decompose ' + inst.name)
             AerStatevector._aer_evolve_circuit(aer_state, definition, qubits)
 

--- a/qiskit_aer/quantum_info/states/aer_statevector.py
+++ b/qiskit_aer/quantum_info/states/aer_statevector.py
@@ -22,7 +22,7 @@ from qiskit.quantum_info.states import Statevector
 from qiskit_aer import AerSimulator
 from .aer_state import AerState
 from ...backends.aerbackend import AerError
-
+from ...backends.backend_utils import BASIS_GATES
 
 class AerStatevector(Statevector):
     """AerStatevector class
@@ -149,6 +149,14 @@ class AerStatevector(Statevector):
         for config_key, config_value in configs.items():
             aer_state.configure(config_key, config_value)
 
+        if 'method' in configs:
+            method = configs['method']
+        else:
+            method = 'statevector'
+            aer_state.configure('method', method)
+
+        basis_gates = BASIS_GATES[method] 
+
         aer_state.allocate_qubits(inst.num_qubits)
         num_qubits = inst.num_qubits
 
@@ -161,14 +169,14 @@ class AerStatevector(Statevector):
             aer_state.apply_global_phase(inst.global_phase)
 
         if isinstance(inst, QuantumCircuit):
-            AerStatevector._aer_evolve_circuit(aer_state, inst, range(num_qubits))
+            AerStatevector._aer_evolve_circuit(aer_state, inst, range(num_qubits), basis_gates)
         else:
-            AerStatevector._aer_evolve_instruction(aer_state, inst, range(num_qubits))
+            AerStatevector._aer_evolve_instruction(aer_state, inst, range(num_qubits), basis_gates)
 
         return aer_state.move_to_ndarray(), aer_state
 
     @staticmethod
-    def _aer_evolve_circuit(aer_state, circuit, qubits):
+    def _aer_evolve_circuit(aer_state, circuit, qubits, basis_gates=[]):
         """Apply circuit into aer_state"""
         for instruction in circuit.data:
             if instruction.clbits:
@@ -179,43 +187,63 @@ class AerStatevector(Statevector):
             qargs = instruction.qubits
             AerStatevector._aer_evolve_instruction(aer_state, inst,
                                                    [qubits[circuit.find_bit(qarg).index]
-                                                    for qarg in qargs])
+                                                    for qarg in qargs], basis_gates)
 
     @staticmethod
-    def _aer_evolve_instruction(aer_state, inst, qubits):
+    def _aer_evolve_instruction(aer_state, inst, qubits, basis_gates=[]):
         """Apply instruction into aer_state"""
 
         params = inst.params
+        applied = True
 
-        if inst.name in ['u', 'u3']:
-            aer_state.apply_u(qubits[0], params[0], params[1], params[2])
-        elif inst.name == 'h':
-            aer_state.apply_h(qubits[0])
-        elif inst.name == 'x':
-            aer_state.apply_x(qubits[0])
-        elif inst.name == 'cx':
-            aer_state.apply_cx(qubits[0], qubits[1])
-        elif inst.name == 'y':
-            aer_state.apply_y(qubits)
-        elif inst.name == 'cy':
-            aer_state.apply_cy(qubits[0], qubits[1])
-        elif inst.name == 'z':
-            aer_state.apply_z(qubits)
-        elif inst.name == 'cz':
-            aer_state.apply_cz(qubits[0], qubits[1])
-        elif inst.name == 'unitary':
-            aer_state.apply_unitary(qubits, inst.params[0])
-        elif inst.name == 'diagonal':
-            aer_state.apply_diagonal(qubits, inst.params[0])
+        if inst.name in basis_gates:
+            if inst.name in ['u3', 'u']:
+                aer_state.apply_u(qubits[0], params[0], params[1], params[2])
+            elif inst.name == 'h':
+                aer_state.apply_h(qubits[0])
+            elif inst.name == 'x':
+                aer_state.apply_x(qubits[0])
+            elif inst.name == 'cx':
+                aer_state.apply_cx(qubits[0], qubits[1])
+            elif inst.name == 'y':
+                aer_state.apply_y(qubits[0])
+            elif inst.name == 'cy':
+                aer_state.apply_cy(qubits[0], qubits[1])
+            elif inst.name == 'z':
+                aer_state.apply_z(qubits[0])
+            elif inst.name == 'cz':
+                aer_state.apply_cz(qubits[0], qubits[1])
+            elif inst.name == 'unitary':
+                aer_state.apply_unitary(qubits, inst.params[0])
+            elif inst.name == 'diagonal':
+                aer_state.apply_diagonal(qubits, inst.params)
+            elif inst.name == 'cu':
+                aer_state.apply_cu(qubits[0], qubits[1], params[0], params[1], params[2], params[3])
+            elif inst.name == 'mcu':
+                aer_state.apply_mcu(qubits[0:len(qubits) - 1], qubits[len(qubits) - 1],
+                    params[0], params[1], params[2], params[3])
+            elif inst.name in 'mcx':
+                aer_state.apply_mcx(qubits[0:len(qubits) - 1], qubits[len(qubits) - 1])
+            elif inst.name in 'mcy':
+                aer_state.apply_mcy(qubits[0:len(qubits) - 1], qubits[len(qubits) - 1])
+            elif inst.name in 'mcz':
+                aer_state.apply_mcz(qubits[0:len(qubits) - 1], qubits[len(qubits) - 1])
+            elif inst.name == 'id':
+                pass
+            else:
+                applied = False
         elif inst.name == 'reset':
             aer_state.apply_reset(qubits)
-        elif inst.name in ['barrier', 'id']:
+        elif inst.name == 'barrier':
             pass
         else:
+            applied = False
+
+        if not applied:
             definition = inst.definition
             if definition is inst or definition is None:
                 raise AerError('cannot decompose ' + inst.name)
-            AerStatevector._aer_evolve_circuit(aer_state, definition, qubits)
+            AerStatevector._aer_evolve_circuit(aer_state, definition, qubits, basis_gates)
 
     @classmethod
     def from_label(cls, label):

--- a/releasenotes/notes/fix_aer_statevector_mps-c3dd40b936700ff4.yaml
+++ b/releasenotes/notes/fix_aer_statevector_mps-c3dd40b936700ff4.yaml
@@ -1,0 +1,8 @@
+---
+issues:
+  - |
+    Fix two bugs in AerStatevector. AerStatevector uses mc* instructions, which are
+    not enabled in matrix_product_state method. This commit changes AerStatevector
+    not to use MC* and use H, X, Y, Z, U and CX. AerStatevector also failed if an
+    instruction is decomposed to empty QuantumCircuit. This commit allows such
+    instruction.

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -200,17 +200,35 @@ public:
   // Apply Specialized Gates
   //-----------------------------------------------------------------------
 
+  // Apply an optimized X gate
+  virtual void apply_x(const uint_t qubit);
+
+  // Apply an optimized CX gate
+  virtual void apply_cx(const reg_t &qubits);
+
   // Apply a general N-qubit multi-controlled X-gate
   // If N=1 this implements an optimized X gate
   // If N=2 this implements an optimized CX gate
   // If N=3 this implements an optimized Toffoli gate
   virtual void apply_mcx(const reg_t &qubits);
 
+  // Apply an optimized Y gate
+  virtual void apply_y(const uint_t qubit);
+
+  // Apply an optimized CY gate
+  virtual void apply_cy(const reg_t &qubits);
+
   // Apply a general multi-controlled Y-gate
   // If N=1 this implements an optimized Y gate
   // If N=2 this implements an optimized CY gate
   // If N=3 this implements an optimized CCY gate
   virtual void apply_mcy(const reg_t &qubits);
+
+  // Apply an optimized Z gate
+  virtual void apply_z(const uint_t qubit);
+
+  // Apply an optimized CZ gate
+  virtual void apply_cz(const reg_t &qubits);
 
   // Apply a general multi-controlled Z-gate
   // If N=1 this implements an optimized Z gate
@@ -224,6 +242,15 @@ public:
   // If N=2 this implements an optimized CPhase gate
   // If N=3 this implements an optimized CCPhase gate
   virtual void apply_mcphase(const reg_t &qubits, const std::complex<double> phase);
+
+  // Apply an optimized H gate
+  virtual void apply_h(const uint_t qubit);
+
+  // Apply an optimized single-qubit U gate
+  virtual void apply_u(const uint_t qubit, const double theta, const double phi, const double lambda);
+
+  // Apply an optimized CU gate
+  virtual void apply_cu(const reg_t &qubits, const double theta, const double phi, const double lambda);
 
   // Apply a general multi-controlled single-qubit unitary gate
   // If N=1 this implements an optimized single-qubit U gate
@@ -813,6 +840,28 @@ void AerState::apply_multiplexer(const reg_t &control_qubits, const reg_t &targe
 // Apply Specialized Gates
 //-----------------------------------------------------------------------
 
+void AerState::apply_x(const uint_t qubit) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "x";
+  op.qubits = {qubit};
+
+  buffer_op(std::move(op));
+}
+
+void AerState::apply_cx(const reg_t &qubits) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "cx";
+  op.qubits = qubits;
+
+  buffer_op(std::move(op));
+}
+
 void AerState::apply_mcx(const reg_t &qubits) {
   assert_initialized();
 
@@ -824,12 +873,56 @@ void AerState::apply_mcx(const reg_t &qubits) {
   buffer_op(std::move(op));
 }
 
+void AerState::apply_y(const uint_t qubit) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "y";
+  op.qubits = {qubit};
+
+  buffer_op(std::move(op));
+}
+
+void AerState::apply_cy(const reg_t &qubits) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "cy";
+  op.qubits = qubits;
+
+  buffer_op(std::move(op));
+}
+
 void AerState::apply_mcy(const reg_t &qubits) {
   assert_initialized();
 
   Operations::Op op;
   op.type = Operations::OpType::gate;
   op.name = "mcy";
+  op.qubits = qubits;
+
+  buffer_op(std::move(op));
+}
+
+void AerState::apply_z(const uint_t qubit) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "z";
+  op.qubits = {qubit};
+
+  buffer_op(std::move(op));
+}
+
+void AerState::apply_cz(const reg_t &qubits) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "cz";
   op.qubits = qubits;
 
   buffer_op(std::move(op));
@@ -854,6 +947,42 @@ void AerState::apply_mcphase(const reg_t &qubits, const std::complex<double> pha
   op.name = "mcp";
   op.qubits = qubits;
   op.params.push_back(phase);
+
+  buffer_op(std::move(op));
+}
+
+void AerState::apply_h(const uint_t qubit) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "h";
+  op.qubits = {qubit};
+  op.params = {};
+
+  buffer_op(std::move(op));
+}
+
+void AerState::apply_u(const uint_t qubit, const double theta, const double phi, const double lambda) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "u";
+  op.qubits = {qubit};
+  op.params = {theta, phi, lambda, 0.0};
+
+  buffer_op(std::move(op));
+}
+
+void AerState::apply_cu(const reg_t &qubits, const double theta, const double phi, const double lambda) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.name = "cu";
+  op.qubits = qubits;
+  op.params = {theta, phi, lambda, 0.0};
 
   buffer_op(std::move(op));
 }

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -250,13 +250,13 @@ public:
   virtual void apply_u(const uint_t qubit, const double theta, const double phi, const double lambda);
 
   // Apply an optimized CU gate
-  virtual void apply_cu(const reg_t &qubits, const double theta, const double phi, const double lambda);
+  virtual void apply_cu(const reg_t &qubits, const double theta, const double phi, const double lambda, const double gammma);
 
   // Apply a general multi-controlled single-qubit unitary gate
   // If N=1 this implements an optimized single-qubit U gate
   // If N=2 this implements an optimized CU gate
   // If N=3 this implements an optimized CCU gate
-  virtual void apply_mcu(const reg_t &qubits, const double theta, const double phi, const double lambda);
+  virtual void apply_mcu(const reg_t &qubits, const double theta, const double phi, const double lambda, const double gammma);
 
   // Apply a general multi-controlled SWAP gate
   // If N=2 this implements an optimized SWAP  gate
@@ -975,26 +975,26 @@ void AerState::apply_u(const uint_t qubit, const double theta, const double phi,
   buffer_op(std::move(op));
 }
 
-void AerState::apply_cu(const reg_t &qubits, const double theta, const double phi, const double lambda) {
+void AerState::apply_cu(const reg_t &qubits, const double theta, const double phi, const double lambda, const double gamma) {
   assert_initialized();
 
   Operations::Op op;
   op.type = Operations::OpType::gate;
   op.name = "cu";
   op.qubits = qubits;
-  op.params = {theta, phi, lambda, 0.0};
+  op.params = {theta, phi, lambda, gamma};
 
   buffer_op(std::move(op));
 }
 
-void AerState::apply_mcu(const reg_t &qubits, const double theta, const double phi, const double lambda) {
+void AerState::apply_mcu(const reg_t &qubits, const double theta, const double phi, const double lambda, const double gamma) {
   assert_initialized();
 
   Operations::Op op;
   op.type = Operations::OpType::gate;
   op.name = "mcu";
   op.qubits = qubits;
-  op.params = {theta, phi, lambda, 0.0};
+  op.params = {theta, phi, lambda, gamma};
 
   buffer_op(std::move(op));
 }

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -828,10 +828,10 @@ std::vector<reg_t> State::
     rnds_list.push_back(rands);
   }
 
-  //#pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
+  #pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
   {
     MPS temp;
-    //#pragma omp for
+    #pragma omp for
     for (int_t i=0; i<static_cast<int_t>(shots);  i++) {
       temp.initialize(qreg_);
       auto single_result = temp.apply_measure_internal(sorted_qubits, rnds_list[i]);

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -828,10 +828,10 @@ std::vector<reg_t> State::
     rnds_list.push_back(rands);
   }
 
-  #pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
+  //#pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
   {
     MPS temp;
-    #pragma omp for
+    //#pragma omp for
     for (int_t i=0; i<static_cast<int_t>(shots);  i++) {
       temp.initialize(qreg_);
       auto single_result = temp.apply_measure_internal(sorted_qubits, rnds_list[i]);

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -68,6 +68,40 @@ class TestAerStatevector(common.QiskitAerTestCase):
 
         self.assertEqual(state1, state2)
 
+    def test_GHZ(self):
+        """Test each method can process ghz"""
+        ghz = QuantumCircuit(4)
+        ghz.h(0)
+        ghz.cx(0, 1)
+        ghz.cx(1, 2)
+        ghz.cx(2, 3)
+
+        for method in ["statevector", "matrix_product_state"]:
+            sv = AerStatevector(ghz, method=method)
+            counts = sv.sample_counts(shots=1024)
+            self.assertEqual(2, len(counts))
+            self.assertTrue('0000' in counts)
+            self.assertTrue('1111' in counts)
+
+    def test_QFT(self):
+        """Test each method can process qft"""
+        qft = QuantumCircuit(4)
+        qft.h(range(4))
+        qft.compose(QFT(4), inplace=True)
+
+        for method in ["statevector", "matrix_product_state"]:
+            sv = AerStatevector(qft, method=method)
+            counts = sv.sample_counts(shots=1024)
+            self.assertEqual(1, len(counts))
+            self.assertTrue('0000' in counts)
+
+    def test_single_qubit_QV(self):
+        """Test single qubit QuantumVolume"""
+        state = AerStatevector(QuantumVolume(1))
+        counts = state.sample_counts(shots=1024)
+        self.assertEqual(1, len(counts))
+        self.assertTrue('0' in counts)
+
     def test_evolve(self):
         """Test method and device properties"""
         circ1 = QuantumVolume(5, seed=1111)

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -124,7 +124,7 @@ class TestAerStatevector(common.QiskitAerTestCase):
         state1 = AerStatevector(circ)
 
     def test_ry(self):
-        # Test tensor product of 1-qubit gates
+        # Test ry
         circuit = QuantumCircuit(3)
         circuit.h(0)
         circuit.x(1)
@@ -133,11 +133,104 @@ class TestAerStatevector(common.QiskitAerTestCase):
         target = AerStatevector.from_label("000").evolve(Operator(circuit))
         self.assertEqual(target, psi)
 
-    def test_h(self):
-        # Test tensor product of 1-qubit gates
+    def test_u(self):
+        # Test u
         circuit = QuantumCircuit(3)
         circuit.h(0)
         circuit.h(1)
+        circuit.u(0.1, 0.1, 0.1, 0)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_cu(self):
+        # Test cu
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.h(1)
+        circuit.cu(0.1, 0.1, 0.1, 0.1, 0, 1)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_h(self):
+        # Test h
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.h(1)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_x(self):
+        # Test x
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.x(1)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_cx(self):
+        # Test cx
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_y(self):
+        # Test y
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.y(1)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_cy(self):
+        # Test cy
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cy(0, 1)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_z(self):
+        # Test z
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.z(0)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_cz(self):
+        # Test cz
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cz(0, 1)
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_unitary(self):
+        # Test unitary
+        circuit = QuantumCircuit(3)
+        mat = random_unitary(8).data
+        circuit.unitary(mat, range(3))
+        target = AerStatevector.from_label("000").evolve(Operator(circuit))
+        psi = AerStatevector.from_instruction(circuit)
+        self.assertEqual(psi, target)
+
+    def test_diagonal(self):
+        # Test diagonal
+        circuit = QuantumCircuit(3)
+        circuit.h(range(3))
+        diagonal = [ 1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, -1.0 ]
+        circuit.diagonal(diagonal, list(range(3)))
         target = AerStatevector.from_label("000").evolve(Operator(circuit))
         psi = AerStatevector.from_instruction(circuit)
         self.assertEqual(psi, target)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Solve #1640 and #1641 by updateing `_aer_evolve_instruction`.

### Details and comments

MC* instructions were mainly used in `AerStatevector`. However, these instructions are not supported in some methods, such as `matrix_product_state`, and an exception is thrown if they are called. This PR fixes this bug by using `X`. `Y`, `Z`, `CX`. `CY`, `CZ`, `H` and `U`. 