### PR TITLE
Define environment variable to allow Qiskit-Aer to be built without CUDA requirements

### DIFF
--- a/releasenotes/notes/skip-cuda-requirements-927ddce79b9e7108.yaml
+++ b/releasenotes/notes/skip-cuda-requirements-927ddce79b9e7108.yaml
@@ -1,0 +1,23 @@
+---
+prelude: >
+    Build environment variable was added to enable building Qiskit-Aer without the CUDA 
+    requirements. The new variable is ``QISKIT_ADD_CUDA_REQUIREMENTS`` and can be set to 
+    False/No/Off or True/Yes/On. By default, it is assumed True.
+    
+features:
+  - |
+    A new environment variable ``QISKIT_ADD_CUDA_REQUIREMENTS`` can be sed to control 
+    whether or not build the Python package for Qiskit-Aer with CUDA requirements. This 
+    flag can be set to False/No/Off or True/Yes/On. By default it is assumed True. This 
+    is useful in case a CUDA instalation is already available on the system where 
+    Qiskit-Aer will run. Not including the requirements results in a smaller footprint 
+    and facilitates leveraging different CUDA installs for development purposes. 
+    The new flag can used like::
+    
+        cd <Qiskit-Aer source folder>
+        
+        QISKIT_AER_PACKAGE_NAME='qiskit-aer-gpu' \
+        QISKIT_AER_CUDA_MAJOR=$CUDA_MAJOR \
+        QISKIT_ADD_CUDA_REQUIREMENTS=False \
+           python3 setup.py bdist_wheel -- \
+              -DAER_THRUST_BACKEND=CUDA ...

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,13 @@ from skbuild import setup
 PACKAGE_NAME = os.getenv("QISKIT_AER_PACKAGE_NAME", "qiskit-aer")
 CUDA_MAJOR = os.getenv("QISKIT_AER_CUDA_MAJOR", "12")
 
+# Allow build without the CUDA requirements. This is useful in case one intends to use a CUDA that exists in the host system.
+ADD_CUDA_REQUIREMENTS = (
+    False
+    if os.getenv("QISKIT_ADD_CUDA_REQUIREMENTS", "true").lower() in ["false", "off", "no"]
+    else True
+)
+
 extras_requirements = {"dask": ["dask", "distributed"]}
 
 requirements = [
@@ -38,7 +45,8 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 
-if "gpu" in PACKAGE_NAME:
+
+if ADD_CUDA_REQUIREMENTS and "gpu" in PACKAGE_NAME:
     if "11" in CUDA_MAJOR:
         requirements_cuda = [
             "nvidia-cuda-runtime-cu11>=11.8.89",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Define environment variable to allow Qiskit-Aer to be built without CUDA requirements


### Details and comments
It is convenient to sometimes be able to leverage an existing system CUDA installation as opposed to load redundant python CUDA packages that provide the same functionality. This enables having smaller footprint in the Qiskit-Aer installation and facilitates development and testing with CUDA. This PR enables an environment variable to control this at build time.

