### PR TITLE
Remove setup_requires and forced pip installs in setup.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version}}-pip-
             ${{ runner.os }}-${{ matrix.python-version}}-
       - name: Install Deps
-        run: python -m pip install -U setuptools wheel virtualenv
+        run: python -m pip install -U setuptools wheel virtualenv build
       - name: Install openblas
         run: |
           set -e
@@ -72,7 +72,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev
         shell: bash
       - name: Build Sdist
-        run: python setup.py sdist
+        run: python -I -m build --sdist
       - name: Install from sdist and test
         run: |
           set -e
@@ -162,7 +162,7 @@ jobs:
       - name: Install Aer
         run: |
           set -e
-          python setup.py bdist_wheel -- -DTEST_JSON=1
+          python -I -m build --wheel --config-setting=--build-option=-- --config-setting=--build-option=-DTEST_JSON=1
           pip install --find-links=dist qiskit-aer
       - name: Run Tests
         run: |
@@ -239,11 +239,13 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Install Deps
-        run: python -m pip install -U -c constraints.txt -r requirements-dev.txt wheel
+        run: python -m pip install -U -c constraints.txt -r requirements-dev.txt wheel build
       - name: Install Aer Windows
+        env:
+          CMAKE_GENERATOR: "Visual Studio 16 2019"
         run: |
           set -e
-          python setup.py bdist_wheel -- -G 'Visual Studio 16 2019'
+          python -I -m build --wheel
           pip install --find-links=dist qiskit-aer
         shell: bash
       - name: Run Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version}}-pip-
             ${{ runner.os }}-${{ matrix.python-version}}-
       - name: Install Deps
-        run: python -m pip install -U -c constraints.txt -r requirements-dev.txt wheel
+        run: python -m pip install -U -c constraints.txt -r requirements-dev.txt wheel build
       - name: Install openblas
         run: |
           set -e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -342,7 +342,8 @@ As any other Python package, we can install from source code by just running:
 This will build and install `Aer` with the default options which is probably suitable for most of the users.
 There's another Pythonic approach to build and install software: build the wheels distributable file.
 
-    qiskit-aer$ python ./setup.py bdist_wheel
+    qiskit-aer$ pip install build
+    qiskit-aer$ python -I -m build --wheel
 
 This is also the way we will choose to change default `Aer` behavior by passing parameters to the build system.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,9 @@ most of the dependencies needed by the C++ source code. Internet connection may 
 when dependencies are added/updated, in order to download the required packages if they are not in your **Conan** local
 repository.
 
->  Note: Conan use can be disabled with the flag or environment variable ``DISABLE_CONAN=ON`` .
+>  Note: Conan use can be disabled with the flag or environment variable ``DISABLE_CONAN=ON``.  The Python package `conan`
+> is still required as a build dependency, it just will not called or used.
+
 This is useful for building from source offline, or to reuse the installed package dependencies.
 
 If we are only building the standalone version and do not want to install all Python requirements you can just install

--- a/releasenotes/notes/remove-setup_requires-751a406e2782885e.yaml
+++ b/releasenotes/notes/remove-setup_requires-751a406e2782885e.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    Aer's ``setup.py`` has been updated to no longer attempt to make calls to ``pip`` to
+    install build requirements, both manually and via the ``setup_requires`` option in
+    ``setuptools.setup``.  The preferred way to build Aer is to use a PEP 517-compatible
+    builder such as:
+
+    .. code-block:: text
+
+      pip install .
+
+    This change means that a direct call to ``setup.py`` will no longer work if the
+    build requirements are not installed.  This is inline with modern Python packaging
+    guidelines.

--- a/setup.py
+++ b/setup.py
@@ -3,87 +3,24 @@
 """
 Main setup file for qiskit-aer
 """
-import importlib
-import inspect
 import os
-import setuptools
-import subprocess
-import sys
-from pkg_resources import parse_version
 import platform
 
