### PR TITLE
Add optimization_level=0 to transpiler for compiling dynamic circuits

### DIFF
--- a/qiskit_aer/backends/aer_compiler.py
+++ b/qiskit_aer/backends/aer_compiler.py
@@ -99,7 +99,9 @@ class AerCompiler:
                 circuit = self._inline_initialize(circuit, compiled_optypes[idx])
                 if self._is_dynamic(circuit, compiled_optypes[idx]):
                     compiled_circ = transpile(
-                        self._inline_circuit(circuit, None, None), basis_gates=basis_gates
+                        self._inline_circuit(circuit, None, None),
+                        basis_gates=basis_gates,
+                        optimization_level=0,
                     )
                     compiled_circuits.append(compiled_circ)
                     # Recompute optype for compiled circuit

--- a/releasenotes/notes/fix_transpiler_lvl_for_dynamic_circuit-4ead3b497bbcc632.yaml
+++ b/releasenotes/notes/fix_transpiler_lvl_for_dynamic_circuit-4ead3b497bbcc632.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    For dynamic circuits, aer_compiler calls transpiler without optimizaiton
+    level. Because id gates are removed by transpiler, noise applied id gates
+    did not work correctly. This fix adds optimization_level=0 not to remove
+    id gates of dynamic circuits


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes issue #1997 


### Details and comments
id gate was removed by transpiler called from aer_compiler without optimization_level for dynamic circuits.
adding optimization_level=0 to avoid removing id gates
