### PR TITLE
Fixed MPS save failure when memory limit is ignored

### DIFF
--- a/releasenotes/notes/fix_mps_save_without_memory_limit-64d927c4b4e1e2d4.yaml
+++ b/releasenotes/notes/fix_mps_save_without_memory_limit-64d927c4b4e1e2d4.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a bug preventing the MPS simulator from running when its estimate
+    for the required memory is too large, even when `max_memory_mb=-1`.

--- a/src/simulators/circuit_executor.hpp
+++ b/src/simulators/circuit_executor.hpp
@@ -428,7 +428,7 @@ uint_t Executor<state_t>::get_max_parallel_shots(
     const Config &config, const Circuit &circ,
     const Noise::NoiseModel &noise) const {
   uint_t mem = required_memory_mb(config, circ, noise);
-  if (mem == 0)
+  if (mem == 0 || !check_required_memory_)
     return circ.shots * circ.num_bind_params;
 
   if (sim_device_ == Device::GPU && num_gpus_ > 0) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes a bug preventing MPS runs when the estimated memory usage is too big, even if memory limit is disabled.

Fixes #2246 


### Details and comments
When `max_memory_mb=-1` the maximum memory amount check for MPS should be disabled; however, `Executor<state_t>::get_max_parallel_shots` still uses the estimated memory in its computation, which might result in the value `0`, disabling the run of the engine altogether. To prevent this, `get_max_parallel_shots` results to the `mem==0` case if the maximum memory amount check is disabled.
