### PR TITLE
Remove remaining diagonal, isometry and uc

### DIFF
--- a/test/terra/backends/aer_simulator/test_conditional.py
+++ b/test/terra/backends/aer_simulator/test_conditional.py
@@ -12,12 +12,12 @@
 """
 AerSimulator Integration Tests
 """
-
 from ddt import ddt
 from test.terra.reference import ref_conditionals
 from test.terra.backends.simulator_test_case import SimulatorTestCase, supported_methods
 
-from qiskit import QuantumCircuit
+from qiskit import transpile, QuantumCircuit
+from qiskit.circuit.library import DiagonalGate
 
 
 @ddt
@@ -366,13 +366,13 @@ class TestConditionalDiagonal(SimulatorTestCase):
         circuit0 = QuantumCircuit(4, 4)
         for i in range(1, 4):
             circuit0.h(i)
-        circuit0.diagonal([-1, -1], [1]).c_if(circuit0.clbits[0], 0)
+        circuit0.append(DiagonalGate([-1, -1]), [1]).c_if(circuit0.clbits[0], 0)
         circuit0.save_statevector(label="diff")
 
         circuit1 = QuantumCircuit(4, 4)
         for i in range(1, 4):
             circuit1.h(i)
-        circuit1.diagonal([-1, -1], [1]).c_if(circuit1.clbits[0], 1)
+        circuit1.append(DiagonalGate([-1, -1]), [1]).c_if(circuit1.clbits[0], 1)
         circuit1.save_statevector(label="equal")
 
         result = backend.run([circuit, circuit0, circuit1], shots=1).result()

--- a/test/terra/backends/aer_simulator/test_conditional.py
+++ b/test/terra/backends/aer_simulator/test_conditional.py
@@ -16,7 +16,7 @@ from ddt import ddt
 from test.terra.reference import ref_conditionals
 from test.terra.backends.simulator_test_case import SimulatorTestCase, supported_methods
 
-from qiskit import transpile, QuantumCircuit
+from qiskit import QuantumCircuit
 from qiskit.circuit.library import DiagonalGate
 
 

--- a/test/terra/reference/ref_diagonal_gate.py
+++ b/test/terra/reference/ref_diagonal_gate.py
@@ -17,7 +17,7 @@ Test circuits and reference outputs for diagonal instruction.
 
 import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
-from qiskit.circuit.library import Diagonal
+from qiskit.circuit.library import DiagonalGate
 
 
 def diagonal_gate_circuits_deterministic(final_measure=True):
@@ -38,7 +38,7 @@ def diagonal_gate_circuits_deterministic(final_measure=True):
         for diag in [arg, np.array(arg), np.array(arg, dtype=float), np.array(arg, dtype=complex)]:
             circuit = QuantumCircuit(*regs)
             circuit.h(qubit)
-            circuit.append(Diagonal(diag), [qubit])
+            circuit.append(DiagonalGate(diag), [qubit])
             circuit.h(qubit)
             if final_measure:
                 circuit.barrier(qr)
@@ -50,7 +50,7 @@ def diagonal_gate_circuits_deterministic(final_measure=True):
     for diag in [arg, np.array(arg), np.array(arg, dtype=float), np.array(arg, dtype=complex)]:
         circuit = QuantumCircuit(*regs)
         circuit.h(qr)
-        circuit.append(Diagonal(diag), qr)
+        circuit.append(DiagonalGate(diag), qr)
         circuit.h(qr)
         if final_measure:
             circuit.barrier(qr)
@@ -61,7 +61,7 @@ def diagonal_gate_circuits_deterministic(final_measure=True):
     for diag in [np.array([1, 1, 1, np.exp(-1j * np.pi / k)]) for k in [10, 100, 1000, 10000]]:
         circuit = QuantumCircuit(*regs)
         circuit.x(qr)
-        circuit.append(Diagonal(diag), qr)
+        circuit.append(DiagonalGate(diag), qr)
         if final_measure:
             circuit.barrier(qr)
             circuit.measure(qr, cr)

