### PR TITLE
Optimization of stabilizer simulator

### DIFF
--- a/releasenotes/notes/optimized_stabilizer-f696742e7f881d0d.yaml
+++ b/releasenotes/notes/optimized_stabilizer-f696742e7f881d0d.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Optimization of stabilizer simulator performance by changing data order.
+    By this change, data access have been improved to use cache memory
+    effectivelly. And also integer bit operations have been improved.

--- a/src/framework/pybind_casts.hpp
+++ b/src/framework/pybind_casts.hpp
@@ -55,17 +55,17 @@ public:
   }
 };
 
-template <> struct type_caster<Clifford::Clifford>{
-    using base = type_caster_base<Clifford::Clifford>;
+template <> struct type_caster<AER::Clifford::Clifford>{
+    using base = type_caster_base<AER::Clifford::Clifford>;
 public:
-    PYBIND11_TYPE_CASTER(Clifford::Clifford, _("clifford"));
+    PYBIND11_TYPE_CASTER(AER::Clifford::Clifford, _("clifford"));
     // Conversion part 1 (Python->C++):
     bool load(py::handle src, bool convert){
-        Clifford::build_from(src, value);
+        AER::Clifford::build_from(src, value);
         return true;
     }
     // Conversion part 2 (C++ -> Python):
-    static py::handle cast(Clifford::Clifford, py::return_value_policy policy, py::handle parent){
+    static py::handle cast(AER::Clifford::Clifford, py::return_value_policy policy, py::handle parent){
         throw std::runtime_error("Casting from Clifford to python not supported.");
     }
 };

--- a/src/simulators/stabilizer/clifford.hpp
+++ b/src/simulators/stabilizer/clifford.hpp
@@ -15,9 +15,15 @@
 #ifndef _clifford_hpp_
 #define _clifford_hpp_
 
-#include "pauli.hpp"
-#include "../../framework/json_parser.hpp"
+#include "framework/types.hpp"
+#include "framework/utils.hpp"
 
+#include "pauli.hpp"
+#include "framework/json_parser.hpp"
+
+#include <omp.h>
+
+namespace AER {
 namespace Clifford {
 
 /*******************************************************************************
@@ -31,6 +37,8 @@ public:
   using phase_t = int8_t;
   using phasevec_t = std::vector<phase_t>;
 
+  friend class CliffordThrust;
+
   //-----------------------------------------------------------------------
   // Constructors and Destructor
   //-----------------------------------------------------------------------
@@ -40,6 +48,8 @@ public:
   //-----------------------------------------------------------------------
   // Utility functions
   //-----------------------------------------------------------------------
+  //initialize
+  void initialize(const uint64_t nqubit);
 
   // Get number of qubits of the Clifford table
   uint64_t num_qubits() const {return num_qubits_;}
@@ -51,25 +61,19 @@ public:
   json_t json() const;
 
   // Access stabilizer table
-  Pauli::Pauli &operator[](uint64_t j) {return table_[j];}
-  const Pauli::Pauli& operator[](uint64_t j) const {return table_[j];}
+//  Pauli::Pauli<BV::BinaryVector> &operator[](uint64_t j) {return table_[j];}
+//  const Pauli::Pauli<BV::BinaryVector>& operator[](uint64_t j) const {return table_[j];}
 
-  // Return reference to internal Stabilizer table
-  std::vector<Pauli::Pauli>& table() {return table_;}
-  const std::vector<Pauli::Pauli>& table() const {return table_;}
+  //set stabilizer
+  void set_destabilizer(const int i, const Pauli::Pauli<BV::BinaryVector>& P);
+  void set_stabilizer(const int i, const Pauli::Pauli<BV::BinaryVector>& P);
 
-  // Return reference to internal phases vector
-  phasevec_t& phases() {return phases_;}
-  const phasevec_t& phases() const {return phases_;}
+  //set phase
+  void set_destabilizer_phases(const int i, const bool p);
+  void set_stabilizer_phases(const int i, const bool p);
 
-  // Return n-th destabilizer from internal stabilizer table
-  Pauli::Pauli &destabilizer(uint64_t n) {return table_[n];}
-  const Pauli::Pauli& destabilizer(uint64_t n) const {return table_[n];}
-
-  // Return n-th stabilizer from internal stabilizer table
-  Pauli::Pauli &stabilizer(uint64_t n) {return table_[num_qubits_ + n];}
-  const Pauli::Pauli& stabilizer(uint64_t n) const {return table_[num_qubits_ + n];}
-
+  // Set the state of the simulator to a given Clifford
+  void apply_set_stabilizer(const Clifford &clifford);
 
   //-----------------------------------------------------------------------
   // Apply basic Clifford gates
@@ -84,13 +88,13 @@ public:
   // Apply Phase (S, square root of Z) gate
   void append_s(const uint64_t qubit);
 
-  // Apply Pauli::Pauli X gate
+  // Apply Pauli::Pauli<BV::BinaryVector> X gate
   void append_x(const uint64_t qubit);
 
-  // Apply Pauli::Pauli Y gate
+  // Apply Pauli::Pauli<BV::BinaryVector> Y gate
   void append_y(const uint64_t qubit);
 
-  // Apply Pauli::Pauli Z gate
+  // Apply Pauli::Pauli<BV::BinaryVector> Z gate
   void append_z(const uint64_t qubit);
 
   //-----------------------------------------------------------------------
@@ -105,6 +109,9 @@ public:
   // update the stabilizer to the conditional (post measurement) state if
   // the outcome was random.
   bool measure_and_update(const uint64_t qubit, const uint64_t randint);
+
+  double expval_pauli(const reg_t &qubits,
+                                const std::string& pauli);
 
   //-----------------------------------------------------------------------
   // Configuration settings
@@ -129,14 +136,15 @@ public:
   // Get the qubit threshold for activating OpenMP.
   uint64_t get_omp_threshold() {return omp_threshold_;}
 
-private:
+protected:
 
   //-----------------------------------------------------------------------
   // Protected data members
   //-----------------------------------------------------------------------
-
-  std::vector<Pauli::Pauli> table_;
-  phasevec_t phases_;
+  std::vector<Pauli::Pauli<BV::BinaryVector>> destabilizer_table_;
+  std::vector<Pauli::Pauli<BV::BinaryVector>> stabilizer_table_;
+  BV::BinaryVector destabilizer_phases_;
+  BV::BinaryVector stabilizer_phases_;
   uint64_t num_qubits_ = 0;
 
   //-----------------------------------------------------------------------
@@ -159,9 +167,6 @@ private:
   // Check if there exists stabilizer or destabilizer row anticommuting
   // with X[qubit]. If so return pair (true, row), else return (false, 0)
   std::pair<bool, uint64_t> x_anticommuting(const uint64_t qubit) const;
-
-  void rowsum_helper(const Pauli::Pauli &row, const phase_t row_phase,
-                     Pauli::Pauli &accum, phase_t &accum_phase) const;
 };
 
 /*******************************************************************************
@@ -192,97 +197,188 @@ void Clifford::set_omp_threshold(int n) {
 // Constructors & Destructor
 //------------------------------------------------------------------------------
 
-Clifford::Clifford(uint64_t nq) : num_qubits_(nq) {
-  // initial state = all zeros
-  // add destabilizers
-  #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < static_cast<int64_t>(nq); i++) {
-    Pauli::Pauli P(nq);
-    P.X.setValue(1, i);
-    table_.push_back(P);
-  }
-  // add stabilizers
-  #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < static_cast<int64_t>(nq); i++) {
-    Pauli::Pauli P(nq);
-    P.Z.setValue(1, i);
-    table_.push_back(P);
-  }
+Clifford::Clifford(uint64_t nq) : num_qubits_(nq) 
+{
+  initialize(nq);
+}
+
+void Clifford::initialize(uint64_t nq)
+{
+  num_qubits_ = nq;
+
+  destabilizer_table_.resize(nq);
+  stabilizer_table_.resize(nq);
+
+  int nid = omp_get_num_threads();
+  auto init_func = [this, nq](AER::int_t i)
+  {
+    destabilizer_table_[i].X.setLength(nq);
+    destabilizer_table_[i].Z.setLength(nq);
+    destabilizer_table_[i].X.setValue(1,i);
+
+    stabilizer_table_[i].X.setLength(nq);
+    stabilizer_table_[i].Z.setLength(nq);
+    stabilizer_table_[i].Z.setValue(1,i);
+  };
+  AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, nq, init_func, omp_threads_);
+
   // Add phases
-  phases_.resize(2 * nq);
+  destabilizer_phases_.setLength(nq);
+  stabilizer_phases_.setLength(nq);
 }
 
 //------------------------------------------------------------------------------
 // Apply Clifford gates
 //------------------------------------------------------------------------------
 
-void Clifford::append_cx(const uint64_t qcon, const uint64_t qtar) {
-  #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++) {
-    phases_[i] ^= (table_[i].X[qcon] && table_[i].Z[qtar] &&
-                  (table_[i].X[qtar] ^ table_[i].Z[qcon] ^ 1));
-    table_[i].X.setValue(table_[i].X[qtar] ^ table_[i].X[qcon], qtar);
-    table_[i].Z.setValue(table_[i].Z[qtar] ^ table_[i].Z[qcon], qcon);
-  }
+void Clifford::append_cx(const uint64_t qcon, const uint64_t qtar) 
+{
+  const uint64_t mask = (~0ull);
+
+  int nid = omp_get_num_threads();
+  auto cx_func = [this, qtar, qcon, mask](AER::int_t i)
+  {
+    destabilizer_phases_(i) = destabilizer_phases_(i) ^ (destabilizer_table_[qcon].X(i) & destabilizer_table_[qtar].Z(i) &
+                                                        (destabilizer_table_[qtar].X(i) ^ destabilizer_table_[qcon].Z(i) ^ mask));
+    stabilizer_phases_(i) = stabilizer_phases_(i) ^ (stabilizer_table_[qcon].X(i) & stabilizer_table_[qtar].Z(i) &
+                                                    (stabilizer_table_[qtar].X(i) ^ stabilizer_table_[qcon].Z(i) ^ mask));
+
+    destabilizer_table_[qtar].X(i) = destabilizer_table_[qtar].X(i) ^ destabilizer_table_[qcon].X(i);
+    destabilizer_table_[qcon].Z(i) = destabilizer_table_[qtar].Z(i) ^ destabilizer_table_[qcon].Z(i);
+    stabilizer_table_[qtar].X(i) = stabilizer_table_[qtar].X(i) ^ stabilizer_table_[qcon].X(i);
+    stabilizer_table_[qcon].Z(i) = stabilizer_table_[qtar].Z(i) ^ stabilizer_table_[qcon].Z(i);
+  };
+  AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, destabilizer_phases_.blockLength(), cx_func, omp_threads_);
 }
 
-void Clifford::append_h(const uint64_t qubit) {
-  #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++) {
-    phases_[i] ^= (table_[i].X[qubit] && table_[i].Z[qubit]);
+void Clifford::append_h(const uint64_t qubit) 
+{
+  int nid = omp_get_num_threads();
+  auto h_func = [this, qubit](AER::int_t i)
+  {
+    destabilizer_phases_(i) ^= (destabilizer_table_[qubit].X(i) & destabilizer_table_[qubit].Z(i));
+    stabilizer_phases_(i) ^= (stabilizer_table_[qubit].X(i) & stabilizer_table_[qubit].Z(i));
     // exchange X and Z
-    bool b = table_[i].X[qubit];
-    table_[i].X.setValue(table_[i].Z[qubit], qubit);
-    table_[i].Z.setValue(b, qubit);
-  }
+    uint64_t t = destabilizer_table_[qubit].X(i);
+    destabilizer_table_[qubit].X(i) = destabilizer_table_[qubit].Z(i);
+    destabilizer_table_[qubit].Z(i) = t;
+    t = stabilizer_table_[qubit].X(i);
+    stabilizer_table_[qubit].X(i) = stabilizer_table_[qubit].Z(i);
+    stabilizer_table_[qubit].Z(i) = t;
+  };
+  AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, destabilizer_phases_.blockLength(), h_func, omp_threads_);
 }
 
-void Clifford::append_s(const uint64_t qubit) {
-  #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++) {
-    phases_[i] ^= (table_[i].X[qubit] && table_[i].Z[qubit]);
-    table_[i].Z.setValue(table_[i].Z[qubit] ^ table_[i].X[qubit], qubit);
-  }
+void Clifford::append_s(const uint64_t qubit)
+{
+  int nid = omp_get_num_threads();
+  auto s_func = [this, qubit](AER::int_t i)
+  {
+    destabilizer_phases_(i) ^= (destabilizer_table_[qubit].X(i) & destabilizer_table_[qubit].Z(i));
+    destabilizer_table_[qubit].Z(i) ^= destabilizer_table_[qubit].X(i);
+    stabilizer_phases_(i) ^= (stabilizer_table_[qubit].X(i) & stabilizer_table_[qubit].Z(i));
+    stabilizer_table_[qubit].Z(i) ^= stabilizer_table_[qubit].X(i);
+  };
+  AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, destabilizer_phases_.blockLength(), s_func, omp_threads_);
 }
 
-void Clifford::append_x(const uint64_t qubit) {
-  #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++)
-    phases_[i] ^= table_[i].Z[qubit];
+void Clifford::append_x(const uint64_t qubit) 
+{
+  int nid = omp_get_num_threads();
+  auto x_func = [this, qubit](AER::int_t i)
+  {
+    destabilizer_phases_(i) ^= destabilizer_table_[qubit].Z(i);
+    stabilizer_phases_(i) ^= stabilizer_table_[qubit].Z(i);
+  };
+  AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, destabilizer_phases_.blockLength(), x_func, omp_threads_);
 }
 
-void Clifford::append_y(const uint64_t qubit) {
-  #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++)
-    phases_[i] ^= (table_[i].Z[qubit] ^ table_[i].X[qubit]);
+void Clifford::append_y(const uint64_t qubit) 
+{
+  int nid = omp_get_num_threads();
+  auto y_func = [this, qubit](AER::int_t i)
+  {
+    destabilizer_phases_(i) ^= (destabilizer_table_[qubit].Z(i) ^ destabilizer_table_[qubit].X(i));
+    stabilizer_phases_(i) ^= (stabilizer_table_[qubit].Z(i) ^ stabilizer_table_[qubit].X(i));
+  };
+  AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, destabilizer_phases_.blockLength(), y_func, omp_threads_);
 }
 
-void Clifford::append_z(const uint64_t qubit) {
-  #pragma omp parallel for if (num_qubits_ > omp_threshold_ && omp_threads_ > 1) num_threads(omp_threads_)
-  for (int64_t i = 0; i < static_cast<int64_t>(2 * num_qubits_); i++)
-    phases_[i] ^= table_[i].X[qubit];
+void Clifford::append_z(const uint64_t qubit) 
+{
+  int nid = omp_get_num_threads();
+  auto z_func = [this, qubit](AER::int_t i)
+  {
+    destabilizer_phases_(i) ^= destabilizer_table_[qubit].X(i);
+    stabilizer_phases_(i) ^= stabilizer_table_[qubit].X(i);
+  };
+  AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, destabilizer_phases_.blockLength(), z_func, omp_threads_);
 }
-
 
 //------------------------------------------------------------------------------
 // Utility
 //------------------------------------------------------------------------------
-
-std::pair<bool, uint64_t> Clifford::z_anticommuting(const uint64_t qubit) const {
-  for (uint64_t p = num_qubits_; p < 2 * num_qubits_; p++) {
-    if (table_[p].X[qubit])
-      return std::make_pair(true, p);
+std::pair<bool, uint64_t> Clifford::z_anticommuting(const uint64_t qubit) const 
+{
+  for (uint_t i = 0; i < stabilizer_table_[qubit].X.blockLength(); i++) {
+    if (stabilizer_table_[qubit].X(i) != 0){
+      uint_t p = i << stabilizer_table_[qubit].X.BLOCK_BITS;
+      for (uint_t j = 0; j < stabilizer_table_[qubit].X.BLOCK_SIZE; j++) {
+        if (stabilizer_table_[qubit].X[p+j])
+          return std::make_pair(true, p+j);
+      }
+    }
   }
   return std::make_pair(false, 0);
 }
 
 
-std::pair<bool, uint64_t> Clifford::x_anticommuting(const uint64_t qubit) const {
-  for (uint64_t p = num_qubits_; p < 2 * num_qubits_; p++) {
-    if (table_[p].Z[qubit])
-      return std::make_pair(true, p);
+std::pair<bool, uint64_t> Clifford::x_anticommuting(const uint64_t qubit) const 
+{
+  for (uint_t i = 0; i < stabilizer_table_[qubit].Z.blockLength(); i++) {
+    if (stabilizer_table_[qubit].Z(i) != 0){
+      uint_t p = i << stabilizer_table_[qubit].Z.BLOCK_BITS;
+      for (uint_t j = 0; j < stabilizer_table_[qubit].Z.BLOCK_SIZE; j++) {
+        if (stabilizer_table_[qubit].Z[p+j])
+          return std::make_pair(true, p+j);
+      }
+    }
   }
   return std::make_pair(false, 0);
+}
+
+void Clifford::set_destabilizer(const int idx, const Pauli::Pauli<BV::BinaryVector>& P)
+{
+  for (int64_t i = 0; i < static_cast<int64_t>( num_qubits_); i++){
+    destabilizer_table_[i].X.setValue(P.X[i], idx);
+    destabilizer_table_[i].Z.setValue(P.Z[i], idx);
+  }
+}
+
+void Clifford::set_stabilizer(const int idx, const Pauli::Pauli<BV::BinaryVector>& P)
+{
+  for (int64_t i = 0; i < static_cast<int64_t>( num_qubits_); i++){
+    stabilizer_table_[i].X.setValue(P.X[i], idx);
+    stabilizer_table_[i].Z.setValue(P.Z[i], idx);
+  }
+}
+
+void Clifford::set_destabilizer_phases(const int i, const bool p)
+{
+  destabilizer_phases_.setValue(p, i);
+}
+
+void Clifford::set_stabilizer_phases(const int i, const bool p)
+{
+  stabilizer_phases_.setValue(p, i);
+}
+
+void Clifford::apply_set_stabilizer(const Clifford &clifford)
+{
+  destabilizer_table_ = clifford.destabilizer_table_;
+  stabilizer_table_ = clifford.stabilizer_table_;
+  destabilizer_phases_ = clifford.destabilizer_phases_;
+  stabilizer_phases_ = clifford.stabilizer_phases_;
 }
 
 //------------------------------------------------------------------------------
@@ -296,74 +392,319 @@ bool Clifford::is_deterministic_outcome(const uint64_t& qubit) const {
   return !z_anticommuting(qubit).first;
 }
 
-bool Clifford::measure_and_update(const uint64_t qubit, const uint64_t randint) {
+bool Clifford::measure_and_update(const uint64_t qubit, const uint64_t randint) 
+{
   // Clifford state measurements only have three probabilities:
   // (p0, p1) = (0.5, 0.5), (1, 0), or (0, 1)
   // The random case happens if there is a row anti-commuting with Z[qubit]
   auto anticom = z_anticommuting(qubit);
+
+  int nid = omp_get_num_threads();
+
   if (anticom.first) {
     bool outcome = (randint == 1);
     auto row = anticom.second;
-    for (uint64_t i = 0; i < 2 * num_qubits_; i++) {
-      // the last condition is not in the AG paper but we seem to need it
-      if ((table_[i].X[qubit]) && (i != row) && (i != (row - num_qubits_))) {
-        rowsum_helper(table_[row], phases_[row], table_[i], phases_[i]);
+
+    uint64_t rS = 0ull - (uint64_t)stabilizer_phases_[row];
+
+    auto measure_non_determinisitic_func = [this, rS, row, qubit](AER::int_t i)
+    {
+      uint64_t row_mask = ~0ull;
+      if((row >> destabilizer_phases_.BLOCK_BITS) == i)
+        row_mask ^= (1ull << (row & destabilizer_phases_.BLOCK_MASK));
+
+      uint64_t d_mask = row_mask & destabilizer_table_[qubit].X(i);
+      uint64_t s_mask = row_mask & stabilizer_table_[qubit].X(i);
+
+      if(d_mask != 0 || s_mask != 0){
+        //calculating exponents by 2-bits integer * 64-qubits at once
+        uint64_t d0 = 0, d1 = 0;
+        uint64_t s0 = 0, s1 = 0;
+        for (size_t q = 0; q < num_qubits_; q++){
+          uint64_t t0,t1;
+          uint64_t rX = 0ull - (uint64_t)stabilizer_table_[q].X[row];
+          uint64_t rZ = 0ull - (uint64_t)stabilizer_table_[q].Z[row];
+
+          //destabilizer
+          t0 = destabilizer_table_[q].X(i) & rZ;
+          t1 = destabilizer_table_[q].Z(i) ^ rX;
+
+          d1 ^= (t0 & d0);
+          d0 ^= t0;
+          d1 ^= (t0 & t1);
+
+          t0 = rX & destabilizer_table_[q].Z(i);
+          t1 = rZ ^ destabilizer_table_[q].X(i);
+          t1 ^= t0;
+
+          d1 ^= (t0 & d0);
+          d0 ^= t0;
+          d1 ^= (t0 & t1);
+
+          destabilizer_table_[q].X(i) ^= (d_mask & rX);
+          destabilizer_table_[q].Z(i) ^= (d_mask & rZ);
+
+          //stabilizer
+          t0 = stabilizer_table_[q].X(i) & rZ;
+          t1 = stabilizer_table_[q].Z(i) ^ rX;
+
+          s1 ^= (t0 & s0);
+          s0 ^= t0;
+          s1 ^= (t0 & t1);
+
+          t0 = rX & stabilizer_table_[q].Z(i);
+          t1 = rZ ^ stabilizer_table_[q].X(i);
+          t1 ^= t0;
+
+          s1 ^= (t0 & s0);
+          s0 ^= t0;
+          s1 ^= (t0 & t1);
+
+          stabilizer_table_[q].X(i) ^= (s_mask & rX);
+          stabilizer_table_[q].Z(i) ^= (s_mask & rZ);
+        }
+        d1 ^= (rS ^ destabilizer_phases_(i));
+        destabilizer_phases_(i) = (destabilizer_phases_(i) & (~d_mask)) | (d1 & d_mask);
+        s1 ^= (rS ^ stabilizer_phases_(i));
+        stabilizer_phases_(i) = (stabilizer_phases_(i) & (~s_mask)) | (s1 & s_mask);
+      }
+    };
+    AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, destabilizer_phases_.blockLength(), measure_non_determinisitic_func, omp_threads_);
+
+    // Update state
+    auto measure_update_func = [this, row](AER::int_t q)
+    {
+      destabilizer_table_[q].X.setValue(stabilizer_table_[q].X[row], row);
+      destabilizer_table_[q].Z.setValue(stabilizer_table_[q].Z[row], row);
+      stabilizer_table_[q].X.setValue(0, row);
+      stabilizer_table_[q].Z.setValue(0, row);
+    };
+    AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, num_qubits_, measure_update_func, omp_threads_);
+
+    destabilizer_phases_.setValue(stabilizer_phases_[row], row);
+    stabilizer_table_[qubit].Z.setValue(1, row);
+    stabilizer_phases_.setValue(outcome, row);
+    return outcome;
+  }
+  else {
+    // Deterministic outcome
+    bool outcome = false;
+    Pauli::Pauli<BV::BinaryVector> accum(num_qubits_);
+    uint64_t blocks = destabilizer_phases_.blockLength();
+
+    if(blocks < 2){
+      for (uint64_t i = 0; i < num_qubits_; i++) {
+        if (destabilizer_table_[qubit].X[i]) {
+          bool b0 = false, b1 = false;
+          for (size_t q = 0; q < num_qubits_; q++){
+            bool t0,t1,add;
+            bool accumX = accum.X[q];
+            bool accumZ = accum.Z[q];
+
+            t0 = accumX & stabilizer_table_[q].Z[i];
+            t1 = accumZ ^ stabilizer_table_[q].X[i];
+
+            b1 ^= (t0 & b0);
+            b0 ^= t0;
+            b1 ^= (t0 & t1);
+
+            t0 = stabilizer_table_[q].X[i] & accumZ;
+            t1 = stabilizer_table_[q].Z[i] ^ accumX;
+            t1 ^= t0;
+
+            b1 ^= (t0 & b0);
+            b0 ^= t0;
+            b1 ^= (t0 & t1);
+
+            accum.X.setValue(stabilizer_table_[q].X[i] ^ accum.X[q], q);
+            accum.Z.setValue(stabilizer_table_[q].Z[i] ^ accum.Z[q], q);
+          }
+          b1 ^= (stabilizer_phases_[i] ^ outcome);
+
+          if(b0){
+            throw std::runtime_error("Clifford: rowsum error");
+          }
+          outcome = b1;
+        }
       }
     }
-    // Update state
-    table_[row - num_qubits_].X = table_[row].X;
-    table_[row - num_qubits_].Z = table_[row].Z;
-    phases_[row - num_qubits_] = phases_[row];
-    table_[row].X.makeZero();
-    table_[row].Z.makeZero();
-    table_[row].Z.setValue(1, qubit);
-    phases_[row] = outcome;
-    return outcome;
-  } else {
-    // Deterministic outcome
-    Pauli::Pauli accum(num_qubits_);
-    phase_t outcome = 0;
-    for (uint64_t i = 0; i < num_qubits_; i++) {
-      if (table_[i].X[qubit]) {
-        rowsum_helper(table_[i + num_qubits_], phases_[i + num_qubits_],
-                      accum, outcome);
+    else{
+      uint64_t blockSize = destabilizer_phases_.blockSize();
+
+      //loop for cache blocking 
+      for (uint64_t ii = 0; ii < blocks; ii++) {
+        uint64_t destabilizer_mask = destabilizer_table_[qubit].X(ii);
+        if(destabilizer_mask == 0)
+          continue;
+
+        uint64_t exponent_l = 0;
+        uint64_t exponent_lc = 0;
+        uint64_t exponent_h = 0;
+
+        auto measure_determinisitic_func = [this, &accum, &exponent_l, &exponent_lc, &exponent_h, blocks, blockSize, destabilizer_mask, ii](AER::int_t qq)
+        {
+          uint64_t qs = qq*blockSize;
+          uint64_t qe = qs + blockSize;
+          if(qe > num_qubits_)
+            qe = num_qubits_;
+
+          uint64_t local_exponent_l = 0;
+          uint64_t local_exponent_h = 0;
+
+          for (uint64_t q = qs; q < qe; q++){
+            uint64_t sX = stabilizer_table_[q].X(ii);
+            uint64_t sZ = stabilizer_table_[q].Z(ii);
+
+            //set accum for this block
+            uint64_t accumX = destabilizer_mask & sX;
+            uint64_t accumZ = destabilizer_mask & sZ;
+            for(int b=1;b<blockSize;b*=2){
+              accumX ^= (accumX << b);
+              accumZ ^= (accumZ << b);
+            }
+            accumX ^= (0ull - (uint64_t)accum.X[q]);
+            accumZ ^= (0ull - (uint64_t)accum.Z[q]);
+            accum.X.setValue((accumX >> (blockSize - 1)), q);
+            accum.Z.setValue((accumZ >> (blockSize - 1)), q);
+
+            accumX ^= sX;
+            accumZ ^= sZ;
+
+            //exponents for this block
+            uint64_t t0,t1;
+
+            t0 = accumX & sZ;
+            t1 = accumZ ^ sX;
+
+            local_exponent_h ^= (t0 & local_exponent_l);
+            local_exponent_l ^= t0;
+            local_exponent_h ^= (t0 & t1);
+
+            t0 = sX & accumZ;
+            t1 = sZ ^ accumX;
+            t1 ^= t0;
+
+            local_exponent_h ^= (t0 & local_exponent_l);
+            local_exponent_l ^= t0;
+            local_exponent_h ^= (t0 & t1);
+          }
+
+#pragma omp atomic
+          exponent_lc |= local_exponent_l;
+#pragma omp atomic
+          exponent_l ^= local_exponent_l;
+#pragma omp atomic
+          exponent_h ^= local_exponent_h;
+        };
+        AER::Utils::apply_omp_parallel_for((num_qubits_ > omp_threshold_ && omp_threads_ > 1 && nid == 1), 0, blocks, measure_determinisitic_func, omp_threads_);
+
+        exponent_h ^= (exponent_lc ^ exponent_l);   //if exponent_l is 0 and any of local_exponent_l is 1, then flip exponent_h
+
+        exponent_h ^= (stabilizer_phases_(ii) & destabilizer_mask);
+        outcome ^= ((AER::Utils::popcount(exponent_h) & 1) != 0);
       }
     }
     return outcome;
   }
 }
 
-void Clifford::rowsum_helper(const Pauli::Pauli &row, const phase_t row_phase,
-                             Pauli::Pauli &accum, phase_t &accum_phase) const {
-  int8_t newr = ((2 * row_phase + 2 * accum_phase) +
-                 Pauli::Pauli::phase_exponent(row, accum)) % 4;
-  // Since we are only using +1 and -1 phases in our Clifford phases
-  // the exponent must be 0 (for +1) or 2 (for -1)
-  if ((newr != 0) && (newr != 2)) {
-    throw std::runtime_error("Clifford: rowsum error");
+double Clifford::expval_pauli(const reg_t &qubits,
+                              const std::string& pauli)
+{
+  // Construct Pauli on N-qubits
+  Pauli::Pauli<BV::BinaryVector> P(num_qubits_);
+  uint_t phase = 0;
+  for (size_t i = 0; i < qubits.size(); ++i) {
+    switch (pauli[pauli.size() - 1 - i]) {
+      case 'X':
+        P.X.set1(qubits[i]);
+        break;
+      case 'Y':
+        P.X.set1(qubits[i]);
+        P.Z.set1(qubits[i]);
+        phase += 1;
+        break;
+      case 'Z':
+        P.Z.set1(qubits[i]);
+        break;
+      default:
+        break;
+    };
   }
-  accum_phase = (newr == 2);
-  accum.X += row.X;
-  accum.Z += row.Z;
+
+  // Check if there is a stabilizer that anti-commutes with an odd number of qubits
+  // If so expectation value is 0
+  for (size_t i = 0; i < num_qubits_; i++) {
+    size_t num_anti = 0;
+    for (const auto& qubit : qubits) {
+      if (P.Z[qubit] & stabilizer_table_[qubit].X[i]) {
+	      num_anti++;
+      }
+      if (P.X[qubit] & stabilizer_table_[qubit].Z[i]) {
+	      num_anti++;
+      }
+    }
+    if(num_anti % 2 == 1)
+      return 0.0;
+  }
+
+  // Otherwise P is (-1)^a prod_j S_j^b_j for Clifford stabilizers
+  // If P anti-commutes with D_j then b_j = 1.
+  // Multiply P by stabilizers with anti-commuting destabilizers
+  auto PZ = P.Z; // Make a copy of P.Z 
+  for (size_t i = 0; i < num_qubits_; i++) {
+    // Check if destabilizer anti-commutes
+    size_t num_anti = 0;
+    for (const auto& qubit : qubits) {
+      if (P.Z[qubit] & destabilizer_table_[qubit].X[i]) {
+	      num_anti++;
+      }
+      if (P.X[qubit] & destabilizer_table_[qubit].Z[i]) {
+	      num_anti++;
+      }
+    }
+    if (num_anti % 2 == 0) continue;
+
+    // If anti-commutes multiply Pauli by stabilizer
+    phase += 2 * (uint_t)stabilizer_phases_[i];
+    for (size_t k = 0; k < num_qubits_; k++) {
+      phase += stabilizer_table_[k].Z[i] & stabilizer_table_[k].X[i];
+      phase += 2 * (PZ[k] & stabilizer_table_[k].X[i]);
+      PZ.setValue(PZ[k] ^ stabilizer_table_[k].Z[i], k);
+    }
+  }
+  return (phase % 4) ? -1.0 : 1.0;
 }
+
 
 //------------------------------------------------------------------------------
 // JSON Serialization
 //------------------------------------------------------------------------------
 
-json_t Clifford::json() const {
+json_t Clifford::json() const 
+{
   json_t js = json_t::object();
   // Add destabilizers
   json_t stab;
   for (size_t i = 0; i < num_qubits_; i++) {
     // Destabilizer
-    std::string label = (phases_[i] == 0) ? "+" : "-";
-    label += table_[i].str();
+    std::string label = (destabilizer_phases_[i] == 0) ? "+" : "-";
+
+    Pauli::Pauli<BV::BinaryVector> P(num_qubits_);
+    for (size_t j = 0; j < num_qubits_; j++) {
+      P.X.setValue(destabilizer_table_[j].X[i], j);
+      P.Z.setValue(destabilizer_table_[j].Z[i], j);
+    }
+    label += P.str();
     js["destabilizer"].push_back(label);
 
     // Stabilizer
-    label = (phases_[num_qubits_ + i] == 0) ? "+" : "-";
-    label += table_[num_qubits_ + i].str();
+    label = (stabilizer_phases_[i] == 0) ? "+" : "-";
+    for (size_t j = 0; j < num_qubits_; j++) {
+      P.X.setValue(stabilizer_table_[j].X[i], j);
+      P.Z.setValue(stabilizer_table_[j].Z[i], j);
+    }
+    label += P.str();
     js["stabilizer"].push_back(label);
   }
   return js;
@@ -374,7 +715,8 @@ inline void to_json(json_t &js, const Clifford &clif) {
 }
 
 template <typename inputdata_t>
-void build_from(const inputdata_t& input, Clifford& clif){
+void build_from(const inputdata_t& input, Clifford& clif)
+{
   bool has_keys = AER::Parser<inputdata_t>::check_keys({"stabilizer", "destabilizer"}, input);
   if (!has_keys)
     throw std::invalid_argument("Invalid Clifford JSON.");
@@ -388,24 +730,24 @@ void build_from(const inputdata_t& input, Clifford& clif){
     throw std::invalid_argument("Invalid Clifford JSON: stabilizer and destabilizer lengths do not match.");
   }
 
-  clif = Clifford(nq);
+  clif.initialize(nq);
   for (size_t i = 0; i < nq; i++) {
     std::string label;
     // Get destabilizer
     label = destab[i];
     switch (label[0]) {
       case '-':
-        clif.phases()[i] = 1;
-        clif.table()[i] = Pauli::Pauli(label.substr(1, nq));
+        clif.set_destabilizer_phases(i,1);
+        clif.set_destabilizer(i, Pauli::Pauli<BV::BinaryVector>(label.substr(1, nq)));
         break;
       case '+':
-        clif.table()[i] = Pauli::Pauli(label.substr(1, nq));
+        clif.set_destabilizer(i, Pauli::Pauli<BV::BinaryVector>(label.substr(1, nq)));
         break;
       case 'I':
       case 'X':
       case 'Y':
       case 'Z':
-        clif.table()[i] = Pauli::Pauli(label);
+        clif.set_destabilizer(i, Pauli::Pauli<BV::BinaryVector>(label));
         break;
       default:
         throw std::invalid_argument("Invalid Stabilizer JSON string.");
@@ -414,17 +756,17 @@ void build_from(const inputdata_t& input, Clifford& clif){
     label = stab[i];
     switch (label[0]) {
       case '-':
-        clif.phases()[i + nq] = 1;
-        clif.table()[i + nq] = Pauli::Pauli(label.substr(1, nq));
+        clif.set_stabilizer_phases(i, 1);
+        clif.set_stabilizer(i, Pauli::Pauli<BV::BinaryVector>(label.substr(1, nq)));
         break;
       case '+':
-        clif.table()[i + nq] = Pauli::Pauli(label.substr(1, nq));
+        clif.set_stabilizer(i, Pauli::Pauli<BV::BinaryVector>(label.substr(1, nq)));
         break;
       case 'I':
       case 'X':
       case 'Y':
       case 'Z':
-        clif.table()[i + nq] = Pauli::Pauli(label);
+        clif.set_stabilizer(i, Pauli::Pauli<BV::BinaryVector>(label));
         break;
       default:
         throw std::invalid_argument("Invalid Stabilizer JSON string.");
@@ -432,17 +774,19 @@ void build_from(const inputdata_t& input, Clifford& clif){
   }
 }
 
-inline void from_json(const json_t &js, Clifford &clif) {
-    build_from(js, clif);
+inline void from_json(const json_t &js, Clifford &clif) 
+{
+  build_from(js, clif);
 }
 
 //------------------------------------------------------------------------------
 } // end namespace Clifford
+} // AER
 //------------------------------------------------------------------------------
 
 // ostream overload for templated qubitvector
 template <class statevector_t>
-std::ostream &operator<<(std::ostream &out, const Clifford::Clifford &clif) {
+std::ostream &operator<<(std::ostream &out, const AER::Clifford::Clifford &clif) {
   out << clif.json().dump();
   return out;
 }

--- a/src/simulators/stabilizer/pauli.hpp
+++ b/src/simulators/stabilizer/pauli.hpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include "binary_vector.hpp"
 
+namespace AER {
 namespace Pauli {
 
 /*******************************************************************************
@@ -26,14 +27,15 @@ namespace Pauli {
  *
  ******************************************************************************/
 
+template <typename bv_type>
 class Pauli {
 public:
   // Symplectic binary vectors
-  BV::BinaryVector X;
-  BV::BinaryVector Z;
+  bv_type X;
+  bv_type Z;
 
   // Construct an empty pauli
-  Pauli() : X(0), Z(0) {};
+  Pauli() {};
 
   // Construct an n-qubit identity Pauli
   explicit Pauli(uint64_t len) : X(len), Z(len) {};
@@ -45,7 +47,7 @@ public:
   std::string str() const;
 
   // exponent g of i such that P(x1,z1) P(x2,z2) = i^g P(x1+x2,z1+z2)
-  static int8_t phase_exponent(const Pauli& pauli1, const Pauli& pauli2);
+  static int8_t phase_exponent(const Pauli<bv_type>& pauli1, const Pauli<bv_type>& pauli2);
 };
 
 
@@ -55,10 +57,11 @@ public:
  *
  ******************************************************************************/
 
-Pauli::Pauli(const std::string &label) {
+template <typename bv_type>
+Pauli<bv_type>::Pauli(const std::string &label) {
   const auto num_qubits = label.size();
-  X = BV::BinaryVector(num_qubits);
-  Z = BV::BinaryVector(num_qubits);
+  X = bv_type(num_qubits);
+  Z = bv_type(num_qubits);
   // The label corresponds to tensor product order
   // So the first element of label is the last qubit and vice versa
   for (size_t i =0; i < num_qubits; i++) {
@@ -82,7 +85,8 @@ Pauli::Pauli(const std::string &label) {
   }
 }
 
-std::string Pauli::str() const {
+template <typename bv_type>
+std::string Pauli<bv_type>::str() const {
   // Check X and Z are same length
   const auto num_qubits = X.getLength();
   if (Z.getLength() != num_qubits)
@@ -102,7 +106,8 @@ std::string Pauli::str() const {
   return label;
 }
 
-int8_t Pauli::phase_exponent(const Pauli& pauli1, const Pauli& pauli2) {
+template <typename bv_type>
+int8_t Pauli<bv_type>::phase_exponent(const Pauli<bv_type>& pauli1, const Pauli<bv_type>& pauli2) {
   int8_t exponent = 0;
   for (size_t q = 0; q < pauli1.X.getLength(); q++) {
     exponent += pauli2.X[q] * pauli1.Z[q] * (1 + 2 * pauli2.Z[q] + 2 * pauli1.X[q]);
@@ -116,11 +121,12 @@ int8_t Pauli::phase_exponent(const Pauli& pauli1, const Pauli& pauli2) {
 
 //------------------------------------------------------------------------------
 } // end namespace Pauli
+} // AER
 //------------------------------------------------------------------------------
 
 // ostream overload for templated qubitvector
-template <class statevector_t>
-inline std::ostream &operator<<(std::ostream &out, const Pauli::Pauli &pauli) {
+template <typename bv_type>
+inline std::ostream &operator<<(std::ostream &out, const AER::Pauli::Pauli<bv_type> &pauli) {
   out << pauli.str();
   return out;
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR improves performance of stabilizer simulator.


### Details and comments
This PR changes data layout of stabilizer/destabilizer bit register, this will improve memory access of bit wise operations. Now most of operations can be written as 64-bits integer logical calculations. This layout change will be effective for GPU implementation (future work)
Also measure operation is improved by implementing 2-bits integer adder to calculate phase. 

This graph shows simulation time comparison using surface code for 10000 shots.
![image](https://user-images.githubusercontent.com/30102488/216261353-6f2dc2f4-84bf-45c6-b932-a0ad9733706f.png)
