### PR TITLE
Derive from `BaseSamplerV1` rather than `BaseSampler`

### DIFF
--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -22,14 +22,14 @@ import numpy as np
 from qiskit.circuit import ParameterExpression, QuantumCircuit
 from qiskit.compiler import transpile
 from qiskit.exceptions import QiskitError
-from qiskit.primitives import BaseSampler, SamplerResult
+from qiskit.primitives import BaseSamplerV1, SamplerResult
 from qiskit.primitives.utils import final_measurement_mapping, init_circuit
 from qiskit.result import QuasiDistribution
 
 from .. import AerSimulator
 
 
-class Sampler(BaseSampler):
+class Sampler(BaseSamplerV1):
     """
     Aer implementation of Sampler class.
 


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This change is in accordance with the following warning that is triggered by the Qiskit 1.2 rc:

> qiskit_aer/primitives/sampler.py:69: DeprecationWarning: The class ``qiskit.primitives.base.base_sampler.BaseSampler`` is deprecated as of qiskit 1.2. It will be removed no earlier than 3 months after the release date. The `BaseSampler` class is a type alias for the `BaseSamplerV1` interface that has been deprecated in favor of explicitly versioned interface classes. It is recommended to migrate all implementations to use `BaseSamplerV2`. However, for implementations incompatible with `BaseSamplerV2`, `BaseSampler` can be replaced with the explicitly versioned `BaseSamplerV1` class.

### Details and comments

