### PR TITLE
Fix extended stabilizer thread safety in apply_ops_parallel

### DIFF
--- a/releasenotes/notes/fix_extstabilizer_thread_safety-c85e926c7ecb8dfb.yaml
+++ b/releasenotes/notes/fix_extstabilizer_thread_safety-c85e926c7ecb8dfb.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Extended stabilizer simulation was sharing a single copy of RngEngine amongst
+    parallelized states in ``ExtendedStabilizer::State::apply_ops_parallel``, 
+    leading to thread safety issue. Now, a new RngEngine is seeded for each parallel
+    state.

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -463,6 +463,12 @@ template <typename InputIterator>
 void State::apply_ops_parallel(InputIterator first, InputIterator last,
                                ExperimentResult &result, RngEngine &rng) {
   const int_t NUM_STATES = BaseState::qreg_.get_num_states();
+
+  std::vector<size_t> rng_seeds(NUM_STATES);
+  for (int_t i = 0; i < NUM_STATES; i++) {
+    rng_seeds[i] = size_t(rng.rand_int(0ULL, 18446744073709551615ULL));
+  }
+
 #pragma omp parallel for if (BaseState::qreg_.check_omp_threshold() &&         \
                              BaseState::threads_ > 1)                          \
     num_threads(BaseState::threads_)
@@ -470,10 +476,11 @@ void State::apply_ops_parallel(InputIterator first, InputIterator last,
     if (!BaseState::qreg_.check_eps(i)) {
       continue;
     }
+    RngEngine local_rng(rng_seeds[i]);
     for (auto it = first; it != last; it++) {
       switch (it->type) {
       case Operations::OpType::gate:
-        apply_gate(*it, rng, i);
+        apply_gate(*it, local_rng, i);
         break;
       case Operations::OpType::barrier:
       case Operations::OpType::qerror_loc:

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -466,7 +466,7 @@ void State::apply_ops_parallel(InputIterator first, InputIterator last,
 
   std::vector<size_t> rng_seeds(NUM_STATES);
   for (int_t i = 0; i < NUM_STATES; i++) {
-    rng_seeds[i] = size_t(rng.rand_int(0ULL, 18446744073709551615ULL));
+    rng_seeds[i] = rng.rand_int<size_t>(0, SIZE_MAX);
   }
 
 #pragma omp parallel for if (BaseState::qreg_.check_omp_threshold() &&         \


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes issue #1932. Extended stabilizer simulator was sharing a random number engine between states in ``apply_ops_parallel``, leading to thread safety issues.


### Details and comments
Now, a new random number engine is provided for each state in parallel, so results should be consistent with the same initial random seed. 

