### PR TITLE
Fix test cases for Qiskit 0.45.2

### DIFF
--- a/releasenotes/notes/fix_test_for_Qiskit0.45.2-e0544949be8e77fb.yaml
+++ b/releasenotes/notes/fix_test_for_Qiskit0.45.2-e0544949be8e77fb.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixes test cases failed due to upgrade of Qiskit.
+
+    Removed importing Aer from qiskit.
+
+    QuantumCircuit.diagonal was deprecated, using circuit.library.Diagonal instead
+
+    Replace unittest.TestCase to testtools.TestCase to remove warmings on Python 3.12

--- a/releasenotes/notes/fix_test_for_Qiskit0.45.2-e0544949be8e77fb.yaml
+++ b/releasenotes/notes/fix_test_for_Qiskit0.45.2-e0544949be8e77fb.yaml
@@ -6,5 +6,3 @@ fixes:
     Removed importing Aer from qiskit.
 
     QuantumCircuit.diagonal was deprecated, using circuit.library.Diagonal instead
-
-    Replace unittest.TestCase to testtools.TestCase to remove warmings on Python 3.12

--- a/test/benchmark/vqe_application.py
+++ b/test/benchmark/vqe_application.py
@@ -16,14 +16,13 @@ import sys
 import numpy as np
 import multiprocessing
 from time import time
-from qiskit import Aer
 from qiskit.aqua.algorithms import VQE
 from qiskit.aqua.components.optimizers import SLSQP
 from qiskit.chemistry.applications import MolecularGroundStateEnergy
 from qiskit.chemistry.components.initial_states import HartreeFock
 from qiskit.chemistry.components.variational_forms import UCCSD
 from qiskit.chemistry.drivers import PySCFDriver, UnitsType
-
+from qiskit_aer import AerProvider
 
 class UCCSDBenchmarkSuite:
     def __init__(self, name="uccsd_benchmark"):
@@ -67,7 +66,7 @@ class UCCSDBenchmarkSuite:
                 optimizer=SLSQP(maxiter=5000),
                 max_evals_grouped=256,
             )
-            vqe.quantum_instance = Aer.get_backend("qasm_simulator")
+            vqe.quantum_instance = AerProvider.get_backend("qasm_simulator")
             vqe.quantum_instance.backend_options["backend_options"] = {
                 "max_parallel_experiments": threads,
                 "method": method,

--- a/test/benchmark/vqe_application.py
+++ b/test/benchmark/vqe_application.py
@@ -24,6 +24,7 @@ from qiskit.chemistry.components.variational_forms import UCCSD
 from qiskit.chemistry.drivers import PySCFDriver, UnitsType
 from qiskit_aer import AerProvider
 
+
 class UCCSDBenchmarkSuite:
     def __init__(self, name="uccsd_benchmark"):
         self.mol_strings = {

--- a/test/terra/backends/aer_simulator/test_truncate.py
+++ b/test/terra/backends/aer_simulator/test_truncate.py
@@ -9,7 +9,7 @@
 AerSimulator Integration Tests
 """
 from ddt import ddt
-from qiskit import transpile, QuantumCircuit, Aer
+from qiskit import transpile, QuantumCircuit
 from qiskit.providers.fake_provider import FakeQuito
 from qiskit_aer.noise import NoiseModel
 from test.terra.backends.simulator_test_case import SimulatorTestCase, supported_methods

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -18,7 +18,7 @@ import inspect
 import logging
 import os
 import warnings
-import testtools
+import unittest
 from enum import Enum
 from itertools import repeat
 from math import pi
@@ -44,7 +44,7 @@ class Path(Enum):
 
 
 @enforce_subclasses_call(["setUp", "setUpClass", "tearDown", "tearDownClass"])
-class BaseQiskitAerTestCase(testtools.TestCase):
+class BaseQiskitAerTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__setup_called = False

--- a/test/terra/common.py
+++ b/test/terra/common.py
@@ -18,7 +18,7 @@ import inspect
 import logging
 import os
 import warnings
-import unittest
+import testtools
 from enum import Enum
 from itertools import repeat
 from math import pi
@@ -44,7 +44,7 @@ class Path(Enum):
 
 
 @enforce_subclasses_call(["setUp", "setUpClass", "tearDown", "tearDownClass"])
-class BaseQiskitAerTestCase(unittest.TestCase):
+class BaseQiskitAerTestCase(testtools.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__setup_called = False

--- a/test/terra/reference/ref_diagonal_gate.py
+++ b/test/terra/reference/ref_diagonal_gate.py
@@ -17,10 +17,7 @@ Test circuits and reference outputs for diagonal instruction.
 
 import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
-
-# Backwards compatibility for Terra <= 0.13
-if not hasattr(QuantumCircuit, "diagonal"):
-    QuantumCircuit.diagonal = QuantumCircuit.diag_gate
+from qiskit.circuit.library import Diagonal
 
 
 def diagonal_gate_circuits_deterministic(final_measure=True):
@@ -41,7 +38,7 @@ def diagonal_gate_circuits_deterministic(final_measure=True):
         for diag in [arg, np.array(arg), np.array(arg, dtype=float), np.array(arg, dtype=complex)]:
             circuit = QuantumCircuit(*regs)
             circuit.h(qubit)
-            circuit.diagonal(list(diag), [qubit])
+            circuit.append(Diagonal(diag), [qubit])
             circuit.h(qubit)
             if final_measure:
                 circuit.barrier(qr)
@@ -53,7 +50,7 @@ def diagonal_gate_circuits_deterministic(final_measure=True):
     for diag in [arg, np.array(arg), np.array(arg, dtype=float), np.array(arg, dtype=complex)]:
         circuit = QuantumCircuit(*regs)
         circuit.h(qr)
-        circuit.diagonal(list(diag), qr)
+        circuit.append(Diagonal(diag), qr)
         circuit.h(qr)
         if final_measure:
             circuit.barrier(qr)
@@ -64,7 +61,7 @@ def diagonal_gate_circuits_deterministic(final_measure=True):
     for diag in [np.array([1, 1, 1, np.exp(-1j * np.pi / k)]) for k in [10, 100, 1000, 10000]]:
         circuit = QuantumCircuit(*regs)
         circuit.x(qr)
-        circuit.diagonal(list(diag), qr)
+        circuit.append(Diagonal(diag), qr)
         if final_measure:
             circuit.barrier(qr)
             circuit.measure(qr, cr)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is fix of test cases for update on the latest Qiskit


### Details and comments
Removed unnecessary `from qiskit import Aer `

Using `circuit.library.Diagonal` instead of deprecated `QuantumCircuit.diagonal`

<s>Replace unittest.TestCase to testtools.TestCase to remove warmings on Python 3.12</s> reverted because  testtools.TestCase does not have subTest
