### PR TITLE
Remove use of opflow in `Estimator`

### DIFF
--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -23,7 +23,6 @@ from warnings import warn
 import numpy as np
 from qiskit.circuit import ParameterExpression, QuantumCircuit
 from qiskit.compiler import transpile
-from qiskit.opflow import PauliSumOp
 from qiskit.primitives import BaseEstimator, EstimatorResult
 from qiskit.primitives.primitive_job import PrimitiveJob
 from qiskit.primitives.utils import _circuit_key, _observable_key, init_observable
@@ -174,7 +173,7 @@ class Estimator(BaseEstimator):
     def _run(
         self,
         circuits: Sequence[QuantumCircuit],
-        observables: Sequence[BaseOperator | PauliSumOp],
+        observables: Sequence[BaseOperator],
         parameter_values: Sequence[Sequence[float]],
         **run_options,
     ) -> PrimitiveJob:

--- a/releasenotes/notes/remove-opflow-estimator-a3b64cfe8a4fd6b3.yaml
+++ b/releasenotes/notes/remove-opflow-estimator-a3b64cfe8a4fd6b3.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The :meth:`qiskit_aer.primitives.Estimator.run` method no longer supports
+    ``observables`` input arguments of type ``PauliSumOp``. The ``PauliSumOp``
+    class was deprecated in Qiskit 0.44 and will be removed in Qiskit 1.0.
+    Alternative types that you can use instead of ``PauliSumOp`` are
+    :class:`qiskit.quantum_info.SparsePauliOp` or :class:`qiskit.quantum_info.Pauli`.

--- a/test/terra/primitives/test_estimator.py
+++ b/test/terra/primitives/test_estimator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -23,7 +23,6 @@ from ddt import data, ddt
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.exceptions import QiskitError
-from qiskit.opflow import PauliSumOp
 from qiskit.primitives import EstimatorResult
 from qiskit.quantum_info import Operator, SparsePauliOp
 
@@ -53,19 +52,6 @@ class TestEstimator(QiskitAerTestCase):
     def test_estimator(self, abelian_grouping):
         """test for a simple use case"""
         lst = [("XX", 1), ("YY", 2), ("ZZ", 3)]
-        with self.assertWarns(DeprecationWarning):
-            with self.subTest("PauliSumOp"):
-                observable = PauliSumOp.from_list(lst)
-                ansatz = RealAmplitudes(num_qubits=2, reps=2)
-                est = Estimator(
-                    backend_options={"method": "statevector"}, abelian_grouping=abelian_grouping
-                )
-                result = est.run(
-                    ansatz, observable, parameter_values=[[0, 1, 1, 2, 3, 5]], seed=15
-                ).result()
-                self.assertIsInstance(result, EstimatorResult)
-                np.testing.assert_allclose(result.values, [1.728515625])
-
         with self.subTest("SparsePauliOp"):
             observable = SparsePauliOp.from_list(lst)
             ansatz = RealAmplitudes(num_qubits=2, reps=2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR removes the only `opflow` dependency in Aer (supporting `PauliSumOp` as an input to the Estimator). The `opflow` module was deprecated and is on its way of being removed from Qiskit, which means it will no longer be available for downstream projects (see https://github.com/Qiskit/qiskit/pull/11111). Once the linked PR is merged, importing `opflow` in the Aer primitives will break the neko integration tests (see https://github.com/Qiskit/qiskit/actions/runs/6848167193/job/18617803285?pr=11111#step:2:1073), so if I am not mistaken, the optimal path would be to remove the use of opflow first in Aer and then in Qiskit.


### Details and comments
I have added an upgrade release note documenting the removal of the supported type.

