### PR TITLE
Add `BaseQuantumError` class

### DIFF
--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -33,7 +33,7 @@ from qiskit.transpiler import CouplingMap
 from ..aererror import AerError
 from ..jobs import AerJob, AerJobSet, split_qobj
 from ..noise.noise_model import NoiseModel, QuantumErrorLocation
-from ..noise.errors.quantum_error import QuantumChannelInstruction
+from ..noise.errors.base_quantum_error import QuantumChannelInstruction
 from .aer_compiler import compile_circuit, assemble_circuits, generate_aer_config
 from .backend_utils import format_save_type, circuit_optypes
 from .name_mapping import NAME_MAPPING

--- a/qiskit_aer/noise/errors/base_quantum_error.py
+++ b/qiskit_aer/noise/errors/base_quantum_error.py
@@ -35,13 +35,7 @@ class BaseQuantumError(BaseOperator):
 
     def __repr__(self):
         """Display QuantumError."""
-        return f"<{self._repr_name}>"
-
-    def __eq__(self, other):
-        """Test if two QuantumErrors are equal as SuperOps"""
-        if not isinstance(other, BaseQuantumError):
-            return False
-        return self.to_quantumchannel() == other.to_quantumchannel()
+        return f"<{self._repr_name()}>"
 
     def __hash__(self):
         return hash(self._id)

--- a/qiskit_aer/noise/errors/base_quantum_error.py
+++ b/qiskit_aer/noise/errors/base_quantum_error.py
@@ -1,0 +1,125 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018-2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Base quantum error class for Aer noise model
+"""
+import copy
+import uuid
+from abc import abstractmethod
+
+from qiskit.circuit import QuantumCircuit, Instruction, QuantumRegister
+from qiskit.quantum_info.operators.base_operator import BaseOperator
+from qiskit.quantum_info.operators.channel import Kraus
+
+
+class BaseQuantumError(BaseOperator):
+    """Base quantum error class for Aer noise model"""
+
+    def __init__(self, num_qubits: int):
+        """Base class for a quantum error supported by Aer."""
+        # Unique ID for BaseQuantumError
+        self._id = uuid.uuid4().hex
+        super().__init__(num_qubits=num_qubits)
+
+    def _repr_name(self) -> str:
+        return f"{type(self).__name__}[{self.id}]"
+
+    def __repr__(self):
+        """Display QuantumError."""
+        return f"<{self._repr_name}>"
+
+    def __eq__(self, other):
+        """Test if two QuantumErrors are equal as SuperOps"""
+        if not isinstance(other, BaseQuantumError):
+            return False
+        return self.to_quantumchannel() == other.to_quantumchannel()
+
+    def __hash__(self):
+        return hash(self._id)
+
+    @property
+    def id(self):  # pylint: disable=invalid-name
+        """Return unique ID string for error"""
+        return self._id
+
+    def copy(self):
+        """Make a copy of current QuantumError."""
+        # pylint: disable=no-value-for-parameter
+        # The constructor of subclasses from raw data should be a copy
+        return copy.deepcopy(self)
+
+    def to_instruction(self):
+        """Convert the QuantumError to a circuit Instruction."""
+        return QuantumChannelInstruction(self)
+
+    @abstractmethod
+    def ideal(self):
+        """Return True if this error object is composed only of identity operations.
+        Note that the identity check is best effort and up to global phase."""
+
+    @abstractmethod
+    def to_quantumchannel(self):
+        """Convert the QuantumError to a SuperOp quantum channel.
+        Required to enable SuperOp(QuantumError)."""
+
+    @abstractmethod
+    def to_dict(self):
+        """Return the current error as a dictionary."""
+
+    @abstractmethod
+    def compose(self, other, qargs=None, front=False):
+        pass
+
+    @abstractmethod
+    def tensor(self, other):
+        pass
+
+    @abstractmethod
+    def expand(self, other):
+        return other.tensor(self)
+
+    def __rmul__(self, other):
+        raise NotImplementedError(
+            f"'{type(self).__name__}' does not support scalar multiplication."
+        )
+
+    def __truediv__(self, other):
+        raise NotImplementedError(f"'{type(self).__name__}' does not support division.")
+
+    def __add__(self, other):
+        raise NotImplementedError(f"'{type(self).__name__}' does not support addition.")
+
+    def __sub__(self, other):
+        raise NotImplementedError(f"'{type(self).__name__}' does not support subtraction.")
+
+    def __neg__(self):
+        raise NotImplementedError(f"'{type(self).__name__}' does not support negation.")
+
+
+class QuantumChannelInstruction(Instruction):
+    """Container instruction for adding BaseQuantumError to circuit"""
+
+    def __init__(self, quantum_error):
+        """Initialize a quantum error circuit instruction.
+
+        Args:
+            quantum_error (BaseQuantumError): the error to add as an instruction.
+        """
+        super().__init__("quantum_channel", quantum_error.num_qubits, 0, [])
+        self._quantum_error = quantum_error
+
+    def _define(self):
+        """Allow unrolling to a Kraus instruction"""
+        q = QuantumRegister(self.num_qubits, "q")
+        qc = QuantumCircuit(q, name=self.name)
+        qc._append(Kraus(self._quantum_error).to_instruction(), q, [])
+        self.definition = qc

--- a/qiskit_aer/noise/errors/quantum_error.py
+++ b/qiskit_aer/noise/errors/quantum_error.py
@@ -12,28 +12,26 @@
 """
 Quantum error class for Aer noise model
 """
-import copy
 import numbers
-import uuid
 from typing import Iterable
-
 import numpy as np
 
-from qiskit.circuit import QuantumCircuit, Instruction, QuantumRegister, Reset
+from qiskit.circuit import QuantumCircuit, Instruction, Reset
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.library.generalized_gates import PauliGate, UnitaryGate
 from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
 from qiskit.exceptions import QiskitError
+from qiskit.quantum_info import Kraus, SuperOp, Clifford, Pauli
 from qiskit.quantum_info.operators.base_operator import BaseOperator
-from qiskit.quantum_info.operators.channel import Kraus, SuperOp
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
 from qiskit.quantum_info.operators.mixins import TolerancesMixin
 from qiskit.quantum_info.operators.predicates import is_identity_matrix
-from qiskit.quantum_info.operators.symplectic import Clifford
+
+from .base_quantum_error import BaseQuantumError
 from ..noiseerror import NoiseError
 
 
-class QuantumError(BaseOperator, TolerancesMixin):
+class QuantumError(BaseQuantumError, TolerancesMixin):
     """
     Quantum error class for Aer noise model
 
