### PR TITLE
Remove unnecessary numpy build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,6 @@ requires = [
   "cmake!=3.17.1,!=3.17.0",
   "ninja",
   "pybind11>2.6",
-  "oldest-supported-numpy; python_version>'3.7' or platform_machine=='aarch64' or platform_python_implementation=='PyPy'",
-  "numpy==1.16.3; python_version<='3.7' and platform_machine!='aarch64' or platform_python_implementation=='PyPy'",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
numpy C bindings are handled through pybind11 which does not depend on numpy. numpy is otherwise only a runtime dependency of qiskit-aer. This change just saves a download during build.