### PR TITLE
Install qiskit-aer without `-e` option in neko integration tests.

### DIFF
--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -14,4 +14,7 @@ jobs:
       - uses: Qiskit/qiskit-neko@main
         with:
           test_selection: backend
-          repo_install_command: pip install -e .
+          repo_install_command: |
+            pip install -r requirements-dev.txt
+            pip install .
+            rm -rf qiskit_aer

--- a/releasenotes/notes/fix_python_version_in_neko-367ea7ca0abbfc2a.yaml
+++ b/releasenotes/notes/fix_python_version_in_neko-367ea7ca0abbfc2a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the version of Python in neko to avoid load python
+    packages from the working directory in its integration tests.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Install qiskit-aer without `-e` option in neko integration tests.

### Details and comments

Resolve #1695.
