### PR TITLE
Deprecate Python 3.7 support in Qiskit Aer

### DIFF
--- a/qiskit_aer/__init__.py
+++ b/qiskit_aer/__init__.py
@@ -52,14 +52,14 @@ Exceptions
    AerError
 """
 
-# https://github.com/Qiskit/qiskit-aer/issues/1
-# Because of this issue, we need to make sure that Numpy's OpenMP library is initialized
-# before loading our simulators, so we force it using this ugly trick
 import platform
 import sys
 import warnings
 
 
+# https://github.com/Qiskit/qiskit-aer/issues/1
+# Because of this issue, we need to make sure that Numpy's OpenMP library is initialized
+# before loading our simulators, so we force it using this ugly trick
 if platform.system() == "Darwin":
     import numpy as np
     np.dot(np.zeros(100), np.zeros(100))

--- a/qiskit_aer/__init__.py
+++ b/qiskit_aer/__init__.py
@@ -60,6 +60,8 @@ if platform.system() == "Darwin":
     import numpy as np
     np.dot(np.zeros(100), np.zeros(100))
 # ... ¯\_(ツ)_/¯
+import sys
+import warnings
 
 # pylint: disable=wrong-import-position
 from .aerprovider import AerProvider
@@ -72,6 +74,15 @@ from . import quantum_info
 from . import noise
 from . import utils
 from .version import __version__
+
+if sys.version_info < (3, 8):
+    warnings.warn(
+        "Using Qiskit Aer with Python 3.7 is deprecated as of the 0.12.0 release. "
+        "Support for running Qiskit Aer with Python 3.7 will be removed in a future "
+        "release",
+        DeprecationWarning,
+    )
+
 
 # Global instance to be used as the entry point for convenience.
 Aer = AerProvider()  # pylint: disable=invalid-name

--- a/qiskit_aer/__init__.py
+++ b/qiskit_aer/__init__.py
@@ -56,12 +56,14 @@ Exceptions
 # Because of this issue, we need to make sure that Numpy's OpenMP library is initialized
 # before loading our simulators, so we force it using this ugly trick
 import platform
+import sys
+import warnings
+
+
 if platform.system() == "Darwin":
     import numpy as np
     np.dot(np.zeros(100), np.zeros(100))
 # ... ¯\_(ツ)_/¯
-import sys
-import warnings
 
 # pylint: disable=wrong-import-position
 from .aerprovider import AerProvider

--- a/releasenotes/notes/deprecate-37-b3ec705b9f469b0b.yaml
+++ b/releasenotes/notes/deprecate-37-b3ec705b9f469b0b.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    Support for running Qiskit Aer with Python 3.7 support has been deprecated
+    and will be removed in a future release. This means
+    starting in a future release you will need to upgrade the Python
+    version you're using to Python 3.8 or above.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit deprecates Python 3.7 support. During the deprecation window we will continue to fully support Python 3.7 and test it in CI, but it will emit a warning that we will be removing support for 3.7 in the future to inform users to upgrade to Python 3.8 or newer. The removal will occur during a future release at some point over the summer as the upstream Python EoL date is in June 2023. [1]

### Details and comments

[1] https://devguide.python.org/versions/
