### PR TITLE
Fix AerCompiler to use custom pass manager to decompose control flow ops

### DIFF
--- a/qiskit_aer/backends/aer_compiler.py
+++ b/qiskit_aer/backends/aer_compiler.py
@@ -36,7 +36,6 @@ from qiskit.circuit.controlflow import (
     SwitchCaseOp,
     CASE_DEFAULT,
 )
-from qiskit.compiler import transpile
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import Decompose
 

--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -517,12 +517,7 @@ class AerBackend(Backend, ABC):
         optypes = [circuit_optypes(circ) for circ in circuits]
 
         # Compile Qasm3 instructions
-        if self._target is not None:
-            circuits, optypes = compile_circuit(
-                circuits, basis_gates=self.configuration().basis_gates, optypes=optypes
-            )
-        else:
-            circuits, optypes = compile_circuit(circuits, optypes=optypes)
+        circuits, optypes = compile_circuit(circuits, optypes=optypes)
 
         # run option noise model
         circuits, noise_model, run_options = self._assemble_noise_model(

--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -517,9 +517,12 @@ class AerBackend(Backend, ABC):
         optypes = [circuit_optypes(circ) for circ in circuits]
 
         # Compile Qasm3 instructions
-        circuits, optypes = compile_circuit(
-            circuits, basis_gates=self.configuration().basis_gates, optypes=optypes
-        )
+        if self._target is not None:
+            circuits, optypes = compile_circuit(
+                circuits, basis_gates=self.configuration().basis_gates, optypes=optypes
+            )
+        else:
+            circuits, optypes = compile_circuit(circuits, optypes=optypes)
 
         # run option noise model
         circuits, noise_model, run_options = self._assemble_noise_model(

--- a/releasenotes/notes/fix_noise_dynamic_circuits-59c6cf0061e956a8.yaml
+++ b/releasenotes/notes/fix_noise_dynamic_circuits-59c6cf0061e956a8.yaml
@@ -5,4 +5,5 @@ fixes:
     transpiled in AerCompiler that causes wrong noise simulation result,
     because some gates noise to be applied were transpiled to other gates.
 
-    Fixes AerCompiler to build basis_gates with input circuit, not to be transpiled
+    This fix uses custom pass manager to decompose only jump and mark ops
+    Aer uses internally.

--- a/releasenotes/notes/fix_noise_dynamic_circuits-59c6cf0061e956a8.yaml
+++ b/releasenotes/notes/fix_noise_dynamic_circuits-59c6cf0061e956a8.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    When the circuit is a dynamic circuit, the input circuit was not correctly
+    transpiled in AerCompiler that causes wrong noise simulation result,
+    because some gates noise to be applied were transpiled to other gates.
+
+    Fixes AerCompiler to build basis_gates with input circuit, not to be transpiled


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is fix for issue #2091 

### Details and comments

This issue was caused by transpiler called inside AerCompiler to build circuit with control flow ops, that translates some gates into unnecessary gate and some labels for noise were dropped. 
To prevent this, this fix uses custom pass manager only with Decompose jump and mark ops
