### PR TITLE
Fix incorrect excited state population when building noise model from BackendV2

### DIFF
--- a/qiskit_aer/noise/device/models.py
+++ b/qiskit_aer/noise/device/models.py
@@ -171,12 +171,15 @@ def basic_device_gate_errors(
         )
 
     # Generate custom gate time dict
+    # Units used in the following computation: ns (time), Hz (frequency), mK (temperature).
     custom_times = {}
     relax_params = []
     if thermal_relaxation:
         # If including thermal relaxation errors load
-        # T1, T2, and frequency values from properties
+        # T1 [ns], T2 [ns], and frequency [GHz] values from properties
         relax_params = thermal_relaxation_values(properties)
+        # Unit conversion: GHz -> Hz
+        relax_params = [(t1, t2, freq * 1e9) for t1, t2, freq in relax_params]
         # If we are specifying custom gate times include
         # them in the custom times dict
         if gate_lengths:
@@ -207,7 +210,7 @@ def basic_device_gate_errors(
         # Get relaxation error
         if thermal_relaxation:
             relax_error = _device_thermal_relaxation_error(
-                qubits, relax_time, relax_params, temperature, thermal_relaxation
+                qubits, relax_time, relax_params, temperature
             )
 
         # Get depolarizing error channel
@@ -239,6 +242,8 @@ def _basic_device_target_gate_errors(
     Note that, in the resulting error list, non-Gate instructions (e.g. Reset) will have
     no gate errors while they may have thermal relaxation errors. Exceptionally,
     Measure instruction will have no errors, neither gate errors nor relaxation errors.
+
+    Note: Units in use: Time [s], Frequency [Hz], Temperature [mK]
     """
     errors = []
     for op_name, inst_prop_dic in target.items():
@@ -329,12 +334,18 @@ def _device_depolarizing_error(qubits, error_param, relax_error=None):
     return None
 
 
-def _device_thermal_relaxation_error(
-    qubits, gate_time, relax_params, temperature, thermal_relaxation=True
-):
-    """Construct a thermal_relaxation_error for device"""
+def _device_thermal_relaxation_error(qubits, gate_time, relax_params, temperature):
+    """Construct a thermal_relaxation_error for device.
+    Note that the time unit for gate_time and T1/T2 in relax_params must be the same.
+
+    Args:
+        qubits: qubits to compute thermal relaxation errors.
+        gate_time (float): duration of the gate.
+        relax_params (dict): maps a qubit (int) to T1, T2, frequency [Hz] (tuple).
+        temperature (float): temperature [mK].
+    """
     # Check trivial case
-    if not thermal_relaxation or gate_time is None or gate_time == 0:
+    if gate_time is None or gate_time == 0:
         return None
 
     # Construct a tensor product of single qubit relaxation errors
@@ -368,7 +379,7 @@ def _truncate_t2_value(t1, t2):
 
 
 def _excited_population(freq, temperature):
-    """Return excited state population from freq [GHz] and temperature [mK]."""
+    """Return excited state population from freq [Hz] and temperature [mK]."""
     if freq is None or temperature is None:
         return 0
     population = 0
@@ -379,10 +390,10 @@ def _excited_population(freq, temperature):
         # Boltzman constant  kB = 8.617333262e-5 (eV/K)
         # Planck constant h = 4.135667696e-15 (eV.s)
         # qubit temperature temperatue = T (mK)
-        # qubit frequency frequency = f (GHz)
-        # excited state population = 1/(1+exp((h*f*1e9)/(kb*T*1e-3)))
+        # qubit frequency frequency = f (Hz)
+        # excited state population = 1/(1+exp((h*f)/(kb*T*1e-3)))
         # See e.g. Phys. Rev. Lett. 114, 240501 (2015).
-        exp_param = exp((47.99243 * freq) / abs(temperature))
+        exp_param = exp((47.99243 * 1e-9 * freq) / abs(temperature))
         population = 1 / (1 + exp_param)
         if temperature < 0:
             # negative temperate implies |1> is thermal ground

--- a/qiskit_aer/noise/device/models.py
+++ b/qiskit_aer/noise/device/models.py
@@ -336,13 +336,9 @@ def _device_depolarizing_error(qubits, error_param, relax_error=None):
 
 def _device_thermal_relaxation_error(qubits, gate_time, relax_params, temperature):
     """Construct a thermal_relaxation_error for device.
-    Note that the time unit for gate_time and T1/T2 in relax_params must be the same.
 
-    Args:
-        qubits: qubits to compute thermal relaxation errors.
-        gate_time (float): duration of the gate.
-        relax_params (dict): maps a qubit (int) to T1, T2, frequency [Hz] (tuple).
-        temperature (float): temperature [mK].
+    Expected units: frequency in relax_params [Hz], temperature [mK].
+    Note that gate_time and T1/T2 in relax_params must be in the same time unit.
     """
     # Check trivial case
     if gate_time is None or gate_time == 0:

--- a/releasenotes/notes/fix-excitation-population-6af281a61f659dda.yaml
+++ b/releasenotes/notes/fix-excitation-population-6af281a61f659dda.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug where :meth:`~.NoiseModel.from_backend` with ``BackendV2`` and non-zero ``temperature``
+    produces relaxation noises with incorrect excitation population.
+    Fixed `#1937 <https://github.com/Qiskit/qiskit-aer/issues/1937>`__.

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
 [testenv:lint]
 envdir = .tox/lint
 basepython = python3
+allowlist_externals = sh
 commands =
   sh tools/clang-format.sh --Werror -n
   black --check {posargs} qiskit_aer test tools setup.py


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed a bug where thermal relaxation errors with incorrect excited state population are created when building a noise model from BackendV2 with non-zero temperature.
Fixed #1937 .


### Details and comments
Fixed an oversight in the handling of frequency units when building a noise model from BackendV2. For that, as suggested in #1937, I changed the `qiskit_aer.noise.device.models._excited_population` to expect the frequency argument in Hz (from GHz) so that the path for BackendV2 works correctly without any updates, and, instead, updated the path for BackendV1.
