### PR TITLE
Fix GPU wheel builds on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,7 +135,6 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
-          remove-docker-images: 'true'
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         name: Install Python
@@ -179,7 +178,6 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
-          remove-docker-images: 'true'
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         name: Install Python


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

For the previous few releases the GPU wheel builds have failed to upload. The root cause of this issue was that an earlier CI stage was deleting on the locally cached docker images to free up space for installing CUDA and all the GPU build requirements in the test VM. Removing these docker images prevented the upstream action we run to publish the wheels from working as it relied on having a docker image available that couldn't be fetched from the default image repository. This commit fixes this issue for future releases by ensuring we don't delete the local docker cache in the GPU publish jobs. For the 0.13.2 releases this was manually applied and run to publish the wheels and this PR is applying the fix for future releases.


### Details and comments