### PR TITLE
Fix how to reference to config.cuStateVec_enable

### DIFF
--- a/releasenotes/notes/fix-cuStateVec_enable-0936f2269466e3be.yaml
+++ b/releasenotes/notes/fix-cuStateVec_enable-0936f2269466e3be.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an error when building Qiskit Aer with cuQuautum support.
+    CPU and normal GPU-enabled build are fine, but there was an
+    incorrect reference to a config when cuQuamtum support was enabled.

--- a/releasenotes/notes/fix-cuStateVec_enable-0936f2269466e3be.yaml
+++ b/releasenotes/notes/fix-cuStateVec_enable-0936f2269466e3be.yaml
@@ -1,6 +1,5 @@
 ---
 fixes:
   - |
-    Fixed an error when building Qiskit Aer with cuQuautum support.
-    CPU and normal GPU-enabled build are fine, but there was an
-    incorrect reference to a config when cuQuamtum support was enabled.
+    Fixed a build break to compile Qiskit Aer with cuQuautum support (`AER_ENABLE_CUQUANTUM=true`).
+    This change does not affect build for CPU and normal GPU binaries.

--- a/src/simulators/state_chunk.hpp
+++ b/src/simulators/state_chunk.hpp
@@ -474,7 +474,7 @@ void StateChunk<state_t>::set_config(const Config &config) {
 
 #ifdef AER_CUSTATEVEC
   // cuStateVec configs
-  if (config.cuStateVec_enable)
+  if (config.cuStateVec_enable.has_value())
     cuStateVec_enable_ = config.cuStateVec_enable.value();
 #endif
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently it seems the cuQuantum support version of Qiskit Aer cannot be built.

### Details and comments

This PR fixes the build error.
I attach a Dockerfile to build a fixed Qiskit Aer with cuQuantum support for reference: [Dockerfile.zip](https://github.com/Qiskit/qiskit-aer/files/11007658/Dockerfile.zip)
This PR branch is cloned and CUDA Compute Capability of 7.5 which is compatible with NVIDIA T4 is used. The Docker image should be approximately 10.7 GB in size.
Example codes used inside a container to verify the operation are as follows:
```python
>>> from qiskit import QuantumCircuit
>>> from qiskit_aer.quantum_info import AerStatevector as Statevector
>>> qc = QuantumCircuit(2)
>>> qc.h(0)
>>> qc.cx(0, 1)
>>> sv = Statevector(qc, device='gpu', custatevec_enable=True)
```