### PR TITLE
Attempt to pin manylinux image version in wheel jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2014:2023-04-09-db9a92f"
-manylinux-i686-image = "manylinux2014:2023-04-09-db9a92f"
+manylinux-x86_64-image = "quay.io/pypa/manylinux2014:2023-04-09-db9a92f"
+manylinux-i686-image = "quay.io/pypa/manylinux2014:2023-04-09-db9a92f"
 skip = "pp* cp36* *musllinux*"
 test-skip = "cp310-win32 cp310-manylinux_i686 cp311-win32 cp311-manylinux_i686"
 test-command = "python {project}/tools/verify_wheels.py"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Recently the linux wheel build jobs are failing because it is unable to find the python 3.7 libraries to link against when building wheels under cibuildwheel. It appears there were new manylinux docker images released around the same time the jobs started failing. This commit pins the docker image version we use in the jobs to try and fix the failure. If this doesn't work the next thing ot try is bumping the cibuildwheel version we use in the job.

### Details and comments