### PR TITLE
Upgrade to qiskit_sphinx_theme 1.12

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,5 +1,6 @@
 name: Docs Publish
 on:
+  workflow_dispatch:
   push:
     tags:
       - "*"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,8 +44,6 @@ project = 'Qiskit Aer'
 copyright = f"2017-{datetime.date.today().year}, Qiskit Development Team"  # pylint: disable=redefined-builtin
 author = 'Qiskit Development Team'
 
-import qiskit_sphinx_theme
-
 # The short X.Y version
 version = '0.13.0'
 # The full version, including alpha/beta/rc tags

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,6 @@ reno>=3.4.0
 ddt>=1.2.0,!=1.4.0
 matplotlib>=3.3
 seaborn>=0.9.0
-qiskit_sphinx_theme>=1.10
+qiskit_sphinx_theme~=1.12.0
 nbsphinx
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,3 +54,9 @@ commands =
   python -I -m build --wheel -C=--build-option=-- -C=--build-option=-- -C=--build-option=-j4
   pip install --find-links={toxinidir}/dist qiskit_aer
   sphinx-build -W -b html docs/ docs/_build/html -j auto {posargs}
+
+[testenv:docs-clean]
+skip_install = true
+deps =
+allowlist_externals = rm
+commands = rm -rf {toxinidir}/docs/stubs/ {toxinidir}/docs/_build


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

The 1.12 theme release is focused on stability, including CSS fixes. See https://github.com/Qiskit/qiskit_sphinx_theme/releases/tag/1.12.0rc1 for the changelog.

This PR pins the theme version for better stability. We try to minimize making breaking changes, but the theme is under active development right now. I will open PRs to upgrade to future versions.

This PR also:
* Allows admins to deploy docs by clicking a button in GitHub's UI.
* Adds `tox -e docs-clean`