### PR TITLE
Reverse ordering to read out error in sampling measure

### DIFF
--- a/releasenotes/notes/fix_sample_measure_roerr-747b955aa2bf778c.yaml
+++ b/releasenotes/notes/fix_sample_measure_roerr-747b955aa2bf778c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes order of applying read out error in sampling measure
+    in circuit executors. Ordering is reversed to fit to the older verison
+    of Aer.
+    Also fixed check of bacth execution.

--- a/src/simulators/batch_shots_executor.hpp
+++ b/src/simulators/batch_shots_executor.hpp
@@ -150,7 +150,7 @@ template <class state_t>
 void BatchShotsExecutor<state_t>::run_circuit_with_sampling(
     Circuit &circ, const Config &config, RngEngine &init_rng,
     ResultItr result_it) {
-  if (circ.num_bind_params == 1 || !enable_batch_multi_shots_) {
+  if (enable_batch_multi_shots_) {
     return Executor<state_t>::run_circuit_with_sampling(circ, config, init_rng,
                                                         result_it);
   }

--- a/src/simulators/batch_shots_executor.hpp
+++ b/src/simulators/batch_shots_executor.hpp
@@ -150,7 +150,7 @@ template <class state_t>
 void BatchShotsExecutor<state_t>::run_circuit_with_sampling(
     Circuit &circ, const Config &config, RngEngine &init_rng,
     ResultItr result_it) {
-  if (enable_batch_multi_shots_) {
+  if (!enable_batch_multi_shots_) {
     return Executor<state_t>::run_circuit_with_sampling(circ, config, init_rng,
                                                         result_it);
   }

--- a/src/simulators/circuit_executor.hpp
+++ b/src/simulators/circuit_executor.hpp
@@ -1073,7 +1073,7 @@ void Executor<state_t>::measure_sampler(InputIterator first_meas,
   uint_t num_registers =
       (register_map.empty()) ? 0ULL : 1 + register_map.rbegin()->first;
   ClassicalRegister creg;
-  for (int_t i = 0; i < all_samples.size(); i++) {
+  for (int_t i = all_samples.size() - 1; i >= 0; i--) {
     creg.initialize(num_memory, num_registers);
 
     // process memory bit measurements

--- a/src/simulators/multi_state_executor.hpp
+++ b/src/simulators/multi_state_executor.hpp
@@ -863,7 +863,7 @@ void MultiStateExecutor<state_t>::measure_sampler(InputIterator first_meas,
       (memory_map.empty()) ? 0ULL : 1 + memory_map.rbegin()->first;
   uint_t num_registers =
       (register_map.empty()) ? 0ULL : 1 + register_map.rbegin()->first;
-  for (int_t i = 0; i < all_samples.size(); i++) {
+  for (int_t i = all_samples.size() - 1; i >= 0; i--) {
     ClassicalRegister creg = state.creg();
 
     // process memory bit measurements


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes order of applying read out error in sampling measures in the circuit executor classes,
 that causes different results from older version of Aer.

### Details and comments
The order to apply read out error in sampling measure was reverse ordering by popping from back of vector in older version of Aer. So this fix reorder loop to apply consistent random values to read out error as older version.
This PR fixes failure of Qiskit's test case `test.python.primitives.test_backend_estimator.TestBackendEstimator.test_layout`

Also this PR includes fix of checking if batch execution on GPU can be applied or not.
