### PR TITLE
support break_loop and continue_loop

### DIFF
--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -455,14 +455,14 @@ class AerSimulator(AerBackend):
             'save_amplitudes', 'save_amplitudes_sq',
             'save_density_matrix', 'save_state', 'save_statevector',
             'save_statevector_dict', 'set_statevector',
-            'if_else', 'for_loop', 'while_loop',
+            'if_else', 'for_loop', 'while_loop', 'break_loop', 'continue_loop',
         ]),
         'density_matrix': sorted([
             'quantum_channel', 'qerror_loc', 'roerror', 'kraus', 'superop',
             'save_state', 'save_expval', 'save_expval_var',
             'save_probabilities', 'save_probabilities_dict',
             'save_density_matrix', 'save_amplitudes_sq', 'set_density_matrix',
-            'if_else', 'for_loop', 'while_loop',
+            'if_else', 'for_loop', 'while_loop', 'break_loop', 'continue_loop',
         ]),
         'matrix_product_state': sorted([
             'quantum_channel', 'qerror_loc', 'roerror', 'kraus',
@@ -471,7 +471,7 @@ class AerSimulator(AerBackend):
             'save_state', 'save_matrix_product_state', 'save_statevector',
             'save_density_matrix', 'save_amplitudes', 'save_amplitudes_sq',
             'set_matrix_product_state',
-            'if_else', 'for_loop', 'while_loop',
+            'if_else', 'for_loop', 'while_loop', 'break_loop', 'continue_loop',
         ]),
         'stabilizer': sorted([
             'quantum_channel', 'qerror_loc', 'roerror',
@@ -479,7 +479,7 @@ class AerSimulator(AerBackend):
             'save_probabilities', 'save_probabilities_dict',
             'save_amplitudes_sq', 'save_state', 'save_clifford',
             'save_stabilizer', 'set_stabilizer',
-            'if_else', 'for_loop', 'while_loop',
+            'if_else', 'for_loop', 'while_loop', 'break_loop', 'continue_loop',
         ]),
         'extended_stabilizer': sorted([
             'quantum_channel', 'qerror_loc', 'roerror', 'save_statevector',

--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -57,19 +57,19 @@ BASIS_GATES = {
         'rzz', 'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx',
         'mcp', 'mcphase', 'mcu', 'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz',
         'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
-        'initialize', 'delay', 'pauli', 'mcx_gray', 'ecr', 'break_loop', 'continue_loop'
+        'initialize', 'delay', 'pauli', 'mcx_gray', 'ecr'
     ]),
     'density_matrix': sorted([
         'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
         'y', 'z', 'h', 's', 'sdg', 'sx', 'sxdg', 't', 'tdg', 'swap', 'cx',
         'cy', 'cz', 'cp', 'cu1', 'rxx', 'ryy', 'rzz', 'rzx', 'ccx',
-        'unitary', 'diagonal', 'delay', 'pauli', 'ecr', 'break_loop', 'continue_loop'
+        'unitary', 'diagonal', 'delay', 'pauli', 'ecr',
     ]),
     'matrix_product_state': sorted([
         'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
         'sdg', 'sx', 'sxdg', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay', 'pauli',
         'r', 'rx', 'ry', 'rz', 'rxx', 'ryy', 'rzz', 'rzx', 'csx', 'cswap', 'diagonal',
-        'initialize', 'break_loop', 'continue_loop'
+        'initialize'
     ]),
     'stabilizer': sorted([
         'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'sxdg', 'cx', 'cy', 'cz',

--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -57,19 +57,19 @@ BASIS_GATES = {
         'rzz', 'rzx', 'ccx', 'cswap', 'mcx', 'mcy', 'mcz', 'mcsx',
         'mcp', 'mcphase', 'mcu', 'mcu1', 'mcu2', 'mcu3', 'mcrx', 'mcry', 'mcrz',
         'mcr', 'mcswap', 'unitary', 'diagonal', 'multiplexer',
-        'initialize', 'delay', 'pauli', 'mcx_gray', 'ecr'
+        'initialize', 'delay', 'pauli', 'mcx_gray', 'ecr', 'break_loop', 'continue_loop'
     ]),
     'density_matrix': sorted([
         'u1', 'u2', 'u3', 'u', 'p', 'r', 'rx', 'ry', 'rz', 'id', 'x',
         'y', 'z', 'h', 's', 'sdg', 'sx', 'sxdg', 't', 'tdg', 'swap', 'cx',
         'cy', 'cz', 'cp', 'cu1', 'rxx', 'ryy', 'rzz', 'rzx', 'ccx',
-        'unitary', 'diagonal', 'delay', 'pauli', 'ecr',
+        'unitary', 'diagonal', 'delay', 'pauli', 'ecr', 'break_loop', 'continue_loop'
     ]),
     'matrix_product_state': sorted([
         'u1', 'u2', 'u3', 'u', 'p', 'cp', 'cx', 'cy', 'cz', 'id', 'x', 'y', 'z', 'h', 's',
         'sdg', 'sx', 'sxdg', 't', 'tdg', 'swap', 'ccx', 'unitary', 'roerror', 'delay', 'pauli',
         'r', 'rx', 'ry', 'rz', 'rxx', 'ryy', 'rzz', 'rzx', 'csx', 'cswap', 'diagonal',
-        'initialize'
+        'initialize', 'break_loop', 'continue_loop'
     ]),
     'stabilizer': sorted([
         'id', 'x', 'y', 'z', 'h', 's', 'sdg', 'sx', 'sxdg', 'cx', 'cy', 'cz',

--- a/releasenotes/notes/support_break_and_continue_gates-bf30316fcacd4b6b.yaml
+++ b/releasenotes/notes/support_break_and_continue_gates-bf30316fcacd4b6b.yaml
@@ -1,7 +1,13 @@
 ---
 fixes:
   - |
-    Aer does not work as a backend to transpile circuits with control-flow
-    because `break_loop` and `continue_loop` are not supported. This PR adds
-    these two gates as basis gates of statevector, density matrix, and mps
-    methods.
+    The :class:`.AerSimulator` backend with methods:
+    
+    * ``statevector``
+    * ``density_matrix``
+    * ``matrix_product_state``
+    * ``stabilizer``
+    
+    now report that they support ``break_loop`` and ``continue_loop`` instructions when used
+    as backends for the Terra :func:`~qiskit.compiler.transpile` function.  The simulators
+    already did support these, but had just not been reporting it.

--- a/releasenotes/notes/support_break_and_continue_gates-bf30316fcacd4b6b.yaml
+++ b/releasenotes/notes/support_break_and_continue_gates-bf30316fcacd4b6b.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Aer does not work as a backend to transpile circuits with control-flow
+    because `break_loop` and `continue_loop` are not supported. This PR adds
+    these two gates as basis gates of statevector, density matrix, and mps
+    methods.

--- a/test/terra/backends/aer_simulator/test_control_flow.py
+++ b/test/terra/backends/aer_simulator/test_control_flow.py
@@ -602,3 +602,18 @@ class TestControlFlow(SimulatorTestCase):
         result = backend.run(circuit, method=method, shots=100).result()
         self.assertSuccess(result)
         self.assertEqual(result.get_counts(), {"010": 100})
+
+    @data("statevector", "density_matrix", "matrix_product_state")
+    def test_transpile_break_and_continue_loop(self, method):
+        """Test that transpiler can transpile break_loop and continue_loop with AerSimulator"""
+
+        qc = QuantumCircuit(2, 1)
+
+        with qc.for_loop(range(5)):
+            qc.measure(0, 0)
+            qc.break_loop().c_if(0, True)
+            qc.continue_loop().c_if(0, True)
+
+        backend = self.backend(method=method)
+
+        transpile(qc, backend)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Resolve #1706 by adding `break_loop` and `continue_loop` as basis gates.

### Details and comments

Now terra supports transpilation of control-flow. This PR adds two basis gates `break_loop` and `continue_loop` to work Aer as a backend of `transpile()`.

