### PR TITLE
Applying global phase multiplication to initialize operation

### DIFF
--- a/releasenotes/notes/fix_initialize_with_global_phase-56d529cd9c09c2fa.yaml
+++ b/releasenotes/notes/fix_initialize_with_global_phase-56d529cd9c09c2fa.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    When applying `initialize`, global phase was not multiplied to state.
+    This fix multiplies global phase to `initialize` operation.
+    Also this fix applies global phase to `matrix_product_state` method,
+    which did not use global phase.

--- a/src/simulators/circuit_executor.hpp
+++ b/src/simulators/circuit_executor.hpp
@@ -101,6 +101,9 @@ protected:
   int parallel_shots_;
   int parallel_state_update_;
 
+  // OpenMP qubit threshold
+  int omp_qubit_threshold_ = 14;
+
   // results are stored independently in each process if true
   bool accept_distributed_results_ = true;
 
@@ -262,6 +265,9 @@ void Executor<state_t>::set_config(const Config &config) {
   max_parallel_threads_ = (max_parallel_threads_ > 0)
                               ? std::min(max_parallel_threads_, omp_threads)
                               : std::max(1, omp_threads);
+
+  // Set OMP threshold for state update functions
+  omp_qubit_threshold_ = config.statevector_parallel_threshold;
 #else
   // No OpenMP so we disable parallelization
   max_parallel_threads_ = 1;

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -728,9 +728,11 @@ void State::apply_initialize(const reg_t &qubits, const cvector_t &params,
   // apply global phase here
   if (BaseState::has_global_phase_) {
     cvector_t tmp(params.size());
-    for (int_t i = 0; i < params.size(); i++) {
+    auto apply_global_phase = [&tmp, params, this](int_t i) {
       tmp[i] = params[i] * BaseState::global_phase_;
-    }
+    };
+    Utils::apply_omp_parallel_for((qubits.size() > 14), 0, params.size(),
+                                  apply_global_phase, BaseState::threads_);
     qreg_.apply_initialize(qubits, tmp, rng);
   } else {
     qreg_.apply_initialize(qubits, params, rng);

--- a/src/simulators/state.hpp
+++ b/src/simulators/state.hpp
@@ -207,6 +207,8 @@ public:
 
   // Set a complex global phase value exp(1j * theta) for the state
   void set_global_phase(double theta);
+  bool has_global_phase() { return has_global_phase_; }
+  complex_t global_phase() { return global_phase_; }
 
   // Set a complex global phase value exp(1j * theta) for the state
   void add_global_phase(double theta);

--- a/src/simulators/statevector/statevector_executor.hpp
+++ b/src/simulators/statevector/statevector_executor.hpp
@@ -104,7 +104,7 @@ protected:
   // computing the tensor product with the new state |psi>
   // /psi> is given in params
   void apply_initialize(const reg_t &qubits, const cvector_t &params,
-                        RngEngine &rng, bool recursive = false);
+                        RngEngine &rng);
 
   void initialize_from_vector(const cvector_t &params);
 
@@ -114,7 +114,7 @@ protected:
 
   void apply_reset(CircuitExecutor::Branch &root, const reg_t &qubits);
   void apply_initialize(CircuitExecutor::Branch &root, const reg_t &qubits,
-                        const cvector_t &params, bool recursive = false);
+                        const cvector_t &params);
   void apply_kraus(CircuitExecutor::Branch &root, const reg_t &qubits,
                    const std::vector<cmatrix_t> &kmats);
 
@@ -1259,18 +1259,23 @@ std::vector<reg_t> Executor<state_t>::sample_measure(const reg_t &qubits,
 
 template <class state_t>
 void Executor<state_t>::apply_initialize(const reg_t &qubits,
-                                         const cvector_t &params,
-                                         RngEngine &rng, bool recursive) {
+                                         const cvector_t &params_in,
+                                         RngEngine &rng) {
   auto sorted_qubits = qubits;
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
   // apply global phase here
-  if (!recursive && Base::states_[0].has_global_phase()) {
-    cvector_t tmp(params.size());
-    for (int_t i = 0; i < params.size(); i++) {
-      tmp[i] = params[i] * Base::states_[0].global_phase();
-    }
-    return apply_initialize(qubits, tmp, rng, true);
+  cvector_t tmp;
+  if (Base::states_[0].has_global_phase()) {
+    tmp.resize(params_in.size());
+    std::complex<double> global_phase = Base::states_[0].global_phase();
+    auto apply_global_phase = [&tmp, &params_in, global_phase](int_t i) {
+      tmp[i] = params_in[i] * global_phase;
+    };
+    Utils::apply_omp_parallel_for((qubits.size() > Base::omp_qubit_threshold_),
+                                  0, params_in.size(), apply_global_phase,
+                                  Base::parallel_state_update_);
   }
+  const cvector_t &params = tmp.empty() ? params_in : tmp;
   if (qubits.size() == Base::num_qubits_) {
     // If qubits is all ordered qubits in the statevector
     // we can just initialize the whole state directly
@@ -1609,16 +1614,21 @@ void Executor<state_t>::apply_reset(CircuitExecutor::Branch &root,
 template <class state_t>
 void Executor<state_t>::apply_initialize(CircuitExecutor::Branch &root,
                                          const reg_t &qubits,
-                                         const cvector_t &params,
-                                         bool recursive) {
+                                         const cvector_t &params_in) {
   // apply global phase here
-  if (!recursive && Base::states_[root.state_index()].has_global_phase()) {
-    cvector_t tmp(params.size());
-    for (int_t i = 0; i < params.size(); i++) {
-      tmp[i] = params[i] * Base::states_[root.state_index()].global_phase();
-    }
-    return apply_initialize(root, qubits, tmp, true);
+  cvector_t tmp;
+  if (Base::states_[root.state_index()].has_global_phase()) {
+    tmp.resize(params_in.size());
+    std::complex<double> global_phase =
+        Base::states_[root.state_index()].global_phase();
+    auto apply_global_phase = [&tmp, params_in, global_phase](int_t i) {
+      tmp[i] = params_in[i] * global_phase;
+    };
+    Utils::apply_omp_parallel_for((qubits.size() > Base::omp_qubit_threshold_),
+                                  0, params_in.size(), apply_global_phase,
+                                  Base::parallel_state_update_);
   }
+  const cvector_t &params = tmp.empty() ? params_in : tmp;
   if (qubits.size() == Base::num_qubits_) {
     auto sorted_qubits = qubits;
     std::sort(sorted_qubits.begin(), sorted_qubits.end());

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -194,7 +194,7 @@ public:
   // computing the tensor product with the new state |psi>
   // /psi> is given in params
   void apply_initialize(const reg_t &qubits, const cvector_t &params,
-                        RngEngine &rng, bool recursive = false);
+                        RngEngine &rng);
 
   void initialize_from_vector(const cvector_t &params);
 
@@ -1055,18 +1055,22 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
 
 template <class statevec_t>
 void State<statevec_t>::apply_initialize(const reg_t &qubits,
-                                         const cvector_t &params,
-                                         RngEngine &rng, bool recursive) {
+                                         const cvector_t &params_in,
+                                         RngEngine &rng) {
   auto sorted_qubits = qubits;
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
   // apply global phase here
-  if (!recursive && BaseState::has_global_phase_) {
-    cvector_t tmp(params.size());
-    for (int_t i = 0; i < params.size(); i++) {
-      tmp[i] = params[i] * BaseState::global_phase_;
-    }
-    return apply_initialize(qubits, tmp, rng, true);
+  cvector_t tmp;
+  if (BaseState::has_global_phase_) {
+    tmp.resize(params_in.size());
+    auto apply_global_phase = [&tmp, &params_in, this](int_t i) {
+      tmp[i] = params_in[i] * BaseState::global_phase_;
+    };
+    Utils::apply_omp_parallel_for((qubits.size() > omp_qubit_threshold_), 0,
+                                  params_in.size(), apply_global_phase,
+                                  BaseState::threads_);
   }
+  const cvector_t &params = tmp.empty() ? params_in : tmp;
   if (qubits.size() == BaseState::qreg_.num_qubits()) {
     // If qubits is all ordered qubits in the statevector
     // we can just initialize the whole state directly

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -194,7 +194,7 @@ public:
   // computing the tensor product with the new state |psi>
   // /psi> is given in params
   void apply_initialize(const reg_t &qubits, const cvector_t &params,
-                        RngEngine &rng);
+                        RngEngine &rng, bool recursive = false);
 
   void initialize_from_vector(const cvector_t &params);
 
@@ -1056,9 +1056,17 @@ std::vector<reg_t> State<statevec_t>::sample_measure(const reg_t &qubits,
 template <class statevec_t>
 void State<statevec_t>::apply_initialize(const reg_t &qubits,
                                          const cvector_t &params,
-                                         RngEngine &rng) {
+                                         RngEngine &rng, bool recursive) {
   auto sorted_qubits = qubits;
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
+  // apply global phase here
+  if (!recursive && BaseState::has_global_phase_) {
+    cvector_t tmp(params.size());
+    for (int_t i = 0; i < params.size(); i++) {
+      tmp[i] = params[i] * BaseState::global_phase_;
+    }
+    return apply_initialize(qubits, tmp, rng, true);
+  }
   if (qubits.size() == BaseState::qreg_.num_qubits()) {
     // If qubits is all ordered qubits in the statevector
     // we can just initialize the whole state directly

--- a/src/simulators/tensor_network/tensor_net_executor.hpp
+++ b/src/simulators/tensor_network/tensor_net_executor.hpp
@@ -62,7 +62,8 @@ protected:
                      const reg_t &cmemory, const reg_t &cregister);
   void apply_reset(CircuitExecutor::Branch &root, const reg_t &qubits);
   void apply_initialize(CircuitExecutor::Branch &root, const reg_t &qubits,
-                        const cvector_t<double> &params);
+                        const cvector_t<double> &params,
+                        bool recursive = false);
   void apply_kraus(CircuitExecutor::Branch &root, const reg_t &qubits,
                    const std::vector<cmatrix_t> &kmats);
 
@@ -249,7 +250,16 @@ void Executor<state_t>::apply_reset(CircuitExecutor::Branch &root,
 template <class state_t>
 void Executor<state_t>::apply_initialize(CircuitExecutor::Branch &root,
                                          const reg_t &qubits,
-                                         const cvector_t<double> &params) {
+                                         const cvector_t<double> &params,
+                                         bool recursive) {
+  // apply global phase here
+  if (!recursive && Base::states_[root.state_index()].has_global_phase()) {
+    cvector_t<double> tmp(params.size());
+    for (int_t i = 0; i < params.size(); i++) {
+      tmp[i] = params[i] * Base::states_[root.state_index()].global_phase();
+    }
+    return apply_initialize(root, qubits, tmp, true);
+  }
   if (qubits.size() == Base::num_qubits_) {
     auto sorted_qubits = qubits;
     std::sort(sorted_qubits.begin(), sorted_qubits.end());

--- a/src/simulators/tensor_network/tensor_net_state.hpp
+++ b/src/simulators/tensor_network/tensor_net_state.hpp
@@ -194,7 +194,7 @@ protected:
   // computing the tensor product with the new state |psi>
   // /psi> is given in params
   void apply_initialize(const reg_t &qubits, const cvector_t<double> &params,
-                        RngEngine &rng);
+                        RngEngine &rng, bool recursive = false);
 
   void initialize_from_matrix(const cmatrix_t &params);
 
@@ -929,9 +929,17 @@ std::vector<reg_t> State<tensor_net_t>::sample_measure(const reg_t &qubits,
 template <class tensor_net_t>
 void State<tensor_net_t>::apply_initialize(const reg_t &qubits,
                                            const cvector_t<double> &params,
-                                           RngEngine &rng) {
+                                           RngEngine &rng, bool recursive) {
   auto sorted_qubits = qubits;
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
+  //apply global phase here
+  if (!recursive && BaseState::has_global_phase_) {
+    cvector_t<double> tmp(params.size());
+    for(int_t i=0;i<params.size();i++){
+      tmp[i] = params[i] * BaseState::global_phase_;
+    }
+    return apply_initialize(qubits, tmp, rng, true);
+  }
   if (qubits.size() == BaseState::qreg_.num_qubits()) {
     // If qubits is all ordered qubits in the statevector
     // we can just initialize the whole state directly

--- a/src/simulators/tensor_network/tensor_net_state.hpp
+++ b/src/simulators/tensor_network/tensor_net_state.hpp
@@ -932,10 +932,10 @@ void State<tensor_net_t>::apply_initialize(const reg_t &qubits,
                                            RngEngine &rng, bool recursive) {
   auto sorted_qubits = qubits;
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
-  //apply global phase here
+  // apply global phase here
   if (!recursive && BaseState::has_global_phase_) {
     cvector_t<double> tmp(params.size());
-    for(int_t i=0;i<params.size();i++){
+    for (int_t i = 0; i < params.size(); i++) {
       tmp[i] = params[i] * BaseState::global_phase_;
     }
     return apply_initialize(qubits, tmp, rng, true);

--- a/test/terra/backends/aer_simulator/test_initialize.py
+++ b/test/terra/backends/aer_simulator/test_initialize.py
@@ -224,3 +224,15 @@ class TestInitialize(SimulatorTestCase):
             actual = backend.run(circ).result().get_statevector(circ)
 
         self.assertAlmostEqual(actual[5], 1)
+
+    @supported_methods(SUPPORTED_METHODS)
+    def test_initialize_with_global_phase(self, method, device):
+        """Test AerSimulator initialize with global phase"""
+        backend = self.backend(method=method, device=device)
+        circ = QuantumCircuit(2)
+        circ.global_phase = np.pi
+        circ.initialize([1, 0, 0, 0])
+        circ.x(0)
+        circ.save_statevector()
+        actual = backend.run(circ).result().get_statevector(circ)
+        self.assertAlmostEqual(actual[1], -1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR is fix for issue #1977 

### Details and comments
The global phase variable was not multiplied after `initialize` operation, this fix multiplies the global phase to the state in `initialize` operation.
Also `matrix_product_state` method did not use global phase, so this PR adds support of global phase in MPS method



