### PR TITLE
Fix for https://github.com/Qiskit/qiskit-aer/issues/1925 (Aer runtime…

### DIFF
--- a/contrib/runtime/aer_runtime.cpp
+++ b/contrib/runtime/aer_runtime.cpp
@@ -139,7 +139,7 @@ void aer_apply_tdg(void *handler, uint_t qubit) {
 // sqrt(NOT) gate
 void aer_apply_sx(void *handler, uint_t qubit) {
   AER::AerState *state = reinterpret_cast<AER::AerState *>(handler);
-  state->apply_mcrx({qubit}, -M_PI / 4.0);
+  state->apply_unitary({qubit}, AER::Linalg::Matrix::SX);
 };
 
 // Rotation around X-axis

--- a/contrib/runtime/aer_runtime.cpp
+++ b/contrib/runtime/aer_runtime.cpp
@@ -139,7 +139,7 @@ void aer_apply_tdg(void *handler, uint_t qubit) {
 // sqrt(NOT) gate
 void aer_apply_sx(void *handler, uint_t qubit) {
   AER::AerState *state = reinterpret_cast<AER::AerState *>(handler);
-  state->apply_unitary({qubit}, AER::Linalg::Matrix::SX);
+  state->apply_mcsx({qubit});
 };
 
 // Rotation around X-axis

--- a/releasenotes/notes/aer-runtime-api-exposed-wrong-sx-op-dadae6cf0787e169.yaml
+++ b/releasenotes/notes/aer-runtime-api-exposed-wrong-sx-op-dadae6cf0787e169.yaml
@@ -2,8 +2,8 @@
 fixes:
   - |
     Aer runtime api (from contrib) exposed the wrong sx operation,
-    implemented with a rx. The implementation is changed now to
-    apply the AER::Linalg::Matrix::SX unitary. This way the api
-    has the same behavior as the documentation states and also
-    how the sx gate behaves in python.
+    implemented with a rx. The implementation is changed now by
+    adding AerState::apply_mcsx and calling it from aer_apply_sx.
+    This way the api has the same behavior as the documentation 
+    states and also how the sx gate behaves in python.
     Fix for: https://github.com/Qiskit/qiskit-aer/issues/1925

--- a/releasenotes/notes/aer-runtime-api-exposed-wrong-sx-op-dadae6cf0787e169.yaml
+++ b/releasenotes/notes/aer-runtime-api-exposed-wrong-sx-op-dadae6cf0787e169.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Aer runtime api (from contrib) exposed the wrong sx operation,
+    implemented with a rx. The implementation is changed now to
+    apply the AER::Linalg::Matrix::SX unitary. This way the api
+    has the same behavior as the documentation states and also
+    how the sx gate behaves in python.
+    Fix for: https://github.com/Qiskit/qiskit-aer/issues/1925

--- a/src/controllers/state_controller.hpp
+++ b/src/controllers/state_controller.hpp
@@ -310,6 +310,12 @@ public:
   // If N=3 this implements an optimized CCRZ gate
   virtual void apply_mcrz(const reg_t &qubits, const double theta);
 
+  // Apply a general N-qubit multi-controlled SX-gate
+  // If N=1 this implements an optimized SX gate
+  // If N=2 this implements an optimized CSX gate
+  // If N=3 this implements an optimized CCSX gate
+  virtual void apply_mcsx(const reg_t &qubits);
+
   //-----------------------------------------------------------------------
   // Apply Non-Unitary Gates
   //-----------------------------------------------------------------------
@@ -1288,6 +1294,17 @@ void AerState::apply_mcrz(const reg_t &qubits, const double theta) {
   op.name = "mcrz";
   op.qubits = qubits;
   op.params = {theta};
+
+  buffer_op(std::move(op));
+}
+
+void AerState::apply_mcsx(const reg_t &qubits) {
+  assert_initialized();
+
+  Operations::Op op;
+  op.type = Operations::OpType::gate;
+  op.qubits = qubits;
+  op.name = "mcsx";
 
   buffer_op(std::move(op));
 }


### PR DESCRIPTION
… api (from contrib) exposes the wrong sx operation)

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Replaced the runtime api sx implementation to the one expected from documentation (and functionality in other places in qiskit aer).

### Details and comments

Issue: https://github.com/Qiskit/qiskit-aer/issues/1925

The sx gate was implemented in the api using a rotation, which added a global phase compared with the regular implementation in qiskit aer. Now it's replaced with the unitary AER::Linalg::Matrix::SX.

