### PR TITLE
Remove usage of ``qiskit.extensions``

### DIFF
--- a/qiskit_aer/backends/aer_compiler.py
+++ b/qiskit_aer/backends/aer_compiler.py
@@ -24,7 +24,7 @@ import numpy as np
 from qiskit.circuit import QuantumCircuit, Clbit, ClassicalRegister, ParameterExpression
 from qiskit.circuit.classical.expr import Expr, Unary, Binary, Var, Value, ExprVisitor, iter_vars
 from qiskit.circuit.classical.types import Bool, Uint
-from qiskit.extensions import Initialize
+from qiskit.circuit.library import Initialize
 from qiskit.providers.options import Options
 from qiskit.pulse import Schedule, ScheduleBlock
 from qiskit.circuit.controlflow import (

--- a/qiskit_aer/backends/name_mapping.py
+++ b/qiskit_aer/backends/name_mapping.py
@@ -34,6 +34,8 @@ from qiskit.circuit.library import (
     CRZGate,
     MCU1Gate,
     MCXGrayCode,
+    Initialize,
+    UCGate,
 )
 from qiskit.circuit.controlflow import (
     IfElseOp,
@@ -43,8 +45,6 @@ from qiskit.circuit.controlflow import (
     BreakLoopOp,
     SwitchCaseOp,
 )
-from qiskit.extensions import Initialize
-from qiskit.extensions.quantum_initializer import UCGate
 from qiskit.quantum_info.operators.channel.kraus import Kraus
 from qiskit.quantum_info.operators.channel import SuperOp
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel

--- a/qiskit_aer/library/default_qubits.py
+++ b/qiskit_aer/library/default_qubits.py
@@ -14,7 +14,6 @@ Helper function
 """
 
 from qiskit.circuit import QuantumRegister
-from qiskit.extensions.exceptions import ExtensionError
 
 
 def default_qubits(circuit, qubits=None):
@@ -27,7 +26,7 @@ def default_qubits(circuit, qubits=None):
             [Default: None]
 
     Raises:
-            ExtensionError: if default qubits fails.
+        ValueError: if default qubits fails.
 
     Returns:
         list: qubits list.
@@ -37,9 +36,9 @@ def default_qubits(circuit, qubits=None):
     # This is needed for full register snapshots like statevector
     if isinstance(qubits, QuantumRegister):
         qubits = qubits[:]
-    if not qubits:
+    if qubits is None:
         qubits = list(circuit.qubits)
         if len(qubits) == 0:
-            raise ExtensionError("no qubits for snapshot")
+            raise ValueError("no qubits for snapshot")
 
     return qubits

--- a/qiskit_aer/library/save_instructions/save_amplitudes.py
+++ b/qiskit_aer/library/save_instructions/save_amplitudes.py
@@ -14,7 +14,6 @@ Simulator instruction to save statevector amplitudes and amplitudes squared.
 """
 
 from qiskit.circuit import QuantumCircuit
-from qiskit.extensions.exceptions import ExtensionError
 from .save_data import SaveSingleData, SaveAverageData
 from ..default_qubits import default_qubits
 
@@ -37,7 +36,7 @@ class SaveAmplitudes(SaveSingleData):
                                 [Default: False].
 
         Raises:
-            ExtensionError: if params is invalid for the specified number of qubits.
+            ValueError: if params is invalid for the specified number of qubits.
         """
         params = _format_amplitude_params(params, num_qubits)
         super().__init__(
@@ -78,7 +77,7 @@ class SaveAmplitudesSquared(SaveAverageData):
                                 [Default: False].
 
         Raises:
-            ExtensionError: if params is invalid for the specified number of qubits.
+            ValueError: if params is invalid for the specified number of qubits.
         """
         params = _format_amplitude_params(params, num_qubits)
         super().__init__(
@@ -109,7 +108,7 @@ def save_amplitudes(self, params, label="amplitudes", pershot=False, conditional
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: if params is invalid for the specified number of qubits.
+        ValueError: if params is invalid for the specified number of qubits.
     """
     qubits = default_qubits(self)
     instr = SaveAmplitudes(
@@ -139,7 +138,7 @@ def save_amplitudes_squared(
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: if params is invalid for the specified number of qubits.
+        ValueError: if params is invalid for the specified number of qubits.
     """
     qubits = default_qubits(self)
     instr = SaveAmplitudesSquared(
@@ -161,7 +160,7 @@ def _format_amplitude_params(params, num_qubits=None):
         else:
             params = [int(i, 2) for i in params]
     if num_qubits and max(params) >= 2**num_qubits:
-        raise ExtensionError("Param values contain a state larger than the number of qubits")
+        raise ValueError("Param values contain a state larger than the number of qubits")
     return params
 
 

--- a/qiskit_aer/library/save_instructions/save_data.py
+++ b/qiskit_aer/library/save_instructions/save_data.py
@@ -16,7 +16,6 @@ Simulator instruction to save custom internal data to results.
 import copy
 
 from qiskit.circuit import Instruction
-from qiskit.extensions.exceptions import ExtensionError
 
 
 class SaveData(Instruction):
@@ -39,19 +38,17 @@ class SaveData(Instruction):
                                    [Default: None].
 
         Raises:
-            ExtensionError: if the subtype string is invalid.
+            TypeError: if the subtype string is invalid.
 
         Additional Information:
             The supported subtypes are 'single', 'list', 'c_list', 'average',
             'c_average', 'accum', 'c_accum'.
         """
         if subtype not in self._allowed_subtypes:
-            raise ExtensionError("Invalid data subtype for SaveData instruction.")
+            raise TypeError("Invalid data subtype for SaveData instruction.")
 
         if not isinstance(label, str):
-            raise ExtensionError(
-                f"Invalid label for save data instruction, {label} must be a string."
-            )
+            raise TypeError(f"Invalid label for save data instruction, {label} must be a string.")
 
         if params is None:
             params = {}

--- a/qiskit_aer/library/save_instructions/save_expectation_value.py
+++ b/qiskit_aer/library/save_instructions/save_expectation_value.py
@@ -16,7 +16,6 @@ Simulator instruction to save exact operator expectation value.
 from numpy import allclose
 from qiskit.quantum_info import Pauli, SparsePauliOp, Operator
 from qiskit.circuit import QuantumCircuit
-from qiskit.extensions.exceptions import ExtensionError
 from .save_data import SaveAverageData
 
 
@@ -51,7 +50,8 @@ class SaveExpectationValue(SaveAverageData):
                                 values [Default: False].
 
         Raises:
-            ExtensionError: if the input operator is invalid or not Hermitian.
+            ValueError: if the input operator is not Hermitian.
+            TypeError: if the input operator is of invalid type.
 
         .. note::
 
@@ -64,7 +64,7 @@ class SaveExpectationValue(SaveAverageData):
         elif not isinstance(operator, SparsePauliOp):
             operator = SparsePauliOp.from_operator(Operator(operator))
         if not allclose(operator.coeffs.imag, 0):
-            raise ExtensionError("Input operator is not Hermitian.")
+            raise ValueError("Input operator is not Hermitian.")
         params = _expval_params(operator, variance=False)
         super().__init__(
             "save_expval",
@@ -109,7 +109,8 @@ class SaveExpectationValueVariance(SaveAverageData):
                                 values [Default: False].
 
         Raises:
-            ExtensionError: if the input operator is invalid or not Hermitian.
+            ValueError: if the input operator is not Hermitian.
+            TypeError: if the input operator is of invalid type.
 
         .. note::
 
@@ -122,7 +123,7 @@ class SaveExpectationValueVariance(SaveAverageData):
         elif not isinstance(operator, SparsePauliOp):
             operator = SparsePauliOp.from_operator(Operator(operator))
         if not allclose(operator.coeffs.imag, 0):
-            raise ExtensionError("Input operator is not Hermitian.")
+            raise ValueError("Input operator is not Hermitian.")
         params = _expval_params(operator, variance=True)
         super().__init__(
             "save_expval_var",
@@ -142,7 +143,7 @@ def _expval_params(operator, variance=False):
     elif not isinstance(operator, SparsePauliOp):
         operator = SparsePauliOp.from_operator(Operator(operator))
     if not isinstance(operator, SparsePauliOp):
-        raise ExtensionError("Invalid input operator")
+        raise TypeError("Invalid input operator")
 
     params = {}
 
@@ -196,7 +197,8 @@ def save_expectation_value(
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: if the input operator is invalid or not Hermitian.
+        ValueError: if the input operator is not Hermitian.
+        TypeError: if the input operator is of invalid type.
 
     .. note::
 
@@ -237,7 +239,8 @@ def save_expectation_value_variance(
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: if the input operator is invalid or not Hermitian.
+        ValueError: if the input operator is not Hermitian.
+        TypeError: if the input operator is of invalid type.
 
     .. note::
 

--- a/qiskit_aer/library/set_instructions/set_density_matrix.py
+++ b/qiskit_aer/library/set_instructions/set_density_matrix.py
@@ -14,7 +14,6 @@ Instruction to set the density matrix simulator state to a matrix.
 """
 
 from qiskit.circuit import QuantumCircuit, Instruction
-from qiskit.extensions.exceptions import ExtensionError
 from qiskit.quantum_info import DensityMatrix
 from ..default_qubits import default_qubits
 
@@ -31,7 +30,7 @@ class SetDensityMatrix(Instruction):
             state (DensityMatrix): a density matrix.
 
         Raises:
-            ExtensionError: if the input density matrix is not valid.
+            ValueError: if the input density matrix is not valid.
 
         .. note::
 
@@ -42,7 +41,7 @@ class SetDensityMatrix(Instruction):
         if not isinstance(state, DensityMatrix):
             state = DensityMatrix(state)
         if not state.num_qubits or not state.is_valid():
-            raise ExtensionError("The input state is not valid")
+            raise ValueError("The input state is not valid")
         super().__init__("set_density_matrix", state.num_qubits, 0, [state.data])
 
 
@@ -56,8 +55,8 @@ def set_density_matrix(self, state):
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: If the density matrix is the incorrect size for the
-                        current circuit.
+        ValueError: If the density matrix is the incorrect size for the
+            current circuit.
 
     .. note:
 
@@ -67,7 +66,7 @@ def set_density_matrix(self, state):
     if not isinstance(state, DensityMatrix):
         state = DensityMatrix(state)
     if not state.num_qubits or state.num_qubits != len(qubits):
-        raise ExtensionError(
+        raise ValueError(
             "The size of the density matrix for the set state"
             " instruction must be equal to the number of qubits"
             f" in the circuit (state.num_qubits ({state.num_qubits})"

--- a/qiskit_aer/library/set_instructions/set_matrix_product_state.py
+++ b/qiskit_aer/library/set_instructions/set_matrix_product_state.py
@@ -14,7 +14,6 @@ Instruction to set the state simulator state to a matrix.
 """
 
 from qiskit.circuit import QuantumCircuit, Instruction
-from qiskit.extensions.exceptions import ExtensionError
 from ..default_qubits import default_qubits
 
 
@@ -52,7 +51,7 @@ def set_matrix_product_state(self, state):
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: If the structure of the state is incorrect
+        ValueError: If the structure of the state is incorrect
 
     .. note:
 
@@ -60,21 +59,21 @@ def set_matrix_product_state(self, state):
     """
     qubits = default_qubits(self)
     if not isinstance(state, tuple) or len(state) != 2:
-        raise ExtensionError(
+        raise ValueError(
             "The input matrix product state is not valid.  Should be a list of 2 elements"
         )
     if not isinstance(state[0], list) or not isinstance(state[1], list):
-        raise ExtensionError(
+        raise ValueError(
             "The first element of the input matrix product state is not valid. Should be a list."
         )
     if len(state[0]) != len(state[1]) + 1:
-        raise ExtensionError(
+        raise ValueError(
             "The input matrix product state is not valid. "
             "Length of q_reg vector should be 1 more than length of lambda_reg"
         )
     for elem in state[0]:
         if not isinstance(elem, tuple) or len(elem) != 2:
-            raise ExtensionError(
+            raise ValueError(
                 "The input matrix product state is not valid."
                 "The first element should be a list of length 2"
             )

--- a/qiskit_aer/library/set_instructions/set_stabilizer.py
+++ b/qiskit_aer/library/set_instructions/set_stabilizer.py
@@ -14,7 +14,6 @@ Instruction to set the simulator state to a stabilizer state.
 """
 
 from qiskit.circuit import QuantumCircuit, Instruction
-from qiskit.extensions.exceptions import ExtensionError
 from qiskit.quantum_info import StabilizerState, Clifford
 from ..default_qubits import default_qubits
 
@@ -53,8 +52,8 @@ def set_stabilizer(self, state):
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: If the state is the incorrect size for the
-                        current circuit.
+        ValueError: If the state is the incorrect size for the
+            current circuit.
 
     .. note:
 
@@ -66,7 +65,7 @@ def set_stabilizer(self, state):
     if not isinstance(state, Clifford):
         state = Clifford(state)
     if state.num_qubits != len(qubits):
-        raise ExtensionError(
+        raise ValueError(
             "The size of the Clifford for the set_stabilizer"
             " instruction must be equal to the number of qubits"
             f" in the circuit (state.num_qubits ({state.num_qubits})"

--- a/qiskit_aer/library/set_instructions/set_statevector.py
+++ b/qiskit_aer/library/set_instructions/set_statevector.py
@@ -14,7 +14,6 @@ Instruction to set the state simulator state to a matrix.
 """
 
 from qiskit.circuit import QuantumCircuit, Instruction
-from qiskit.extensions.exceptions import ExtensionError
 from qiskit.quantum_info import Statevector
 from ..default_qubits import default_qubits
 
@@ -31,7 +30,7 @@ class SetStatevector(Instruction):
             state (Statevector): a statevector.
 
         Raises:
-            ExtensionError: if the input is not a valid state.
+            ValueError: if the input is not a valid state.
 
         .. note::
 
@@ -42,7 +41,7 @@ class SetStatevector(Instruction):
         if not isinstance(state, Statevector):
             state = Statevector(state)
         if not state.num_qubits or not state.is_valid():
-            raise ExtensionError("The input statevector is not valid")
+            raise ValueError("The input statevector is not valid")
         super().__init__("set_statevector", state.num_qubits, 0, [state.data])
 
 
@@ -56,8 +55,8 @@ def set_statevector(self, state):
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: If the state is the incorrect size for the
-                        current circuit.
+        ValueError: If the state is the incorrect size for the
+            current circuit.
 
     .. note:
 
@@ -67,7 +66,7 @@ def set_statevector(self, state):
     if not isinstance(state, Statevector):
         state = Statevector(state)
     if not state.num_qubits or state.num_qubits != len(qubits):
-        raise ExtensionError(
+        raise ValueError(
             "The size of the statevector for the set_statevector"
             " instruction must be equal to the number of qubits"
             f" in the circuit (state.num_qubits ({state.num_qubits})"

--- a/qiskit_aer/library/set_instructions/set_superop.py
+++ b/qiskit_aer/library/set_instructions/set_superop.py
@@ -14,7 +14,6 @@ Instruction to set the state simulator state to a superop matrix.
 """
 
 from qiskit.circuit import QuantumCircuit, Instruction
-from qiskit.extensions.exceptions import ExtensionError
 from qiskit.quantum_info import SuperOp
 from ..default_qubits import default_qubits
 
@@ -31,7 +30,7 @@ class SetSuperOp(Instruction):
             state (QuantumChannel): A CPTP quantum channel.
 
         Raises:
-            ExtensionError: if the input QuantumChannel is not CPTP.
+            ValueError: if the input QuantumChannel is not CPTP.
 
         .. note::
 
@@ -42,7 +41,7 @@ class SetSuperOp(Instruction):
         if not isinstance(state, SuperOp):
             state = SuperOp(state)
         if not state.num_qubits or not state.is_cptp():
-            raise ExtensionError("The input quantum channel is not CPTP")
+            raise ValueError("The input quantum channel is not CPTP")
         super().__init__("set_superop", state.num_qubits, 0, [state.data])
 
 
@@ -56,9 +55,8 @@ def set_superop(self, state):
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: If the state is the incorrect size for the
-                        current circuit.
-        ExtensionError: if the input QuantumChannel is not CPTP.
+        ValueError: If the state is the incorrect size for the current circuit.
+        ValueError: if the input QuantumChannel is not CPTP.
 
     .. note:
 
@@ -68,7 +66,7 @@ def set_superop(self, state):
     if not isinstance(state, SuperOp):
         state = SuperOp(state)
     if not state.num_qubits or state.num_qubits != len(qubits):
-        raise ExtensionError(
+        raise ValueError(
             "The size of the quantum channel for the set_superop"
             " instruction must be equal to the number of qubits"
             f" in the circuit (state.num_qubits ({state.num_qubits})"

--- a/qiskit_aer/library/set_instructions/set_unitary.py
+++ b/qiskit_aer/library/set_instructions/set_unitary.py
@@ -14,7 +14,6 @@ Instruction to set the state simulator state to a matrix.
 """
 
 from qiskit.circuit import QuantumCircuit, Instruction
-from qiskit.extensions.exceptions import ExtensionError
 from qiskit.quantum_info import Operator
 from ..default_qubits import default_qubits
 
@@ -31,7 +30,7 @@ class SetUnitary(Instruction):
             state (Operator): A unitary matrix.
 
         Raises:
-            ExtensionError: if the input matrix is not state.
+            ValueError: if the input matrix is not state.
 
         .. note::
 
@@ -42,7 +41,7 @@ class SetUnitary(Instruction):
         if not isinstance(state, Operator):
             state = Operator(state)
         if not state.num_qubits or not state.is_unitary():
-            raise ExtensionError("The input matrix is not unitary")
+            raise ValueError("The input matrix is not unitary")
         super().__init__("set_unitary", state.num_qubits, 0, [state.data])
 
 
@@ -56,9 +55,8 @@ def set_unitary(self, state):
         QuantumCircuit: with attached instruction.
 
     Raises:
-        ExtensionError: If the state is the incorrect size for the
-                        current circuit.
-        ExtensionError: if the input matrix is not unitary.
+        ValueError: If the state is the incorrect size for the current circuit.
+        ValueError: if the input matrix is not unitary.
 
     .. note:
 
@@ -68,7 +66,7 @@ def set_unitary(self, state):
     if not isinstance(state, Operator):
         state = Operator(state)
     if not state.num_qubits or state.num_qubits != len(qubits):
-        raise ExtensionError(
+        raise ValueError(
             "The size of the unitary matrix for the set_unitary"
             " instruction must be equal to the number of qubits"
             f" in the circuit (state.num_qubits ({state.num_qubits})"

--- a/qiskit_aer/noise/errors/quantum_error.py
+++ b/qiskit_aer/noise/errors/quantum_error.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from qiskit.circuit import QuantumCircuit, Instruction, QuantumRegister, Reset
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.circuit.library.generalized_gates import PauliGate
+from qiskit.circuit.library.generalized_gates import PauliGate, UnitaryGate
 from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.base_operator import BaseOperator
@@ -30,7 +30,6 @@ from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
 from qiskit.quantum_info.operators.mixins import TolerancesMixin
 from qiskit.quantum_info.operators.predicates import is_identity_matrix
 from qiskit.quantum_info.operators.symplectic import Clifford
-from qiskit.extensions import UnitaryGate
 from ..noiseerror import NoiseError
 
 

--- a/qiskit_aer/noise/errors/standard_errors.py
+++ b/qiskit_aer/noise/errors/standard_errors.py
@@ -19,8 +19,8 @@ import numpy as np
 
 from qiskit.circuit import Reset
 from qiskit.circuit.library.standard_gates import IGate, XGate, ZGate
+from qiskit.circuit.library.generalized_gates import UnitaryGate
 from qiskit.exceptions import QiskitError
-from qiskit.extensions import UnitaryGate
 from qiskit.quantum_info.operators import Pauli
 from qiskit.quantum_info.operators.channel import Choi, Kraus
 from qiskit.quantum_info.operators.predicates import is_identity_matrix

--- a/qiskit_aer/noise/noise_model.py
+++ b/qiskit_aer/noise/noise_model.py
@@ -23,8 +23,7 @@ import numpy as np
 from qiskit.circuit import Instruction, Delay
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import Reset
-from qiskit.circuit.library.generalized_gates import PauliGate
-from qiskit.extensions import UnitaryGate
+from qiskit.circuit.library.generalized_gates import PauliGate, UnitaryGate
 from qiskit.providers import QubitProperties
 from qiskit.providers.exceptions import BackendPropertyError
 from qiskit.providers.models import BackendProperties

--- a/test/terra/extensions/test_save_amplitudes.py
+++ b/test/terra/extensions/test_save_amplitudes.py
@@ -13,7 +13,6 @@
 
 import unittest
 
-from qiskit.extensions.exceptions import ExtensionError
 from qiskit_aer.library import SaveAmplitudes
 from ..common import QiskitAerTestCase
 
@@ -23,11 +22,11 @@ class TestSaveAmplitudes(QiskitAerTestCase):
 
     def test_invalid_key_raises(self):
         """Test save instruction key is str"""
-        self.assertRaises(ExtensionError, lambda: SaveAmplitudes(1, [0], 1))
+        self.assertRaises(TypeError, lambda: SaveAmplitudes(1, [0], 1))
 
     def test_invalid_state_raises(self):
         """Test non-Hermitian op raises exception."""
-        self.assertRaises(ExtensionError, lambda: SaveAmplitudes(2, [4], "key"))
+        self.assertRaises(ValueError, lambda: SaveAmplitudes(2, [4], "key"))
 
     def test_default_kwarg(self):
         """Test default kwargs"""

--- a/test/terra/extensions/test_save_expval.py
+++ b/test/terra/extensions/test_save_expval.py
@@ -13,7 +13,6 @@
 import unittest
 
 
-from qiskit.extensions.exceptions import ExtensionError
 from qiskit_aer.library import SaveExpectationValue, SaveExpectationValueVariance
 from qiskit.quantum_info.operators import Pauli
 
@@ -25,12 +24,12 @@ class TestSaveExpectationValue(QiskitAerTestCase):
 
     def test_invalid_key_raises(self):
         """Test save instruction key is str"""
-        self.assertRaises(ExtensionError, lambda: SaveExpectationValue(Pauli("Z"), 1))
+        self.assertRaises(TypeError, lambda: SaveExpectationValue(Pauli("Z"), 1))
 
     def test_nonhermitian_raises(self):
         """Test non-Hermitian op raises exception."""
         op = [[0, 1j], [1j, 0]]
-        self.assertRaises(ExtensionError, lambda: SaveExpectationValue(op, "expval"))
+        self.assertRaises(ValueError, lambda: SaveExpectationValue(op, "expval"))
 
     def test_default_kwarg(self):
         """Test default kwargs"""
@@ -86,12 +85,12 @@ class TestSaveExpectationValueVariance(QiskitAerTestCase):
 
     def test_invalid_key_raises(self):
         """Test save instruction key is str"""
-        self.assertRaises(ExtensionError, lambda: SaveExpectationValueVariance(Pauli("Z"), 1))
+        self.assertRaises(TypeError, lambda: SaveExpectationValueVariance(Pauli("Z"), 1))
 
     def test_nonhermitian_raises(self):
         """Test non-Hermitian op raises exception."""
         op = [[0, 1j], [1j, 0]]
-        self.assertRaises(ExtensionError, lambda: SaveExpectationValueVariance(op, "expval"))
+        self.assertRaises(ValueError, lambda: SaveExpectationValueVariance(op, "expval"))
 
     def test_default_kwarg(self):
         """Test default kwargs"""

--- a/test/terra/noise/test_noise_transformation.py
+++ b/test/terra/noise/test_noise_transformation.py
@@ -19,9 +19,8 @@ import unittest
 import numpy
 
 from qiskit.circuit import Reset
-from qiskit.circuit.library.standard_gates import IGate
-from qiskit.circuit.library.standard_gates import XGate, YGate, ZGate, HGate, SGate
-from qiskit.extensions import UnitaryGate
+from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate, HGate, SGate
+from qiskit.circuit.library.generalized_gates import UnitaryGate
 from qiskit.quantum_info.operators.channel import Kraus
 from qiskit.quantum_info.random import random_unitary
 from qiskit_aer.noise import NoiseModel

--- a/test/terra/noise/test_quantum_error.py
+++ b/test/terra/noise/test_quantum_error.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from qiskit.circuit import QuantumCircuit, Reset, Measure
 from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
-from qiskit.extensions import UnitaryGate
+from qiskit.circuit.library.generalized_gates import UnitaryGate
 from qiskit.quantum_info.operators import SuperOp, Kraus, Pauli
 from qiskit_aer.noise import QuantumError, pauli_error, reset_error
 from qiskit_aer.noise.noiseerror import NoiseError


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The ``qiskit.extensions`` module has been pending deprecation since Qiskit 0.45. It is deprecated for 0.46 and removed in 1.0.

This is blocking Qiskit/qiskit#11488 and Qiskit/qiskit#11498.

### Details and comments

This removal concerns the import location of ``UnitaryGate`` and the usage of the ``ExtensionError``. The first is easily fixed, whereas for the latter I tried using ``ValueError`` or ``TypeError``, which seemed to cover the error meanings. Technically, this is a breaking change and we could introduce an intermediary class that inherits from the deprecated ``ExtensionError`` and the new choice of error. However, since we will soon be changing to 1.0 and we also skipped this in Qiskit Terra (as we thought it highly unlikely that users are actually relying on this error type) it might be fine to just change the error type.
