### PR TITLE
Fix fusion CostBasedFusion::aggregate_operations

### DIFF
--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -1038,7 +1038,8 @@ bool CostBasedFusion::aggregate_operations(oplist_t &ops,
         double estimated_cost =
             estimate_cost(ops, (uint_t)j,
                           i) // fusion gate from j-th to i-th, and
-            + (j == 0 ? 0.0 : costs[j - 1 - fusion_start]); // cost of (j-1)-th
+            + (j <= fusion_start ? 0.0 : costs[j - 1 - fusion_start]);
+                             // cost of (j-1)-th
 
         // update cost
         if (estimated_cost <= costs[i - fusion_start]) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is fix for #2074 

### Details and comments
fixes overrun of cost array

