### PR TITLE
Don't `decode` a unicode string when using git version

### DIFF
--- a/qiskit_aer/version.py
+++ b/qiskit_aer/version.py
@@ -50,7 +50,7 @@ def git_version():
     # Determine if we're at main
     try:
         out = _minimal_ext_cmd(["git", "rev-parse", "HEAD"])
-        git_revision = out.strip().decode("ascii")
+        git_revision = out.strip()
     except OSError:
         git_revision = "Unknown"
 


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #907, the git sha1 was added to the version string on development builds.  In #2158, `encoding="utf-8"` was added in `_minimal_ext_cmd`, which changed the output from a bytestring to a regular string.  However, the original code path still expects a bytestring and calls `.decode()` on it. This fixes it in the way most obvious to me.

### Details and comments

I am a bit puzzle that I am the first to notice this.  My development builds of Aer otherwise result in the `.decode()` failing as soon as the package is imported.  Even with this change, I am still unable to build qiskit-aer in an Ubuntu 24.04 container.  The bug I get afterward is
```
Traceback (most recent call last):
  File "/home/garrison/Qiskit/qiskit-aer/test.py", line 2, in <module>
    from qiskit_aer import AerSimulator
  File "/home/garrison/Qiskit/qiskit-aer/qiskit_aer/__init__.py", line 69, in <module>
    from qiskit_aer.aerprovider import AerProvider
  File "/home/garrison/Qiskit/qiskit-aer/qiskit_aer/aerprovider.py", line 20, in <module>
    from .backends.aer_simulator import AerSimulator
  File "/home/garrison/Qiskit/qiskit-aer/qiskit_aer/backends/__init__.py", line 17, in <module>
    from .aer_simulator import AerSimulator
  File "/home/garrison/Qiskit/qiskit-aer/qiskit_aer/backends/aer_simulator.py", line 24, in <module>
    from .aerbackend import AerBackend, AerError
  File "/home/garrison/Qiskit/qiskit-aer/qiskit_aer/backends/aerbackend.py", line 33, in <module>
    from ..noise.noise_model import NoiseModel, QuantumErrorLocation
  File "/home/garrison/Qiskit/qiskit-aer/qiskit_aer/noise/__init__.py", line 241, in <module>
    from .noise_model import NoiseModel
  File "/home/garrison/Qiskit/qiskit-aer/qiskit_aer/noise/noise_model.py", line 38, in <module>
    from ..backends.backend_utils import BASIS_GATES
  File "/home/garrison/Qiskit/qiskit-aer/qiskit_aer/backends/backend_utils.py", line 30, in <module>
    from .controller_wrappers import aer_initialize_libraries
ModuleNotFoundError: No module named 'qiskit_aer.backends.controller_wrappers'
```
