### PR TITLE
Set different seed for each sampling in AerStatevector

### DIFF
--- a/qiskit_aer/backends/wrappers/bindings.cc
+++ b/qiskit_aer/backends/wrappers/bindings.cc
@@ -66,6 +66,8 @@ PYBIND11_MODULE(controller_wrappers, m) {
     aer_state.def("configure",  &AER::AerState::configure);
     aer_state.def("allocate_qubits",  &AER::AerState::allocate_qubits);
     aer_state.def("reallocate_qubits",  &AER::AerState::reallocate_qubits);
+    aer_state.def("set_random_seed",  &AER::AerState::set_random_seed);
+    aer_state.def("set_seed",  &AER::AerState::set_seed);
     aer_state.def("clear",  &AER::AerState::clear);
     aer_state.def("num_of_qubits",  &AER::AerState::num_of_qubits);
 

--- a/qiskit_aer/quantum_info/states/aer_state.py
+++ b/qiskit_aer/quantum_info/states/aer_state.py
@@ -58,6 +58,14 @@ class AerState:
         if 'method' not in kwargs:
             self.configure('method', 'statevector')
 
+    def renew(self):
+        """Renew AerState for reuse"""
+        self._assert_closed()
+        self._state = _STATE.INITIALIZING
+        self._init_data = None
+        self._moved_data = None
+        self._last_qubit = -1
+
     def _assert_initializing(self):
         if self._state != _STATE.INITIALIZING:
             raise AerError('AerState was already initialized.')
@@ -84,6 +92,10 @@ class AerState:
         if self._state == _STATE.CLOSED:
             raise AerError('AerState has already been closed.')
 
+    def _assert_closed(self):
+        if self._state != _STATE.CLOSED:
+            raise AerError('AerState is not closed.')
+
     def _allocated(self):
         if self._state != _STATE.INITIALIZING:
             raise AerError('unexpected state transition: {self._state}->{_STATE.ALLOCATED}')
@@ -102,6 +114,7 @@ class AerState:
     def _closed(self):
         if self._state not in (_STATE.MOVED, _STATE.MAPPED):
             raise AerError('unexpected state transition: {self._state}->{_STATE.CLOSED}')
+        self._state = _STATE.CLOSED
 
     def configure(self, key, value):
         """configure AerState with options of `AerSimulator`."""
@@ -154,6 +167,13 @@ class AerState:
             self._allocated()
 
         self._last_qubit = num_of_qubits - 1
+
+    def set_seed(self, value=None):
+        """initialize seed with a specified value"""
+        if value is None:
+            self._native_state.set_random_seed()
+        else:
+            self._native_state.set_seed(value)
 
     def close(self):
         """Safely release all releated memory."""

--- a/qiskit_aer/quantum_info/states/aer_statevector.py
+++ b/qiskit_aer/quantum_info/states/aer_statevector.py
@@ -116,7 +116,7 @@ class AerStatevector(Statevector):
 
         configs = self._aer_state.configuration()
         if 'seed_simulator' in configs:
-            configs['seed_simulator'] += 1
+            configs['seed_simulator'] = int(configs['seed_simulator']) + 1
         self._aer_state = AerState(**configs)
 
         self._aer_state.initialize(self._data, copy=False)

--- a/qiskit_aer/quantum_info/states/aer_statevector.py
+++ b/qiskit_aer/quantum_info/states/aer_statevector.py
@@ -113,7 +113,12 @@ class AerStatevector(Statevector):
         else:
             qubits = np.array(qargs)
         self._aer_state.close()
-        self._aer_state = AerState(**self._aer_state.configuration())
+
+        configs = self._aer_state.configuration()
+        if 'seed_simulator' in configs:
+            configs['seed_simulator'] += 1
+        self._aer_state = AerState(**configs)
+
         self._aer_state.initialize(self._data, copy=False)
         samples = self._aer_state.sample_memory(qubits, shots)
         self._data = self._aer_state.move_to_ndarray()

--- a/qiskit_aer/quantum_info/states/aer_statevector.py
+++ b/qiskit_aer/quantum_info/states/aer_statevector.py
@@ -84,6 +84,13 @@ class AerStatevector(Statevector):
         self._result = None
         self._configs = configs
 
+    def seed(self, value=None):
+        """Set the seed for the quantum state RNG."""
+        if value is None or isinstance(value, int):
+            self._aer_state.set_seed(value)
+        else:
+            raise AerError(f'This seed is not supported: type={value.__class__}, value={value}')
+
     def _last_result(self):
         if self._result is None:
             self._result = self._aer_state.last_result()
@@ -114,12 +121,9 @@ class AerStatevector(Statevector):
             qubits = np.array(qargs)
         self._aer_state.close()
 
-        configs = self._aer_state.configuration()
-        if 'seed_simulator' in configs:
-            configs['seed_simulator'] = int(configs['seed_simulator']) + 1
-        self._aer_state = AerState(**configs)
-
+        self._aer_state.renew()
         self._aer_state.initialize(self._data, copy=False)
+
         samples = self._aer_state.sample_memory(qubits, shots)
         self._data = self._aer_state.move_to_ndarray()
         return samples

--- a/releasenotes/notes/set_seed_for_each_in_aerstatevec-ef5fcac628dec63b.yaml
+++ b/releasenotes/notes/set_seed_for_each_in_aerstatevec-ef5fcac628dec63b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Previously seed is not initialized in AerStatevector and then sampled results
+    are always same. With this commit, a seed is initialized for each sampling
+    and sampled results can be vary.

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -101,7 +101,7 @@ public:
   //-----------------------------------------------------------------------
   // Constructors
   //-----------------------------------------------------------------------
-  AerState() = default;
+  AerState() { set_random_seed(); };
 
   virtual ~AerState() { };
 
@@ -124,9 +124,6 @@ public:
 
   // configure custatevec enabled or not
   virtual bool set_custatevec(const bool& enabled);
-
-  // configure seed
-  virtual bool set_seed_simulator(const int& seed);
 
   // configure number of threads to update state
   virtual bool set_parallel_state_update(const uint_t& parallel_state_update);
@@ -152,7 +149,7 @@ public:
   // Return a number of qubits.
   virtual uint_t num_of_qubits() const { return num_of_qubits_; };
 
-  // Clear all the configurations
+  // Clear state and buffered ops
   virtual void clear();
 
   virtual ExperimentResult& last_result() { return last_result_; };
@@ -163,6 +160,12 @@ public:
 
   // Initialize state with given configuration
   void initialize();
+
+  // Initialize random number genrator
+  void set_random_seed();
+
+  // Initialize random number genrator with a given seed
+  void set_seed(int_t seed);
 
   // Allocate qubits with inputted complex array
   // method must be statevector and the length of the array must be 2^{num_qubits}
@@ -326,7 +329,7 @@ private:
   bool initialized_ = false;
   uint_t num_of_qubits_ = 0;
   RngEngine rng_;
-  int seed_ = std::random_device()();
+  int seed_;
   std::shared_ptr<QuantumState::Base> state_;
   json_t configs_;
   ExperimentResult last_result_;
@@ -410,7 +413,7 @@ void AerState::configure(const std::string& _key, const std::string& _value) {
   } else if (key == "custatevec_enable") {
     error = !set_custatevec("true" == value);
   } else if (key == "seed_simulator") {
-    error = !set_seed_simulator(std::stoi(value));
+    set_seed(std::stoi(value));
   } else if (key == "parallel_state_update") {
     error = !set_parallel_state_update(std::stoul(value));
   } else if (key == "fusion_max_qubit") {
@@ -489,12 +492,6 @@ bool AerState::set_precision(const std::string& precision_name) {
 bool AerState::set_custatevec(const bool& enabled) {
   assert_not_initialized();
   cuStateVec_enable_ = enabled;
-  return true;
-};
-
-bool AerState::set_seed_simulator(const int& seed) {
-  assert_not_initialized();
-  seed_ = seed;
   return true;
 };
 
@@ -634,11 +631,19 @@ void AerState::initialize() {
 
   state_->initialize_qreg(num_of_qubits_);
   state_->initialize_creg(num_of_qubits_, num_of_qubits_);
-  rng_.set_seed(seed_);
 
   clear_ops();
 
   initialized_ = true;
+};
+
+void AerState::set_random_seed() {
+  set_seed(std::random_device()());
+};
+
+void AerState::set_seed(int_t seed) {
+  seed_ = seed;
+  rng_.set_seed(seed);
 };
 
 reg_t AerState::allocate_qubits(uint_t num_qubits) {
@@ -685,7 +690,6 @@ reg_t AerState::initialize_statevector(uint_t num_of_qubits, complex_t* data, bo
   state->initialize_creg(num_of_qubits_, num_of_qubits_);
   state->initialize_statevector(num_of_qubits_, std::move(qv));
   state_ = state;
-  rng_.set_seed(seed_);
   initialized_ = true;
   reg_t ret;
   ret.reserve(num_of_qubits);

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -326,7 +326,7 @@ private:
   bool initialized_ = false;
   uint_t num_of_qubits_ = 0;
   RngEngine rng_;
-  int seed_;
+  int seed_ = std::random_device()();
   std::shared_ptr<QuantumState::Base> state_;
   json_t configs_;
   ExperimentResult last_result_;

--- a/test/terra/states/test_aer_state.py
+++ b/test/terra/states/test_aer_state.py
@@ -433,6 +433,22 @@ class TestAerState(common.QiskitAerTestCase):
         for idx in range(0, 2**5):
             self.assertAlmostEqual(actual[idx], expected[idx])
 
+    def test_set_seed(self):
+        """Test set_seed"""
+        init_state = random_statevector(2**5, seed=111)
+
+        state = AerState(seed_simulator=11111)
+        state.allocate_qubits(5)
+        state.initialize(init_state.data)
+        sample1 = state.sample_counts()
+        sample2 = state.sample_counts()
+
+        state.set_seed(11111)
+        sample3 = state.sample_counts()
+
+        self.assertNotEqual(sample1, sample2)
+        self.assertEqual(sample1, sample3)
+
     def test_sampling(self):
         """Test sampling"""
         init_state = random_statevector(2**5, seed=111)

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -57,7 +57,8 @@ class TestAerStatevector(common.QiskitAerTestCase):
     def test_sample_randomness(self):
         """Test randomness of results of sample_counts """
         circ = QuantumVolume(5, seed=1111)
-        state = AerStatevector(circ)
+
+        state = AerStatevector(circ, seed_simulator=1)
 
         shots = 1024
         counts0 = state.sample_counts(shots, qargs=range(5))
@@ -71,9 +72,42 @@ class TestAerStatevector(common.QiskitAerTestCase):
         counts2 = state.sample_counts(shots, qargs=range(5))
         counts3 = state.sample_counts(shots, qargs=range(5))
 
+        self.assertNotEqual(counts2, counts3)
+
         self.assertNotEqual(counts0, counts2)
         self.assertNotEqual(counts1, counts2)
+
+    def test_sample_with_same_seed(self):
+        """Test randomness of results of sample_counts """
+        circ = QuantumVolume(5, seed=1111)
+
+        state = AerStatevector(circ, seed_simulator=1)
+
+        shots = 1024
+        counts0 = state.sample_counts(shots, qargs=range(5))
+        counts1 = state.sample_counts(shots, qargs=range(5))
+
+        self.assertNotEqual(counts0, counts1)
+
+        state = AerStatevector(circ, seed_simulator=1)
+
+        shots = 1024
+        counts2 = state.sample_counts(shots, qargs=range(5))
+        counts3 = state.sample_counts(shots, qargs=range(5))
+
         self.assertNotEqual(counts2, counts3)
+        self.assertEqual(counts0, counts2)
+        self.assertEqual(counts1, counts3)
+
+        shots = 1024
+        state.seed(1)
+        counts4 = state.sample_counts(shots, qargs=range(5))
+        counts5 = state.sample_counts(shots, qargs=range(5))
+
+        self.assertNotEqual(counts4, counts5)
+        self.assertEqual(counts0, counts4)
+        self.assertEqual(counts1, counts5)
+
 
     def test_method_and_device_properties(self):
         """Test method and device properties"""

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -54,6 +54,27 @@ class TestAerStatevector(common.QiskitAerTestCase):
         for e, s in zip(expected, state):
             self.assertAlmostEqual(e, s)
 
+    def test_sample_randomness(self):
+        """Test randomness of results of sample_counts """
+        circ = QuantumVolume(5, seed=1111)
+        state = AerStatevector(circ)
+
+        shots = 1024
+        counts0 = state.sample_counts(shots, qargs=range(5))
+        counts1 = state.sample_counts(shots, qargs=range(5))
+
+        self.assertNotEqual(counts0, counts1)
+
+        state = AerStatevector(circ, seed_simulator=10)
+
+        shots = 1024
+        counts2 = state.sample_counts(shots, qargs=range(5))
+        counts3 = state.sample_counts(shots, qargs=range(5))
+
+        self.assertNotEqual(counts0, counts2)
+        self.assertNotEqual(counts1, counts2)
+        self.assertNotEqual(counts2, counts3)
+
     def test_method_and_device_properties(self):
         """Test method and device properties"""
         circ = QuantumVolume(5, seed=1111)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Previously seed is not initialized in AerStatevector and then sampled results are always same. With this commit, a seed is initialized for each sampling and sampled results can be vary.

### Details and comments

Previously, sampled counts are always same in multiple calls because `AerStatevector` uses the same seed to generate random values which are used in processing `sample_counts()`. More specifically, `_seed` is not initialized in `state_controller` if `seed_simulator` is not set. For example, following two sampled values `count0` and `count1` are the same.
```
circ = QuantumVolume(5, seed=1111)
state = AerStatevector(circ)

shots = 1024
counts0 = state.sample_counts(shots, qargs=range(5))
counts1 = state.sample_counts(shots, qargs=range(5))
```
Even if `seed_simulator` is set, the value is reused to initialize `RngEngine` and sampled counts become same.

With this PR,  `_seed` is initialized with `std::random_device()` and renewed `seed_simulator` for each sampling, and then sampled counts are always different in the same `AerStatevector` instance.