### PR TITLE
Error when trying to import qiskit_aer in a local repository- .decode() on non-byte string

### DIFF
--- a/qiskit_aer/version.py
+++ b/qiskit_aer/version.py
@@ -50,10 +50,10 @@ def git_version():
     # Determine if we're at main
     try:
         out = _minimal_ext_cmd(["git", "rev-parse", "HEAD"])
-        git_revision = out.strip().decode("ascii")
+        git_revision = out.strip()
     except OSError:
         git_revision = "Unknown"
-
+    
     return git_revision
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I tried to import qiskit_aer (v 0.15.1) in a repo that I had previously pushed changes with. I got the error 
`AttributeError: 'str' object has no attribute 'decode'` in `qiskit_aer/version.py`. Removed the `.decode()` method for the `git_revision` variable and this resolved the issue.


### Details and comments
Full Error Message: 
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 1
----> 1 import qiskit_aer

File c:\Users\hkbel\Desktop\Repos\qarith\Lib\site-packages\qiskit_aer\__init__.py:69
     65     np.dot(np.zeros(100), np.zeros(100))
     66 # ... ¯\_(ツ)_/¯
     67 
     68 # pylint: disable=wrong-import-position
---> 69 from qiskit_aer.aerprovider import AerProvider
     70 from qiskit_aer.jobs import AerJob
     71 from qiskit_aer.aererror import AerError

File c:\Users\hkbel\Desktop\Repos\qarith\Lib\site-packages\qiskit_aer\aerprovider.py:20
     17 from qiskit.providers import QiskitBackendNotFoundError
     18 from qiskit.providers.providerutils import filter_backends
---> 20 from .backends.aer_simulator import AerSimulator
     21 from .backends.qasm_simulator import QasmSimulator
     22 from .backends.statevector_simulator import StatevectorSimulator

File c:\Users\hkbel\Desktop\Repos\qarith\Lib\site-packages\qiskit_aer\backends\__init__.py:17
      1 # This code is part of Qiskit.
      2 #
      3 # (C) Copyright IBM 2018, 2019.
   (...)
     10 # copyright notice, and modified files need to carry a notice indicating
     11 # that they have been altered from the originals.
     13 """
     14 Aer Provider Simulator Backends
     15 """
---> 17 from .aer_simulator import AerSimulator
     18 from .qasm_simulator import QasmSimulator
     19 from .statevector_simulator import StatevectorSimulator

File c:\Users\hkbel\Desktop\Repos\qarith\Lib\site-packages\qiskit_aer\backends\aer_simulator.py:23
     20 from qiskit.providers.options import Options
     21 from qiskit.providers.backend import BackendV2, BackendV1
---> 23 from ..version import __version__
     24 from .aerbackend import AerBackend, AerError
     25 from .backendconfiguration import AerBackendConfiguration

File c:\Users\hkbel\Desktop\Repos\qarith\Lib\site-packages\qiskit_aer\version.py:86
     81         full_version += ".dev0+" + git_revision[:7]
     83     return full_version
---> 86 __version__ = get_version_info()

File c:\Users\hkbel\Desktop\Repos\qarith\Lib\site-packages\qiskit_aer\version.py:80, in get_version_info()
     78     return full_version
     79 if not release:
---> 80     git_revision = git_version()
     81     full_version += ".dev0+" + git_revision[:7]
     83 return full_version

File c:\Users\hkbel\Desktop\Repos\qarith\Lib\site-packages\qiskit_aer\version.py:53, in git_version()
     51 try:
     52     out = _minimal_ext_cmd(["git", "rev-parse", "HEAD"])
---> 53     git_revision = out.strip().decode("ascii")
     54 except OSError:
     55     git_revision = "Unknown"

AttributeError: 'str' object has no attribute 'decode'
```
