### PR TITLE
Remove qobj run in AerBackend

### DIFF
--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -18,7 +18,6 @@ import datetime
 import logging
 import time
 import uuid
-import warnings
 from abc import ABC, abstractmethod
 
 from qiskit.circuit import QuantumCircuit, ParameterExpression, Delay

--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -123,7 +123,7 @@ class AerBackend(Backend, ABC):
             validate=False,
             parameter_binds=None,
             **run_options):
-        """Run a qobj on the backend.
+        """Run circuits on the backend.
 
         Args:
             circuits (QuantumCircuit or list): The QuantumCircuit (or list
@@ -159,30 +159,8 @@ class AerBackend(Backend, ABC):
         Raises:
             ValueError: if run is not implemented
         """
-        if isinstance(circuits, (QasmQobj, PulseQobj)):
-            warnings.warn(
-                'Using a qobj for run() is deprecated as of qiskit-aer 0.9.0'
-                ' and will be removed no sooner than 3 months from that release'
-                ' date. Transpiled circuits should now be passed directly using'
-                ' `backend.run(circuits, **run_options).',
-                DeprecationWarning, stacklevel=2)
-            if parameter_binds:
-                raise AerError("Parameter binds can't be used with an input qobj")
-            # A work around to support both qobj options and run options until
-            # qobj is deprecated is to copy all the set qobj.config fields into
-            # run_options that don't override existing fields. This means set
-            # run_options fields will take precidence over the value for those
-            # fields that are set via assemble.
-            if not run_options:
-                run_options = circuits.config.__dict__
-            else:
-                run_options = copy.copy(run_options)
-                for key, value in circuits.config.__dict__.items():
-                    if key not in run_options and value is not None:
-                        run_options[key] = value
-            qobj = self._assemble(circuits, **run_options)
-        else:
-            qobj = self._assemble(circuits, parameter_binds=parameter_binds, **run_options)
+
+        qobj = self._assemble(circuits, parameter_binds=parameter_binds, **run_options)
 
         # Optional validation
         if validate:

--- a/qiskit_aer/backends/pulse_simulator.py
+++ b/qiskit_aer/backends/pulse_simulator.py
@@ -74,11 +74,8 @@ class PulseSimulator(AerBackend):
         # Set the pulse system model for the simulator
         backend_sim.set_options(system_model=system_model)
 
-        # Assemble schedules using PulseSimulator as the backend
-        pulse_qobj = assemble(schedules, backend=backend_sim)
-
         # Run simulation
-        results = backend_sim.run(pulse_qobj)
+        results = backend_sim.run(schedules)
 
     or by supplying the system model at runtime, e.g.:
 
@@ -86,11 +83,8 @@ class PulseSimulator(AerBackend):
 
         backend_sim = qiskit_aer.PulseSimulator()
 
-        # Assemble schedules using PulseSimulator as the backend
-        pulse_qobj = assemble(schedules, backend=backend_sim)
-
         # Run simulation on a PulseSystemModel object
-        results = backend_sim.run(pulse_qobj, system_model=system_model)
+        results = backend_sim.run(schedules, system_model=system_model)
 
     Alternatively, an instance of the ``PulseSimulator`` may be further configured to contain more
     information present in a real backend. The simplest way to do this is to instantiate the
@@ -99,16 +93,15 @@ class PulseSimulator(AerBackend):
     .. code-block:: python
 
         armonk_sim = qiskit_aer.PulseSimulator.from_backend(FakeArmonk())
-        pulse_qobj = assemble(schedules, backend=armonk_sim)
-        armonk_sim.run(pulse_qobj)
+        armonk_sim.run(schedules)
 
     In the above example, the ``PulseSimulator`` copies all configuration and default data from
     ``FakeArmonk()``, and as such has the same affect as ``FakeArmonk()`` when passed as an
-    argument to ``assemble``. Furthermore it constructs a
+    argument to ``run``. Furthermore it constructs a
     :class:`~qiskit_aer.pulse.PulseSystemModel` from the model details in the supplied
     backend, which is then used in simulation.
 
-    **Supported PulseQobj parameters**
+    **Supported parameters**
 
     * ``qubit_lo_freq``: Local oscillator frequencies for each :class:`DriveChannel`.
       Defaults to either the value given in the

--- a/releasenotes/notes/remove_qobj_support-3ee362c7b2165a75.yaml
+++ b/releasenotes/notes/remove_qobj_support-3ee362c7b2165a75.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    :meth:`run` in :class:`~AerSimulator`, :class:`~QasmSimulator`, :class:`~StatevectorSimulator`,
+    :class:`~UnitarySimulator`, and :class:`~PulseSimulator` no longer support qobj as an argument.
+    Now, the method can run only ``QuantumCircuit`` or `Schedule`.

--- a/tools/verify_wheels.py
+++ b/tools/verify_wheels.py
@@ -478,13 +478,13 @@ if __name__ == '__main__':
     # Run pulse simulator
     system_model, schedule = model_and_pi_schedule()
     backend_sim = PulseSimulator()
-    qobj = assemble([schedule],
-                    backend=backend_sim,
-                    qubit_lo_freq=[5.0],
-                    meas_level=1,
-                    meas_return='avg',
-                    shots=1)
-    results = backend_sim.run(qobj, system_model=system_model).result()
+    results = backend_sim.run([schedule],
+                              backend=backend_sim,
+                              qubit_lo_freq=[5.0],
+                              meas_level=1,
+                              meas_return='avg',
+                              shots=1,
+                              system_model=system_model).result()
     state = results.get_statevector(0)
     assertAlmostEqual(state[0], 0, delta=10**-3)
     assertAlmostEqual(state[1], -1j, delta=10**-3)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Remove qobj support in `backend.run()`, which was deprecated 2 years ago.

### Details and comments

#1720
