### PR TITLE
Fix ry gate for stabilizer

### DIFF
--- a/releasenotes/notes/fix_stabilizer_ry_gate-07538d8a2462c09d.yaml
+++ b/releasenotes/notes/fix_stabilizer_ry_gate-07538d8a2462c09d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    fixed ry gate for stabilizer method, PI/2 and PI3/2 was inverted

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -417,16 +417,14 @@ void State::apply_gate(const Operations::Op &op) {
   case Gates::ry:
     pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
     if (pi2 == 1) {
-      // HX
-      BaseState::qreg_.append_x(op.qubits[0]);
       BaseState::qreg_.append_h(op.qubits[0]);
+      BaseState::qreg_.append_x(op.qubits[0]);
     } else if (pi2 == 2) {
       // Y
       BaseState::qreg_.append_y(op.qubits[0]);
     } else if (pi2 == 3) {
-      // Hdg
-      BaseState::qreg_.append_h(op.qubits[0]);
       BaseState::qreg_.append_x(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[0]);
     }
     break;
   case Gates::rz:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is fix for issue #1999 


### Details and comments
The implementation of ry gate of stabilizer method was wrong, conversion of ry(PI/2) and ry(3PI/2) to Clifford gates was inverted
