### PR TITLE
Use Apple-specific API to determine system memory on macOS

### DIFF
--- a/src/framework/utils.hpp
+++ b/src/framework/utils.hpp
@@ -28,8 +28,11 @@
 #include <intrin.h>
 #endif
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__)
 #include <unistd.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#include <sys/types.h>
 #elif defined(_WIN64) || defined(_WIN32)
 // This is needed because windows.h redefine min()/max() so interferes with
 // std::min/max
@@ -1270,10 +1273,13 @@ uint_t (*popcount)(uint_t) = &_naive_weight;
 
 size_t get_system_memory_mb() {
   size_t total_physical_memory = 0;
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__)
   size_t pages = (size_t)sysconf(_SC_PHYS_PAGES);
   size_t page_size = (size_t)sysconf(_SC_PAGE_SIZE);
   total_physical_memory = pages * page_size;
+#elif defined(__APPLE__)
+  size_t len = sizeof(total_physical_memory);
+  sysctlbyname("hw.memsize", &total_physical_memory, &len, NULL, 0);
 #elif defined(_WIN64) || defined(_WIN32)
   MEMORYSTATUSEX status;
   status.dwLength = sizeof(status);


### PR DESCRIPTION
The unistd.h API that had been used for both Linux and macOS is not always available in macOS environments, for example when building with upstream clang rather than AppleClang.

Closes https://github.com/Qiskit/qiskit-aer/issues/1923


