### PR TITLE
Revert too many deprecations in Estimator

### DIFF
--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -39,7 +39,7 @@ from qiskit.transpiler.passes import (
     Optimize1qGatesDecomposition,
     SetLayout,
 )
-from qiskit.utils import deprecate_arg, deprecate_func
+from qiskit.utils import deprecate_func
 
 from .. import AerError, AerSimulator
 
@@ -76,12 +76,6 @@ class Estimator(BaseEstimator):
           normal distribution approximation.
     """
 
-    @deprecate_arg(
-        "approximation",
-        since=0.13,
-        package_name="qiskit-aer",
-        additional_msg="approximation=True will be default in the future.",
-    )
     def __init__(
         self,
         *,

--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -112,7 +112,7 @@ class Estimator(BaseEstimator):
             warn(
                 "Option approximation=False is deprecated as of qiskit-aer 0.13. "
                 "It will be removed no earlier than 3 months after the release date. "
-                "Instead, use BackendEstmator from qiskit.primitives.",
+                "Instead, use BackendEstimator from qiskit.primitives.",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -147,7 +147,7 @@ class Estimator(BaseEstimator):
             warn(
                 "Option approximation=False is deprecated as of qiskit-aer 0.13. "
                 "It will be removed no earlier than 3 months after the release date. "
-                "Instead, use BackendEstmator from qiskit.primitives.",
+                "Instead, use BackendEstimator from qiskit.primitives.",
                 DeprecationWarning,
                 stacklevel=3,
             )

--- a/test/terra/primitives/test_estimator.py
+++ b/test/terra/primitives/test_estimator.py
@@ -287,8 +287,7 @@ class TestEstimator(QiskitAerTestCase):
         """test with shots option."""
         # Note: abelian_gropuing is ignored when approximation is True as documented.
         # The purpose of this test is to make sure the results remain the same.
-        with self.assertWarns(DeprecationWarning):
-            est = Estimator(approximation=True, abelian_grouping=abelian_grouping)
+        est = Estimator(approximation=True, abelian_grouping=abelian_grouping)
         result = est.run(
             self.ansatz, self.observable, parameter_values=[[0, 1, 1, 2, 3, 5]], shots=1024, seed=15
         ).result()
@@ -332,8 +331,7 @@ class TestEstimator(QiskitAerTestCase):
         qc2.ry(np.pi / 2 * param, 0)
         qc2.measure_all()
 
-        with self.assertWarns(DeprecationWarning):
-            estimator = Estimator(approximation=True)
+        estimator = Estimator(approximation=True)
         job = estimator.run([qc1, qc2, qc1, qc1, qc2], ["Z"] * 5, [[], [1], [], [], [1]])
         result = job.result()
         np.testing.assert_allclose(result.values, [1, 0, 1, 1, 0], atol=1e-10)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I deprecated approximation option in Estimator https://github.com/Qiskit/qiskit-aer/pull/1963.
But the argument should not be deprecated because users cannot turn off the warning message.
This PR reverts one deprecation message from the PR.

### Details and comments


