### PR TITLE
Fix `Sampler` with multiple classical registers

### DIFF
--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -136,7 +136,7 @@ class Sampler(BaseSampler):
                 shots = sum(counts.values())
                 quasis.append(
                     QuasiDistribution(
-                        {k: v / shots for k, v in counts.items()},
+                        {k.replace(" ", ""): v / shots for k, v in counts.items()},
                         shots=shots,
                     )
                 )

--- a/releasenotes/notes/fix-split-cregs-5b5494a92c4903e7.yaml
+++ b/releasenotes/notes/fix-split-cregs-5b5494a92c4903e7.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Fix the bug where the :class:`.Sampler` fails if the input circuit has multiple classical
+    registers.

--- a/test/terra/primitives/test_sampler.py
+++ b/test/terra/primitives/test_sampler.py
@@ -20,7 +20,7 @@ from test.terra.decorators import deprecated
 
 import numpy as np
 from ddt import data, ddt
-from qiskit import QuantumCircuit
+from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.exceptions import QiskitError
@@ -536,6 +536,18 @@ class TestSampler(QiskitAerTestCase):
         quasis = result.quasi_dists[0]
         bin_probs = quasis.binary_probabilities()
         self.assertDictAlmostEqual(bin_probs, {"0000": 0.5, "0001": 0.5}, delta=1e-2)
+
+    def test_multiple_cregs(self):
+        """Test for the circuit with multipe cregs"""
+        qc = QuantumCircuit(2)
+        cr1 = ClassicalRegister(1, "cr1")
+        cr2 = ClassicalRegister(1, "cr2")
+        qc.add_register(cr1)
+        qc.add_register(cr2)
+        qc.measure(0, 0)
+        qc.measure(1, 1)
+
+        print(Sampler().run(qc, shots=100).result())
 
 
 if __name__ == "__main__":

--- a/test/terra/primitives/test_sampler.py
+++ b/test/terra/primitives/test_sampler.py
@@ -547,7 +547,8 @@ class TestSampler(QiskitAerTestCase):
         qc.measure(0, 0)
         qc.measure(1, 1)
 
-        print(Sampler().run(qc, shots=100).result())
+        result = Sampler().run(qc, shots=100).result()
+        self.assertDictAlmostEqual(result.quasi_dists[0], {0: 1})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix the bug where the Sampler fails if the input circuit has multiple classical registers.

Fixes https://github.com/Qiskit/qiskit-aer/issues/1679

### Details and comments


