### PR TITLE
Add abelian_grouping to Estimator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run Lint
         run: |
           set -e
-          pycodestyle --ignore=E402,W504 --max-line-length=100 qiskit_aer
+          pycodestyle --ignore=E402,W503,W504 --max-line-length=100 qiskit_aer
           pylint -j 2 -rn qiskit_aer
   sdist:
     runs-on: ${{ matrix.platform.os }}

--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -16,21 +16,23 @@ Estimator class.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Sequence
 from copy import copy
-from itertools import accumulate
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import transpile
 from qiskit.opflow import PauliSumOp
 from qiskit.primitives import BaseEstimator, EstimatorResult
-from qiskit.primitives.utils import init_observable
+from qiskit.primitives.primitive_job import PrimitiveJob
+from qiskit.primitives.utils import _circuit_key, _observable_key, init_observable
 from qiskit.providers import Options
-from qiskit.quantum_info import Pauli
+from qiskit.quantum_info import Pauli, PauliList
 from qiskit.quantum_info.operators.base_operator import BaseOperator
+from qiskit.result.models import ExperimentResult
 
-from .. import AerSimulator
+from .. import AerError, AerSimulator
 
 
 class Estimator(BaseEstimator):
@@ -64,6 +66,7 @@ class Estimator(BaseEstimator):
         run_options: dict | None = None,
         approximation: bool = False,
         skip_transpilation: bool = False,
+        abelian_grouping: bool = True,
     ):
         """
         Args:
@@ -73,6 +76,7 @@ class Estimator(BaseEstimator):
             approximation: If True, it calculates expectation values with normal distribution
                 approximation.
             skip_transpilation: If True, transpilation is skipped.
+            abelian_grouping: Whether the observable should be grouped into commuting
         """
         super().__init__(options=run_options)
 
@@ -92,6 +96,7 @@ class Estimator(BaseEstimator):
         self._layouts = {}
         self._circuit_ids = {}
         self._observable_ids = {}
+        self._abelian_grouping = abelian_grouping
 
     def _call(
         self,
@@ -119,9 +124,6 @@ class Estimator(BaseEstimator):
         parameter_values: Sequence[Sequence[float]],
         **run_options,
     ) -> PrimitiveJob:
-        # pylint: disable=no-name-in-module, import-error, import-outside-toplevel, no-member
-        from qiskit.primitives.primitive_job import PrimitiveJob
-        from qiskit.primitives.utils import _circuit_key, _observable_key
 
         circuit_indices: list = []
         for circuit in circuits:
@@ -152,89 +154,204 @@ class Estimator(BaseEstimator):
     def _compute(self, circuits, observables, parameter_values, run_options):
         # Key for cache
         key = (tuple(circuits), tuple(observables), self.approximation)
-        parameter_binds = []
 
         # Create expectation value experiments.
         if key in self._cache:  # Use a cache
-            experiments, num_observable, experiment_data = self._cache[key]
-            for i, j, value in zip(circuits, observables, parameter_values):
-                self._validate_parameter_length(value, i)
-                observable = self._observables[j]
-                for _ in range(len(observable)):
-                    parameter_binds.append({k: [v] for k, v in zip(self._parameters[i], value)})
+            experiments_dict, obs_maps = self._cache[key]
+            param_binds_dict, param_inds = self._pre_process_params(circuits, parameter_values)
+            experiments, parameter_binds = self._flatten(experiments_dict, param_binds_dict)
+            post_processings = self._create_post_processing(
+                circuits, observables, param_inds, obs_maps, param_binds_dict
+            )
         else:
-            experiments = []
-            experiment_data = []
-            num_observable = []
+            experiments_dict = {}
+            obs_maps = {}
             self._transpile_circuits(circuits)