-
-def strtobool(val):
-    val_lower = val.lower()
-    if val_lower in ('y', 'yes', 't', 'true', 'on', '1'):
-        return True
-    elif val_lower in ('n', 'no', 'f', 'false', 'off', '0'):
-        return False
-    else:
-        raise ValueError(f'Value: "{val}" not recognizes as True or False')
-
-
-PACKAGE_NAME = os.getenv('QISKIT_AER_PACKAGE_NAME', 'qiskit-aer')
-_DISABLE_CONAN = strtobool(os.getenv("DISABLE_CONAN", "OFF"))
-_DISABLE_DEPENDENCY_INSTALL = strtobool(os.getenv("DISABLE_DEPENDENCY_INSTALL", "OFF"))
-
-
-
-def install_needed_req(import_name, package_name=None, min_version=None, max_version=None):
-    if package_name is None:
-        package_name = import_name
-    install_ver = package_name
-    if min_version:
-        install_ver += '>=' + min_version
-    if max_version:
-        install_ver += '<' + max_version
-
-    try:
-        mod = importlib.import_module(import_name)
-        mod_ver = parse_version(mod.__version__)
-        if ((min_version and mod_ver < parse_version(min_version))
-                or (max_version and mod_ver >= parse_version(max_version))):
-            raise RuntimeError(f'{package_name} {mod_ver} is installed '
-                               f'but required version is {install_ver}.')
-
-    except ImportError as err:
-        if _DISABLE_DEPENDENCY_INSTALL:
-            raise ImportError(str(err) +
-                              f"\n{package_name} is a required dependency. "
-                              f"Please provide it and repeat install")
-
-        subprocess.call([sys.executable, '-m', 'pip', 'install', install_ver])
-
-if not _DISABLE_CONAN:
-    install_needed_req('conans', package_name='conan', min_version='1.31.2')
-
-install_needed_req('skbuild', package_name='scikit-build', min_version='0.11.0')
-install_needed_req('pybind11', min_version='2.6')
-
+import setuptools
 from skbuild import setup
 
 
-# These are requirements that are both runtime/install dependencies and
-# also build time/setup requirements and will be added to both lists
-# of requirements
-common_requirements = [
-    'numpy>=1.16.3',
-]
-
-setup_requirements = common_requirements + [
-    'scikit-build>=0.11.0',
-    'cmake!=3.17,!=3.17.0',
-    'pybind11>=2.6',
-]
+PACKAGE_NAME = os.getenv('QISKIT_AER_PACKAGE_NAME', 'qiskit-aer')
 
 extras_requirements = {
     "dask": ["dask", "distributed"]
 }
 
-if not _DISABLE_CONAN:
-    setup_requirements.append('conan>=1.22.2')
-
-requirements = common_requirements + ['qiskit-terra>=0.21.0', 'scipy>=1.0']
+requirements = [
+    'qiskit-terra>=0.21.0',
+    'numpy>=1.16.3',
+    'scipy>=1.0',
+]
 
 VERSION_PATH = os.path.join(os.path.dirname(__file__),
                             "qiskit_aer", "VERSION.txt")
@@ -132,7 +69,6 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=requirements,
-    setup_requires=setup_requirements,
     include_package_data=False,
     package_data={"qiskit_aer": ["VERSION.txt"], "qiskit_aer.library": ["*.csv"]},
     extras_require=extras_requirements,

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,9 @@ setenv =
   SETUPTOOLS_ENABLE_FEATURES=legacy-editable
 deps =
   -r requirements-dev.txt
+  build
 commands =
-    python setup.py bdist_wheel -- -- -j4
+    python -I -m build --wheel -C=--build-option=-- -C=--build-option=-- -C=--build-option=-j4
     pip install --find-links={toxinidir}/dist qiskit_aer
     stestr run {posargs}
 
@@ -38,8 +39,9 @@ commands =
 [testenv:docs]
 deps =
   -r requirements-dev.txt
+  build
   qiskit-ibmq-provider
 commands =
-  python setup.py bdist_wheel -- -- -j4
+  python -I -m build --wheel -C=--build-option=-- -C=--build-option=-- -C=--build-option=-j4
   pip install --find-links={toxinidir}/dist qiskit_aer
   sphinx-build -W -b html docs/ docs/_build/html -j auto {posargs}


### PR DESCRIPTION
### Summary

Executing manual `pip install` commands from within `setup.py` is somewhat frowned upon from a Python packaging perspective.  By far the preferred mechanism now is to clearly state the build dependencies in a non-code format (`pyproject.toml`), and let a PEP-517-compatible builder handle virtual-environment isolation and dependency management.

We already had the dependencies declared statically, this commit just removes the residual code in `setup.py`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #1688.
