### PR TITLE
Fix required memory estimation for MPS

### DIFF
--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -237,10 +237,11 @@ class AerSimulator(AerBackend):
       experiment execution (Default: 0).
 
     * ``max_memory_mb`` (int): Sets the maximum size of memory
-      to store a state vector. If a state vector needs more, an error
-      is thrown. In general, a state vector of n-qubits uses 2^n complex
-      values (16 Bytes). If set to 0, the maximum will be automatically
-      set to the system memory size (Default: 0).
+      to store quantum states. If quantum states need more, an error
+      is thrown unless -1 is set. In general, a state vector of n-qubits
+      uses 2^n complex values (16 Bytes).
+      If set to 0, the maximum will be automatically set to
+      the system memory size (Default: 0).
 
     * ``cuStateVec_enable`` (bool): This option enables accelerating by
       cuStateVec library of cuQuantum from NVIDIA, that has highly optimized

--- a/qiskit_aer/backends/wrappers/aer_controller_binding.hpp
+++ b/qiskit_aer/backends/wrappers/aer_controller_binding.hpp
@@ -139,7 +139,7 @@ void bind_aer_controller(MODULE m) {
   aer_config.def_property(
       "max_memory_mb",
       [](const Config &config) { return config.max_memory_mb.val; },
-      [](Config &config, uint_t val) { config.max_memory_mb.value(val); });
+      [](Config &config, int_t val) { config.max_memory_mb.value(val); });
   aer_config.def_readwrite("fusion_enable", &Config::fusion_enable);
   aer_config.def_readwrite("fusion_verbose", &Config::fusion_verbose);
   aer_config.def_property(

--- a/releasenotes/notes/fix_mps_required_memory_estimation-75a9bb739701046c.yaml
+++ b/releasenotes/notes/fix_mps_required_memory_estimation-75a9bb739701046c.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    Add option to ignore checking system memory availability against
+    required memory if `max_memory_mb=-1` is set
+fixes:
+  - |
+    Fixed required memory size for MPS method. Required memory was wrongly
+    estimated because all the 2-qubits gates increased required memory,
+    but only rxx, ryy and rzx gates (when theta is not multiple of pi/2)
+    and unitary increase memory.

--- a/src/framework/config.hpp
+++ b/src/framework/config.hpp
@@ -81,7 +81,7 @@ struct Config {
   optional<uint_t> max_parallel_threads;
   optional<uint_t> max_parallel_experiments;
   optional<uint_t> max_parallel_shots;
-  optional<uint_t> max_memory_mb;
+  optional<int_t> max_memory_mb;
   bool fusion_enable = true;
   bool fusion_verbose = false;
   optional<uint_t> fusion_max_qubit;

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -328,7 +328,7 @@ size_t State::required_memory_mb(uint_t num_qubits,
                                  const std::vector<Operations::Op> &ops) const {
   if (num_qubits > 1) {
     MPSSizeEstimator est(num_qubits);
-    uint_t size = est.estimate(ops);
+    uint_t size = est.estimate(ops, gateset_);
     return (size >> 20);
   }
   return 0;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes estimation of required memory size for MPS method #2056 

### Details and comments
Estimated too large required memory because memory size was increased by all the 2-qubit gates.

Also this PR adds option to ignore check of required memory vs input circuit if `max_memory_mb=-1` is set
