### PR TITLE
Only run sdist build after wheel builds are uploaded

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,6 +94,7 @@ jobs:
   sdist:
     name: Publish qiskit-aer sdist
     runs-on: ubuntu-latest
+    needs: [publish-shared-wheels]
     environment: release
     permissions:
       id-token: write


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the configuration of the deploy workflow to install the sdist last. Publishing the sdist first causes disruption for downstream projects that are using qiskit aer in CI as pip will eagerly try to download the latest version even if only an sdist is present for it. To avoid disruption for downstream users this updates the sdist job to run only after we've uploaded the wheels for the tier 1 platforms to pypi (which is what most people are running in CI).

### Details and comments