### PR TITLE
Remove deprecated module import

### DIFF
--- a/test/terra/backends/aer_simulator/test_truncate.py
+++ b/test/terra/backends/aer_simulator/test_truncate.py
@@ -12,7 +12,6 @@ from ddt import ddt
 from qiskit import transpile, QuantumCircuit, Aer
 from qiskit.providers.fake_provider import FakeQuito
 from qiskit_aer.noise import NoiseModel
-from qiskit.test import mock
 from test.terra.backends.simulator_test_case import (
     SimulatorTestCase, supported_methods)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
- Remove the import statement of the deprecated module in test.


### Details and comments
- The use of `qiskit.test.mock` is deprecated.
