### PR TITLE
Fix AerBackend.set_max_qubits

### DIFF
--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -354,6 +354,7 @@ class AerBackend(Backend, ABC):
         """Set maximun number of qubits to be used for this backend."""
         if self._target is None:
             self._configuration.n_qubits = max_qubits
+            self._set_configuration_option("n_qubits", max_qubits)
 
     def clear_options(self):
         """Reset the simulator options to default values."""

--- a/releasenotes/notes/fix_AerBackend_set_max_qubits-fee8f0e104580e33.yaml
+++ b/releasenotes/notes/fix_AerBackend_set_max_qubits-fee8f0e104580e33.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    `AerBackend.set_max_qubits` did not update `n_qubits` in configuration
+    that was overwritten by setting backend option `method` at initialization.
+    This fix set `n_qubits` in configuration by calling `_set_configuration_option`

--- a/test/terra/primitives/test_sampler.py
+++ b/test/terra/primitives/test_sampler.py
@@ -27,6 +27,8 @@ from qiskit.primitives import SamplerResult
 
 from qiskit_aer.primitives import Sampler
 
+from test.terra.backends.simulator_test_case import supported_methods
+
 
 @ddt
 class TestSampler(QiskitAerTestCase):
@@ -270,9 +272,21 @@ class TestSampler(QiskitAerTestCase):
         result = Sampler().run(qc, shots=100).result()
         self.assertDictAlmostEqual(result.quasi_dists[0], {0: 1})
 
-    def test_truncate_large_circuit(self):
+    @supported_methods(
+        [
+            "automatic",
+            "statevector",
+            "density_matrix",
+            "matrix_product_state",
+            "stabilizer",
+            "extended_stabilizer",
+            "tensor_network",
+        ]
+    )
+    def test_truncate_large_circuit(self, method, device):
         """Test trancate large circuit in transplier"""
-        sampler = Sampler()
+        options = {"method": method, "device": device}
+        sampler = Sampler(backend_options=options)
         qc = QuantumCircuit(100, 2)
         qc.h(98)
         qc.cx(98, 99)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is fix for PR #2084 again

### Details and comments

Setting method option to Sampler overwrote `n_qubits` of configuration.
So this fix set `n_qubits` by using _`set_configuration_option` function to overwrite again.

I added test case to test all supported methods
