### PR TITLE
Fix MPS size estimator

### DIFF
--- a/releasenotes/notes/fix_mps_size_estimator-0dcf387fd870f5e5.yaml
+++ b/releasenotes/notes/fix_mps_size_estimator-0dcf387fd870f5e5.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    SIGSEGV raised when the circuits with unsupported gates is
+    passed to MPS simulator, because of `std::set.find()` in
+    size estimator for MPS.
+    This fix avoids SIGSEGV if unsupported gates is passed.

--- a/src/simulators/matrix_product_state/matrix_product_state_size_estimator.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_size_estimator.hpp
@@ -74,17 +74,19 @@ uint_t MPSSizeEstimator::estimate(const std::vector<Operations::Op> &ops,
     case Operations::OpType::gate:
       if (ops[i].qubits.size() > 1) {
         auto it = gateset.find(ops[i].name);
-        switch (it->second) {
-        case Gates::rxx:
-        case Gates::ryy:
-        case Gates::rzx:
-          pi2 = std::real(ops[i].params[0]) / M_PI;
-          pi2_int = (double)std::round(pi2);
-          if (!AER::Linalg::almost_equal(pi2, pi2_int))
-            apply_qubits(ops[i].qubits);
-          break;
-        default:
-          break;
+        if (it != gateset.end()) {
+          switch (it->second) {
+          case Gates::rxx:
+          case Gates::ryy:
+          case Gates::rzx:
+            pi2 = std::real(ops[i].params[0]) / M_PI;
+            pi2_int = (double)std::round(pi2);
+            if (!AER::Linalg::almost_equal(pi2, pi2_int))
+              apply_qubits(ops[i].qubits);
+            break;
+          default:
+            break;
+          }
         }
       }
       break;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is fix for SIGSEGV on MPS simulator #2220 

### Details and comments

In size estimator of MPS, SIGSEGV raised at `std::set.find()` if unsupported gates are passed to MPS simulator.
This fix checks return of `std::set.find()` to avoid SIGSEGV

