### PR TITLE
Fix from backend of V2 primitives to use existing AerSimulator

### DIFF
--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -855,7 +855,9 @@ class AerSimulator(AerBackend):
                 open_pulse=False,
                 memory=False,
                 max_shots=int(1e6),
-                coupling_map=list(backend.coupling_map.get_edges()),
+                coupling_map=(
+                    None if backend.coupling_map == None else list(backend.coupling_map.get_edges())
+                ),
                 max_experiments=backend.max_circuits,
                 description=description,
             )

--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -856,7 +856,7 @@ class AerSimulator(AerBackend):
                 memory=False,
                 max_shots=int(1e6),
                 coupling_map=(
-                    None if backend.coupling_map == None else list(backend.coupling_map.get_edges())
+                    None if backend.coupling_map is None else list(backend.coupling_map.get_edges())
                 ),
                 max_experiments=backend.max_circuits,
                 description=description,

--- a/qiskit_aer/primitives/estimator_v2.py
+++ b/qiskit_aer/primitives/estimator_v2.py
@@ -76,7 +76,10 @@ class EstimatorV2(BaseEstimatorV2):
     def from_backend(cls, backend, **options):
         """make new sampler that uses external backend"""
         estimator = cls(**options)
-        estimator._backend = AerSimulator.from_backend(backend)
+        if isinstance(backend, AerSimulator):
+            estimator._backend = backend
+        else:
+            estimator._backend = AerSimulator.from_backend(backend)
         return estimator
 
     @property
@@ -130,6 +133,7 @@ class EstimatorV2(BaseEstimatorV2):
         result = self._backend.run(
             circuit, parameter_binds=[parameter_binds], **self.options.run_options
         ).result()
+        print(result)
 
         # calculate expectation values (evs) and standard errors (stds)
         rng = np.random.default_rng(self.options.run_options.get("seed_simulator"))

--- a/qiskit_aer/primitives/estimator_v2.py
+++ b/qiskit_aer/primitives/estimator_v2.py
@@ -133,7 +133,6 @@ class EstimatorV2(BaseEstimatorV2):
         result = self._backend.run(
             circuit, parameter_binds=[parameter_binds], **self.options.run_options
         ).result()
-        print(result)
 
         # calculate expectation values (evs) and standard errors (stds)
         flat_indices = list(param_indices.ravel())

--- a/qiskit_aer/primitives/sampler_v2.py
+++ b/qiskit_aer/primitives/sampler_v2.py
@@ -104,7 +104,10 @@ class SamplerV2(BaseSamplerV2):
     def from_backend(cls, backend, **options):
         """make new sampler that uses external backend"""
         sampler = cls(**options)
-        sampler._backend = AerSimulator.from_backend(backend)
+        if isinstance(backend, AerSimulator):
+            sampler._backend = backend
+        else:
+            sampler._backend = AerSimulator.from_backend(backend)
         return sampler
 
     @property

--- a/releasenotes/notes/fix_from_backend-a885d43caf390873.yaml
+++ b/releasenotes/notes/fix_from_backend-a885d43caf390873.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    `from_backend` function of V2 primitives are fixed to accept AerSimulator
+    objects as input so that user can define simulator objects outside of
+    primitives


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes `EstimatorV2.from_backend` and `SamplerV2.from_backend` to use pre-defined AerSimulator for simulation

### Details and comments

With this fix, user can define specific simulator object with backend options instead of passing options for V2 primitives.

for example, following script can use AerSimulator with statevector simulation and with noise model
```
sim = AerSimulator(method="statevector", noise_model=noise_model)
estimator = EstimatorV2.from_backend(sim)
```

This PR fixes `from_backend` that initialized backend object by calling `AerSimulator.from_backend` but  when input backend is AerSimulator just copy it.
