### PR TITLE
Remove unsupported qiskit-ibmq-provider from docs job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,6 @@ commands = black qiskit_aer test tools setup.py
 deps =
   -r requirements-dev.txt
   build
-  qiskit-ibmq-provider
 commands =
   python -I -m build --wheel -C=--build-option=-j4
   pip install --find-links={toxinidir}/dist qiskit_aer


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The tox docs job definition was previously installing the qiskit-ibmq-provider which is no longer supported and the project is orphaned. This commit fixes this by removing the unnecessary dependency.

### Details and comments
