### PR TITLE
Improve performance of sampler experiment

### DIFF
--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+import numpy as np
 from qiskit.circuit import ParameterExpression, QuantumCircuit
 from qiskit.compiler import transpile
 from qiskit.exceptions import QiskitError
@@ -207,7 +208,7 @@ class _ExperimentManager:
     @property
     def experiment_indices(self):
         """indices of experiments"""
-        return sum(self._input_indices, [])
+        return np.argsort(sum(self._input_indices, [])).tolist()
 
     def append(
         self,

--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -217,15 +217,13 @@ class _ExperimentManager:
         experiment_circuit: QuantumCircuit,
     ):
         """append experiments"""
-        if key not in self.keys or not parameter_bind:
-            self.experiment_circuits.append(experiment_circuit)
-
         if parameter_bind and key in self.keys:
             key_index = self.keys.index(key)
             for k, vs in self.parameter_binds[key_index].items():
                 vs.append(parameter_bind[k])
             self._input_indices[key_index].append(self._num_experiment)
         else:
+            self.experiment_circuits.append(experiment_circuit)
             self.keys.append(key)
             self.parameter_binds.append({k: [v] for k, v in parameter_bind.items()})
             self._input_indices.append([self._num_experiment])

--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import ParameterExpression, QuantumCircuit
 from qiskit.compiler import transpile
 from qiskit.exceptions import QiskitError
 from qiskit.primitives import BaseSampler, SamplerResult

--- a/releasenotes/notes/sampler-performance-81e1649ec4657aad.yaml
+++ b/releasenotes/notes/sampler-performance-81e1649ec4657aad.yaml
@@ -2,4 +2,5 @@
 ---
 upgrade:
   - |
-    Improved performance when the same circuits and multiple parameters are passed to :class:`~.Sampler`.
+    Improved performance when the same circuits and multiple parameters are passed to
+    :class:`~.Sampler`.

--- a/releasenotes/notes/sampler-performance-81e1649ec4657aad.yaml
+++ b/releasenotes/notes/sampler-performance-81e1649ec4657aad.yaml
@@ -1,0 +1,5 @@
+---
+---
+upgrade:
+  - |
+    Improved performance when the same circuits and multiple parameters are passed to :class:`~.Sampler`.

--- a/releasenotes/notes/sampler-performance-81e1649ec4657aad.yaml
+++ b/releasenotes/notes/sampler-performance-81e1649ec4657aad.yaml
@@ -1,5 +1,4 @@
 ---
----
 upgrade:
   - |
     Improved performance when the same circuits and multiple parameters are passed to


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Same idea with https://github.com/Qiskit/qiskit-aer/pull/1840

### Details and comments

Benchmark code:
```python
import numpy as np

from qiskit.circuit.library import EfficientSU2
from qiskit_aer.primitives import Sampler

rng = np.random.default_rng(15)

qc = EfficientSU2(3)
qc.measure_all()

num_circuits = 1000
sampler = Sampler()
parameter_values = rng.random((num_circuits, qc.num_parameters))
circuits = [qc] * num_circuits

%timeit sampler.run(circuits, parameter_values).result()
```
0.12.2: 716 ms ± 1.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
This PR: 534 ms ± 4.33 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)