### PR TITLE
Fix wrong set of parameters in circuits with barriers

### DIFF
--- a/qiskit_aer/backends/aer_compiler.py
+++ b/qiskit_aer/backends/aer_compiler.py
@@ -572,7 +572,7 @@ def _assemble_op(aer_circ, inst, qubit_indices, clbit_indices, is_conditional, c
     elif name == "superop":
         aer_circ.superop(qubits, params[0], conditional_reg)
     elif name == "barrier":
-        pass
+        aer_circ.barrier(qubits)
     elif name == "jump":
         aer_circ.jump(qubits, params, conditional_reg)
     elif name == "mark":

--- a/qiskit_aer/backends/wrappers/aer_circuit_binding.hpp
+++ b/qiskit_aer/backends/wrappers/aer_circuit_binding.hpp
@@ -94,6 +94,7 @@ void bind_aer_circuit(MODULE m) {
   aer_circuit.def("set_clifford", &Circuit::set_clifford<py::handle>);
   aer_circuit.def("jump", &Circuit::jump);
   aer_circuit.def("mark", &Circuit::mark);
+  aer_circuit.def("barrier", &Circuit::barrier);
   aer_circuit.def("measure", &Circuit::measure);
   aer_circuit.def("reset", &Circuit::reset);
   aer_circuit.def("set_qerror_loc", &Circuit::set_qerror_loc);

--- a/releasenotes/notes/fix_param_binding_for_pram_circuit-50e64efbedaec8fd.yaml
+++ b/releasenotes/notes/fix_param_binding_for_pram_circuit-50e64efbedaec8fd.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    :class:`~.AerCircuit` is created from a circuit by iterating its operations
+    while skipping barrier instructions. However, skipping barrier instructions
+    make wrong positionings of parameter bindings. This fix adds
+    :meth:`~.AerCircuit.barrier` and keeps parametr bindings correct.

--- a/src/framework/circuit.hpp
+++ b/src/framework/circuit.hpp
@@ -241,6 +241,10 @@ public:
     ops.push_back(Operations::make_mark(qubits, params));
   }
 
+  void barrier(const reg_t &qubits) {
+    ops.push_back(Operations::make_barrier(qubits));
+  }
+
   void measure(const reg_t &qubits, const reg_t &memory,
                const reg_t &registers) {
     ops.push_back(Operations::make_measure(qubits, memory, registers));

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -864,6 +864,14 @@ inline Op make_mark(const reg_t &qubits,
   return op;
 }
 
+inline Op make_barrier(const reg_t &qubits) {
+  Op op;
+  op.type = OpType::barrier;
+  op.name = "barrier";
+  op.qubits = qubits;
+  return op;
+}
+
 inline Op make_measure(const reg_t &qubits, const reg_t &memory,
                        const reg_t &registers) {
   Op op;

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -421,11 +421,12 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         circuit.barrier()
         circuit.measure_all()
 
-        parameter_binds = [{theta: [pi/2], phi: [pi/2]}]
+        parameter_binds = [{theta: [pi / 2], phi: [pi / 2]}]
         res = backend.run([circuit], shots=1024, parameter_binds=parameter_binds).result()
 
         self.assertSuccess(res)
         self.assertEqual(res.get_counts(), {"111": 1024})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -406,7 +406,6 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
 
     def test_parameters_with_barrier(self):
         """Test parameterized circuit path with barrier"""
-        shots = 2000
         backend = AerSimulator()
         circuit = QuantumCircuit(3)
         theta = Parameter("theta")

--- a/test/terra/backends/test_parameterized_qobj.py
+++ b/test/terra/backends/test_parameterized_qobj.py
@@ -404,6 +404,28 @@ class TestParameterizedQobj(common.QiskitAerTestCase):
         with self.assertRaises(AerError):
             res = backend.run(circuit, shots=shots, parameter_binds=parameter_binds).result()
 
+    def test_parameters_with_barrier(self):
+        """Test parameterized circuit path with barrier"""
+        shots = 2000
+        backend = AerSimulator()
+        circuit = QuantumCircuit(3)
+        theta = Parameter("theta")
+        phi = Parameter("phi")
+        circuit.rx(theta, 0)
+        circuit.rx(theta, 1)
+        circuit.rx(theta, 2)
+        circuit.barrier()
+        circuit.rx(phi, 0)
+        circuit.rx(phi, 1)
+        circuit.rx(phi, 2)
+        circuit.barrier()
+        circuit.measure_all()
+
+        parameter_binds = [{theta: [pi/2], phi: [pi/2]}]
+        res = backend.run([circuit], shots=1024, parameter_binds=parameter_binds).result()
+
+        self.assertSuccess(res)
+        self.assertEqual(res.get_counts(), {"111": 1024})
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`AerCircuit` is created from a circuit by iterating its instrucitons while skpping barrier. This leads inconsistency with positions of parameter bindings. This commit adds barrier instruction to the class and keeps positions of parameter bindings.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes #1774 

### Details and comments

`AerCircuit` is created while skipping barrier instructions. However, skipping barrier instructions makes positions of parameter bindings wrong. This fix use `barrier()` a new method of `AerCircuit` and then keeps positions of parameter bindings consistent.
