### PR TITLE
Fix an issue in `aer_state_initialize()` of C API

### DIFF
--- a/contrib/runtime/aer_runtime.cpp
+++ b/contrib/runtime/aer_runtime.cpp
@@ -23,10 +23,9 @@ void *aer_state() {
   return handler;
 };
 
-void *aer_state_initialize(void *handler) {
+void aer_state_initialize(void *handler) {
   AER::AerState *state = reinterpret_cast<AER::AerState *>(handler);
   state->initialize();
-  return handler;
 };
 
 // finalize state

--- a/contrib/runtime/aer_runtime_api.h
+++ b/contrib/runtime/aer_runtime_api.h
@@ -20,7 +20,7 @@ typedef uint_fast64_t uint_t;
 void* aer_state();
 
 // initialize aer state
-void* aer_state_initialize();
+void aer_state_initialize(void* state);
 
 // finalize state
 void aer_state_finalize(void* state);

--- a/releasenotes/notes/fix_aer_state_initialize_api-0c2c237a606648ef.yaml
+++ b/releasenotes/notes/fix_aer_state_initialize_api-0c2c237a606648ef.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    A function ``aer_state_initialize()`` in C API wrongly takes no argument though
+    it initializes a state created by ``aer_state()``. Example codes pass ``handler``
+    and rouboustness of C compiler allows its compilation. This commit corrects for
+    ``aer_state_initialize()`` to take an argument ``handler`` to be initialized.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`aer_state_initialize()` needs to take an argument `handler` to be initialized.

### Details and comments

`aer_state_initialize()` in C API does not take any arguments. However, the function is to initialize a state (`handler`) created by `aer_state()` and needs to take `handler`. Actually, example codes pass `handler` to the function (interestingly C compiler allows its compilation).

This PR changes `aer_state_initialize()` from 
```
void* aer_state_initialize();
```
to
```
void aer_state_initialize(void* state);
```
