### PR TITLE
Deprecate Primitives V1

### DIFF
--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -75,6 +75,10 @@ class Estimator(BaseEstimator):
           normal distribution approximation.
     """
 
+    @deprecate_func(
+        since="1.5",
+        additional_msg="Estimator(V1) has been deprecated in favor of EstimatorV2.",
+    )
     def __init__(
         self,
         *,

--- a/qiskit_aer/primitives/sampler.py
+++ b/qiskit_aer/primitives/sampler.py
@@ -25,6 +25,7 @@ from qiskit.exceptions import QiskitError
 from qiskit.primitives import BaseSamplerV1, SamplerResult
 from qiskit.primitives.utils import final_measurement_mapping, init_circuit
 from qiskit.result import QuasiDistribution
+from qiskit.utils.deprecation import deprecate_func
 
 from .. import AerSimulator
 
@@ -51,6 +52,10 @@ class Sampler(BaseSamplerV1):
         4. default.
     """
 
+    @deprecate_func(
+        since="1.5",
+        additional_msg="Sampler(V1) has been deprecated in favor of SamplerV2.",
+    )
     def __init__(
         self,
         *,

--- a/releasenotes/notes/deprecate_primitives_v1-97e89e7809c3ef9d.yaml
+++ b/releasenotes/notes/deprecate_primitives_v1-97e89e7809c3ef9d.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    Primitives V1 (``Sampler`` and ``Estimator`` in `qiskit_aer.primitives`
+    has been deprecated and ``SamplerV2`` and ``EstimatorV2`` are recommended
+    as their successors.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR is to show deprecation warnings when classes of primitives V1 are generated.

### Details and comments

Primitives V1 was already deprecated in Qiskit.
