### PR TITLE
Directly use psutil to get total system memory

### DIFF
--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -16,16 +16,18 @@ Aer simulator backend utils
 """
 import os
 from math import log2
-from qiskit.utils import local_hardware_info
+
+import psutil
 from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import assemble
 from qiskit.qobj import QasmQobjInstruction
 from qiskit.result import ProbDistribution
 from qiskit.quantum_info import Clifford
+
 from .compatibility import Statevector, DensityMatrix, StabilizerState, Operator, SuperOp
 
 # Available system memory
-SYSTEM_MEMORY_GB = local_hardware_info()["memory"]
+SYSTEM_MEMORY_GB = psutil.virtual_memory().total / (1024**3)
 
 # Max number of qubits for complex double statevector
 # given available system memory

--- a/qiskit_aer/backends/statevector_simulator.py
+++ b/qiskit_aer/backends/statevector_simulator.py
@@ -16,7 +16,8 @@ Aer statevector simulator backend.
 import copy
 import logging
 from warnings import warn
-from qiskit.utils import local_hardware_info
+
+import psutil
 from qiskit.providers.options import Options
 from qiskit.providers.models import QasmBackendConfiguration
 
@@ -364,7 +365,7 @@ class StatevectorSimulator(AerBackend):
         if n_qubits > max_qubits:
             raise AerError(
                 f"Number of qubits ({n_qubits}) is greater than max ({max_qubits}) "
-                f'for "{name}" with {int(local_hardware_info()["memory"])} GB system memory.'
+                f'for "{name}" with {int(psutil.virtual_memory().total / (1024**3))} GB system memory.'
             )
 
         if qobj.config.shots != 1:

--- a/qiskit_aer/backends/unitary_simulator.py
+++ b/qiskit_aer/backends/unitary_simulator.py
@@ -17,7 +17,8 @@ Aer Unitary Simulator Backend.
 import copy
 import logging
 from warnings import warn
-from qiskit.utils import local_hardware_info
+
+import psutil
 from qiskit.providers.options import Options
 from qiskit.providers.models import QasmBackendConfiguration
 
@@ -351,7 +352,7 @@ class UnitarySimulator(AerBackend):
             raise AerError(
                 f"Number of qubits ({n_qubits}) is greater than "
                 f'max ({max_qubits}) for "{name}" with '
-                f"{int(local_hardware_info()['memory'])} GB system memory."
+                f"{int(psutil.virtual_memory().total / (1024**3))} GB system memory."
             )
         if qobj.config.shots != 1:
             logger.info('"%s" only supports 1 shot. Setting shots=1.', name)

--- a/releasenotes/notes/psutil-added-ffb2a4b5956fa03d.yaml
+++ b/releasenotes/notes/psutil-added-ffb2a4b5956fa03d.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    Added `psutil <https://pypi.org/project/psutil/>`__ as a dependency for
+    Qiskit Aer. This is used to determine the amount of physical resources
+    available. ``psutil`` is currently a dependency of Qiskit, which is a
+    requirement for Qiskit Aer, so ``psutil`` was effectively already required
+    for any ``qiskit-aer`` installation. But, as qiskit-aer is now using it
+    directly is now a direct dependency for ``qiskit-aer``.

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ requirements = [
     "qiskit>=0.44.0",
     "numpy>=1.16.3",
     "scipy>=1.0",
+    "psutil>=5",
 ]
 
 classifiers = [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently Aer is using Qiskit's local_hardware_info() function which to determine the total amount of system memory which is used to compute the largest statevector the system can build. However, this function wasn't really intended to be used outside of Qiskit and also Qiskit is looking to remove the memory reporting (see: Qiskit/qiskit#11254). This commit just pivots to using psutil directly which is what qiskit is doing internally.

### Details and comments