### PR TITLE
Fix Thrust error whe using CUDA 12.5

### DIFF
--- a/cmake/dependency_utils.cmake
+++ b/cmake/dependency_utils.cmake
@@ -28,7 +28,7 @@ macro(_use_system_libraries)
 
 	if(AER_THRUST_BACKEND AND NOT AER_THRUST_BACKEND STREQUAL "CUDA")
 		string(TOLOWER ${AER_THRUST_BACKEND} THRUST_BACKEND)
-		_import_aer_system_dependency(Thrust 1.9.5)
+		_import_aer_system_dependency(Thrust 2.0.0)
 	endif()
 
 	if(BUILD_TESTS)

--- a/src/simulators/statevector/chunk/thrust_kernels.hpp
+++ b/src/simulators/statevector/chunk/thrust_kernels.hpp
@@ -352,7 +352,7 @@ struct complex_less {
   typedef thrust::complex<data_t> first_argument_type;
   typedef thrust::complex<data_t> second_argument_type;
   typedef bool result_type;
-  __thrust_exec_check_disable__ __host__ __device__ bool
+  __host__ __device__ bool
   operator()(const thrust::complex<data_t> &lhs,
              const thrust::complex<data_t> &rhs) const {
     return lhs.real() < rhs.real();


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When building Aer with CUDA 12.5, `__thrust_exec_check_disable__`  causes error

### Details and comments

Removed `__thrust_exec_check_disable__` and upgraded required Thrust version to 2.0.0
