### PR TITLE
Ensure QuantumCircuit.metadata is always a dict

### DIFF
--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -427,8 +427,8 @@ class AerBackend(Backend, ABC):
         metadata_list = []
         for idx, circ in enumerate(circuits):
             if circ.metadata:
-                circ.metadata = {"metadata_index": idx}
                 metadata_list.append(metadata)
+                circ.metadata = {"metadata_index": idx}
             else:
                 metadata_list.append({})
 

--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -426,11 +426,13 @@ class AerBackend(Backend, ABC):
         # Take metadata from headers of experiments to work around JSON serialization error
         metadata_list = []
         for idx, circ in enumerate(circuits):
+            metadata_list.append(circ.metadata)
+            # TODO: we test for True-like on purpose here to condition against both None and {},
+            # which allows us to support versions of Terra before and after QuantumCircuit.metadata
+            # accepts None as a valid value. This logic should be revisited after terra>=0.24.0 is
+            # required.
             if circ.metadata:
-                metadata_list.append(circ.metadata)
                 circ.metadata = {"metadata_index": idx}
-            else:
-                metadata_list.append({})
 
         # Run simulation
         aer_circuits = assemble_circuits(circuits)

--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -427,12 +427,10 @@ class AerBackend(Backend, ABC):
         metadata_list = []
         for idx, circ in enumerate(circuits):
             if circ.metadata:
-                metadata = circ.metadata
+                circ.metadata = {"metadata_index": idx}
                 metadata_list.append(metadata)
-                circ.metadata = {}
-                circ.metadata["metadata_index"] = idx
             else:
-                metadata_list.append(None)
+                metadata_list.append({})
 
         # Run simulation
         aer_circuits = assemble_circuits(circuits)

--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -427,7 +427,7 @@ class AerBackend(Backend, ABC):
         metadata_list = []
         for idx, circ in enumerate(circuits):
             if circ.metadata:
-                metadata_list.append(metadata)
+                metadata_list.append(circ.metadata)
                 circ.metadata = {"metadata_index": idx}
             else:
                 metadata_list.append({})

--- a/test/terra/backends/aer_simulator/test_metadata.py
+++ b/test/terra/backends/aer_simulator/test_metadata.py
@@ -37,7 +37,7 @@ class TestMetadata(SimulatorTestCase):
     def test_single_circuit_metadata(self, method, device):
         """Test circuits with object metadata."""
         backend = self.backend(method=method, device=device)
-        metadata = {1: object}
+        metadata = {1: object()}
         circuit = QuantumCircuit(1, name="circ0", metadata=metadata.copy())
         result = backend.run(circuit).result()
         self.assertSuccess(result)

--- a/test/terra/backends/aer_simulator/test_metadata.py
+++ b/test/terra/backends/aer_simulator/test_metadata.py
@@ -37,7 +37,7 @@ class TestMetadata(SimulatorTestCase):
     def test_single_circuit_metadata(self, method, device):
         """Test circuits with object metadata."""
         backend = self.backend(method=method, device=device)
-        metadata = {1: object()}
+        metadata = {1: object}
         circuit = QuantumCircuit(1, name="circ0", metadata=metadata.copy())
         result = backend.run(circuit).result()
         self.assertSuccess(result)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The PR https://github.com/Qiskit/qiskit-terra/pull/9849 proposes that `QuantumCircuit.metadata` should always be a ``dict``, rather than a ``dict`` or ``None``. This is a matching PR to ensure that aer does not manually set it to ``None``, which that PR deprecates.