@@ -90,9 +88,6 @@ class QuantumError(BaseOperator, TolerancesMixin):
         Raises:
             NoiseError: If input noise_ops is invalid, e.g. it's not a CPTP map.
         """
-        # Unique ID for QuantumError
-        self._id = uuid.uuid4().hex
-
         # Shallow copy constructor
         if isinstance(noise_ops, QuantumError):
             self._circs = noise_ops.circuits
@@ -212,7 +207,10 @@ class QuantumError(BaseOperator, TolerancesMixin):
 
     def __repr__(self):
         """Display QuantumError."""
-        return f"QuantumError({list(zip(self.circuits, self.probabilities))})"
+        return (
+            f"<{self._repr_name()}, num_qubits={self.num_qubits},"
+            f" size={self.size}, probabilities={self.probabilities}>"
+        )
 
     def __str__(self):
         """Print error information."""
@@ -220,26 +218,6 @@ class QuantumError(BaseOperator, TolerancesMixin):
         for j, pair in enumerate(zip(self.probabilities, self.circuits)):
             output += f"\n  P({j}) = {pair[0]}, Circuit = \n{pair[1]}"
         return output
-
-    def __eq__(self, other):
-        """Test if two QuantumErrors are equal as SuperOps"""
-        if not isinstance(other, QuantumError):
-            return False
-        return self.to_quantumchannel() == other.to_quantumchannel()
-
-    def __hash__(self):
-        return hash(self._id)
-
-    @property
-    def id(self):  # pylint: disable=invalid-name
-        """Return unique ID string for error"""
-        return self._id
-
-    def copy(self):
-        """Make a copy of current QuantumError."""
-        # pylint: disable=no-value-for-parameter
-        # The constructor of subclasses from raw data should be a copy
-        return copy.deepcopy(self)
 
     @property
     def size(self):
@@ -296,10 +274,6 @@ class QuantumError(BaseOperator, TolerancesMixin):
             component = prob * SuperOp(circ)
             ret = ret + component
         return ret
-
-    def to_instruction(self):
-        """Convert the QuantumError to a circuit Instruction."""
-        return QuantumChannelInstruction(self)
 
     def error_term(self, position):
         """
@@ -359,7 +333,7 @@ class QuantumError(BaseOperator, TolerancesMixin):
             or ("instructions" not in error)
             or ("probabilities" not in error)
         ):
-            raise NoiseError("erorr dictionary not containing expected keys")
+            raise NoiseError("error dictionary not containing expected keys")
         error_instructions = error["instructions"]
         error_probabilities = error["probabilities"]
 
@@ -372,7 +346,6 @@ class QuantumError(BaseOperator, TolerancesMixin):
             for elem in inst:
                 inst_name = elem["name"]
                 inst_qubits = elem["qubits"]
-
                 if inst_name == "x":
                     noise_elem.append((XGate(), inst_qubits))
                 elif inst_name == "id":
@@ -381,18 +354,22 @@ class QuantumError(BaseOperator, TolerancesMixin):
                     noise_elem.append((YGate(), inst_qubits))
                 elif inst_name == "z":
                     noise_elem.append((ZGate(), inst_qubits))
