### PR TITLE
Remove REQUIRED to find PythonLibs in FindPybind11

### DIFF
--- a/cmake/FindPybind11.cmake
+++ b/cmake/FindPybind11.cmake
@@ -1,4 +1,4 @@
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs)
 
 message(STATUS ${PYTHON_INCLUDE_DIRS})
 message(STATUS "PYTHON EXECUTABLE: ${PYTHON_EXECUTABLE}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools",
   "conan<2.0.0",
-  "scikit-build>=0.11.0",
+  "scikit-build==0.17.1",
   "cmake!=3.17.1,!=3.17.0",
   "ninja",
   "pybind11>2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools",
   "conan<2.0.0",
-  "scikit-build==0.17.1",
+  "scikit-build<0.17.2",
   "cmake!=3.17.1,!=3.17.0",
   "ninja",
   "pybind11>2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools",
   "conan<2.0.0",
-  "scikit-build<0.17.2",
+  "scikit-build>=0.11.0",
   "cmake!=3.17.1,!=3.17.0",
   "ninja",
   "pybind11>2.6",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Remove `REQUIRED` to find `PythonLibs` in FindPybind11

### Details and comments

As @henryiii mentioned [here](https://github.com/Qiskit/qiskit-aer/pull/1786#issuecomment-1526151867), `REQUIRED` is not necessary to find `PythonLibs`. By removing this, Aer's CI will be back from the following error:

```
Could NOT find PythonLibs (missing: PYTHON_LIBRARIES) (found version "3.7.15")
```
