### PR TITLE
Fix setting MPI processes and ranks

### DIFF
--- a/releasenotes/notes/fix_mpi_procs-68b76c11fe7a6b8e.yaml
+++ b/releasenotes/notes/fix_mpi_procs-68b76c11fe7a6b8e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    MPI parallelization was not enabled since we have not used qobj.
+    This fix sets the number of processes and MPI rank correctly.

--- a/src/controllers/aer_controller.hpp
+++ b/src/controllers/aer_controller.hpp
@@ -852,11 +852,6 @@ Transpile::CacheBlocking Controller::transpile_cache_blocking(
 //-------------------------------------------------------------------------
 template <typename inputdata_t>
 Result Controller::execute(const inputdata_t &input_qobj) {
-#ifdef AER_MPI
-  MPI_Comm_size(MPI_COMM_WORLD, &num_processes_);
-  MPI_Comm_rank(MPI_COMM_WORLD, &myrank_);
-#endif
-
   // Load QOBJ in a try block so we can catch parsing errors and still return
   // a valid JSON output containing the error message.
   try {
@@ -908,6 +903,10 @@ Result Controller::execute(std::vector<Circuit> &circuits,
   // Start QOBJ timer
   auto timer_start = myclock_t::now();
 
+#ifdef AER_MPI
+  MPI_Comm_size(MPI_COMM_WORLD, &num_processes_);
+  MPI_Comm_rank(MPI_COMM_WORLD, &myrank_);
+#endif
   // Determine simulation method for each circuit
   // and enable required noise sampling methods
   auto methods = simulation_methods(circuits, noise_model);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This fix sets MPI processes and ranks correctly to enable MPI parallelization.


### Details and comments
Because qobj is not used, `Aer::Controller::execute` function with qobj is not called and MPI processes and ranks are not set correctly.
So this fix calls `MPI_Comm_size` and `MPI_Comm_rank` in another `execute` function.


