### PR TITLE
Add private primitive attributes removed by qiskit

### DIFF
--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -209,7 +209,8 @@ class Estimator(BaseEstimator):
             parameter_values,
             **run_options,
         )
-        job._submit()
+        # The public submit method was removed in Qiskit 0.46
+        (job.submit if hasattr(job, "submit") else job._submit)()
         return job
 
     def _compute(self, circuits, observables, parameter_values, run_options):

--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -98,7 +98,7 @@ class Estimator(BaseEstimator):
         """
         super().__init__(options=run_options)
         # These three private attributes used to be created by super, but were deprecated in Qiskit
-        # 0.46. See https://github.com/Qiskit/qiskit/pull/11051/files
+        # 0.46. See https://github.com/Qiskit/qiskit/pull/11051
         self._circuits = []
         self._parameters = []
         self._observables = []

--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -209,7 +209,7 @@ class Estimator(BaseEstimator):
             parameter_values,
             **run_options,
         )
-        job.submit()
+        job._submit()
         return job
 
     def _compute(self, circuits, observables, parameter_values, run_options):

--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -97,6 +97,11 @@ class Estimator(BaseEstimator):
                 If approximation is True, this parameter is ignored and assumed to be False.
         """
         super().__init__(options=run_options)
+        # These three private attributes used to be created by super, but were deprecated in Qiskit
+        # 0.46. See https://github.com/Qiskit/qiskit/pull/11051/files
+        self._circuits = []
+        self._parameters = []
+        self._observables = []
 
         backend_options = {} if backend_options is None else backend_options
         method = (

--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -210,7 +210,7 @@ class Estimator(BaseEstimator):
             **run_options,
         )
         # The public submit method was removed in Qiskit 0.46
-        (job.submit if hasattr(job, "submit") else job._submit)()
+        (job.submit if hasattr(job, "submit") else job._submit)()  # pylint: disable=no-member
         return job
 
     def _compute(self, circuits, observables, parameter_values, run_options):

--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -163,7 +163,7 @@ class Sampler(BaseSampler):
                 self._parameters.append(circuit.parameters)
         job = PrimitiveJob(self._call, circuit_indices, parameter_values, **run_options)
         # The public submit method was removed in Qiskit 0.46
-        (job.submit if hasattr(job, "submit") else job._submit)()
+        (job.submit if hasattr(job, "submit") else job._submit)()  # pylint: disable=no-member
         return job
 
     @staticmethod

--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -162,7 +162,8 @@ class Sampler(BaseSampler):
                 self._circuits.append(circuit)
                 self._parameters.append(circuit.parameters)
         job = PrimitiveJob(self._call, circuit_indices, parameter_values, **run_options)
-        job._submit()
+        # The public submit method was removed in Qiskit 0.46
+        (job.submit if hasattr(job, "submit") else job._submit)()
         return job
 
     @staticmethod

--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -67,8 +67,8 @@ class Sampler(BaseSampler):
             skip_transpilation: if True, transpilation is skipped.
         """
         super().__init__(options=run_options)
-        # these two private attributes were deprecated in Qiskit 0.46
-        # https://github.com/Qiskit/qiskit/pull/11051/files
+        # These two private attributes used to be created by super, but were deprecated in Qiskit
+        # 0.46. See https://github.com/Qiskit/qiskit/pull/11051
         self._circuits = []
         self._parameters = []
 

--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -162,7 +162,7 @@ class Sampler(BaseSampler):
                 self._circuits.append(circuit)
                 self._parameters.append(circuit.parameters)
         job = PrimitiveJob(self._call, circuit_indices, parameter_values, **run_options)
-        job.submit()
+        job._submit()
         return job
 
     @staticmethod

--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -67,6 +67,11 @@ class Sampler(BaseSampler):
             skip_transpilation: if True, transpilation is skipped.
         """
         super().__init__(options=run_options)
+        # these two private attributes were deprecated in Qiskit 0.46
+        # https://github.com/Qiskit/qiskit/pull/11051/files
+        self._circuits = []
+        self._parameters = []
+
         self._backend = AerSimulator()
         backend_options = {} if backend_options is None else backend_options
         self._backend.set_options(**backend_options)

--- a/test/terra/primitives/test_estimator.py
+++ b/test/terra/primitives/test_estimator.py
@@ -20,6 +20,7 @@ from test.terra.common import QiskitAerTestCase
 
 import numpy as np
 from ddt import data, ddt
+import qiskit
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.exceptions import QiskitError
@@ -84,6 +85,10 @@ class TestEstimator(QiskitAerTestCase):
             np.testing.assert_allclose(result.values, [-0.4], rtol=0.02)
 
     @data(True, False)
+    @unittest.skipUnless(
+        qiskit.__version__.startswith("0."),
+        reason="Operator support in primitives was removed following Qiskit 0.46",
+    )
     def test_init_observable_from_operator(self, abelian_grouping):
         """test for evaluate without parameters"""
         circuit = self.ansatz.assign_parameters([0, 1, 1, 2, 3, 5])


### PR DESCRIPTION
### Summary

https://github.com/Qiskit/qiskit/pull/11051 removed some private attributes from `Sampler` and `Estimator` in the process of streamlining the API. This PR adds them back in because super() no longer does so.

### Details and comments


