### PR TITLE
Replace IBMQ with IBM Quantum in Aer documention.

### DIFF
--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -56,9 +56,9 @@ class AerSimulator(AerBackend):
         backend = AerSimulator(method='density_matrix',
                                 noise_model=noise_model)
 
-    **Simulating an IBM QUANTUM Backend**
+    **Simulating an IBM Quantum Backend**
 
-    The simulator can be automatically configured to mimic an IBM QUANTUM backend using
+    The simulator can be automatically configured to mimic an IBM Quantum backend using
     the :meth:`from_backend` method. This will configure the simulator to use the
     basic device :class:`NoiseModel` for that backend, and the same basis gates
     and coupling map.

--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -56,9 +56,9 @@ class AerSimulator(AerBackend):
         backend = AerSimulator(method='density_matrix',
                                 noise_model=noise_model)
 
-    **Simulating an IBMQ Backend**
+    **Simulating an IBM QUANTUM Backend**
 
-    The simulator can be automatically configured to mimic an IBMQ backend using
+    The simulator can be automatically configured to mimic an IBM QUANTUM backend using
     the :meth:`from_backend` method. This will configure the simulator to use the
     basic device :class:`NoiseModel` for that backend, and the same basis gates
     and coupling map.

--- a/qiskit_aer/backends/qasm_simulator.py
+++ b/qiskit_aer/backends/qasm_simulator.py
@@ -57,9 +57,9 @@ class QasmSimulator(AerBackend):
         backend = QasmSimulator(method='density_matrix',
                                 noise_model=noise_model)
 
-    **Simulating an IBM QUANTUM Backend**
+    **Simulating an IBM Quantum Backend**
 
-    The simulator can be automatically configured to mimic an IBM QUANTUM backend using
+    The simulator can be automatically configured to mimic an IBM Quantum backend using
     the :meth:`from_backend` method. This will configure the simulator to use the
     basic device :class:`NoiseModel` for that backend, and the same basis gates
     and coupling map.

--- a/qiskit_aer/backends/qasm_simulator.py
+++ b/qiskit_aer/backends/qasm_simulator.py
@@ -57,9 +57,9 @@ class QasmSimulator(AerBackend):
         backend = QasmSimulator(method='density_matrix',
                                 noise_model=noise_model)
 
-    **Simulating an IBMQ Backend**
+    **Simulating an IBM QUANTUM Backend**
 
-    The simulator can be automatically configured to mimic an IBMQ backend using
+    The simulator can be automatically configured to mimic an IBM QUANTUM backend using
     the :meth:`from_backend` method. This will configure the simulator to use the
     basic device :class:`NoiseModel` for that backend, and the same basis gates
     and coupling map.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed #1633 
Replaced IBMQ with IBM Quantum in the documentation of aer_simulator and qasm_simulator.

### Details and comments
Fixed the issue 1633

