### PR TITLE
Suppress Clang++ warnings on macOS

### DIFF
--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -103,6 +103,7 @@ public:
       : expr_type(_expr_type), type(_type) {}
   virtual bool eval_bool(const std::string &memory) { return false; };
   virtual uint_t eval_uint(const std::string &memory) { return 0ul; };
+  virtual ~CExpr() = default;
 
 public:
   const CExprType expr_type;
@@ -139,6 +140,8 @@ public:
       throw std::invalid_argument(R"(invalid cast: from unknown type.)");
   }
 
+  virtual ~CastExpr() = default;
+
 public:
   const std::shared_ptr<CExpr> operand;
 };
@@ -162,6 +165,8 @@ public:
           R"(eval_uint is called for non-uint expression.)");
     return eval_uint_(memory);
   }
+
+  virtual ~VarExpr() = default;
 
 private:
   uint_t eval_uint_(const std::string &memory) {
@@ -199,6 +204,8 @@ public:
 
   virtual uint_t eval_uint(const std::string &memory) { return value; }
 
+  virtual ~UintValue() = default;
+
 public:
   const uint_t value;
 };
@@ -214,6 +221,8 @@ public:
     throw std::invalid_argument(
         R"(eval_uint is called for Bool value without cast.)");
   }
+
+  virtual ~BoolValue() = default;
 
 public:
   const bool value;
@@ -245,6 +254,8 @@ public:
     }
     throw std::invalid_argument(R"(should not reach here.)");
   }
+
+  virtual ~UnaryExpr() = default;
 
 public:
   const UnaryOp op;
@@ -357,6 +368,8 @@ public:
       throw std::invalid_argument(R"(must not reach here.)");
     }
   }
+
+  virtual ~BinaryExpr() = default;
 
 public:
   const BinaryOp op;

--- a/src/simulators/matrix_product_state/svd.cpp
+++ b/src/simulators/matrix_product_state/svd.cpp
@@ -632,7 +632,7 @@ void lapack_csvd_wrapper(cmatrix_t &A, cmatrix_t &U, rvector_t &S,
     zgesdd_("A", &m, &n, lapackA, &m, lapackS, lapackU, &m, lapackV, &n, work_,
             &lwork, rwork, iwork, &info);
 
-    delete iwork;
+    delete[] iwork;
     free(rwork);
     free(work_);
   } else {
@@ -655,8 +655,8 @@ void lapack_csvd_wrapper(cmatrix_t &A, cmatrix_t &U, rvector_t &S,
   validate_SVdD_result(tempA, U, S, V);
   // #endif
 
-  delete lapackS;
-  delete work;
+  delete[] lapackS;
+  delete[] work;
 
   if (info == 0) {
     return;

--- a/src/simulators/parallel_state_executor.hpp
+++ b/src/simulators/parallel_state_executor.hpp
@@ -64,7 +64,7 @@ public:
 protected:
   void set_config(const Config &config) override;
 
-  virtual uint_t qubit_scale(void) { return 1; }
+  virtual uint_t qubit_scale(void) override { return 1; }
 
   bool multiple_chunk_required(const Config &config, const Circuit &circuit,
                                const Noise::NoiseModel &noise) const;

--- a/src/simulators/statevector/statevector_state.hpp
+++ b/src/simulators/statevector/statevector_state.hpp
@@ -213,7 +213,7 @@ public:
   cmatrix_t density_matrix(const reg_t &qubits);
 
   // Apply the global phase
-  void apply_global_phase();
+  void apply_global_phase() override;
 
 protected:
   //-----------------------------------------------------------------------

--- a/src/simulators/superoperator/superoperator.hpp
+++ b/src/simulators/superoperator/superoperator.hpp
@@ -53,7 +53,7 @@ public:
   //-----------------------------------------------------------------------
 
   // Set the size of the vector in terms of qubit number
-  void set_num_qubits(size_t num_qubits);
+  void set_num_qubits(size_t num_qubits) override;
 
   // Returns the number of qubits for the superoperator
   virtual uint_t num_qubits() const override { return num_qubits_; }

--- a/src/simulators/tensor_network/tensor_net_state.hpp
+++ b/src/simulators/tensor_network/tensor_net_state.hpp
@@ -151,7 +151,9 @@ public:
   auto move_to_vector();
   auto copy_to_vector();
 
-  void enable_density_matrix(bool flg) override { enable_density_matrix_ = flg; }
+  void enable_density_matrix(bool flg) override {
+    enable_density_matrix_ = flg;
+  }
 
 protected:
   //-----------------------------------------------------------------------

--- a/src/simulators/tensor_network/tensor_net_state.hpp
+++ b/src/simulators/tensor_network/tensor_net_state.hpp
@@ -151,7 +151,7 @@ public:
   auto move_to_vector();
   auto copy_to_vector();
 
-  void enable_density_matrix(bool flg) { enable_density_matrix_ = flg; }
+  void enable_density_matrix(bool flg) override { enable_density_matrix_ = flg; }
 
 protected:
   //-----------------------------------------------------------------------
@@ -208,7 +208,7 @@ protected:
                    RngEngine &rng);
 
   // Apply the global phase
-  void apply_global_phase(void);
+  void apply_global_phase(void) override;
 
   //-----------------------------------------------------------------------
   // Save data instructions

--- a/src/simulators/unitary/unitary_state.hpp
+++ b/src/simulators/unitary/unitary_state.hpp
@@ -140,7 +140,7 @@ public:
   auto copy_to_matrix();
 
   // Apply the global phase
-  void apply_global_phase();
+  void apply_global_phase() override;
 
 protected:
   //-----------------------------------------------------------------------

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -173,7 +173,7 @@ public:
                                     std::string("fusion"));
   };
 
