### PR TITLE
Fix errors when disabling cuQuantum for GPU simulator

### DIFF
--- a/releasenotes/notes/fix_tensor_network_not_installed-a23b8ef65e6e643e.yaml
+++ b/releasenotes/notes/fix_tensor_network_not_installed-a23b8ef65e6e643e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix build errors and test errors when enabling GPU but disabling cuQuantum.

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -541,8 +541,11 @@ void Controller::set_config(const json_t &config) {
     }
   }
 
-  if(method_ == Method::tensor_network && sim_device_ != Device::GPU){
-    throw std::runtime_error("Invalid combination of simulation method and device, \"tensor_network\" only supports \"device=GPU\"");
+  if(method_ == Method::tensor_network){
+#if defined(AER_THRUST_CUDA) && defined(AER_CUTENSORNET)
+    if(sim_device_ != Device::GPU)
+#endif
+      throw std::runtime_error("Invalid combination of simulation method and device, \"tensor_network\" only supports \"device=GPU\"");
   }
 
   std::string precision;

--- a/src/simulators/tensor_network/tensor_net.hpp
+++ b/src/simulators/tensor_network/tensor_net.hpp
@@ -31,7 +31,7 @@
 #include "simulators/tensor_network/tensor.hpp"
 
 #include "simulators/tensor_network/tensor_net_contractor.hpp"
-#ifdef AER_THRUST_CUDA && AER_CUTENSORNET
+#if defined(AER_THRUST_CUDA) && defined(AER_CUTENSORNET)
 #include "simulators/tensor_network/tensor_net_contractor_cuTensorNet.hpp"
 #endif
 
@@ -322,7 +322,7 @@ protected:
 };
 
 //TODO : implement CPU version of contractor
-#ifdef AER_THRUST_CUDA && AER_CUTENSORNET
+#if defined(AER_THRUST_CUDA) && defined(AER_CUTENSORNET)
 #define create_contractor(contractor) \
   contractor = new TensorNetContractor_cuTensorNet<data_t>
 #else

--- a/test/terra/backends/simulator_test_case.py
+++ b/test/terra/backends/simulator_test_case.py
@@ -74,8 +74,9 @@ def supported_devices(func):
 
 def _method_device(methods):
     """Return list of (methods, device) supported on current system"""
+    available_methods = AerSimulator().available_methods()
     if not methods:
-        methods = AerSimulator().available_methods()
+        methods = available_methods
     available_devices = AerSimulator().available_devices()
     #add special test device for cuStateVec if available
     cuStateVec = check_cuStateVec(available_devices)
@@ -83,24 +84,25 @@ def _method_device(methods):
     gpu_methods = ['statevector', 'density_matrix', 'unitary', 'tensor_network']
     data_args = []
     for method in methods:
-        if method in gpu_methods:
-            if 'tensor_network' == method:
-                for device in available_devices:
-                    if device == 'GPU':
-	                    data_args.append((method, 'GPU'))
+        if method in available_methods:
+            if method in gpu_methods:
+                if 'tensor_network' == method:
+                    for device in available_devices:
+                        if device == 'GPU':
+                            data_args.append((method, 'GPU'))
+                else:
+                    for device in available_devices:
+                        data_args.append((method, device))
+                        if device == 'GPU':
+                            #add batched optimization test for GPU
+                            data_args.append((method, 'GPU_batch'))
+                    #add test cases for cuStateVec if available using special device = 'GPU_cuStateVec'
+                    #'GPU_cuStateVec' is used only inside tests not available in Aer
+                    #and this is converted to "device='GPU'" and option "cuStateVec_enalbe = True" is added
+                    if cuStateVec and 'tensor_network' != method:
+                        data_args.append((method, 'GPU_cuStateVec'))
             else:
-                for device in available_devices:
-                    data_args.append((method, device))
-                    if device == 'GPU':
-                        #add batched optimization test for GPU
-                        data_args.append((method, 'GPU_batch'))
-                #add test cases for cuStateVec if available using special device = 'GPU_cuStateVec'
-                #'GPU_cuStateVec' is used only inside tests not available in Aer
-                #and this is converted to "device='GPU'" and option "cuStateVec_enalbe = True" is added
-                if cuStateVec and 'tensor_network' != method:
-                    data_args.append((method, 'GPU_cuStateVec'))
-        else:
-            data_args.append((method, 'CPU'))
+                data_args.append((method, 'CPU'))
     return data_args
 
 def check_cuStateVec(devices):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix two issues:
Build error occurs when disabling cuQuantum for GPU enabled simulator. 
Also tensor network test cases run and fail even though tensor network method is not available.

### Details and comments
Preprocessor to test cuQuantum is enabled was not correct.

Methods to be tested in test cases was not selected from available methods.
