### PR TITLE
fix bit mapping inconsistency in inline of AerCompiler

### DIFF
--- a/qiskit_aer/backends/aer_compiler.py
+++ b/qiskit_aer/backends/aer_compiler.py
@@ -269,9 +269,15 @@ class AerCompiler:
             inlined_body = self._inline_circuit(body, continue_label, break_label, inner_bit_map)
             if loop_parameter is not None:
                 inlined_body = inlined_body.assign_parameters({loop_parameter: index})
-            #            parent.append(inlined_body, qargs, cargs)
             for inst in inlined_body:
-                parent.append(inst, qargs, cargs)
+                parent.append(
+                    inst.replace(
+                        qubits=[inner_bit_map[bit] for bit in inst.qubits],
+                        clbits=[inner_bit_map[bit] for bit in inst.clbits],
+                    ),
+                    qargs,
+                    cargs,
+                )
             parent.append(AerMark(continue_label, len(qargs), len(cargs)), qargs, cargs)
 
         if inlined_body is not None:
@@ -289,17 +295,18 @@ class AerCompiler:
         continue_label = f"{loop_name}_continue"
         loop_start_label = f"{loop_name}_start"
         break_label = f"{loop_name}_end"
+        inline_bit_map = {
+            inner: bit_map[outer]
+            for inner, outer in itertools.chain(
+                zip(body.qubits, instruction.qubits),
+                zip(body.clbits, instruction.clbits),
+            )
+        }
         inlined_body = self._inline_circuit(
             body,
             continue_label,
             break_label,
-            {
-                inner: bit_map[outer]
-                for inner, outer in itertools.chain(
-                    zip(body.qubits, instruction.qubits),
-                    zip(body.clbits, instruction.clbits),
-                )
-            },
+            inline_bit_map,
         )
         qargs = [bit_map[q] for q in instruction.qubits]
         cargs = [bit_map[c] for c in instruction.clbits]
@@ -323,7 +330,14 @@ class AerCompiler:
         parent.append(AerJump(break_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)
         parent.append(AerMark(loop_start_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)
         for inst in inlined_body:
-            parent.append(inst, qargs, cargs)
+            parent.append(
+                inst.replace(
+                    qubits=[inline_bit_map[bit] for bit in inst.qubits],
+                    clbits=[inline_bit_map[bit] for bit in inst.clbits],
+                ),
+                qargs,
+                cargs,
+            )
         parent.append(AerJump(continue_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)
         parent.append(AerMark(break_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)
 
@@ -373,7 +387,14 @@ class AerCompiler:
         parent.append(AerMark(if_true_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)
         child = self._inline_circuit(true_body, continue_label, break_label, true_bit_map)
         for inst in child.data:
-            parent.append(inst, qargs, cargs)
+            parent.append(
+                inst.replace(
+                    qubits=[true_bit_map[bit] for bit in inst.qubits],
+                    clbits=[true_bit_map[bit] for bit in inst.clbits],
+                ),
+                qargs,
+                cargs,
+            )
 
         if false_body:
             false_bit_map = {
@@ -387,7 +408,14 @@ class AerCompiler:
             parent.append(AerMark(if_else_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)
             child = self._inline_circuit(false_body, continue_label, break_label, false_bit_map)
             for inst in child.data:
-                parent.append(inst, qargs, cargs)
+                parent.append(
+                    inst.replace(
+                        qubits=[false_bit_map[bit] for bit in inst.qubits],
+                        clbits=[false_bit_map[bit] for bit in inst.clbits],
+                    ),
+                    qargs,
+                    cargs,
+                )
 
         parent.append(AerMark(if_end_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)
 
@@ -472,7 +500,14 @@ class AerCompiler:
                 case_data.body, continue_label, break_label, case_data.bit_map
             )
             for inst in child.data:
-                parent.append(inst, qargs, cargs)
+                parent.append(
+                    inst.replace(
+                        qubits=[case_data.bit_map[bit] for bit in inst.qubits],
+                        clbits=[case_data.bit_map[bit] for bit in inst.clbits],
+                    ),
+                    qargs,
+                    cargs,
+                )
             parent.append(AerJump(switch_end_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)
 
         parent.append(AerMark(switch_end_label, len(qargs), len(mark_cargs)), qargs, mark_cargs)

--- a/releasenotes/notes/fix_inline_in_compiler-6ecdfcf38e2fa0c9.yaml
+++ b/releasenotes/notes/fix_inline_in_compiler-6ecdfcf38e2fa0c9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+     Fix an issue of inline of ``AerCompiler``. Mappings of qubits and clbits are broken
+     since cf510a2 and this fix correct them by coping `CircuitInstruction` with
+     correct qubits and clbits. This fix resolves https://github.com/Qiskit/qiskit-aer/issues/2171.

--- a/test/terra/backends/aer_simulator/test_control_flow.py
+++ b/test/terra/backends/aer_simulator/test_control_flow.py
@@ -1280,7 +1280,6 @@ class TestControlFlow(SimulatorTestCase):
         self.assertEqual(len(counts), 1)
         self.assertIn("0010101", counts)
 
-
     def test_bit_mapping_in_compiler(self):
         """Test different bit mappings are correctly inlined"""
         parent = QuantumCircuit(5, 2)

--- a/test/terra/backends/aer_simulator/test_control_flow.py
+++ b/test/terra/backends/aer_simulator/test_control_flow.py
@@ -1279,3 +1279,22 @@ class TestControlFlow(SimulatorTestCase):
         counts = backend.run(qc).result().get_counts()
         self.assertEqual(len(counts), 1)
         self.assertIn("0010101", counts)
+
+
+    def test_bit_mapping_in_compiler(self):
+        """Test different bit mappings are correctly inlined"""
+        parent = QuantumCircuit(5, 2)
+        parent.x(0)
+        parent.measure(0, 0)
+
+        true_body = QuantumCircuit(1, 0)
+        true_body.x(0)
+
+        parent.append(IfElseOp((parent.clbits[0], 1), true_body), [1], [])
+
+        parent.measure(1, 1)
+
+        simulator = self.backend()
+        counts = simulator.run(parent).result().get_counts()
+        self.assertEqual(len(counts), 1)
+        self.assertIn("11", counts)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Resolve #2171 

### Details and comments

Qubit mapping is not correctly resolved in control flow since cf510a2. This PR is to fix this issue.

In `AerCompiler`, all of instructions are inlined. Qubits and clbits of a sub-circuit may be different from of its parent. Therefore, previously, they are inlined by using decomposition of trranspiler and transpiler coordinates correct qubits and clbits. However, in cf510a2, decomposition is implemented in `AerCompier` and mapping of qubits and clbits may be broken.

With this PR, qubits and clbits of top-parent are always used in the inlined circuits.