### PR TITLE
Fix for a bug in the compilation of controlled gates

### DIFF
--- a/qiskit_aer/backends/aer_compiler.py
+++ b/qiskit_aer/backends/aer_compiler.py
@@ -920,17 +920,17 @@ def _assemble_op(
         if ctrl_state_pos > 0:
             # Add x gates for ctrl qubits which state=0
             ctrl_state = int(name[ctrl_state_pos+2:len(name)])
-            for i in range(len(qubits)):
+            for i in range(len(qubits)-1):
                 if (ctrl_state >> i) & 1 == 0:
-                    qubits_i = [qubits[len(qubits) - 1 - i]]
+                    qubits_i = [qubits[i]]
                     aer_circ.gate("x", qubits_i, params, [], conditional_reg, aer_cond_expr,
                                   label if label else "x")
                     num_of_aer_ops += 1
             aer_circ.gate(gate_name, qubits, params, [], conditional_reg, aer_cond_expr,
                           label if label else gate_name)
-            for i in range(len(qubits)):
+            for i in range(len(qubits)-1):
                 if (ctrl_state >> i) & 1 == 0:
-                    qubits_i = [qubits[len(qubits) - 1 - i]]
+                    qubits_i = [qubits[i]]
                     aer_circ.gate("x", qubits_i, params, [], conditional_reg, aer_cond_expr,
                                   label if label else "x")
                     num_of_aer_ops += 1

--- a/releasenotes/notes/fix_controlled_gate_compile-c94fb7c41fa961db.yaml
+++ b/releasenotes/notes/fix_controlled_gate_compile-c94fb7c41fa961db.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a bug in the compilation of circuits with controlled gates that resulted
+    in adding X gates on the incorrect qubits.


### PR DESCRIPTION
### Summary
Fixes a bug in the compilation of controlled gates resulting in X gates added in incorrect positions.

Fixes https://github.com/Qiskit/qiskit-aer/issues/2252

### Details and comments
When adding a gate with control qubits, a control state string determines whether the control qubit should be 1 or 0. In the case of `0`, compilation adds an X gate before and after the application of a standard, controlled-by-1 gate. The code for adding the X gates is
```
for i in range(len(qubits)):
   if (ctrl_state >> i) & 1 == 0:
     qubits_i = [qubits[len(qubits) - 1 - i]]
     aer_circ.gate("x", qubits_i, params, [], conditional_reg, aer_cond_expr, label if label else "x")
```
The code goes over the qubit list in reverse order, which does not correspond to the way the control string is interpreted in `Qiskit`, and the loop goes over all the qubits in the gate, including the target qubit, resulting in X gates always added before and after this qubit (creating a non-equivalent behavior if, e.g. the controlled gate is Z).

This PR addresses this issue by going over the qubits in the standard order and not handling the last one in the qubits list.
