### PR TITLE
Fix name map of aerbackend

### DIFF
--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -87,6 +87,8 @@ class AerBackend(Backend, ABC):
         self._options_properties = {}
         self._target = None
         self._mapping = NAME_MAPPING
+        self._add_delay = False
+        self._filter_faulty = False
 
         # Set options from backend_options dictionary
         if backend_options is not None:
@@ -352,7 +354,12 @@ class AerBackend(Backend, ABC):
     @property
     def target(self):
         self._target = convert_to_target(
-            self.configuration(), self.properties(), self.defaults(), self._mapping
+            self.configuration(),
+            self.properties(),
+            self.defaults(),
+            self._mapping,
+            add_delay=self._add_delay,
+            filter_faulty=self._filter_faulty,
         )
         return self._target
 

--- a/qiskit_aer/backends/name_mapping.py
+++ b/qiskit_aer/backends/name_mapping.py
@@ -14,28 +14,17 @@
 """
 Qiskit Aer simulator name mapping for Target object
 """
-from qiskit.circuit import ControlledGate, Parameter
-from qiskit.circuit.parameterexpression import ParameterValueType
-from qiskit.circuit.reset import Reset
+from qiskit.circuit import Parameter
+
+
 from qiskit.circuit.library import (
-    SXGate,
+
     MCPhaseGate,
     MCXGate,
     MCU1Gate,
-    RZGate,
-    RXGate,
     U2Gate,
-    U1Gate,
-    U3Gate,
-    YGate,
-    ZGate,
     PauliGate,
-    SwapGate,
-    RGate,
     MCXGrayCode,
-    RYGate,
-    CZGate,
-    ECRGate,
     UnitaryGate,
     UCGate,
     Initialize,
@@ -49,8 +38,8 @@ from qiskit.circuit.controlflow import (
     BreakLoopOp,
     SwitchCaseOp,
 )
-from qiskit.extensions import Initialize, UnitaryGate
-from qiskit.extensions.quantum_initializer import DiagonalGate, UCGate
+
+
 from qiskit.quantum_info.operators.channel.kraus import Kraus
 from qiskit.quantum_info.operators.channel import SuperOp
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel

--- a/qiskit_aer/backends/name_mapping.py
+++ b/qiskit_aer/backends/name_mapping.py
@@ -15,11 +15,13 @@
 Qiskit Aer simulator name mapping for Target object
 """
 from qiskit.circuit import ControlledGate, Parameter
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.reset import Reset
 from qiskit.circuit.library import (
     SXGate,
     MCPhaseGate,
     MCXGate,
+    MCU1Gate,
     RZGate,
     RXGate,
     U2Gate,
@@ -32,6 +34,12 @@ from qiskit.circuit.library import (
     RGate,
     MCXGrayCode,
     RYGate,
+    CZGate,
+    ECRGate,
+    UnitaryGate,
+    UCGate,
+    Initialize,
+    DiagonalGate,
 )
 from qiskit.circuit.controlflow import (
     IfElseOp,
@@ -73,209 +81,23 @@ from ..library import (
 from ..noise.errors import ReadoutError
 from ..noise.noise_model import QuantumErrorLocation
 
-
-class MCSXGate(ControlledGate):
-    """mcsx gate"""
-
-    def __init__(self, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcsx",
-            1 + num_ctrl_qubits,
-            [],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=SXGate(),
-        )
-
-
-class MCYGate(ControlledGate):
-    """mcy gate"""
-
-    def __init__(self, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcy",
-            1 + num_ctrl_qubits,
-            [],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=YGate(),
-        )
-
-
-class MCZGate(ControlledGate):
-    """mcz gate"""
-
-    def __init__(self, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcz",
-            1 + num_ctrl_qubits,
-            [],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=ZGate(),
-        )
-
-
-class MCRXGate(ControlledGate):
-    """mcrx gate"""
-
-    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcrx",
-            1 + num_ctrl_qubits,
-            [theta],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=RXGate(theta),
-        )
-
-
-class MCRYGate(ControlledGate):
-    """mcry gate"""
-
-    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcry",
-            1 + num_ctrl_qubits,
-            [theta],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=RYGate(theta),
-        )
-
-
-class MCRZGate(ControlledGate):
-    """mcrz gate"""
-
-    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcrz",
-            1 + num_ctrl_qubits,
-            [theta],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=RZGate(theta),
-        )
-
-
-class MCRGate(ControlledGate):
-    """mcr gate"""
-
-    def __init__(self, theta, phi, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcr",
-            1 + num_ctrl_qubits,
-            [theta, phi],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=RGate(theta, phi),
-        )
-
-
-class MCU1Gate(ControlledGate):
-    """mcu1 gate"""
-
-    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcu1",
-            1 + num_ctrl_qubits,
-            [theta],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=U1Gate(theta),
-        )
-
-
-class MCU2Gate(ControlledGate):
-    """mcu2 gate"""
-
-    def __init__(self, theta, lam, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcu2",
-            1 + num_ctrl_qubits,
-            [theta, lam],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=U2Gate(theta, lam),
-        )
-
-
-class MCU3Gate(ControlledGate):
-    """mcu3 gate"""
-
-    def __init__(self, theta, lam, phi, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcu3",
-            1 + num_ctrl_qubits,
-            [theta, phi, lam],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=U3Gate(theta, phi, lam),
-        )
-
-
-class MCUGate(ControlledGate):
-    """mcu gate"""
-
-    def __init__(self, theta, lam, phi, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcu",
-            1 + num_ctrl_qubits,
-            [theta, phi, lam],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=U3Gate(theta, phi, lam),
-        )
-
-
-class MCSwapGate(ControlledGate):
-    """mcswap gate"""
-
-    def __init__(self, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcswap",
-            2 + num_ctrl_qubits,
-            [],
-            None,
-            num_ctrl_qubits,
-            ctrl_state=ctrl_state,
-            base_gate=SwapGate(),
-        )
-
-
 PHI = Parameter("phi")
 LAM = Parameter("lam")
 NAME_MAPPING = {
-    "mcsx": MCSXGate,
     "mcp": MCPhaseGate,
     "mcphase": MCPhaseGate,
-    "initialize": Initialize,
     "quantum_channel": QuantumChannel,
+    "initialize": Initialize,
     "save_expval": SaveExpectationValue,
     "diagonal": DiagonalGate,
     "save_amplitudes": SaveAmplitudes,
     "roerror": ReadoutError,
-    "mcrx": MCRXGate,
     "kraus": Kraus,
     "save_statevector_dict": SaveStatevectorDict,
     "mcx": MCXGate,
     "mcu1": MCU1Gate,
-    "mcu2": MCU2Gate,
-    "mcu3": MCU3Gate,
     "save_superop": SaveSuperOp,
     "multiplexer": UCGate,
-    "mcy": MCYGate,
     "superop": SuperOp,
     "save_clifford": SaveClifford,
     "save_matrix_product_state": SaveMatrixProductState,
@@ -288,30 +110,21 @@ NAME_MAPPING = {
     "break_loop": BreakLoopOp,
     "continue_loop": ContinueLoopOp,
     "save_statevector": SaveStatevector,
-    "mcu": MCUGate,
     "set_density_matrix": SetDensityMatrix,
     "qerror_loc": QuantumErrorLocation,
     "unitary": UnitaryGate,
-    "mcz": MCZGate,
     "pauli": PauliGate,
     "set_unitary": SetUnitary,
     "save_state": SaveState,
-    "mcswap": MCSwapGate,
     "set_matrix_product_state": SetMatrixProductState,
     "save_unitary": SaveUnitary,
-    "mcr": MCRGate,
     "mcx_gray": MCXGrayCode,
-    "mcrz": MCRZGate,
     "set_superop": SetSuperOp,
     "save_expval_var": SaveExpectationValueVariance,
     "save_stabilizer": SaveStabilizer,
     "set_statevector": SetStatevector,
-    "mcry": MCRYGate,
     "set_stabilizer": SetStabilizer,
     "save_amplitudes_sq": SaveAmplitudesSquared,
     "save_probabilities_dict": SaveProbabilitiesDict,
-    "save_probs_ket": SaveProbabilitiesDict,
-    "save_probs": SaveProbabilities,
     "cu2": U2Gate(PHI, LAM).control(),
-    "reset": Reset(),
 }

--- a/qiskit_aer/backends/name_mapping.py
+++ b/qiskit_aer/backends/name_mapping.py
@@ -14,24 +14,20 @@
 """
 Qiskit Aer simulator name mapping for Target object
 """
-from qiskit.circuit import ControlledGate, Parameter
-from qiskit.circuit.reset import Reset
+from qiskit.circuit import Parameter
+
+
 from qiskit.circuit.library import (
-    SXGate,
     MCPhaseGate,
     MCXGate,
-    RZGate,
-    RXGate,
+    MCU1Gate,
     U2Gate,
-    U1Gate,
-    U3Gate,
-    YGate,
-    ZGate,
     PauliGate,
-    SwapGate,
-    RGate,
     MCXGrayCode,
-    RYGate,
+    UnitaryGate,
+    UCGate,
+    Initialize,
+    DiagonalGate,
 )
 from qiskit.circuit.controlflow import (
     IfElseOp,
@@ -41,8 +37,8 @@ from qiskit.circuit.controlflow import (
     BreakLoopOp,
     SwitchCaseOp,
 )
-from qiskit.extensions import Initialize, UnitaryGate
-from qiskit.extensions.quantum_initializer import DiagonalGate, UCGate
+
+from qiskit.extensions import UnitaryGate
 from qiskit.quantum_info.operators.channel.kraus import Kraus
 from qiskit.quantum_info.operators.channel import SuperOp
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
@@ -73,209 +69,23 @@ from ..library import (
 from ..noise.errors import ReadoutError
 from ..noise.noise_model import QuantumErrorLocation
 
-
-class MCSXGate(ControlledGate):
-    """mcsx gate"""
-
-    def __init__(self, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcsx",
-            int(num_ctrl_qubits) + 1,
-            [],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=SXGate(),
-        )
-
-
-class MCYGate(ControlledGate):
-    """mcy gate"""
-
-    def __init__(self, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcy",
-            int(num_ctrl_qubits) + 1,
-            [],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=YGate(),
-        )
-
-
-class MCZGate(ControlledGate):
-    """mcz gate"""
-
-    def __init__(self, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcz",
-            int(num_ctrl_qubits) + 1,
-            [],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=ZGate(),
-        )
-
-
-class MCRXGate(ControlledGate):
-    """mcrx gate"""
-
-    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcrx",
-            int(num_ctrl_qubits) + 1,
-            [theta],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=RXGate(theta),
-        )
-
-
-class MCRYGate(ControlledGate):
-    """mcry gate"""
-
-    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcry",
-            int(num_ctrl_qubits) + 1,
-            [theta],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=RYGate(theta),
-        )
-
-
-class MCRZGate(ControlledGate):
-    """mcrz gate"""
-
-    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcrz",
-            int(num_ctrl_qubits) + 1,
-            [theta],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=RZGate(theta),
-        )
-
-
-class MCRGate(ControlledGate):
-    """mcr gate"""
-
-    def __init__(self, theta, phi, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcr",
-            int(num_ctrl_qubits) + 1,
-            [theta, phi],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=RGate(theta, phi),
-        )
-
-
-class MCU1Gate(ControlledGate):
-    """mcu1 gate"""
-
-    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcu1",
-            int(num_ctrl_qubits) + 1,
-            [theta],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=U1Gate(theta),
-        )
-
-
-class MCU2Gate(ControlledGate):
-    """mcu2 gate"""
-
-    def __init__(self, theta, lam, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcu2",
-            int(num_ctrl_qubits) + 1,
-            [theta, lam],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=U2Gate(theta, lam),
-        )
-
-
-class MCU3Gate(ControlledGate):
-    """mcu3 gate"""
-
-    def __init__(self, theta, lam, phi, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcu3",
-            int(num_ctrl_qubits) + 1,
-            [theta, phi, lam],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=U3Gate(theta, phi, lam),
-        )
-
-
-class MCUGate(ControlledGate):
-    """mcu gate"""
-
-    def __init__(self, theta, lam, phi, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcu",
-            int(num_ctrl_qubits) + 1,
-            [theta, phi, lam],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=U3Gate(theta, phi, lam),
-        )
-
-
-class MCSwapGate(ControlledGate):
-    """mcswap gate"""
-
-    def __init__(self, num_ctrl_qubits, ctrl_state=None):
-        super().__init__(
-            "mcswap",
-            2 + num_ctrl_qubits,
-            [],
-            None,
-            int(num_ctrl_qubits),
-            ctrl_state=ctrl_state,
-            base_gate=SwapGate(),
-        )
-
-
 PHI = Parameter("phi")
 LAM = Parameter("lam")
 NAME_MAPPING = {
-    "mcsx": MCSXGate,
     "mcp": MCPhaseGate,
     "mcphase": MCPhaseGate,
-    "initialize": Initialize,
     "quantum_channel": QuantumChannel,
+    "initialize": Initialize,
     "save_expval": SaveExpectationValue,
     "diagonal": DiagonalGate,
     "save_amplitudes": SaveAmplitudes,
     "roerror": ReadoutError,
-    "mcrx": MCRXGate,
     "kraus": Kraus,
     "save_statevector_dict": SaveStatevectorDict,
     "mcx": MCXGate,
     "mcu1": MCU1Gate,
-    "mcu2": MCU2Gate,
-    "mcu3": MCU3Gate,
     "save_superop": SaveSuperOp,
     "multiplexer": UCGate,
-    "mcy": MCYGate,
     "superop": SuperOp,
     "save_clifford": SaveClifford,
     "save_matrix_product_state": SaveMatrixProductState,
@@ -288,30 +98,21 @@ NAME_MAPPING = {
     "break_loop": BreakLoopOp,
     "continue_loop": ContinueLoopOp,
     "save_statevector": SaveStatevector,
-    "mcu": MCUGate,
     "set_density_matrix": SetDensityMatrix,
     "qerror_loc": QuantumErrorLocation,
     "unitary": UnitaryGate,
-    "mcz": MCZGate,
     "pauli": PauliGate,
     "set_unitary": SetUnitary,
     "save_state": SaveState,
-    "mcswap": MCSwapGate,
     "set_matrix_product_state": SetMatrixProductState,
     "save_unitary": SaveUnitary,
-    "mcr": MCRGate,
     "mcx_gray": MCXGrayCode,
-    "mcrz": MCRZGate,
     "set_superop": SetSuperOp,
     "save_expval_var": SaveExpectationValueVariance,
     "save_stabilizer": SaveStabilizer,
     "set_statevector": SetStatevector,
-    "mcry": MCRYGate,
     "set_stabilizer": SetStabilizer,
     "save_amplitudes_sq": SaveAmplitudesSquared,
     "save_probabilities_dict": SaveProbabilitiesDict,
-    "save_probs_ket": SaveProbabilitiesDict,
-    "save_probs": SaveProbabilities,
     "cu2": U2Gate(PHI, LAM).control(),
-    "reset": Reset(),
 }

--- a/qiskit_aer/backends/name_mapping.py
+++ b/qiskit_aer/backends/name_mapping.py
@@ -18,7 +18,6 @@ from qiskit.circuit import Parameter
 
 
 from qiskit.circuit.library import (
-
     MCPhaseGate,
     MCXGate,
     MCU1Gate,

--- a/qiskit_aer/backends/name_mapping.py
+++ b/qiskit_aer/backends/name_mapping.py
@@ -14,20 +14,24 @@
 """
 Qiskit Aer simulator name mapping for Target object
 """
-from qiskit.circuit import Parameter
-
-
+from qiskit.circuit import ControlledGate, Parameter
+from qiskit.circuit.reset import Reset
 from qiskit.circuit.library import (
+    SXGate,
     MCPhaseGate,
     MCXGate,
-    MCU1Gate,
+    RZGate,
+    RXGate,
     U2Gate,
+    U1Gate,
+    U3Gate,
+    YGate,
+    ZGate,
     PauliGate,
+    SwapGate,
+    RGate,
     MCXGrayCode,
-    UnitaryGate,
-    UCGate,
-    Initialize,
-    DiagonalGate,
+    RYGate,
 )
 from qiskit.circuit.controlflow import (
     IfElseOp,
@@ -37,8 +41,8 @@ from qiskit.circuit.controlflow import (
     BreakLoopOp,
     SwitchCaseOp,
 )
-
-
+from qiskit.extensions import Initialize, UnitaryGate
+from qiskit.extensions.quantum_initializer import DiagonalGate, UCGate
 from qiskit.quantum_info.operators.channel.kraus import Kraus
 from qiskit.quantum_info.operators.channel import SuperOp
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
@@ -69,23 +73,209 @@ from ..library import (
 from ..noise.errors import ReadoutError
 from ..noise.noise_model import QuantumErrorLocation
 
+
+class MCSXGate(ControlledGate):
+    """mcsx gate"""
+
+    def __init__(self, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcsx",
+            int(num_ctrl_qubits) + 1,
+            [],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=SXGate(),
+        )
+
+
+class MCYGate(ControlledGate):
+    """mcy gate"""
+
+    def __init__(self, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcy",
+            int(num_ctrl_qubits) + 1,
+            [],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=YGate(),
+        )
+
+
+class MCZGate(ControlledGate):
+    """mcz gate"""
+
+    def __init__(self, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcz",
+            int(num_ctrl_qubits) + 1,
+            [],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=ZGate(),
+        )
+
+
+class MCRXGate(ControlledGate):
+    """mcrx gate"""
+
+    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcrx",
+            int(num_ctrl_qubits) + 1,
+            [theta],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=RXGate(theta),
+        )
+
+
+class MCRYGate(ControlledGate):
+    """mcry gate"""
+
+    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcry",
+            int(num_ctrl_qubits) + 1,
+            [theta],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=RYGate(theta),
+        )
+
+
+class MCRZGate(ControlledGate):
+    """mcrz gate"""
+
+    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcrz",
+            int(num_ctrl_qubits) + 1,
+            [theta],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=RZGate(theta),
+        )
+
+
+class MCRGate(ControlledGate):
+    """mcr gate"""
+
+    def __init__(self, theta, phi, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcr",
+            int(num_ctrl_qubits) + 1,
+            [theta, phi],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=RGate(theta, phi),
+        )
+
+
+class MCU1Gate(ControlledGate):
+    """mcu1 gate"""
+
+    def __init__(self, theta, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcu1",
+            int(num_ctrl_qubits) + 1,
+            [theta],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=U1Gate(theta),
+        )
+
+
+class MCU2Gate(ControlledGate):
+    """mcu2 gate"""
+
+    def __init__(self, theta, lam, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcu2",
+            int(num_ctrl_qubits) + 1,
+            [theta, lam],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=U2Gate(theta, lam),
+        )
+
+
+class MCU3Gate(ControlledGate):
+    """mcu3 gate"""
+
+    def __init__(self, theta, lam, phi, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcu3",
+            int(num_ctrl_qubits) + 1,
+            [theta, phi, lam],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=U3Gate(theta, phi, lam),
+        )
+
+
+class MCUGate(ControlledGate):
+    """mcu gate"""
+
+    def __init__(self, theta, lam, phi, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcu",
+            int(num_ctrl_qubits) + 1,
+            [theta, phi, lam],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=U3Gate(theta, phi, lam),
+        )
+
+
+class MCSwapGate(ControlledGate):
+    """mcswap gate"""
+
+    def __init__(self, num_ctrl_qubits, ctrl_state=None):
+        super().__init__(
+            "mcswap",
+            2 + num_ctrl_qubits,
+            [],
+            None,
+            int(num_ctrl_qubits),
+            ctrl_state=ctrl_state,
+            base_gate=SwapGate(),
+        )
+
+
 PHI = Parameter("phi")
 LAM = Parameter("lam")
 NAME_MAPPING = {
+    "mcsx": MCSXGate,
     "mcp": MCPhaseGate,
     "mcphase": MCPhaseGate,
-    "quantum_channel": QuantumChannel,
     "initialize": Initialize,
+    "quantum_channel": QuantumChannel,
     "save_expval": SaveExpectationValue,
     "diagonal": DiagonalGate,
     "save_amplitudes": SaveAmplitudes,
     "roerror": ReadoutError,
+    "mcrx": MCRXGate,
     "kraus": Kraus,
     "save_statevector_dict": SaveStatevectorDict,
     "mcx": MCXGate,
     "mcu1": MCU1Gate,
+    "mcu2": MCU2Gate,
+    "mcu3": MCU3Gate,
     "save_superop": SaveSuperOp,
     "multiplexer": UCGate,
+    "mcy": MCYGate,
     "superop": SuperOp,
     "save_clifford": SaveClifford,
     "save_matrix_product_state": SaveMatrixProductState,
@@ -98,21 +288,30 @@ NAME_MAPPING = {
     "break_loop": BreakLoopOp,
     "continue_loop": ContinueLoopOp,
     "save_statevector": SaveStatevector,
+    "mcu": MCUGate,
     "set_density_matrix": SetDensityMatrix,
     "qerror_loc": QuantumErrorLocation,
     "unitary": UnitaryGate,
+    "mcz": MCZGate,
     "pauli": PauliGate,
     "set_unitary": SetUnitary,
     "save_state": SaveState,
+    "mcswap": MCSwapGate,
     "set_matrix_product_state": SetMatrixProductState,
     "save_unitary": SaveUnitary,
+    "mcr": MCRGate,
     "mcx_gray": MCXGrayCode,
+    "mcrz": MCRZGate,
     "set_superop": SetSuperOp,
     "save_expval_var": SaveExpectationValueVariance,
     "save_stabilizer": SaveStabilizer,
     "set_statevector": SetStatevector,
+    "mcry": MCRYGate,
     "set_stabilizer": SetStabilizer,
     "save_amplitudes_sq": SaveAmplitudesSquared,
     "save_probabilities_dict": SaveProbabilitiesDict,
+    "save_probs_ket": SaveProbabilitiesDict,
+    "save_probs": SaveProbabilities,
     "cu2": U2Gate(PHI, LAM).control(),
+    "reset": Reset(),
 }

--- a/releasenotes/notes/fix_name_mapping-1cf7af45bafcb203.yaml
+++ b/releasenotes/notes/fix_name_mapping-1cf7af45bafcb203.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Removed some name maps that causes error in Qiskit's controlled gate test
+    cases.

--- a/releasenotes/notes/fix_name_mapping-1cf7af45bafcb203.yaml
+++ b/releasenotes/notes/fix_name_mapping-1cf7af45bafcb203.yaml
@@ -1,5 +1,6 @@
 ---
 fixes:
   - |
-    Removed some name maps that causes error in Qiskit's controlled gate test
-    cases.
+    `num_ctrl_qubits` should be integer but in Qiskit's test case
+    `test.python.circuit.test_controlled_gate` float type is passed
+    so add cast to integer


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix name maps that causes error in Qiskit's controlled gate testcases.

### Details and comments
Some custom multi controlled gates are caused test failure in `test.python.circuit.test_controlled_gate` in Qiskit because control qubits are sets only when the custom gates are MCU1Gate, MCPhaseGate and MCXGate, but float type value is passed,
so I added type cast to integer to avoid failure

