### PR TITLE
Revert NoiseModel.from_dict

### DIFF
--- a/qiskit_aer/noise/noise_model.py
+++ b/qiskit_aer/noise/noise_model.py
@@ -20,7 +20,8 @@ from warnings import warn, catch_warnings, filterwarnings
 
 import numpy as np
 
-from qiskit.circuit import Instruction, Delay
+from qiskit.circuit import QuantumCircuit, Instruction, Delay, Reset
+from qiskit.circuit.library.generalized_gates import PauliGate, UnitaryGate
 from qiskit.providers import QubitProperties
 from qiskit.providers.exceptions import BackendPropertyError
 from qiskit.providers.models.backendproperties import BackendProperties
@@ -958,6 +959,105 @@ class NoiseModel:
             ret = json.loads(json.dumps(ret, cls=AerJSONEncoder))
 
         return ret
+
+    @staticmethod
+    def from_dict(noise_dict):
+        """
+        Load NoiseModel from a dictionary.
+        Args:
+            noise_dict (dict): A serialized noise model.
+        Returns:
+            NoiseModel: the noise model.
+        Raises:
+            NoiseError: if dict cannot be converted to NoiseModel.
+        """
+        warn(
+            "from_dict has been deprecated as of qiskit-aer 0.15.0"
+            " and will be removed no earlier than 3 months from that release date.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        def inst_dic_list_to_circuit(dic_list):
+            num_qubits = max(max(dic["qubits"]) for dic in dic_list) + 1
+            circ = QuantumCircuit(num_qubits)
+            for dic in dic_list:
+                if dic["name"] == "reset":
+                    circ.append(Reset(), qargs=dic["qubits"])
+                elif dic["name"] == "kraus":
+                    circ.append(
+                        Instruction(
+                            name="kraus",
+                            num_qubits=len(dic["qubits"]),
+                            num_clbits=0,
+                            params=dic["params"],
+                        ),
+                        qargs=dic["qubits"],
+                    )
+                elif dic["name"] == "unitary":
+                    circ.append(UnitaryGate(data=dic["params"][0]), qargs=dic["qubits"])
+                elif dic["name"] == "pauli":
+                    circ.append(PauliGate(dic["params"][0]), qargs=dic["qubits"])
+                else:
+                    with catch_warnings():
+                        filterwarnings(
+                            "ignore",
+                            category=DeprecationWarning,
+                            module="qiskit_aer.noise.errors.errorutils",
+                        )
+                        circ.append(
+                            UnitaryGate(
+                                label=dic["name"], data=_standard_gate_unitary(dic["name"])
+                            ),
+                            qargs=dic["qubits"],
+                        )
+            return circ
+
+        # Return noise model
+        noise_model = NoiseModel()
+
+        # Get error terms
+        errors = noise_dict.get("errors", [])
+
+        for error in errors:
+            error_type = error["type"]
+
+            # Add QuantumError
+            if error_type == "qerror":
+                circuits = [inst_dic_list_to_circuit(dics) for dics in error["instructions"]]
+                noise_ops = tuple(zip(circuits, error["probabilities"]))
+                qerror = QuantumError(noise_ops)
+                qerror._id = error.get("id", None) or qerror.id
+                instruction_names = error["operations"]
+                all_gate_qubits = error.get("gate_qubits", None)
+                if all_gate_qubits is not None:
+                    for gate_qubits in all_gate_qubits:
+                        # Add local quantum error
+                        noise_model.add_quantum_error(
+                            qerror, instruction_names, gate_qubits, warnings=False
+                        )
+                else:
+                    # Add all-qubit quantum error
+                    noise_model.add_all_qubit_quantum_error(
+                        qerror, instruction_names, warnings=False
+                    )
+
+            # Add ReadoutError
+            elif error_type == "roerror":
+                probabilities = error["probabilities"]
+                all_gate_qubits = error.get("gate_qubits", None)
+                roerror = ReadoutError(probabilities)
+                # Add local readout error
+                if all_gate_qubits is not None:
+                    for gate_qubits in all_gate_qubits:
+                        noise_model.add_readout_error(roerror, gate_qubits, warnings=False)
+                # Add all-qubit readout error
+                else:
+                    noise_model.add_all_qubit_readout_error(roerror, warnings=False)
+            # Invalid error type
+            else:
+                raise NoiseError("Invalid error type: {}".format(error_type))
+        return noise_model
 
     def _instruction_names_labels(self, instructions):
         """Return two lists of instruction name strings and label strings."""

--- a/releasenotes/notes/revert_noise_from_dict-b3a85bf28582a9b1.yaml
+++ b/releasenotes/notes/revert_noise_from_dict-b3a85bf28582a9b1.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    Reverting NoiseModel.from_dict temporary to extend deprecation period
+    for qiskit-ibm-runtime, but we will remove again in the future release


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR reverts `NoiseModel.from_dict` removed on Aer 0.15 required by `qiskit-ibm-runtime`

### Details and comments

We will remove `from_dict` again in the future release