-                elif inst_name == "kraus":
-                    if "params" not in inst[0]:
-                        raise NoiseError("kraus does not have a parameter value")
-                    noise_elem.append((Kraus(inst[0]["params"]), inst_qubits))
                 elif inst_name == "reset":
                     noise_elem.append((Reset(), inst_qubits))
                 elif inst_name == "measure":
                     raise NoiseError("instruction 'measure' not supported")
+                elif inst_name == "pauli":
+                    if "params" not in elem:
+                        raise NoiseError("pauli does not have a parameter value")
+                    noise_elem.append((Pauli(elem["params"][0]), inst_qubits))
+                elif inst_name == "kraus":
+                    if "params" not in elem:
+                        raise NoiseError("kraus does not have a parameter value")
+                    noise_elem.append((Kraus(elem["params"]), inst_qubits))
                 elif inst_name == "unitary":
-                    if "params" not in inst[0]:
+                    if "params" not in elem:
                         raise NoiseError("unitary does not have a parameter value")
-                    noise_elem.append((UnitaryGate(inst[0]["params"][0]), inst_qubits))
+                    noise_elem.append((UnitaryGate(elem["params"][0]), inst_qubits))
                 else:
                     raise NoiseError("error gate for instruction not recognized")
 
@@ -457,39 +434,3 @@ class QuantumError(BaseOperator, TolerancesMixin):
 
     def expand(self, other):
         return other.tensor(self)
-
-    # Overloads
-    def __rmul__(self, other):
-        raise NotImplementedError("'QuantumError' does not support scalar multiplication.")
-
-    def __truediv__(self, other):
-        raise NotImplementedError("'QuantumError' does not support division.")
-
-    def __add__(self, other):
-        raise NotImplementedError("'QuantumError' does not support addition.")
-
-    def __sub__(self, other):
-        raise NotImplementedError("'QuantumError' does not support subtraction.")
-
-    def __neg__(self):
-        raise NotImplementedError("'QuantumError' does not support negation.")
-
-
-class QuantumChannelInstruction(Instruction):
-    """Container instruction for adding QuantumError to circuit"""
-
-    def __init__(self, quantum_error):
-        """Initialize a quantum error circuit instruction.
-
-        Args:
-            quantum_error (QuantumError): the error to add as an instruction.
-        """
-        super().__init__("quantum_channel", quantum_error.num_qubits, 0, [])
-        self._quantum_error = quantum_error
-
-    def _define(self):
-        """Allow unrolling to a Kraus instruction"""
-        q = QuantumRegister(self.num_qubits, "q")
-        qc = QuantumCircuit(q, name=self.name)
-        qc._append(Kraus(self._quantum_error).to_instruction(), q, [])
-        self.definition = qc

--- a/qiskit_aer/noise/errors/quantum_error.py
+++ b/qiskit_aer/noise/errors/quantum_error.py
@@ -219,6 +219,12 @@ class QuantumError(BaseQuantumError, TolerancesMixin):
             output += f"\n  P({j}) = {pair[0]}, Circuit = \n{pair[1]}"
         return output
 
+    def __eq__(self, other):
+        """Test if two QuantumErrors are equal as SuperOps"""
+        if not isinstance(other, BaseQuantumError):
+            return False
+        return self.to_quantumchannel() == other.to_quantumchannel()
+
     @property
     def size(self):
         """Return the number of error circuit."""

--- a/test/terra/noise/test_noise_model.py
+++ b/test/terra/noise/test_noise_model.py
@@ -419,25 +419,6 @@ class TestNoiseModel(QiskitAerTestCase):
         result = AerSimulator().run(qc, noise_model=noise_model).result()
         self.assertTrue(result.success)
 
-    def test_from_dict(self):
-        noise_ops_1q = [((IGate(), [0]), 0.9), ((XGate(), [0]), 0.1)]
-
-        noise_ops_2q = [
-            ((PauliGate("II"), [0, 1]), 0.9),
-            ((PauliGate("IX"), [0, 1]), 0.045),
-            ((PauliGate("XI"), [0, 1]), 0.045),
-            ((PauliGate("XX"), [0, 1]), 0.01),
-        ]
-
-        noise_model = NoiseModel()
-        with self.assertWarns(DeprecationWarning):
-            noise_model.add_quantum_error(QuantumError(noise_ops_1q), "h", [0])
-            noise_model.add_quantum_error(QuantumError(noise_ops_1q), "h", [1])
-            noise_model.add_quantum_error(QuantumError(noise_ops_2q), "cx", [0, 1])
-            noise_model.add_quantum_error(QuantumError(noise_ops_2q), "cx", [1, 0])
-            deserialized = NoiseModel.from_dict(noise_model.to_dict())
-            self.assertEqual(noise_model, deserialized)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This refactors QuantumError to inherit from a `BaseQuantumError` class, and `NoiseModel` to allow adding BaseQuantumErrors rather than only QuantumErrors.

~Depends on #2158~

### Details and comments

This is a pre requisit for adding the optimized PauliLindbladError and PauliError operators proposed in #2154 
On its own this PR should have no visible changes to current users.