--- a/test/terra/reference/ref_multiplexer.py
+++ b/test/terra/reference/ref_multiplexer.py
@@ -27,6 +27,7 @@ from test.terra.reference.ref_non_clifford import (
 from qiskit.quantum_info.states import Statevector
 from qiskit.circuit.library import Isometry, UCGate
 
+
 def multiplexer_cx_gate_circuits_deterministic(final_measure=True):
     """multiplexer-gate simulating cx gate, test circuits with deterministic counts."""
     circuits = []

--- a/test/terra/reference/ref_multiplexer.py
+++ b/test/terra/reference/ref_multiplexer.py
@@ -25,7 +25,7 @@ from test.terra.reference.ref_non_clifford import (
     ccx_gate_counts_deterministic,
 )
 from qiskit.quantum_info.states import Statevector
-
+from qiskit.circuit.library import Isometry, UCGate
 
 def multiplexer_cx_gate_circuits_deterministic(final_measure=True):
     """multiplexer-gate simulating cx gate, test circuits with deterministic counts."""
@@ -289,14 +289,14 @@ def multiplexer_no_control_qubits(final_measure=True):
     qc = QuantumCircuit(1, 1)
     vector = [0.2, 0.1]
     vector_circuit = QuantumCircuit(1)
-    vector_circuit.isometry(vector / np.linalg.norm(vector), [0], None)
+    vector_circuit.append(Isometry(vector / np.linalg.norm(vector), 0, 0), [0])
     vector_circuit = vector_circuit.inverse()
     qc.append(vector_circuit, [0])
 
     sv = Statevector(qc)
     gate_list = [np.array([[sv[0], -sv[1]], [sv[1], sv[0]]])]
     qc = QuantumCircuit(1, 1)
-    qc.uc(gate_list, [], [0])
+    qc.append(UCGate(gate_list), [0])
 
     if final_measure:
         qc.measure(0, 0)

--- a/test/terra/states/test_aer_state.py
+++ b/test/terra/states/test_aer_state.py
@@ -20,6 +20,8 @@ import numpy as np
 from qiskit.circuit import QuantumCircuit, Gate
 from qiskit.quantum_info.random import random_unitary
 from qiskit.quantum_info import random_statevector, random_density_matrix
+from qiskit.circuit.library import DiagonalGate
+
 from qiskit_aer import AerSimulator
 
 from test.terra import common
@@ -375,9 +377,9 @@ class TestAerState(common.QiskitAerTestCase):
 
         circuit = QuantumCircuit(5)
         circuit.initialize(init_state, [0, 1, 2, 3, 4])
-        circuit.diagonal(diag_1, [0])
-        circuit.diagonal(diag_2, [1, 2])
-        circuit.diagonal(diag_3, [3, 4, 0])
+        circuit.append(DiagonalGate(diag_1), [0])
+        circuit.append(DiagonalGate(diag_2), [1, 2])
+        circuit.append(DiagonalGate(diag_3), [3, 4, 0])
         circuit.save_statevector()
 
         aer_simulator = AerSimulator(method="statevector")

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -34,6 +34,7 @@ from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
 from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit.visualization.state_visualization import state_to_latex
 from qiskit.circuit.library import QFT, HGate
+from qiskit.circuit.library import DiagonalGate
 
 from test.terra import common
 from qiskit_aer import AerSimulator
@@ -289,7 +290,7 @@ class TestAerStatevector(common.QiskitAerTestCase):
         circuit = QuantumCircuit(3)
         circuit.h(range(3))
         diagonal = [1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, -1.0]
-        circuit.diagonal(diagonal, list(range(3)))
+        circuit.append(DiagonalGate(diagonal), list(range(3)))
         target = AerStatevector.from_label("000").evolve(Operator(circuit))
         psi = AerStatevector.from_instruction(circuit)
         self.assertEqual(psi, target)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR removed remaining diagonal, isometry and uc that causes test failure with the latest Qiskit


### Details and comments
Removed `circuit.diagonal` used in test cases and replaced to `circuit.append(DiagonalGate(), [])`
Replacing isometry and uc as well
