### PR TITLE
Switch from relative to absolute imports in root qiskit_aer

### DIFF
--- a/qiskit_aer/__init__.py
+++ b/qiskit_aer/__init__.py
@@ -66,16 +66,16 @@ if platform.system() == "Darwin":
 # ... ¯\_(ツ)_/¯
 
 # pylint: disable=wrong-import-position
-from .aerprovider import AerProvider
-from .jobs import AerJob, AerJobSet
-from .aererror import AerError
-from .backends import *
-from . import library
-from . import pulse
-from . import quantum_info
-from . import noise
-from . import utils
-from .version import __version__
+from qiskit_aer.aerprovider import AerProvider
+from qiskit_aer.jobs import AerJob, AerJobSet
+from qiskit_aer.aererror import AerError
+from qiskit_aer.backends import *
+from qiskit_aer import library
+from qiskit_aer import pulse
+from qiskit_aer import quantum_info
+from qiskit_aer import noise
+from qiskit_aer import utils
+from qiskit_aer.version import __version__
 
 if sys.version_info < (3, 8):
     warnings.warn(


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Previously the root of the qiskit_aer we were exporing certain modules and objects using relative imports to do this. However, the qiskit package sets up a metaimporter to redirect imports from qiskit.providers.aer to qiskit_aer (for backwards compatibility with the old aer name) the source package for these relative imports can get confused on subsequent imports if something also uses the legacy name (which qiskit itself does on it's optional imports to aer, so that it supports >1 version). While all the code functions correctly in this case Python emits a warning saying the package __spec__ doesn't match anymore. The simplest way to address these warnings is to use an absoulte import with the package name in it so there is no ambiguity in the source package on imports.

This commit makes that change to the root of the pacakge which fixes the warnings. The only thing I'm not sure of is if any other relative imports elsewhere in the qiskit_aer package will have the same problem or if this is fixed by just updating the root package. We might need to do further testing to check.

### Details and comments

Fixes #1692