-  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const {
+  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const override {
     if (op.conditional || op.sample_noise)
       return false;
     switch (op.type) {
@@ -220,7 +220,7 @@ public:
     return Operations::make_superop(qubits, std::move(superop));
   };
 
-  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const {
+  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const override {
     if (op.conditional || op.sample_noise)
       return false;
     switch (op.type) {
@@ -270,7 +270,7 @@ public:
     return Operations::make_kraus(qubits, Utils::superop2kraus(superop, dim));
   };
 
-  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const {
+  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const override {
     if (op.conditional || op.sample_noise)
       return false;
     switch (op.type) {
@@ -346,7 +346,7 @@ void Fuser::allocate_new_operation(oplist_t &ops, const uint_t idx,
       ops[i].type = optype_t::nop;
 }
 
-class CostBasedFusion : public Fuser {
+class CostBasedFusion final : public Fuser {
 public:
   CostBasedFusion() { std::fill_n(costs_, 64, -1); };
 
@@ -377,7 +377,7 @@ private:
 };
 
 template <size_t N>
-class NQubitFusion : public Fuser {
+class NQubitFusion final : public Fuser {
 public:
   NQubitFusion() : opt_name(std::to_string(N) + "_qubits") {}
 

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -173,7 +173,8 @@ public:
                                     std::string("fusion"));
   };
 
-  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const override {
+  virtual bool can_apply(const op_t &op,
+                         uint_t max_fused_qubits) const override {
     if (op.conditional || op.sample_noise)
       return false;
     switch (op.type) {
@@ -220,7 +221,8 @@ public:
     return Operations::make_superop(qubits, std::move(superop));
   };
 
-  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const override {
+  virtual bool can_apply(const op_t &op,
+                         uint_t max_fused_qubits) const override {
     if (op.conditional || op.sample_noise)
       return false;
     switch (op.type) {
@@ -270,7 +272,8 @@ public:
     return Operations::make_kraus(qubits, Utils::superop2kraus(superop, dim));
   };
 
-  virtual bool can_apply(const op_t &op, uint_t max_fused_qubits) const override {
+  virtual bool can_apply(const op_t &op,
+                         uint_t max_fused_qubits) const override {
     if (op.conditional || op.sample_noise)
       return false;
     switch (op.type) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I tried to suppress all warnings on my mac environment.

- Apple clang version 15.0.0 (clang-1500.3.9.4)
- macOS 14.6.1

### Details and comments


