### PR TITLE
Add git blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+0366c51c0e8d23ff0aa9a17eb4bc790c57feaf63

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1102,3 +1102,28 @@ Now we can run the Python interpreter and pass the arguments (the python file to
     Target 0: (python) stopped.
 
 After this, you can step through the code and continue with your debug session as always.
+
+
+## Dealing with the git blame ignore list
+
+In the qiskit-aer repository we maintain a list of commits for git blame to
+ignore. This is mostly commits that are code style changes that don't change
+the functionality but just change the code formatting (for example, when we
+migrated to use black for code formatting). This file, `.git-blame-ignore-revs`
+just contains a list of commit SHA1s you can tell git to ignore when using the
+`git blame` command. This can be done one time with something like
+
+```
+git blame --ignore-revs-file .git-blame-ignore-revs qiskit/version.py
+
+```
+
+from the root of the repository. If you'd like to enable this by default you
+can update your local repository's configuration with:
+
+```
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+which will update your local repositories configuration to use the ignore list
+by default.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new file with the SHA1 of commits to ignore when running git blame. This is important because of the recent adoption of black and clang-format as our code formatting tool in #1630 we caused a large amount of code churn to change the code formatting. However, using the ignore file is a local opt-in feature for git and not something we can enable globally by default. To facilitate this a section is added to the bottom of the contributing guide to document how this file can be used.

### Details and comments