### PR TITLE
correct bit ordering in measure of state_controller

### DIFF
--- a/releasenotes/notes/correct_measure_in_state_controller-a92692fd7083c476.yaml
+++ b/releasenotes/notes/correct_measure_in_state_controller-a92692fd7083c476.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``measure`` in libaer.so wrongly read classical memory by assuming
+    opposite ordering of its indices. This fix corrects the assumed ordering.
+    This change affects only libaer.so and not python applications.

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -1313,8 +1313,9 @@ uint_t AerState::apply_measure(const reg_t &qubits) {
 
   uint_t bitstring = 0;
   uint_t bit = 1;
+  uint_t mem_size = state_->creg().memory_size();
   for (const auto &qubit : qubits) {
-    if (state_->creg().creg_memory()[qubit] == '1')
+    if (state_->creg().creg_memory()[mem_size - qubit - 1] == '1')
       bitstring |= bit;
     bit <<= 1;
   }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`measure` in libaer.so was wrong.

### Details and comments

In libaer.so, measured `i`-th qubit stores in `N-i-1`-th memory slot. Therefore, to read measured value, libaer.so must read `N-i-1`-th memory slot. Originally, it reads `i`-th memory slot wrongly.