-            for i, j, value in zip(circuits, observables, parameter_values):
-                self._validate_parameter_length(value, i)
-                observable = self._observables[j]
-                num_observable.append(len(observable))
-                circuit = (
-                    self._circuits[i] if self._skip_transpilation else self._transpiled_circuits[i]
-                )
-                # Measurement circuit
-                for pauli, coeff in zip(observable.paulis, observable.coeffs):
-                    coeff = np.real_if_close(coeff).item()
-                    is_identity = not pauli.x.any() and not pauli.z.any()
-                    experiment_data.append({"is_identity": is_identity, "coeff": coeff})
-                    # If observable is constant multiplicaition of I, empty circuit is set.
-                    if is_identity:
-                        experiments.append(QuantumCircuit(0))
-                        parameter_binds.append({})
-                        continue
-                    experiment = circuit.copy()
-                    meas_circuit = self._measurement_circuit(observable.num_qubits, pauli, i)
-                    for creg in meas_circuit.cregs:
-                        experiment.add_register(creg)
-                    experiment.compose(meas_circuit, inplace=True)
-                    experiments.append(experiment)
-                    parameter_binds.append({k: [v] for k, v in zip(self._parameters[i], value)})
-                self._cache[key] = (experiments, num_observable, experiment_data)
-        # Run experiments
-        parameter_binds = parameter_binds if any(parameter_binds) else None
-        result = self._backend.run(
-            experiments, parameter_binds=parameter_binds, **run_options
-        ).result()
-        results = result.results
-
-        # Post processing (calculate expectation values)
-        experiment_index = [0] + list(accumulate(num_observable))
-        expectation_values = []
-        metadata = []
-        for start, end in zip(experiment_index, experiment_index[1:]):
-            combined_expval = 0.0
-            combined_var = 0.0
-            shots = 0
-            simulator_metadata = []
-            for result, experiment_datum in zip(results[start:end], experiment_data[start:end]):
-                # If observable is constant multiplicaition of I, expval is trivial.
-                if experiment_datum["is_identity"]:
-                    expval, var = 1, 0
+            circ_obs_map = defaultdict(list)
+            for circ_ind, obs_ind in zip(circuits, observables):
+                circ_obs_map[circ_ind].append(obs_ind)
+            for circ_ind, obs_indices in circ_obs_map.items():
+                pauli_list = sum(
+                    [self._observables[obs_ind].paulis for obs_ind in obs_indices]
+                ).unique()
+                if self._abelian_grouping:
+                    pauli_lists = pauli_list.group_commuting(qubit_wise=True)
                 else:
-                    count = result.data.counts
-                    shots += sum(count.values())
-                    expval, var = _expval_with_variance(count)
-                    simulator_metadata.append(result.metadata)
-                # Accumulate
-                coeff = experiment_datum["coeff"]
-                combined_expval += expval * coeff
-                combined_var += var * coeff**2
-            expectation_values.append(combined_expval)
-            metadata.append(
-                {
-                    "shots": shots,
-                    "variance": combined_var,
-                    "simulator_metadata": simulator_metadata,
-                }
+                    pauli_lists = [PauliList(pauli) for pauli in pauli_list]
+                obs_map = defaultdict(list)
+                for obs_ind in obs_indices:
+                    for pauli in self._observables[obs_ind].paulis:
+                        for exp_ind, pauli_list in enumerate(pauli_lists):
+                            if pauli in pauli_list:
+                                obs_map[obs_ind].append(exp_ind)
+                                break
+                obs_maps[circ_ind] = obs_map
+                paulis = [
+                    Pauli(
+                        (
+                            np.logical_or.reduce(pauli_list.z),  # pylint:disable=no-member
+                            np.logical_or.reduce(pauli_list.x),  # pylint:disable=no-member
+                        )
+                    )
+                    for pauli_list in pauli_lists
+                ]
+                if len(paulis) == 1 and not paulis[0].x.any() and not paulis[0].z.any():
+                    break
+                meas_circuits = [self._create_meas_circuit(basis, circ_ind) for basis in paulis]
+                circuit = (
+                    self._circuits[circ_ind]
+                    if self._skip_transpilation
+                    else self._transpiled_circuits[circ_ind]
+                )
+                experiments_dict[circ_ind] = self._combine_circs(circuit, meas_circuits)
+            self._cache[key] = experiments_dict, obs_maps
+
+            param_binds_dict, param_inds = self._pre_process_params(circuits, parameter_values)
+
+            # Flatten
+            experiments, parameter_binds = self._flatten(experiments_dict, param_binds_dict)
+
+            # Create PostProcessing
+            post_processings = self._create_post_processing(
+                circuits, observables, param_inds, obs_maps, param_binds_dict
             )
 
+        # Run experiments
+        if experiments:
+            results = (
+                self._backend.run(
+                    circuits=experiments,
+                    parameter_binds=parameter_binds if any(parameter_binds) else None,
+                    **run_options,
+                )
+                .result()
+                .results
+            )
+        else:
+            results = []
+
+        # Post processing (calculate expectation values)
+        expectation_values = []
+        metadata = []
+        for post_processing in post_processings:
+            expval, meta = post_processing.run(results)
+            expectation_values.append(expval)
+            metadata.append(meta)
         return EstimatorResult(np.real_if_close(expectation_values), metadata)
+
+    def _pre_process_params(self, circuits, parameter_values):
+        param_inds = []
+        param_binds_dict = {}
+        for circ_ind, param_val in zip(circuits, parameter_values):
+            self._validate_parameter_length(param_val, circ_ind)
+            if circ_ind in param_binds_dict and len(self._parameters[circ_ind]) > 0:
+                param_inds.append(len(next(iter(param_binds_dict[circ_ind].values()))))
+                for k, v in zip(self._parameters[circ_ind], param_val):
+                    param_binds_dict[circ_ind][k].append(v)
+            else:
+                param_binds_dict[circ_ind] = {
+                    k: [v] for k, v in zip(self._parameters[circ_ind], param_val)
+                }
+                param_inds.append(0)
+        return param_binds_dict, param_inds
+
+    def _create_meas_circuit(self, basis: Pauli, circuit_index):
+        qargs = np.arange(basis.num_qubits)[basis.z | basis.x]
+        meas_circuit = QuantumCircuit(basis.num_qubits, len(qargs))
+        for clbit, qarg in enumerate(qargs):
+            if basis.x[qarg]:
+                if basis.z[qarg]:
+                    meas_circuit.sdg(qarg)
+                meas_circuit.h(qarg)
+            meas_circuit.measure(qarg, clbit)
+        meas_circuit.metadata = {"basis": basis}
+        if self._skip_transpilation:
+            return meas_circuit
+        transpile_opts = copy(self._transpile_options)
+        transpile_opts.update_options(initial_layout=self._layouts[circuit_index])
+        return transpile(meas_circuit, self._backend, **transpile_opts.__dict__)
+
+    @staticmethod
+    def _combine_circs(circuit: QuantumCircuit, meas_circuits: list[QuantumCircuit]):
+        circs = []
+        for meas_circuit in meas_circuits:
+            new_circ = circuit.copy()
+            for creg in meas_circuit.cregs:
+                new_circ.add_register(creg)
+            new_circ.compose(meas_circuit, inplace=True)
+            _update_metadata(new_circ, meas_circuit.metadata)
+            circs.append(new_circ)
+        return circs
+
+    @staticmethod
+    def _calculate_result_index(
+        obs_maps, param_ind, circ_ind, obs_ind, term_ind, param_binds
+    ) -> int:
+        circ_dup_num = {
+            circ_ind: len(next(iter(v.values()))) if v else 1 for circ_ind, v in param_binds.items()
+        }
+        obs_dup_num = {
+            circ_ind: {obs_ind: max(exp_inds) + 1 for obs_ind, exp_inds in obs_map.items()}
+            for circ_ind, obs_map in obs_maps.items()
+        }
+        result_index = 0
+        for _circ_ind, obs_num_dict in obs_dup_num.items():
+            for _obs_ind, obs_num in obs_num_dict.items():
+                if circ_ind == _circ_ind and obs_ind == _obs_ind:
+                    obs_offset = obs_maps[circ_ind][obs_ind][term_ind]
+                    result_index += obs_offset * circ_dup_num[circ_ind] + param_ind
+                    return result_index
+                result_index += circ_dup_num[_circ_ind] * obs_num
+        raise AerError(
+            "Bug. Please report from isssue: https://github.com/Qiskit/qiskit-aer/issues"
+        )
+
+    @staticmethod
+    def _flatten(experiments, param_binds):
+        experiments_list = []
+        parameter_binds = []
+        for circ_ind in experiments:
+            experiments_list.extend(experiments[circ_ind])
+            for _ in range(len(experiments[circ_ind])):
+                parameter_binds.append(param_binds[circ_ind])
+        return experiments_list, parameter_binds
+
+    def _create_post_processing(
+        self, circuits, observables, param_inds, obs_maps, param_binds
+    ) -> list[_PostProcessing]:
+        post_processings = []
+        for circ_ind, obs_ind, param_ind in zip(circuits, observables, param_inds):
+            result_indices = []
+            paulis = []
+            coeffs = []
+            observable = self._observables[obs_ind]
+            for term_ind, (pauli, coeff) in enumerate(zip(observable.paulis, observable.coeffs)):
+                # Identity
+                if not pauli.x.any() and not pauli.z.any():
+                    result_indices.append(None)
+                    paulis.append(PauliList(pauli))
+                    coeffs.append([coeff])
+                    continue
+
+                result_index = self._calculate_result_index(
+                    obs_maps, param_ind, circ_ind, obs_ind, term_ind, param_binds
+                )
+                if result_index in result_indices:
+                    i = result_indices.index(result_index)
+                    paulis[i] += pauli
+                    coeffs[i].append(coeff)
+                else:
+                    result_indices.append(result_index)
+                    paulis.append(PauliList(pauli))
+                    coeffs.append([coeff])
+            post_processings.append(_PostProcessing(result_indices, paulis, coeffs))
+        return post_processings
 
     def _compute_with_approximation(
         self, circuits, observables, parameter_values, run_options, seed
     ):
+        if self._abelian_grouping:
+            raise AerError("approximation and abelian_grouping cannot be True at the same time.")
         # Key for cache
         key = (tuple(circuits), tuple(observables), self.approximation)
         parameter_binds = []
@@ -310,21 +427,6 @@ class Estimator(BaseEstimator):
                 f"the number of parameters ({len(self._parameters[circuit_index])})."
             )
 
