### PR TITLE
Fix cuStateVec_enable option

### DIFF
--- a/releasenotes/notes/fix_enabling_cuStateVec-1a2f1d3e35f3129d.yaml
+++ b/releasenotes/notes/fix_enabling_cuStateVec-1a2f1d3e35f3129d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The option `cuStateVec_enable=True` was not set correctly.
+    This fix set this option to statevector, unitary and density_matrix
+    simulator states classes before allocating their memory

--- a/src/simulators/density_matrix/densitymatrix_state.hpp
+++ b/src/simulators/density_matrix/densitymatrix_state.hpp
@@ -344,6 +344,9 @@ bool State<densmat_t>::allocate(uint_t num_qubits, uint_t block_bits,
     BaseState::qreg_.set_max_sampling_shots(BaseState::max_sampling_shots_);
 
   BaseState::qreg_.set_target_gpus(BaseState::target_gpus_);
+#ifdef AER_CUSTATEVEC
+  BaseState::qreg_.cuStateVec_enable(BaseState::cuStateVec_enable_);
+#endif
   BaseState::qreg_.chunk_setup(block_bits * 2, block_bits * 2, 0, 1);
 
   return true;

--- a/src/simulators/parallel_state_executor.hpp
+++ b/src/simulators/parallel_state_executor.hpp
@@ -339,6 +339,7 @@ bool ParallelStateExecutor<state_t>::allocate_states(uint_t num_states,
         Base::num_threads_per_group_);
     Base::states_[0].set_num_global_qubits(Base::num_qubits_);
 #ifdef AER_CUSTATEVEC
+    Base::states_[0].cuStateVec_enable(Base::cuStateVec_enable_);
     Base::states_[0].qreg().cuStateVec_enable(Base::cuStateVec_enable_);
 #endif
     Base::states_[0].qreg().set_target_gpus(Base::target_gpus_);
@@ -346,6 +347,9 @@ bool ParallelStateExecutor<state_t>::allocate_states(uint_t num_states,
         squbits, gqubits, Base::global_state_index_, num_states);
     for (i = 1; i < num_states_allocated; i++) {
       Base::states_[i].set_config(config);
+#ifdef AER_CUSTATEVEC
+      Base::states_[i].cuStateVec_enable(Base::cuStateVec_enable_);
+#endif
       Base::states_[i].qreg().chunk_setup(Base::states_[0].qreg(),
                                           Base::global_state_index_ + i);
       Base::states_[i].qreg().set_num_threads_per_group(

--- a/src/simulators/parallel_state_executor.hpp
+++ b/src/simulators/parallel_state_executor.hpp
@@ -339,7 +339,7 @@ bool ParallelStateExecutor<state_t>::allocate_states(uint_t num_states,
         Base::num_threads_per_group_);
     Base::states_[0].set_num_global_qubits(Base::num_qubits_);
 #ifdef AER_CUSTATEVEC
-    Base::states_[0].cuStateVec_enable(Base::cuStateVec_enable_);
+    Base::states_[0].enable_cuStateVec(Base::cuStateVec_enable_);
     Base::states_[0].qreg().cuStateVec_enable(Base::cuStateVec_enable_);
 #endif
     Base::states_[0].qreg().set_target_gpus(Base::target_gpus_);
@@ -348,7 +348,7 @@ bool ParallelStateExecutor<state_t>::allocate_states(uint_t num_states,
     for (i = 1; i < num_states_allocated; i++) {
       Base::states_[i].set_config(config);
 #ifdef AER_CUSTATEVEC
-      Base::states_[i].cuStateVec_enable(Base::cuStateVec_enable_);
+      Base::states_[i].enable_cuStateVec(Base::cuStateVec_enable_);
 #endif
       Base::states_[i].qreg().chunk_setup(Base::states_[0].qreg(),
                                           Base::global_state_index_ + i);

--- a/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
+++ b/src/simulators/statevector/chunk/cuStateVec_chunk_container.hpp
@@ -131,7 +131,6 @@ uint_t cuStateVecChunkContainer<data_t>::Allocate(
   nc = BaseContainer::Allocate(idev, chunk_bits, num_qubits, chunks, buffers,
                                multi_shots, matrix_bit, max_shots,
                                density_matrix);
-
   // initialize custatevevtor handle
   custatevecStatus_t err;
 

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -439,6 +439,9 @@ bool State<statevec_t>::allocate(uint_t num_qubits, uint_t block_bits,
     BaseState::qreg_.set_max_sampling_shots(BaseState::max_sampling_shots_);
 
   BaseState::qreg_.set_target_gpus(BaseState::target_gpus_);
+#ifdef AER_CUSTATEVEC
+  BaseState::qreg_.cuStateVec_enable(BaseState::cuStateVec_enable_);
+#endif
   BaseState::qreg_.chunk_setup(block_bits, num_qubits, 0, 1);
 
   return true;

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -383,6 +383,9 @@ bool State<unitary_matrix_t>::allocate(uint_t num_qubits, uint_t block_bits,
     BaseState::qreg_.set_max_matrix_bits(BaseState::max_matrix_qubits_);
 
   BaseState::qreg_.set_target_gpus(BaseState::target_gpus_);
+#ifdef AER_CUSTATEVEC
+  BaseState::qreg_.cuStateVec_enable(BaseState::cuStateVec_enable_);
+#endif
   BaseState::qreg_.chunk_setup(block_bits * 2, num_qubits * 2, 0, 1);
 
   return true;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR is fix for issue #2144 `cuStateVec_enable=True` was not correctly set to the simulators

### Details and comments

`cuStateVec_enable` option was only enabled on parallel simulators since CircuitExecutor classes were implemented.
This fix sets this option correctly before allocating the simulator states.
