### PR TITLE
Fix basis gates of Aer backends

### DIFF
--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -516,6 +516,8 @@ class AerSimulator(AerBackend):
                 "while_loop",
                 "break_loop",
                 "continue_loop",
+                "reset",
+                "switch_case",
             ]
         ),
         "density_matrix": sorted(
@@ -538,6 +540,8 @@ class AerSimulator(AerBackend):
                 "while_loop",
                 "break_loop",
                 "continue_loop",
+                "reset",
+                "switch_case",
             ]
         ),
         "matrix_product_state": sorted(
@@ -562,6 +566,8 @@ class AerSimulator(AerBackend):
                 "while_loop",
                 "break_loop",
                 "continue_loop",
+                "reset",
+                "switch_case",
             ]
         ),
         "stabilizer": sorted(
@@ -583,6 +589,8 @@ class AerSimulator(AerBackend):
                 "while_loop",
                 "break_loop",
                 "continue_loop",
+                "reset",
+                "switch_case",
             ]
         ),
         "extended_stabilizer": sorted(
@@ -591,6 +599,7 @@ class AerSimulator(AerBackend):
                 "qerror_loc",
                 "roerror",
                 "save_statevector",
+                "reset",
             ]
         ),
         "unitary": sorted(
@@ -598,6 +607,7 @@ class AerSimulator(AerBackend):
                 "save_state",
                 "save_unitary",
                 "set_unitary",
+                "reset",
             ]
         ),
         "superop": sorted(
@@ -609,6 +619,7 @@ class AerSimulator(AerBackend):
                 "save_state",
                 "save_superop",
                 "set_superop",
+                "reset",
             ]
         ),
         "tensor_network": sorted(
@@ -630,6 +641,8 @@ class AerSimulator(AerBackend):
                 "save_statevector_dict",
                 "set_statevector",
                 "set_density_matrix",
+                "reset",
+                "switch_case",
             ]
         ),
     }

--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -109,8 +109,6 @@ BASIS_GATES = {
             "pauli",
             "mcx_gray",
             "ecr",
-            "reset",
-            "switch_case",
         ]
     ),
     "density_matrix": sorted(
@@ -151,8 +149,6 @@ BASIS_GATES = {
             "delay",
             "pauli",
             "ecr",
-            "reset",
-            "switch_case",
         ]
     ),
     "matrix_product_state": sorted(
@@ -195,8 +191,6 @@ BASIS_GATES = {
             "cswap",
             "diagonal",
             "initialize",
-            "reset",
-            "switch_case",
         ]
     ),
     "stabilizer": sorted(
@@ -216,12 +210,10 @@ BASIS_GATES = {
             "swap",
             "delay",
             "pauli",
-            "reset",
             "ecr",
             "rx",
             "ry",
             "rz",
-            "switch_case",
         ]
     ),
     "extended_stabilizer": sorted(
@@ -247,7 +239,6 @@ BASIS_GATES = {
             "ccz",
             "delay",
             "pauli",
-            "reset",
         ]
     ),
     "unitary": sorted(
@@ -309,7 +300,6 @@ BASIS_GATES = {
             "delay",
             "pauli",
             "ecr",
-            "reset",
         ]
     ),
     "superop": sorted(
@@ -349,7 +339,6 @@ BASIS_GATES = {
             "diagonal",
             "delay",
             "pauli",
-            "reset",
         ]
     ),
     "tensor_network": sorted(
@@ -412,7 +401,6 @@ BASIS_GATES = {
             "delay",
             "pauli",
             "mcx_gray",
-            "reset",
         ]
     ),
 }

--- a/qiskit_aer/backends/qasm_simulator.py
+++ b/qiskit_aer/backends/qasm_simulator.py
@@ -365,7 +365,6 @@ class QasmSimulator(AerBackend):
             "pauli",
             "mcx_gray",
             "ecr",
-            "reset",
         ]
     )
 
@@ -389,6 +388,7 @@ class QasmSimulator(AerBackend):
             "set_statevector",
             "set_density_matrix",
             "set_stabilizer",
+            "reset",
         ]
     )
 

--- a/qiskit_aer/backends/statevector_simulator.py
+++ b/qiskit_aer/backends/statevector_simulator.py
@@ -213,7 +213,6 @@ class StatevectorSimulator(AerBackend):
                 "initialize",
                 "delay",
                 "pauli",
-                "reset",
             ]
         ),
         "custom_instructions": sorted(
@@ -231,6 +230,7 @@ class StatevectorSimulator(AerBackend):
                 "save_amplitudes_sq",
                 "save_state",
                 "set_statevector",
+                "reset",
             ]
         ),
         "gates": [],

--- a/qiskit_aer/backends/unitary_simulator.py
+++ b/qiskit_aer/backends/unitary_simulator.py
@@ -216,10 +216,9 @@ class UnitarySimulator(AerBackend):
                 "multiplexer",
                 "delay",
                 "pauli",
-                "reset",
             ]
         ),
-        "custom_instructions": sorted(["save_unitary", "save_state", "set_unitary"]),
+        "custom_instructions": sorted(["save_unitary", "save_state", "set_unitary", "reset"]),
         "gates": [],
     }
 

--- a/releasenotes/notes/fix_basis_gates-5edf9708e3eec097.yaml
+++ b/releasenotes/notes/fix_basis_gates-5edf9708e3eec097.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed basis gates sets of Aer backend, moved `reset` and `switch_case`
+    to custom instructions.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is fix for issue #1975 


### Details and comments
Moved `reset` and `switch_case` from BASIS_GATES to _CUSTOM_INSTR not to be excluded when using noise model