-    def _measurement_circuit(self, num_qubits: int, pauli: Pauli, circuit_index: int):
-        qubit_indices = np.arange(pauli.num_qubits)[pauli.z | pauli.x]
-        meas_circuit = QuantumCircuit(num_qubits, len(qubit_indices))
-        for clbit, i in enumerate(qubit_indices):
-            if pauli.x[i]:
-                if pauli.z[i]:
-                    meas_circuit.sdg(i)
-                meas_circuit.h(i)
-            meas_circuit.measure(i, clbit)
-        if self._skip_transpilation:
-            return meas_circuit
-        transpile_opts = copy(self._transpile_options)
-        transpile_opts.update_options(initial_layout=self._layouts[circuit_index])
-        return transpile(meas_circuit, self._backend, **transpile_opts.__dict__)
-
     def _transpile(self, circuits):
         if self._skip_transpilation:
             return circuits
@@ -361,3 +463,93 @@ def _expval_with_variance(counts) -> tuple[float, float]:
     # Compute variance
     variance = 1 - expval**2
     return expval, variance
+
+
+class _PostProcessing:
+    def __init__(
+        self, circuit_indices: list[int], paulis: list[PauliList], coeffs: list[list[float]]
+    ):
+        self._circuit_indices = circuit_indices
+        self._paulis = paulis
+        self._coeffs = [np.array(c) for c in coeffs]
+
+    def run(self, results: list[ExperimentResult]) -> tuple[float, dict]:
+        """Coumpute expectation value.
+
+        Args:
+            results: list of ExperimentResult.
+
+        Returns:
+            tuple of an expectation value and metadata.
+        """
+        combined_expval = 0.0
+        combined_var = 0.0
+        simulator_metadata = []
+        for c_i, paulis, coeffs in zip(self._circuit_indices, self._paulis, self._coeffs):
+            if c_i is None:
+                # Observable is identity
+                expvals, variances = [1], [0]
+                shots = 0
+            else:
+                result = results[c_i]
+                count = result.data.counts
+                shots = sum(count.values())
+                basis = result.header.metadata["basis"]
+                indices = np.where(basis.z | basis.x)[0]
+                measured_paulis = PauliList.from_symplectic(
+                    paulis.z[:, indices], paulis.x[:, indices], 0
+                )
+                expvals, variances = _pauli_expval_with_variance(count, measured_paulis)
+                simulator_metadata.append(result.metadata)
+            combined_expval += np.dot(expvals, coeffs)
+            combined_var += np.dot(variances, coeffs**2)
+        metadata = {
+            "shots": shots,
+            "variance": combined_var,
+            "simulator_metadata": simulator_metadata,
+        }
+        return combined_expval, metadata
+
+
+def _update_metadata(circuit: QuantumCircuit, metadata: dict) -> QuantumCircuit:
+    if circuit.metadata:
+        circuit.metadata.update(metadata)
+    else:
+        circuit.metadata = metadata
+    return circuit
+
+
+def _pauli_expval_with_variance(counts: dict, paulis: PauliList) -> tuple[np.ndarray, np.ndarray]:
+    # Diag indices
+    size = len(paulis)
+    diag_inds = _paulis2inds(paulis)
+
+    expvals = np.zeros(size, dtype=float)
+    denom = 0  # Total shots for counts dict
+    for hex_outcome, freq in counts.items():
+        outcome = int(hex_outcome, 16)
+        denom += freq
+        for k in range(size):
+            coeff = (-1) ** _parity(diag_inds[k] & outcome)
+            expvals[k] += freq * coeff
+
+    # Divide by total shots
+    expvals /= denom
+
+    variances = 1 - expvals**2
+    return expvals, variances
+
+
+def _paulis2inds(paulis: PauliList) -> list[int]:
+    nonid = paulis.z | paulis.x
+    packed_vals = np.packbits(nonid, axis=1, bitorder="little").astype(  # pylint:disable=no-member
+        object
+    )
+    power_uint8 = 1 << (8 * np.arange(packed_vals.shape[1], dtype=object))
+    inds = packed_vals @ power_uint8
+    return inds.tolist()
+
+
+def _parity(integer: int) -> int:
+    """Return the parity of an integer"""
+    return bin(integer).count("1") % 2

