### PR TITLE
Fix the grouping index bug in Estimator

### DIFF
--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -321,8 +321,7 @@ class Estimator(BaseEstimator):
 
         result_index = 0
         for _circ_ind, basis_map in exp_map.items():
-            for _basis_ind in range(len(basis_map)):
-                param_vals = basis_map[_basis_ind][1]
+            for _basis_ind, (_, (_, param_vals)) in enumerate(basis_map.items()):
                 if circ_ind == _circ_ind and basis_ind == _basis_ind:
                     result_index += param_vals.index(param_val)
                     return result_index

--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -145,7 +145,11 @@ class Estimator(BaseEstimator):
                 self._observable_ids[_observable_key(observable)] = len(self._observables)
                 self._observables.append(observable)
         job = PrimitiveJob(
-            self._call, circuit_indices, observable_indices, parameter_values, **run_options
+            self._call,
+            circuit_indices,
+            observable_indices,
+            parameter_values,
+            **run_options,
         )
         job.submit()
         return job
@@ -299,14 +303,13 @@ class Estimator(BaseEstimator):
 
         result_index = 0
         for _circ_ind, basis_map in exp_map.items():
-            for _basis_ind, (_, param_vals) in basis_map.items():
+            for _basis_ind in range(len(basis_map)):
+                param_vals = basis_map[_basis_ind][1]
                 if circ_ind == _circ_ind and basis_ind == _basis_ind:
                     result_index += param_vals.index(param_val)
                     return result_index
                 result_index += len(param_vals)
-        raise AerError(
-            "Bug. Please report from isssue: https://github.com/Qiskit/qiskit-aer/issues"
-        )
+        raise AerError("Bug. Please report from issue: https://github.com/Qiskit/qiskit-aer/issues")
 
     def _create_post_processing(
         self, circuits, observables, parameter_values, obs_maps, exp_map
@@ -457,7 +460,10 @@ def _expval_with_variance(counts) -> tuple[float, float]:
 
 class _PostProcessing:
     def __init__(
-        self, result_indices: list[int], paulis: list[PauliList], coeffs: list[list[float]]
+        self,
+        result_indices: list[int],
+        paulis: list[PauliList],
+        coeffs: list[list[float]],
     ):
         self._result_indices = result_indices
         self._paulis = paulis

--- a/releasenotes/notes/primitives-grouping-index-bug-56f69afbdc3e86a0.yaml
+++ b/releasenotes/notes/primitives-grouping-index-bug-56f69afbdc3e86a0.yaml
@@ -1,0 +1,5 @@
+---
+issues:
+  - |
+    Fix a bug that returns wrong expectation values in :class:`~Estimator` when
+    ``abelian_grouping=True``.

--- a/test/terra/primitives/test_estimator.py
+++ b/test/terra/primitives/test_estimator.py
@@ -74,6 +74,21 @@ class TestEstimator(QiskitAerTestCase):
             self.assertIsInstance(result, EstimatorResult)
             np.testing.assert_allclose(result.values, [1.728515625])
 
+        with self.subTest("SparsePauliOp with another grouping"):
+            observable = SparsePauliOp.from_list(
+                [
+                    ("YZ", 0.39793742484318045),
+                    ("ZI", -0.39793742484318045),
+                    ("ZZ", -0.01128010425623538),
+                    ("XX", 0.18093119978423156),
+                ]
+            )
+            ansatz = RealAmplitudes(num_qubits=2, reps=2)
+            est = Estimator(abelian_grouping=abelian_grouping)
+            result = est.run(ansatz, observable, parameter_values=[[0] * 6], seed=15).result()
+            self.assertIsInstance(result, EstimatorResult)
+            np.testing.assert_allclose(result.values, [-0.4], rtol=0.02)
+
     @data(True, False)
     def test_init_observable_from_operator(self, abelian_grouping):
         """test for evaluate without parameters"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #1837 

### Details and comments

I misunderstand the order of list of operators from `PauliList.group_commuting`, so the indices are incorrect.