### PR TITLE
Update usage of ``QuantumCircuit.id``

### DIFF
--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -443,7 +443,7 @@ def available_methods(controller, methods, devices):
     """Check available simulation methods by running a dummy circuit."""
     # Test methods are available using the controller
     dummy_circ = QuantumCircuit(1)
-    dummy_circ.i(0)
+    dummy_circ.id(0)
 
     valid_methods = []
     for device in devices:
@@ -462,7 +462,7 @@ def available_devices(controller, devices):
     """Check available simulation devices by running a dummy circuit."""
     # Test methods are available using the controller
     dummy_circ = QuantumCircuit(1)
-    dummy_circ.i(0)
+    dummy_circ.id(0)
 
     valid_devices = []
     for device in devices:

--- a/test/terra/backends/simulator_test_case.py
+++ b/test/terra/backends/simulator_test_case.py
@@ -116,7 +116,7 @@ def check_cuStateVec(devices):
     """Return if the system supports cuStateVec or not"""
     if "GPU" in devices:
         dummy_circ = QuantumCircuit(1)
-        dummy_circ.i(0)
+        dummy_circ.id(0)
         qobj = assemble(
             dummy_circ,
             optimization_level=0,

--- a/test/terra/decorators.py
+++ b/test/terra/decorators.py
@@ -21,10 +21,6 @@ from qiskit import QuantumCircuit, execute
 
 from qiskit_aer import AerProvider, AerSimulator
 
-# Backwards compatibility for Terra <= 0.13
-if not hasattr(QuantumCircuit, "i"):
-    QuantumCircuit.i = QuantumCircuit.iden
-
 
 def is_method_available(backend, method):
     """Check if input method is available for the qasm simulator."""

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -59,7 +59,7 @@ class TestNoiseModel(QiskitAerTestCase):
         for _ in range(30):
             # Add noisy identities
             circuit.barrier(qr)
-            circuit.i(qr)
+            circuit.id(qr)
         circuit.barrier(qr)
         circuit.measure(qr, cr)
         shots = 4000

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -143,7 +143,7 @@ class TestQuantumError(QiskitAerTestCase):
 
         # up to global phase
         qc = QuantumCircuit(1, global_phase=0.5)
-        qc.i(0)
+        qc.id(0)
         self.assertTrue(QuantumError(qc).ideal())
         self.assertTrue(QuantumError(UnitaryGate(-1.0 * np.eye(2))).ideal())
 

--- a/test/terra/reference/ref_algorithms.py
+++ b/test/terra/reference/ref_algorithms.py
@@ -17,10 +17,6 @@ Test circuits and reference outputs for standard algorithms.
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 
-# Backwards compatibility for Terra <= 0.13
-if not hasattr(QuantumCircuit, "i"):
-    QuantumCircuit.i = QuantumCircuit.iden
-
 
 def grovers_circuit(final_measure=True, allow_sampling=True):
     """Testing a circuit originated in the Grover algorithm"""
@@ -66,7 +62,7 @@ def grovers_circuit(final_measure=True, allow_sampling=True):
         circuit.measure(qr[1], cr[1])
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
     circuits.append(circuit)
 
     return circuits

--- a/test/terra/reference/ref_kraus_noise.py
+++ b/test/terra/reference/ref_kraus_noise.py
@@ -20,10 +20,6 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit_aer.noise import NoiseModel
 from qiskit_aer.noise.errors.standard_errors import amplitude_damping_error
 
-# Backwards compatibility for Terra <= 0.13
-if not hasattr(QuantumCircuit, "i"):
-    QuantumCircuit.i = QuantumCircuit.iden
-
 
 # ==========================================================================
 # Amplitude damping error
@@ -42,7 +38,7 @@ def kraus_gate_error_circuits():
     for _ in range(30):
         # Add noisy identities
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
     circuit.barrier(qr)
     circuit.measure(qr, cr)
     circuits.append(circuit)

--- a/test/terra/reference/ref_measure.py
+++ b/test/terra/reference/ref_measure.py
@@ -37,7 +37,7 @@ def measure_circuits_deterministic(allow_sampling=True):
     circuit.measure(qr, cr)
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
@@ -49,7 +49,7 @@ def measure_circuits_deterministic(allow_sampling=True):
     circuit.measure(qr, cr)
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
@@ -61,7 +61,7 @@ def measure_circuits_deterministic(allow_sampling=True):
     circuit.measure(qr, cr)
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
@@ -73,7 +73,7 @@ def measure_circuits_deterministic(allow_sampling=True):
     circuit.measure(qr, cr)
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
@@ -89,7 +89,7 @@ def measure_circuits_deterministic(allow_sampling=True):
     circuit.measure(1, 0)
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.measure(1, 0)
     circuits.append(circuit)
@@ -185,7 +185,7 @@ def measure_circuits_nondeterministic(allow_sampling=True):
     circuit.measure(qr, cr)
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.measure(qr, cr)
     circuits.append(circuit)
@@ -228,7 +228,7 @@ def multiqubit_measure_circuits_deterministic(allow_sampling=True):
     circuit.append(measure_n(2), [0, 1], [0, 1])
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.append(measure_n(2), [0, 1], [0, 1])
     circuits.append(circuit)
@@ -243,7 +243,7 @@ def multiqubit_measure_circuits_deterministic(allow_sampling=True):
     circuit.append(measure_n(3), [0, 1, 2], [0, 1, 2])
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.append(measure_n(3), [0, 1, 2], [0, 1, 2])
     circuits.append(circuit)
@@ -258,7 +258,7 @@ def multiqubit_measure_circuits_deterministic(allow_sampling=True):
     circuit.append(measure_n(4), [0, 1, 2, 3], [0, 1, 2, 3])
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.append(measure_n(4), [0, 1, 2, 3], [0, 1, 2, 3])
     circuits.append(circuit)
@@ -344,7 +344,7 @@ def multiqubit_measure_circuits_nondeterministic(allow_sampling=True):
     circuit.append(measure_n(2), [0, 1], [0, 1])
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.append(measure_n(2), [0, 1], [0, 1])
     circuits.append(circuit)
@@ -359,7 +359,7 @@ def multiqubit_measure_circuits_nondeterministic(allow_sampling=True):
     circuit.append(measure_n(3), [0, 1, 2], [0, 1, 2])
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
         circuit.barrier(qr)
         circuit.append(measure_n(3), [0, 1, 2], [0, 1, 2])
     circuits.append(circuit)

--- a/test/terra/reference/ref_pauli_noise.py
+++ b/test/terra/reference/ref_pauli_noise.py
@@ -20,10 +20,6 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit_aer.noise import NoiseModel
 from qiskit_aer.noise.errors.standard_errors import pauli_error
 
-# Backwards compatibility for Terra <= 0.13
-if not hasattr(QuantumCircuit, "i"):
-    QuantumCircuit.i = QuantumCircuit.iden
-
 
 # ==========================================================================
 # Pauli Gate Errors
@@ -39,28 +35,28 @@ def pauli_gate_error_circuits():
 
     # 100% all-qubit Pauli error on "id" gate
     circuit = QuantumCircuit(qr, cr)
-    circuit.i(qr)
+    circuit.id(qr)
     circuit.barrier(qr)
     circuit.measure(qr, cr)
     circuits.append(circuit)
 
     # 25% all-qubit Pauli error on "id" gates
     circuit = QuantumCircuit(qr, cr)
-    circuit.i(qr)
+    circuit.id(qr)
     circuit.barrier(qr)
     circuit.measure(qr, cr)
     circuits.append(circuit)
 
     # 100% Pauli error on "id" gates on qubit-1
     circuit = QuantumCircuit(qr, cr)
-    circuit.i(qr)
+    circuit.id(qr)
     circuit.barrier(qr)
     circuit.measure(qr, cr)
     circuits.append(circuit)
 
     # 25% all-qubit Pauli error on "id" gates on qubit-0
     circuit = QuantumCircuit(qr, cr)
-    circuit.i(qr)
+    circuit.id(qr)
     circuit.barrier(qr)
     circuit.measure(qr, cr)
     circuits.append(circuit)

--- a/test/terra/reference/ref_reset_noise.py
+++ b/test/terra/reference/ref_reset_noise.py
@@ -20,10 +20,6 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit_aer.noise import NoiseModel
 from qiskit_aer.noise.errors.standard_errors import reset_error
 
-# Backwards compatibility for Terra <= 0.13
-if not hasattr(QuantumCircuit, "i"):
-    QuantumCircuit.i = QuantumCircuit.iden
-
 
 # ==========================================================================
 # Reset Gate Errors
@@ -65,7 +61,7 @@ def reset_gate_error_circuits():
     qr = QuantumRegister(1, "qr")
     cr = ClassicalRegister(1, "cr")
     circuit = QuantumCircuit(qr, cr)
-    circuit.i(qr)
+    circuit.id(qr)
     circuit.barrier(qr)
     circuit.measure(qr, cr)
     circuits.append(circuit)
@@ -74,7 +70,7 @@ def reset_gate_error_circuits():
     qr = QuantumRegister(2, "qr")
     cr = ClassicalRegister(2, "cr")
     circuit = QuantumCircuit(qr, cr)
-    circuit.i(qr[0])
+    circuit.id(qr[0])
     circuit.x(qr[1])
     circuit.barrier(qr)
     circuit.measure(qr, cr)

--- a/test/terra/reference/ref_save_expval.py
+++ b/test/terra/reference/ref_save_expval.py
@@ -275,7 +275,7 @@ def save_expval_circuit_parameterized(
     circuit.u(0, 0, 0, 1)
     circuit.cu(0, 0, 0, 0, 0, 1)
     circuit.u(0, 0, 0, 1)
-    circuit.i(0)
+    circuit.id(0)
     if snapshot:
         for label, (params, qubits) in save_expval_params(pauli=True).items():
             circuit.save_expectation_value(

--- a/tools/generate_qobj.py
+++ b/tools/generate_qobj.py
@@ -58,7 +58,7 @@ def grovers_circuit(final_measure=True, allow_sampling=True):
         circuit.measure(qr[1], cr[1])
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.iden(qr)
+        circuit.id(qr)
     circuits.append(circuit)
 
     return circuits

--- a/tools/verify_wheels.py
+++ b/tools/verify_wheels.py
@@ -20,10 +20,6 @@ from qiskit_aer import QasmSimulator
 from qiskit_aer import StatevectorSimulator
 from qiskit_aer import UnitarySimulator
 
-# Backwards compatibility for Terra <= 0.13
-if not hasattr(QuantumCircuit, "i"):
-    QuantumCircuit.i = QuantumCircuit.iden
-
 
 def assertAlmostEqual(first, second, places=None, msg=None, delta=None):
     """Test of 2 object are almost equal.
@@ -105,7 +101,7 @@ def grovers_circuit(final_measure=True, allow_sampling=True):
         circuit.measure(qr[1], cr[1])
     if not allow_sampling:
         circuit.barrier(qr)
-        circuit.i(qr)
+        circuit.id(qr)
     circuits.append(circuit)
 
     return circuits


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit/qiskit#10797 deprecates `QuantumCircuit.i` in favor of `QuantumCircuit.id` (along with another bunch of duplicated gate methods), so this PR updates the usage. 

Also `QuantumCircuit.iden` doesn't exist since quite some time, so that usage is also removed.

It might be good to hold off merging this until Qiskit/qiskit#10797 has gone through, to be sure there aren't any last minute changes.