--- a/releasenotes/notes/add-grouping-fcc4fad69ccdac26.yaml
+++ b/releasenotes/notes/add-grouping-fcc4fad69ccdac26.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add ``abelian_grouping`` option to :class:`~Estimator`.
+upgrade:
+  - |
+    In default, :class:`~Estimator` groups the qubit-wise commutable observables.
+    The grouping reduces the number of circuits to be executed and improves the performance.

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
   pycodestyle
   pylint
 commands =
-  pycodestyle --ignore=E402,W504 --max-line-length=100 qiskit_aer
+  pycodestyle --ignore=E402,W503,W504 --max-line-length=100 qiskit_aer
   pylint -j 2 -rn qiskit_aer
 
 [testenv:docs]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

https://github.com/Qiskit/qiskit-aer/issues/1700


### Details and comments

### Benchmark for diagonal operators

Benchmark code:
```python
ansatz = RealAmplitudes(num_qubits=num_qubits, reps=1)
observables = [SparsePauliOp("".join(pauli_str)) for pauli_str in product("IZ", repeat=num_qubits)]
parameter_values = list(np.random.rand(1, ansatz.num_parameters))
estimator = Estimator(abelian_grouping=abelian_grouping)
start = time()
result = estimator.run(circuits=[ansatz]*len(observables), observables=observables, parameter_values=parameter_values*len(observables)).result()
elapsed_time = time() - start

```
Benchmark result:
<img width="562" alt="image" src="https://user-images.githubusercontent.com/6814928/217283141-c01d74c4-4990-4cf3-a5e9-02d9e71fbb44.png">
