### PR TITLE
Restore MacOS Arm64 for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,6 @@ jobs:
       - name: Build Wheels
         env:
           CIBW_ARCHS_MACOS: arm64
-          CIBW_SKIP: "pp* cp38* cp39*"
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,6 @@ jobs:
       - name: Build Wheels
         env:
           CIBW_ARCHS_MACOS: arm64
-          CIBW_SKIP: "pp* cp38* cp39*"
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,7 +192,7 @@ jobs:
           stestr run --slowest
         shell: bash
   tests_macos:
-    runs-on: macos-13
+    runs-on: macos-latest
     name: macOS Python ${{ matrix.python-version }}
     needs: [sdist, lint]
     timeout-minutes: 60

--- a/releasenotes/notes/restore_arm64_macos-3d41e85b0963dcd8.yaml
+++ b/releasenotes/notes/restore_arm64_macos-3d41e85b0963dcd8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Distribution packages for Python 3.8 and 3.9 for MacOS on Arm64
+    was disabled by #2106
+    This fix restore these distributions, because Python 3.8 and 3.9 supports
+    MacOS on Arm64 now


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR restores distributions for Python 3.8 and 3.9 for MacOS on Arm64 #2167

### Details and comments

In `deploy.yml` and `build.yml`, we skipped Python 3.8 and 3.9, and we restore them in this fix
