### PR TITLE
Deprecate PulseSimulator backend

### DIFF
--- a/qiskit_aer/aerprovider.py
+++ b/qiskit_aer/aerprovider.py
@@ -13,6 +13,8 @@
 # pylint: disable=invalid-name
 """Provider for Qiskit Aer backends."""
 
+import warnings
+
 from qiskit.providers import ProviderV1 as Provider
 from qiskit.providers.providerutils import filter_backends
 
@@ -59,6 +61,14 @@ class AerProvider(Provider):
             AerProvider._BACKENDS = backends
 
     def get_backend(self, name=None, **kwargs):
+        if name == "pulse_simulator":
+            warnings.warn(
+                "The Pulse simulator backend in Qiskit Aer is deprecated and will "
+                "be removed in a future release. Instead the qiskit-dynamics "
+                "library should be used instead for simulating at the pulse level.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return super().get_backend(name=name, **kwargs)
 
     def backends(self, name=None, filters=None, **kwargs):

--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -84,20 +84,28 @@ class AerBackend(Backend, ABC):
 
     def _convert_circuit_binds(self, circuit, binds):
         parameterizations = []
-        for index, inst_tuple in enumerate(circuit.data):
-            if inst_tuple[0].is_parameterized():
-                for bind_pos, param in enumerate(inst_tuple[0].params):
+        for index, instruction in enumerate(circuit.data):
+            if instruction.operation.is_parameterized():
+                for bind_pos, param in enumerate(instruction.operation.params):
                     if param in binds:
-                        parameterizations.append([[index, bind_pos], binds[param]])
+                        parameterizations.append([(index, bind_pos), binds[param]])
                     elif isinstance(param, ParameterExpression):
                         # If parameter expression has no unbound parameters
                         # it's already bound and should be skipped
                         if not param.parameters:
                             continue
-                        local_binds = {k: v for k, v in binds.items() if k in param.parameters}
-                        bind_list = [dict(zip(local_binds, t)) for t in zip(*local_binds.values())]
+                        if not binds:
+                            raise AerError("The element of parameter_binds is empty.")
+                        len_vals = len(next(iter(binds.values())))
+                        bind_list = [
+                            {
+                                parameter: binds[parameter][i]
+                                for parameter in param.parameters & binds.keys()
+                            }
+                            for i in range(len_vals)
+                        ]
                         bound_values = [float(param.bind(x)) for x in bind_list]
-                        parameterizations.append([[index, bind_pos], bound_values])
+                        parameterizations.append([(index, bind_pos), bound_values])
         return parameterizations
 
     def _convert_binds(self, circuits, parameter_binds):

--- a/qiskit_aer/backends/pulse_simulator.py
+++ b/qiskit_aer/backends/pulse_simulator.py
@@ -54,7 +54,14 @@ DEFAULT_CONFIGURATION = {
 
 
 class PulseSimulator(AerBackend):
-    r"""Pulse schedule simulator backend.
+    r"""Deprecated: Pulse schedule simulator backend.
+
+    .. warning::
+
+       This simulator is deprecated having been superseded by the
+       `Qiskit Dynamics <https://qiskit.org/documentation/dynamics/>`__ library.
+       If you need to perform pulse level simulation you should use the
+       Qiskit Dynamics library instead.
 
     The ``PulseSimulator`` simulates continuous time Hamiltonian dynamics of a quantum system,
     with controls specified by pulse :class:`~qiskit.Schedule` objects, and the model of the
@@ -154,6 +161,13 @@ class PulseSimulator(AerBackend):
                  defaults=None,
                  provider=None,
                  **backend_options):
+        warn(
+            "The Pulse simulator backend in Qiskit Aer is deprecated and will "
+            "be removed in a future release. Instead the qiskit-dynamics "
+            "library should be used instead for simulating at the pulse level.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         if configuration is None:
             configuration = BackendConfiguration.from_dict(

--- a/releasenotes/notes/deprecate-pulse-simulator-27cde3ece112c346.yaml
+++ b/releasenotes/notes/deprecate-pulse-simulator-27cde3ece112c346.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    The :class:`~.PulseSimulator` backend has been deprecated and will be
+    removed in a future release. If you're using the :class:`~.PulseSimulator`
+    backend to perform pulse level simulation, instead you should use the
+    `Qiskit Dynamics <https://qiskit.org/documentation/dynamics/>`__ library
+    instead to perform the simulation. Qiskit Dynamics provides a more
+    flexible and robust pulse level simulation framework than the
+    :class:`~.PulseSimulator` backend.

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -378,6 +378,19 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         res2 = backend.run(circuit, shots=shots, parameter_binds=parameter_binds, seed_simulator=seed_simulator_list[0]).result()
         self.assertEqual(seed_simulator_list, [ result.seed_simulator for result in res2.results ])
 
+    def test_run_empty(self):
+        """Test parameterized circuit with empty dict path via backed.run()"""
+        shots = 1000
+        backend = AerSimulator()
+        circuit = QuantumCircuit(2)
+        theta = Parameter('theta')
+        circuit.rx(theta, 0)
+        circuit.cx(0, 1)
+        circuit.measure_all()
+        parameter_binds = [{}]
+        with self.assertRaises(AerError):
+            res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit deprecates the PulseSimulator backend for qiskit aer. For the past several releases development on the pulse simulator has mostly been frozen as the combined efforts for improving pulse level simulation have been working on Qiskit Dynamics instead. This commit marks the legacy PulseSimulator as deprecated and points existing users to Qiskit Dynamics instead.

### Details and comments

Closes #1722