### PR TITLE
Fix legacy accesses of `CircuitInstruction` in tests

### DIFF
--- a/test/terra/backends/aer_simulator/test_noise.py
+++ b/test/terra/backends/aer_simulator/test_noise.py
@@ -243,12 +243,13 @@ class TestNoise(SimulatorTestCase):
 
         # manaully build noise circuit
         noise_circuit = QuantumCircuit(3)
-        for inst, qargs, cargs in ideal_circuit.data:
-            noise_circuit.append(inst, qargs, cargs)
-            if inst.name == "h":
-                noise_circuit.append(error1, qargs)
-            elif inst.name in ["cp", "swap"]:
-                noise_circuit.append(error2, qargs)
+        for inst in ideal_circuit.data:
+            noise_circuit.append(inst)
+            name = inst.operation.name
+            if name == "h":
+                noise_circuit.append(error1, inst.qubits)
+            elif name in ["cp", "swap"]:
+                noise_circuit.append(error2, inst.qubits)
         # compute target counts
         noise_state = DensityMatrix(noise_circuit)
         ref_target = {i: shots * p for i, p in noise_state.probabilities_dict().items()}

--- a/test/terra/backends/aer_simulator/test_shot_branching.py
+++ b/test/terra/backends/aer_simulator/test_shot_branching.py
@@ -494,12 +494,13 @@ class TestShotBranching(SimulatorTestCase):
 
         # manaully build noise circuit
         noise_circuit = QuantumCircuit(3)
-        for inst, qargs, cargs in ideal_circuit.data:
-            noise_circuit.append(inst, qargs, cargs)
-            if inst.name == "h":
-                noise_circuit.append(error1, qargs)
-            elif inst.name in ["cp", "swap"]:
-                noise_circuit.append(error2, qargs)
+        for inst in ideal_circuit.data:
+            noise_circuit.append(inst)
+            name = inst.operation.name
+            if name == "h":
+                noise_circuit.append(error1, inst.qubits)
+            elif name in ["cp", "swap"]:
+                noise_circuit.append(error2, inst.qubits)
         # compute target counts
         noise_state = DensityMatrix(noise_circuit)
         ref_target = {i: shots * p for i, p in noise_state.probabilities_dict().items()}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is a follow-up to #2179.  This PR provides similar fixes in two tests.

### Details and comments


