### PR TITLE
pin numpy version lower than 1.25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_requirements = {"dask": ["dask", "distributed"]}
 
 requirements = [
     "qiskit-terra>=0.21.0",
-    "numpy>=1.16.3",
+    "numpy>=1.16.3,<1.25",
     "scipy>=1.0",
 ]
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Until https://github.com/Qiskit/qiskit-terra/pull/10309 is included in terra's release, Aer CI needs numpy with lower version than 1.25.

### Details and comments

`product` is deprecated since numpy 1.25. https://github.com/Qiskit/qiskit-terra/pull/10309 replaced it with `prod` but is not released yet. Until the next terra is released, Aer needs lower version than numpy 1.25.
