### PR TITLE
fix fail of qobj run without run_options

### DIFF
--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -186,8 +186,8 @@ class AerBackend(Backend, ABC):
                 for key, value in circuits.config.__dict__.items():
                     if key not in run_options and value is not None:
                         run_options[key] = value
-                if "parameter_binds" in run_options:
-                    parameter_binds = run_options.pop("parameter_binds")
+            if "parameter_binds" in run_options:
+                parameter_binds = run_options.pop("parameter_binds")
             return self._run_qobj(circuits, validate, parameter_binds, **run_options)
 
         only_circuits = True

--- a/releasenotes/notes/fix_qobj_run-8ea657a93ce9acd2.yaml
+++ b/releasenotes/notes/fix_qobj_run-8ea657a93ce9acd2.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Aer still supports Qobj as an argument of :meth:`~.AerSimulator.run` though
+    it was deprecated. However, since 0.12.0, it always fails if no ``run_options``
+    is specified. This fix enables simulation of Qobj without ``run_options``.

--- a/test/terra/backends/aer_simulator/test_circuit.py
+++ b/test/terra/backends/aer_simulator/test_circuit.py
@@ -14,7 +14,7 @@ AerSimulator Integration Tests
 """
 from math import sqrt
 from ddt import ddt
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, assemble
 from qiskit.circuit import CircuitInstruction
 from test.terra.reference import ref_algorithms
 
@@ -171,3 +171,26 @@ class TestVariousCircuit(SimulatorTestCase):
         self.assertEqual(result.status, "PARTIAL COMPLETED")
         self.assertTrue(hasattr(result.results[1].data, "counts"))
         self.assertFalse(hasattr(result.results[0].data, "counts"))
+
+    def test_run_qobj(self):
+        """Test qobj run"""
+
+        qubits = QuantumRegister(3)
+        clbits = ClassicalRegister(3)
+
+        circuit = QuantumCircuit(qubits, clbits)
+        circuit.h(qubits[0])
+        circuit.cx(qubits[0], qubits[1])
+        circuit.cx(qubits[0], qubits[2])
+
+        for q, c in zip(qubits, clbits):
+            circuit.measure(q, c)
+
+        backend = self.backend()
+
+        shots = 1000
+        with self.assertWarns(DeprecationWarning):
+            result = backend.run(assemble(circuit), shots=shots).result()
+
+        self.assertSuccess(result)
+        self.compare_counts(result, [circuit], [{"0x0": 500, "0x7": 500}], delta=0.05 * shots)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

resolve #1771.

### Details and comments

This PR is to avoid duplicated arguments to call `backend. _run_qobj()`.
