### PR TITLE
Remove `AerCircuit` from result of `backend.run()`

### DIFF
--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -458,7 +458,7 @@ class AerBackend(Backend, ABC):
         for result in output["results"]:
             if "header" not in result:
                 continue
-            result["header"]["metadata"] = metadata_map[result["circuit"]]
+            result["header"]["metadata"] = metadata_map[result.pop("circuit")]
 
         # Add execution time
         output["time_taken"] = time.time() - start

--- a/releasenotes/notes/remove_aer_circuit_from_metadata-e4fe09029c1a3a3c.yaml
+++ b/releasenotes/notes/remove_aer_circuit_from_metadata-e4fe09029c1a3a3c.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Results of `backend.run()` were not serializable because they include `AerCircuit`s.
-    This commit makes the results serializable by removing `AerCircuit`s from metadata.
+    Results of ``backend.run()`` were not serializable because they include :class:`.AerCircuit`\ s.
+    This commit makes the results serializable by removing :class:`.AerCircuit`\ s from metadata.

--- a/releasenotes/notes/remove_aer_circuit_from_metadata-e4fe09029c1a3a3c.yaml
+++ b/releasenotes/notes/remove_aer_circuit_from_metadata-e4fe09029c1a3a3c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Results of `backend.run()` were not serializable because they include `AerCircuit`s.
+    This commit makes the results serializable by removing `AerCircuit`s from metadata.

--- a/test/terra/backends/aer_simulator/test_circuit.py
+++ b/test/terra/backends/aer_simulator/test_circuit.py
@@ -13,6 +13,7 @@
 AerSimulator Integration Tests
 """
 from math import sqrt
+from copy import deepcopy
 from ddt import ddt
 import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, assemble
@@ -190,7 +191,7 @@ class TestVariousCircuit(SimulatorTestCase):
             self.assertEqual(circuit.metadata["foo"], "bar")
             self.assertEqual(circuit.metadata["object"], object)
 
-        job.result()
+        deepcopy(job.result())
 
     def test_run_qobj(self):
         """Test qobj run"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since #1772, results of C++ library include `AerCircuit` as metadata to identify a template circuit. This metadata is internally delivered to users by calling `backend.run().result()`. If a user copies the metadata, errors are happened because `AerCircuit` is not serializable.

### Details and comments

Remove `AerCircuit` objects from any results of `backend.run()`
