### PR TITLE
Fix legacy accesses of `CircuitInstruction`

### DIFF
--- a/qiskit_aer/backends/aer_compiler.py
+++ b/qiskit_aer/backends/aer_compiler.py
@@ -758,8 +758,8 @@ def _assemble_type(expr_type):
 
 def _iter_var_recursive(circuit):
     yield from circuit.iter_vars()
-    for data in circuit.data:
-        for param in data[0].params:
+    for instruction in circuit.data:
+        for param in instruction.operation.params:
             if isinstance(param, QuantumCircuit):
                 yield from _iter_var_recursive(param)
 

--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -558,7 +558,7 @@ def circuit_optypes(circuit):
     if not isinstance(circuit, QuantumCircuit):
         return set()
     optypes = set()
-    for inst, _, _ in circuit._data:
-        optypes.update(type(inst).mro())
+    for instruction in circuit.data:
+        optypes.update(type(instruction.operation).mro())
     optypes.discard(object)
     return optypes

--- a/qiskit_aer/noise/errors/quantum_error.py
+++ b/qiskit_aer/noise/errors/quantum_error.py
@@ -253,7 +253,8 @@ class QuantumError(BaseQuantumError, TolerancesMixin):
                 pass
 
             # Component-wise check for non-Clifford circuits
-            for op, _, _ in circ:
+            for instruction in circ:
+                op = instruction.operation
                 if isinstance(op, IGate):
                     continue
                 if isinstance(op, PauliGate):
@@ -310,9 +311,9 @@ class QuantumError(BaseQuantumError, TolerancesMixin):
         instructions = []
         for circ in self._circs:
             circ_inst = []
-            for inst, qargs, _ in circ.data:
-                qobj_inst = inst.assemble()
-                qobj_inst.qubits = [circ.find_bit(q).index for q in qargs]
+            for inst in circ.data:
+                qobj_inst = inst.operation.assemble()
+                qobj_inst.qubits = [circ.find_bit(q).index for q in inst.qubits]
                 circ_inst.append(qobj_inst.to_dict())
             instructions.append(circ_inst)
         # Construct error dict

--- a/qiskit_aer/utils/noise_model_inserter.py
+++ b/qiskit_aer/utils/noise_model_inserter.py
@@ -50,16 +50,17 @@ def insert_noise(circuits, noise_model, transpile=False):
         qubit_indices = {bit: index for index, bit in enumerate(transpiled_circuit.qubits)}
         result_circuit = transpiled_circuit.copy(name=transpiled_circuit.name + "_with_noise")
         result_circuit.data = []
-        for inst, qargs, cargs in transpiled_circuit.data:
-            result_circuit.data.append((inst, qargs, cargs))
-            qubits = tuple(qubit_indices[q] for q in qargs)
+        for inst in transpiled_circuit.data:
+            result_circuit.data.append(inst)
+            qubits = tuple(qubit_indices[q] for q in inst.qubits)
             # Priority for error model used:
             # local error > default error
-            if inst.name in local_errors and qubits in local_errors[inst.name]:
-                error = local_errors[inst.name][qubits]
-                result_circuit.append(error.to_instruction(), qargs)
-            elif inst.name in default_errors.keys():
-                error = default_errors[inst.name]
-                result_circuit.append(error.to_instruction(), qargs)
+            name = inst.operation.name
+            if name in local_errors and qubits in local_errors[name]:
+                error = local_errors[name][qubits]
+                result_circuit.append(error.to_instruction(), inst.qubits)
+            elif name in default_errors.keys():
+                error = default_errors[name]
+                result_circuit.append(error.to_instruction(), inst.qubits)
         result_circuits.append(result_circuit)
     return result_circuits if is_circuits_list else result_circuits[0]


### PR DESCRIPTION
### Summary

Using Terra's `CircuitInstruction` like a tuple is a legacy access pattern.  The pattern of using named access attributes was introduced about two years ago, and the legacy format is about to be deprecated. This fixes up the last couple of uses.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

Terra 1.2 will likely deprecate this.
