### PR TITLE
use `omp_set_max_active_levels` instead of `omp_set_nested`

### DIFF
--- a/releasenotes/notes/use_omp_set_max_active_levels-7e6c1d301c4434a6.yaml
+++ b/releasenotes/notes/use_omp_set_max_active_levels-7e6c1d301c4434a6.yaml
@@ -1,7 +1,4 @@
 ---
 fixes:
   - |
-    Aer used `omp_set_nested` to efficiently use nested OpenMP pragma, which
-    is deprecated and produces warning in some environment. This fix replaces
-    call of `omp_set_nested` with of `omp_set_max_active_levels` and stop
-    warning in any environment.
+    Aer will now use ``omp_set_max_active_levels()`` instead of the deprecated ``omp_set_nested()`` when compiled against recent versions of OpenMP.

--- a/releasenotes/notes/use_omp_set_max_active_levels-7e6c1d301c4434a6.yaml
+++ b/releasenotes/notes/use_omp_set_max_active_levels-7e6c1d301c4434a6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Aer used `omp_set_nested` to efficiently use nested OpenMP pragma, which
+    is deprecated and produces warning in some environment. This fix replaces
+    call of `omp_set_nested` with of `omp_set_max_active_levels` and stop
+    warning in any environment.

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -963,7 +963,7 @@ Result Controller::execute(std::vector<Circuit> &circuits,
       parallel_nested_ = true;
 
       // nested should be set to zero if num_threads clause will be used
-      omp_set_nested(0);
+      omp_set_max_active_levels(0);
 
       result.metadata.add(parallel_nested_, "omp_nested");
     } else {

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -963,10 +963,10 @@ Result Controller::execute(std::vector<Circuit> &circuits,
       parallel_nested_ = true;
 
       // nested should be set to zero if num_threads clause will be used
-#if defined(_WIN64) || defined(_WIN32)
-      omp_set_nested(0);
-#else
+#if _OPENMP >= 200805
       omp_set_max_active_levels(0);
+#else
+      omp_set_nested(0);
 #endif
 
       result.metadata.add(parallel_nested_, "omp_nested");

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -963,7 +963,11 @@ Result Controller::execute(std::vector<Circuit> &circuits,
       parallel_nested_ = true;
 
       // nested should be set to zero if num_threads clause will be used
+#if defined(_WIN64) || defined(_WIN32)
+      omp_set_nested(0);
+#else
       omp_set_max_active_levels(0);
+#endif
 
       result.metadata.add(parallel_nested_, "omp_nested");
     } else {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #1751

### Details and comments

This PR uses `omp_set_max_active_levels` instead of `omp_set_nested` which shows warnings in some environment.
