### PR TITLE
Fix incorrect computation of excited state population

### DIFF
--- a/qiskit_aer/noise/device/models.py
+++ b/qiskit_aer/noise/device/models.py
@@ -378,17 +378,19 @@ def _truncate_t2_value(t1, t2):
 
 
 def _excited_population(freq, temperature):
-    """Return excited state population"""
+    """Return excited state population from freq [GHz] and temperature [mK]."""
     population = 0
     if freq != inf and temperature != 0:
-        # Compute the excited state population from qubit
-        # frequency and temperature
-        # Boltzman constant  kB = 8.617333262-5 (eV/K)
+        # Compute the excited state population from qubit frequency and temperature
+        # based on Maxwell-Boltzmann distribution
+        # considering only qubit states (|0> and |1>), i.e. truncating higher energy states.
+        # Boltzman constant  kB = 8.617333262e-5 (eV/K)
         # Planck constant h = 4.135667696e-15 (eV.s)
         # qubit temperature temperatue = T (mK)
         # qubit frequency frequency = f (GHz)
-        # excited state population = 1/(1+exp((2*h*f*1e9)/(kb*T*1e-3)))
-        exp_param = exp((95.9849 * freq) / abs(temperature))
+        # excited state population = 1/(1+exp((h*f*1e9)/(kb*T*1e-3)))
+        # See e.g. Phys. Rev. Lett. 114, 240501 (2015).
+        exp_param = exp((47.99243 * freq) / abs(temperature))
         population = 1 / (1 + exp_param)
         if temperature < 0:
             # negative temperate implies |1> is thermal ground

--- a/releasenotes/notes/fix-temperature-a9c51c4599af3a49.yaml
+++ b/releasenotes/notes/fix-temperature-a9c51c4599af3a49.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in computation of the excited population from qubit frequency and temperature
+    in noise model construction. Previously, there was an incorrect exponential factor of 2
+    and hence the excited population was incorrectly squared. This fix will affects users
+    who generate a noise model using :meth:`NoiseModel.from_backend` with ``temperature``
+    option while it won't affect users of the default noise model that assumes no excitation.

--- a/releasenotes/notes/fix-temperature-a9c51c4599af3a49.yaml
+++ b/releasenotes/notes/fix-temperature-a9c51c4599af3a49.yaml
@@ -3,6 +3,6 @@ fixes:
   - |
     Fixed a bug in computation of the excited population from qubit frequency and temperature
     in noise model construction. Previously, there was an incorrect exponential factor of 2
-    and hence the excited population was incorrectly squared. This fix will affects users
-    who generate a noise model using :meth:`NoiseModel.from_backend` with ``temperature``
-    option while it won't affect users of the default noise model that assumes no excitation.
+    and hence the excited population was incorrect. This fix affects users
+    who generate a noise model using :meth:`NoiseModel.from_backend` with non-zero
+    ``temperature`` while it does not affect users of the default noise model (temperature=0).

--- a/releasenotes/notes/fix-temperature-a9c51c4599af3a49.yaml
+++ b/releasenotes/notes/fix-temperature-a9c51c4599af3a49.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixed a bug in computation of the excited population from qubit frequency and temperature
-    in noise model construction. Previously, there was an incorrect exponential factor of 2
-    and hence the excited population was incorrect. This fix affects users
-    who generate a noise model using :meth:`NoiseModel.from_backend` with non-zero
-    ``temperature`` while it does not affect users of the default noise model (temperature=0).
+    Fixed a bug in :meth:`NoiseModel.from_backend` where using the ``temperature`` kwarg with
+    a non-default value would incorrectly compute the excited state population for
+    the specified temperature. Previously, there was an additional factor of 2 in
+    the Boltzman distribution calculation leading to an incorrect smaller value
+    for the excited state population.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix a bug in computation of the excited population from qubit frequency and temperature that can be used in noise model construction. 

### Details and comments
As reported in #1638, there was an incorrect exponential factor of 2 and hence the excited population was incorrect (almost squared). This fix will affect users who generate a noise model using `NoiseModel.from_backend` with `temperature` option while it won't affect users of the default noise model that assumes no excitation (temperature=0).