### PR TITLE
Fix device noise model from BackendV2 not to have excessive quantum errors on measures/resets

### DIFF
--- a/qiskit_aer/noise/device/models.py
+++ b/qiskit_aer/noise/device/models.py
@@ -163,9 +163,6 @@ def basic_device_gate_errors(properties=None,
             temperature=temperature
         )
 
-    # Initilize empty errors
-    depol_error = None
-    relax_error = None
     # Generate custom gate time dict
     custom_times = {}
     relax_params = []
@@ -189,6 +186,9 @@ def basic_device_gate_errors(properties=None,
     # Construct quantum errors
     errors = []
     for name, qubits, gate_length, error_param in device_gate_params:
+        # Initilize empty errors
+        depol_error = None
+        relax_error = None
         # Check for custom gate time
         relax_time = gate_length
         # Override with custom value
@@ -201,7 +201,7 @@ def basic_device_gate_errors(properties=None,
                 # get first value
                 relax_time = filtered[0]
         # Get relaxation error
-        if thermal_relaxation:
+        if thermal_relaxation and name != "reset":
             relax_error = _device_thermal_relaxation_error(
                 qubits, relax_time, relax_params, temperature,
                 thermal_relaxation)

--- a/qiskit_aer/noise/device/models.py
+++ b/qiskit_aer/noise/device/models.py
@@ -21,6 +21,7 @@ from warnings import warn, catch_warnings, filterwarnings
 from numpy import inf, exp, allclose
 
 import qiskit.quantum_info as qi
+from qiskit.circuit import Gate
 from .parameters import _NANOSECOND_UNITS
 from .parameters import gate_param_values
 from .parameters import readout_error_values
@@ -78,7 +79,7 @@ def basic_device_readout_errors(properties=None, target=None):
     return errors
 
 
-def basic_device_gate_errors(properties,
+def basic_device_gate_errors(properties=None,
                              gate_error=True,
                              thermal_relaxation=True,
                              gate_lengths=None,
@@ -88,7 +89,7 @@ def basic_device_gate_errors(properties,
                              warnings=None,
                              target=None):
     """
-    Return QuantumErrors derived from a devices BackendProperties.
+    Return QuantumErrors derived from either of a devices BackendProperties or Target.
 
     If non-default values are used gate_lengths should be a list
     of tuples ``(name, qubits, value)`` where ``name`` is the gate
@@ -96,8 +97,11 @@ def basic_device_gate_errors(properties,
     to apply gate time to this gate one any set of qubits,
     and ``value`` is the gate time in nanoseconds.
 
+    Note that only errors on ``Gate`` objects are generated,
+    e.g. no errors are generated on measures.
+
     Args:
-        properties (BackendProperties): device backend properties
+        properties (BackendProperties): device backend properties.
         gate_error (bool): Include depolarizing gate errors (Default: True).
         thermal_relaxation (Bool): Include thermal relaxation errors
                                    (Default: True).
@@ -126,6 +130,9 @@ def basic_device_gate_errors(properties,
     Raises:
         NoiseError: If invalid arguments are supplied.
     """
+    if properties is None and target is None:
+        raise NoiseError("Either properties or target must be supplied.")
+
     if standard_gates is not None:
         warn(
             '"standard_gates" option has been deprecated as of qiskit-aer 0.10.0'
@@ -232,9 +239,12 @@ def _basic_device_target_gate_errors(target,
                                      gate_error=True,
                                      thermal_relaxation=True,
                                      temperature=0):
-    """Return QuantumErrors derived from a devices Target."""
+    """Return QuantumErrors derived from a devices Target.
+    Note that return no errors on non-Gate instructions."""
     errors = []
     for op_name, inst_prop_dic in target.items():
+        if not isinstance(target.operation_from_name(op_name), Gate):
+            continue
         if inst_prop_dic is None:  # ideal simulator
             continue
         for qubits, inst_prop in inst_prop_dic.items():
@@ -315,8 +325,14 @@ def _device_depolarizing_error(qubits,
         max_param = 4**num_qubits / (4**num_qubits - 1)
         if depol_param > max_param:
             depol_param = min(depol_param, max_param)
-        return depolarizing_error(
-            depol_param, num_qubits, standard_gates=standard_gates)
+        with catch_warnings():
+            filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                module="qiskit_aer.noise.device.models"
+            )
+            return depolarizing_error(
+                depol_param, num_qubits, standard_gates=standard_gates)
     return None
 
 

--- a/releasenotes/notes/fix-device-noise-models-2eca2f9c9dc25771.yaml
+++ b/releasenotes/notes/fix-device-noise-models-2eca2f9c9dc25771.yaml
@@ -4,14 +4,8 @@ fixes:
     Fixes a bug where :meth:`NoiseModel.from_backend` with a ``BackendV2`` object may generate
     a noise model with excessive ``QuantumError`` s on non-Gate instructions while,
     for example, only ``ReadoutError`` s should be sufficient for measures.
-    This commit updates :func:`noise.device.models.basic_device_gate_errors`
-    so that it (and hence :meth:`NoiseModel.from_backend`) does not produce
-    any QuantumErrors on non-Gate objects (e.g. measures and resets).
-upgrade:
-  - |
-    Noise models created from backend (via :meth:`NoiseModel.from_backend`) contains
-    ``QuantumError`` s only on ``Gate`` instructions. That means they no longer contains
-    errors on ``Reset`` instructions. Previously, they had relaxation errors on reset instructions.
-    The change may affect users who use :meth:`NoiseModel.from_backend` with ``temperature > 0``
-    while it should affect those who use with default value ``temperature = 0``.
-    Note that they still have ``ReadoutError`` s on ``Measure`` instructions.
+    This commit updates :meth:`NoiseModel.from_backend` with a ``BackendV2`` object so that
+    it returns the same noise model as that called with the corresponding ``BackendV1`` object.
+    That is, the resulting noise model does not contain any ``QuantumError`` s on measures and
+    it may contain only thermal relaxation errors on other non-gate instructions such as resets.
+    Note that it still contains ``ReadoutError`` s on measures.

--- a/releasenotes/notes/fix-device-noise-models-2eca2f9c9dc25771.yaml
+++ b/releasenotes/notes/fix-device-noise-models-2eca2f9c9dc25771.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes a bug where :meth:`NoiseModel.from_backend` with a ``BackendV2`` object may generate
+    a noise model with excessive ``QuantumError`` s on non-Gate instructions while,
+    for example, only ``ReadoutError`` s should be sufficient for measures.
+    This commit updates :func:`noise.device.models.basic_device_gate_errors`
+    so that it (and hence :meth:`NoiseModel.from_backend`) does not produce
+    any QuantumErrors on non-Gate objects (e.g. measures and resets).

--- a/releasenotes/notes/fix-device-noise-models-2eca2f9c9dc25771.yaml
+++ b/releasenotes/notes/fix-device-noise-models-2eca2f9c9dc25771.yaml
@@ -7,3 +7,11 @@ fixes:
     This commit updates :func:`noise.device.models.basic_device_gate_errors`
     so that it (and hence :meth:`NoiseModel.from_backend`) does not produce
     any QuantumErrors on non-Gate objects (e.g. measures and resets).
+upgrade:
+  - |
+    Noise models created from backend (via :meth:`NoiseModel.from_backend`) contains
+    ``QuantumError`` s only on ``Gate`` instructions. That means they no longer contains
+    errors on ``Reset`` instructions. Previously, they had relaxation errors on reset instructions.
+    The change may affect users who use :meth:`NoiseModel.from_backend` with ``temperature > 0``
+    while it should affect those who use with default value ``temperature = 0``.
+    Note that they still have ``ReadoutError`` s on ``Measure`` instructions.

--- a/test/terra/noise/test_device_models.py
+++ b/test/terra/noise/test_device_models.py
@@ -1,0 +1,34 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Tests for utility functions to create device noise model.
+"""
+
+from test.terra.common import QiskitAerTestCase
+
+from qiskit.providers.fake_provider import FakeManilaV2
+from qiskit_aer.noise.device.models import basic_device_gate_errors
+
+
+class TestDeviceNoiseModel(QiskitAerTestCase):
+    """Testing device noise model"""
+
+    def test_basic_device_gate_errors_from_target(self):
+        """Test if the resulting gate errors does not include errors on non-gate instructions"""
+        target = FakeManilaV2().target
+        gate_errors = basic_device_gate_errors(target=target)
+        errors_on_measure = [name for name, _, _ in gate_errors if name == "measure"]
+        errors_on_reset = [name for name, _, _ in gate_errors if name == "reset"]
+        self.assertEqual(len(errors_on_measure), 0)
+        self.assertEqual(len(errors_on_reset), 0)
+        self.assertEqual(len(gate_errors), 23)

--- a/test/terra/noise/test_device_models.py
+++ b/test/terra/noise/test_device_models.py
@@ -16,7 +16,7 @@ Tests for utility functions to create device noise model.
 
 from test.terra.common import QiskitAerTestCase
 
-from qiskit.providers.fake_provider import FakeManilaV2
+from qiskit.providers.fake_provider import FakeNairobi, FakeNairobiV2
 from qiskit_aer.noise.device.models import basic_device_gate_errors
 
 
@@ -24,11 +24,23 @@ class TestDeviceNoiseModel(QiskitAerTestCase):
     """Testing device noise model"""
 
     def test_basic_device_gate_errors_from_target(self):
-        """Test if the resulting gate errors does not include errors on non-gate instructions"""
-        target = FakeManilaV2().target
+        """Test if the resulting gate errors never include errors on non-gate instructions"""
+        target = FakeNairobiV2().target
         gate_errors = basic_device_gate_errors(target=target)
         errors_on_measure = [name for name, _, _ in gate_errors if name == "measure"]
         errors_on_reset = [name for name, _, _ in gate_errors if name == "reset"]
         self.assertEqual(len(errors_on_measure), 0)
         self.assertEqual(len(errors_on_reset), 0)
-        self.assertEqual(len(gate_errors), 23)
+        self.assertEqual(len(gate_errors), 33)
+
+    def test_basic_device_gate_errors_from_target_and_properties(self):
+        """Test if the device same gate errors are produced both from target and properties"""
+        errors_from_properties = basic_device_gate_errors(properties=FakeNairobi().properties())
+        errors_from_target = basic_device_gate_errors(target=FakeNairobiV2().target)
+        self.assertEqual(len(errors_from_properties), len(errors_from_target))
+        for err_properties, err_target in zip(errors_from_properties, errors_from_target):
+            name1, qargs1, err1 = err_properties
+            name2, qargs2, err2 = err_target
+            self.assertEqual(name1, name2)
+            self.assertEqual(tuple(qargs1), qargs2)
+            self.assertEqual(err1, err2)

--- a/test/terra/noise/test_device_models.py
+++ b/test/terra/noise/test_device_models.py
@@ -30,8 +30,8 @@ class TestDeviceNoiseModel(QiskitAerTestCase):
         errors_on_measure = [name for name, _, _ in gate_errors if name == "measure"]
         errors_on_reset = [name for name, _, _ in gate_errors if name == "reset"]
         self.assertEqual(len(errors_on_measure), 0)
-        self.assertEqual(len(errors_on_reset), 0)
-        self.assertEqual(len(gate_errors), 33)
+        self.assertEqual(len(errors_on_reset), 7)
+        self.assertEqual(len(gate_errors), 40)
 
     def test_basic_device_gate_errors_from_target_and_properties(self):
         """Test if the device same gate errors are produced both from target and properties"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1648 by updating device noise models not to have excessive quantum errors on non-gate instructions such as measures and resets when creating them from BackendV2.

### Details and comments
This commit fixes `qiskit_aer.noise.device.models.basic_device_gate_errors` not to generate `QuantumError`s (neither depolarizing nor relaxation) for `Measure` instruction and not to generate depolarizing errors for other non-Gate instructions when `Target` object is supplied.

