### PR TITLE
Use sphinx.ext.linkcode for more precise source code links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,8 +226,5 @@ def linkcode_resolve(domain, info):
         ending_lineno = lineno + len(source) - 1
         linespec = f"#L{lineno}-L{ending_lineno}"
 
-    if "qiskit/" in file_name:
-        base_url = "https://github.com/Qiskit/qiskit/tree/"
-    else:
-        base_url = "https://github.com/Qiskit/qiskit-aer/tree/"
-    return f"{base_url}{GITHUB_BRANCH}/{file_name}{linespec}"
+    repo_name = "qiskit" if "qiskit/" in file_name else "qiskit-aer"
+    return f"https://github.com/Qiskit/{repo_name}/tree/{GITHUB_BRANCH}/{file_name}{linespec}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,9 +227,8 @@ def linkcode_resolve(domain, info):
         ending_lineno = lineno + len(source) - 1
         linespec = f"#L{lineno}-L{ending_lineno}"
 
-    github_branch = determine_github_branch()
     if "qiskit/" in file_name:
-        base_url = "https://github.com/Qiskit/qiskit-aer/tree/"
-    else:
         base_url = "https://github.com/Qiskit/qiskit/tree/"
-    return f"{base_url}{github_branch}/{file_name}{linespec}"
+    else:
+        base_url = "https://github.com/Qiskit/qiskit-aer/tree/"
+    return f"{base_url}{GITHUB_BRANCH}/{file_name}{linespec}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,5 +226,5 @@ def linkcode_resolve(domain, info):
         ending_lineno = lineno + len(source) - 1
         linespec = f"#L{lineno}-L{ending_lineno}"
 
-    repo_name = "qiskit" if "qiskit/" in file_name else "qiskit-aer"
+    repo_name = "qiskit" if "qiskit/" in str(file_name) else "qiskit-aer"
     return f"https://github.com/Qiskit/{repo_name}/tree/{GITHUB_BRANCH}/{file_name}{linespec}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,4 +229,8 @@ def linkcode_resolve(domain, info):
         linespec = f"#L{lineno}-L{ending_lineno}"
 
     github_branch = determine_github_branch()
-    return f"https://github.com/Qiskit/qiskit-aer/tree/{github_branch}/{file_name}{linespec}"
+    if "qiskit/" in file_name:
+        base_url = "https://github.com/Qiskit/qiskit-aer/tree/"
+    else:
+        base_url = "https://github.com/Qiskit/qiskit/tree/"
+    return f"{base_url}{github_branch}/{file_name}{linespec}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,6 @@ import inspect
 import os
 import re
 from pathlib import Path
-
 # Set env flag so that we can doc functions that may otherwise not be loaded
 # see for example interactive visualizations in qiskit.visualization.
 os.environ['QISKIT_DOCS'] = 'TRUE'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -214,7 +214,8 @@ def linkcode_resolve(domain, info):
     if full_file_name is None:
         return None
     try:
-        file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
+        relative_file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
+        file_name = re.sub(r"\.tox\/.+\/site-packages\/", "", str(relative_file_name))
     except ValueError:
         return None
 

--- a/releasenotes/notes/switch_source_links_to_link_directly_to_github-bc554dee4f145c7b.yaml
+++ b/releasenotes/notes/switch_source_links_to_link_directly_to_github-bc554dee4f145c7b.yaml
@@ -1,0 +1,5 @@
+
+features:
+  - |
+    Source links in the API documentation will now link to the exact lines in the GitHub repository.
+

--- a/releasenotes/notes/switch_source_links_to_link_directly_to_github-bc554dee4f145c7b.yaml
+++ b/releasenotes/notes/switch_source_links_to_link_directly_to_github-bc554dee4f145c7b.yaml
@@ -1,5 +1,0 @@
-
-features:
-  - |
-    Source links in the API documentation will now link to the exact lines in the GitHub repository.
-

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
   SETUPTOOLS_ENABLE_FEATURES=legacy-editable
+passenv=
+  GITHUB_REF_NAME,
+  GITHUB_BASE_REF
 whitelist_externals = sh
 deps =
   -r requirements-dev.txt


### PR DESCRIPTION
### Summary
This is a follow-up to https://github.com/Qiskit/qiskit/pull/11851 and addresses https://github.com/Qiskit/documentation/issues/517 by switching out the sphinx.ext.viewcode for the sphinx.ext.linkcode extension which allows our GitHub links in the documentation to be linked to the specific lines of code, not just the file. This was tested successfully in https://github.com/Qiskit/qiskit_sphinx_theme/pull/589 so now we want to implement it in the qiskit, runtime, and provider repos.

Example links generated in this PR build:

a class definition https://github.com/Qiskit/qiskit-aer/blob/main/qiskit_aer/backends/aer_simulator.py#L40-L1046
a method https://github.com/Qiskit/qiskit-aer/blob/main/qiskit_aer/noise/noise_model.py#L849-L910
a function https://github.com/Qiskit/qiskit-aer/blob/main/qiskit_aer/utils/noise_transformation.py#L141-L232

### Details and comments
Since some references in the API documentation actually refer to methods from the inherited `qiskit` classes, it was necessary to add a check at the end to change the base url if the method was from the `qiskit` class and link ot the qiskit repo.

