### PR TITLE
Rewrite `CircuitInstruction` as iterable to avoid deprecation warning of Qiskit 1.2

### DIFF
--- a/qiskit_aer/backends/aer_compiler.py
+++ b/qiskit_aer/backends/aer_compiler.py
@@ -123,7 +123,8 @@ class AerCompiler:
         if isinstance(optype, set) and Initialize not in optype:
             return circ
 
-        for inst, _, _ in circ.data:
+        for datum in circ.data:
+            inst = datum.operation
             if isinstance(inst, Initialize) and (
                 (not isinstance(inst.params[0], complex)) or (len(inst.params) == 1)
             ):
@@ -133,7 +134,8 @@ class AerCompiler:
 
         new_circ = circ.copy()
         new_circ.data = []
-        for inst, qargs, cargs in circ.data:
+        for datum in circ.data:
+            inst, qargs, cargs = datum.operation, datum.qubits, datum.clbits
             if isinstance(inst, Initialize) and (
                 (not isinstance(inst.params[0], complex)) or (len(inst.params) == 1)
             ):

--- a/qiskit_aer/backends/aerbackend.py
+++ b/qiskit_aer/backends/aerbackend.py
@@ -615,7 +615,8 @@ class AerBackend(Backend, ABC):
             ):
                 updated_circ = False
                 new_data = []
-                for inst, qargs, cargs in circ.data:
+                for datum in circ.data:
+                    inst, qargs, cargs = datum.operation, datum.qubits, datum.clbits
                     if isinstance(inst, QuantumChannelInstruction):
                         updated_circ = True
                         if not updated_noise:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Rewrite some codes to avoid the following deprecation warning of Qiskit 1.2

> DeprecationWarning: Treating CircuitInstruction as an iterable is deprecated legacy behavior since Qiskit 1.2, and will be removed in Qiskit 2.0. Instead, use the operation, qubits and clbits named attributes.


### Details and comments


