### PR TITLE
Fix handling of None in noise model construction from BackendV2

### DIFF
--- a/qiskit_aer/noise/device/models.py
+++ b/qiskit_aer/noise/device/models.py
@@ -107,11 +107,12 @@ def basic_device_gate_errors(
         properties (BackendProperties): device backend properties.
         gate_error (bool): Include depolarizing gate errors (Default: True).
         thermal_relaxation (Bool): Include thermal relaxation errors (Default: True).
-                If ``T1`` or ``T2`` value is not supplied via ``target`` (i.e. None) for some qubits,
-                no thermal relaxation errors are added to the qubits even if this flag is True.
-                If ``frequency`` is not defined (i.e. None) for a qubit, no excitation is considered
-                in the thermal relaxation error on the qubit even if non-zero ``temperature``
-                is supplied.
+                If no ``t1`` and ``t2`` values are provided (i.e. None) in ``target`` for a qubit,
+                an identity ``QuantumError` (i.e. effectively no thermal relaxation error)
+                will be added to the qubit even if this flag is set to True.
+                If no ``frequency`` is not defined (i.e. None) in ``target`` for a qubit,
+                no excitation is considered in the thermal relaxation error on the qubit
+                even with non-zero ``temperature``.
         gate_lengths (list): Override device gate times with custom
                              values. If None use gate times from
                              backend properties. (Default: None).

--- a/qiskit_aer/noise/device/models.py
+++ b/qiskit_aer/noise/device/models.py
@@ -106,21 +106,25 @@ def basic_device_gate_errors(
     Args:
         properties (BackendProperties): device backend properties.
         gate_error (bool): Include depolarizing gate errors (Default: True).
-        thermal_relaxation (Bool): Include thermal relaxation errors
-                                   (Default: True).
+        thermal_relaxation (Bool): Include thermal relaxation errors (Default: True).
+                If ``T1`` or ``T2`` value is not supplied via ``target`` (i.e. None) for some qubits,
+                no thermal relaxation errors are added to the qubits even if this flag is True.
+                If ``frequency`` is not defined (i.e. None) for a qubit, no excitation is considered
+                in the thermal relaxation error on the qubit even if non-zero ``temperature``
+                is supplied.
         gate_lengths (list): Override device gate times with custom
                              values. If None use gate times from
                              backend properties. (Default: None).
-        gate_length_units (str): Time units for gate length values in gate_lengths.
+        gate_length_units (str): Time units for gate length values in ``gate_lengths``.
                                  Can be 'ns', 'ms', 'us', or 's' (Default: 'ns').
         temperature (double): qubit temperature in milli-Kelvin (mK)
                               (Default: 0).
         warnings (bool): DEPRECATED, Display warnings (Default: None).
         target (Target): device backend target (Default: None). When this is supplied,
                          several options are disabled:
-                         `properties`, `gate_lengths` and `gate_length_units` are not used
+                         ``properties``, ``gate_lengths`` and ``gate_length_units`` are not used
                          during the construction of gate errors.
-                         Default values are always used for `warnings`.
+                         Default values are always used for ``warnings``.
 
     Returns:
         list: A list of tuples ``(label, qubits, QuantumError)``, for gates
@@ -339,6 +343,10 @@ def _device_thermal_relaxation_error(
     for qubit in qubits:
         t1, t2, freq = relax_params[qubit]
         t2 = _truncate_t2_value(t1, t2)
+        if t1 is None:
+            t1 = inf
+        if t2 is None:
+            t2 = inf
         population = _excited_population(freq, temperature)
         if first:
             error = thermal_relaxation_error(t1, t2, gate_time, population)
@@ -351,14 +359,17 @@ def _device_thermal_relaxation_error(
 
 def _truncate_t2_value(t1, t2):
     """Return t2 value truncated to 2 * t1 (for t2 > 2 * t1)"""
-    new_t2 = t2
-    if t2 > 2 * t1:
-        new_t2 = 2 * t1
-    return new_t2
+    if t1 is None:
+        return t2
+    if t2 is None:
+        return None
+    return min(t2, 2 * t1)
 
 
 def _excited_population(freq, temperature):
     """Return excited state population from freq [GHz] and temperature [mK]."""
+    if freq is None or temperature is None:
+        return 0
     population = 0
     if freq != inf and temperature != 0:
         # Compute the excited state population from qubit frequency and temperature

--- a/qiskit_aer/noise/device/models.py
+++ b/qiskit_aer/noise/device/models.py
@@ -359,10 +359,8 @@ def _device_thermal_relaxation_error(
 
 def _truncate_t2_value(t1, t2):
     """Return t2 value truncated to 2 * t1 (for t2 > 2 * t1)"""
-    if t1 is None:
+    if t1 is None or t2 is None:
         return t2
-    if t2 is None:
-        return None
     return min(t2, 2 * t1)
 
 

--- a/qiskit_aer/noise/noise_model.py
+++ b/qiskit_aer/noise/noise_model.py
@@ -435,8 +435,8 @@ class NoiseModel:
                 t1s = [prop.t1 for prop in all_qubit_properties]
                 t2s = [_truncate_t2_value(prop.t1, prop.t2) for prop in all_qubit_properties]
                 delay_pass = RelaxationNoisePass(
-                    t1s=t1s,
-                    t2s=t2s,
+                    t1s=[np.inf if x is None else x for x in t1s],  # replace None with np.inf
+                    t2s=[np.inf if x is None else x for x in t2s],  # replace None with np.inf
                     dt=dt,
                     op_types=Delay,
                     excited_state_populations=excited_state_populations,

--- a/qiskit_aer/noise/noise_model.py
+++ b/qiskit_aer/noise/noise_model.py
@@ -474,10 +474,14 @@ class NoiseModel:
         Args:
             backend_properties (BackendProperties): The property of backend.
             gate_error (Bool): Include depolarizing gate errors (Default: True).
-            readout_error (Bool): Include readout errors in model
-                                  (Default: True).
-            thermal_relaxation (Bool): Include thermal relaxation errors
-                                       (Default: True).
+            readout_error (Bool): Include readout errors in model (Default: True).
+            thermal_relaxation (Bool): Include thermal relaxation errors (Default: True).
+                If no ``t1`` and ``t2`` values are provided (i.e. None) in ``target`` for a qubit,
+                an identity ``QuantumError` (i.e. effectively no thermal relaxation error)
+                will be added to the qubit even if this flag is set to True.
+                If no ``frequency`` is not defined (i.e. None) in ``target`` for a qubit,
+                no excitation is considered in the thermal relaxation error on the qubit
+                even with non-zero ``temperature``.
             temperature (double): qubit temperature in milli-Kelvin (mK) for
                                   thermal relaxation errors (Default: 0).
             gate_lengths (Optional[list]): Custom gate times for thermal relaxation errors.

--- a/releasenotes/notes/fix-none-handling-in-noise-model-34fcc9a3e3cbdf6f.yaml
+++ b/releasenotes/notes/fix-none-handling-in-noise-model-34fcc9a3e3cbdf6f.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a bug in :meth:`~.NoiseModel.from_backend` that raised an error when
+    the backend has no T1 and T2 values (i.e. None) for a qubit in its qubit properties.
+    This commit updates :meth:`NoiseModel.from_backend` and :func:`basic_device_gate_errors`
+    so that they add an identity ``QuantumError` (i.e. no thermal relaxation error)
+    to a qubit with no T1 and T2 values for all gates acting on qubits including the qubit.
+    Fixed `#1779 <https://github.com/Qiskit/qiskit-aer/issues/1779>`__
+    and `#1815 <https://github.com/Qiskit/qiskit-aer/issues/1815>`__.

--- a/releasenotes/notes/fix-none-handling-in-noise-model-34fcc9a3e3cbdf6f.yaml
+++ b/releasenotes/notes/fix-none-handling-in-noise-model-34fcc9a3e3cbdf6f.yaml
@@ -4,7 +4,7 @@ fixes:
     Fixed a bug in :meth:`~.NoiseModel.from_backend` that raised an error when
     the backend has no T1 and T2 values (i.e. None) for a qubit in its qubit properties.
     This commit updates :meth:`NoiseModel.from_backend` and :func:`basic_device_gate_errors`
-    so that they add an identity ``QuantumError` (i.e. no thermal relaxation error)
+    so that they add an identity ``QuantumError`` (i.e. effectively no thermal relaxation error)
     to a qubit with no T1 and T2 values for all gates acting on qubits including the qubit.
     Fixed `#1779 <https://github.com/Qiskit/qiskit-aer/issues/1779>`__
     and `#1815 <https://github.com/Qiskit/qiskit-aer/issues/1815>`__.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes `NoiseModel.from_backend` not to fail when calling it with a V2 backend having faulty qubits such that T1 and T2 are None in the `target.qubit_properties`. Fixes #1779 and #1815.

### Details and comments
Previously, `NoiseModel.from_backend`  had no handling of None case for T1 or T2 value defined in a `target.qubit_properties` and raised a `TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'` as reported in #1779 and #1815. This commit updates `basic_device_gate_errors` function and `NoiseModel.form_backend` method so that both handle None for T1 or T2 without failure. After this commit, in the case when T1 and T2 values are None for a qubit, an identity QuantumError (i.e. effectively no thermal relaxation error) will be added to the qubit for all gates acting on qubits including the qubit.