### PR TITLE
Fix tests for the latest Qiskit

### DIFF
--- a/test/terra/backends/aer_simulator/test_chunk.py
+++ b/test/terra/backends/aer_simulator/test_chunk.py
@@ -32,6 +32,7 @@ class TestChunkSimulators(SimulatorTestCase):
     def test_chunk_QuantumVolume(self, method, device):
         """Test multi-chunk with quantum volume"""
         opts = {"blocking_enable": True, "blocking_qubits": 2}
+        opts["basis_gates"] = ["h", "cx", "u3"]
 
         backend = self.backend(method=method, device=device, **opts)
         backend_no_chunk = self.backend(method=method, device=device)
@@ -57,10 +58,12 @@ class TestChunkSimulators(SimulatorTestCase):
         opts_no_chunk = {
             "fusion_enable": True,
             "fusion_threshold": 5,
+            "fusion_max_qubit": 4,
         }
         opts_chunk = copy.copy(opts_no_chunk)
         opts_chunk["blocking_enable"] = True
-        opts_chunk["blocking_qubits"] = 4
+        opts_chunk["blocking_qubits"] = 5
+        opts_chunk["basis_gates"] = ["h", "cx", "u3"]
 
         backend = self.backend(method=method, device=device, **opts_chunk)
         backend_no_chunk = self.backend(method=method, device=device, **opts_no_chunk)

--- a/test/terra/primitives/test_sampler_v2.py
+++ b/test/terra/primitives/test_sampler_v2.py
@@ -513,6 +513,12 @@ class TestSamplerV2(QiskitAerTestCase):
             self.assertEqual(len(result), 1)
             self._assert_allclose(result[0].data.meas, np.array({1: self._shots}))
 
+    def get_data_bin_len(self, data):
+        if "keys" in dir(data):  # qiskit 1.1 or later
+            return len(data.keys())
+        else:
+            return len(astuple(data))
+
     def test_circuit_with_multiple_cregs(self):
         """Test for circuit with multiple classical registers."""
         cases = []
@@ -581,7 +587,7 @@ class TestSamplerV2(QiskitAerTestCase):
                 result = sampler.run([qc], shots=self._shots).result()
                 self.assertEqual(len(result), 1)
                 data = result[0].data
-                self.assertEqual(len(astuple(data)), 3)
+                self.assertEqual(self.get_data_bin_len(data), 3)
                 for creg in qc.cregs:
                     self.assertTrue(hasattr(data, creg.name))
                     self._assert_allclose(getattr(data, creg.name), np.array(target[creg.name]))
@@ -614,7 +620,7 @@ class TestSamplerV2(QiskitAerTestCase):
         result = sampler.run([qc2], shots=self._shots).result()
         self.assertEqual(len(result), 1)
         data = result[0].data
-        self.assertEqual(len(astuple(data)), 3)
+        self.assertEqual(self.get_data_bin_len(data), 3)
         for creg_name in target:
             self.assertTrue(hasattr(data, creg_name))
             self._assert_allclose(getattr(data, creg_name), np.array(target[creg_name]))

--- a/test/terra/states/test_aer_densitymatrix.py
+++ b/test/terra/states/test_aer_densitymatrix.py
@@ -145,12 +145,12 @@ class TestAerDensityMatrix(common.QiskitAerTestCase):
         self.assertEqual(1, len(counts))
         self.assertTrue("0000" in counts)
 
-    def test_single_qubit_QV(self):
+    def test_two_qubit_QV(self):
         """Test single qubit QuantumVolume"""
-        state = AerDensityMatrix(QuantumVolume(1))
+        state = AerDensityMatrix(QuantumVolume(2))
         counts = state.sample_counts(shots=1024)
-        self.assertEqual(1, len(counts))
-        self.assertTrue("0" in counts)
+        self.assertEqual(4, len(counts))
+        self.assertTrue("00" in counts)
 
     def test_evolve(self):
         """Test evolve method for circuits"""

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -153,12 +153,12 @@ class TestAerStatevector(common.QiskitAerTestCase):
             self.assertEqual(1, len(counts))
             self.assertTrue("0000" in counts)
 
-    def test_single_qubit_QV(self):
-        """Test single qubit QuantumVolume"""
-        state = AerStatevector(QuantumVolume(1))
+    def test_two_qubit_QV(self):
+        """Test two qubit QuantumVolume"""
+        state = AerStatevector(QuantumVolume(2))
         counts = state.sample_counts(shots=1024)
-        self.assertEqual(1, len(counts))
-        self.assertTrue("0" in counts)
+        self.assertEqual(4, len(counts))
+        self.assertTrue("00" in counts)
 
     def test_evolve(self):
         """Test method and device properties"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is fix of test cases fails with the latest Qiskit

### Details and comments

The test case with chunk parallelization fails, because qiskit.transpiler returns circuit with large unitary gates from QuantumVolume circuit that can not be cache blocked for chunk parallelization. So for this test I set basis_gates without unitary gate not to be fused by transpiler.

Also modified some tests for the latest Qiskit
