### PR TITLE
Fix the internal compiler error with gcc 12/13 and CUDA 12.4/12.5

### DIFF
--- a/src/simulators/density_matrix/densitymatrix.hpp
+++ b/src/simulators/density_matrix/densitymatrix.hpp
@@ -478,8 +478,8 @@ DensityMatrix<data_t>::expval_pauli(const reg_t &qubits,
   auto phase = std::complex<data_t>(initial_phase);
   QV::add_y_phase(num_y, phase);
 
-  const uint_t mask_u = ~MASKS[x_max + 1];
-  const uint_t mask_l = MASKS[x_max];
+  uint_t mask_u = ~MASKS[x_max + 1];
+  uint_t mask_l = MASKS[x_max];
   auto lambda = [&](const int_t i, double &val_re, double &val_im) -> void {
     (void)val_im; // unused
     auto idx_vec = ((i << 1) & mask_u) | (i & mask_l);

--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -2324,8 +2324,8 @@ double QubitVector<data_t>::expval_pauli(const reg_t &qubits,
     return std::real(apply_reduction_lambda(std::move(lambda)));
   }
 
-  const uint_t mask_u = ~MASKS[x_max + 1];
-  const uint_t mask_l = MASKS[x_max];
+  uint_t mask_u = ~MASKS[x_max + 1];
+  uint_t mask_l = MASKS[x_max];
   auto lambda = [&](const int_t i, double &val_re, double &val_im) -> void {
     (void)val_im; // unused
     int_t idxs[2];
@@ -2415,8 +2415,8 @@ void QubitVector<data_t>::apply_pauli(const reg_t &qubits,
     return;
   }
 
-  const uint_t mask_u = ~MASKS[x_max + 1];
-  const uint_t mask_l = MASKS[x_max];
+  uint_t mask_u = ~MASKS[x_max + 1];
+  uint_t mask_l = MASKS[x_max];
   auto lambda = [&](const int_t i) -> void {
     int_t idxs[2];
     idxs[0] = ((i << 1) & mask_u) | (i & mask_l);

--- a/src/simulators/statevector/transformer.hpp
+++ b/src/simulators/statevector/transformer.hpp
@@ -240,7 +240,7 @@ void Transformer<Container, data_t>::apply_diagonal_matrix(
     return;
   }
 
-  const size_t N = qubits.size();
+  size_t N = qubits.size();
   auto func = [&](const areg_t<2> &inds,
                   const cvector_t<data_t> &_diag) -> void {
     for (int_t i = 0; i < 2; ++i) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Compiling qiskit-aer with CUDA support and gcc 12/13 resulted in some internal compiler error, see #2227.

The error was resolved by removing the `const ` expression in from of the lambda functions. The issue is that the above `const` declared variables are passed to the lambda function using `&` as the default capture of the lambda function. Passing a constant value by reference to a lambda function causes issues by gcc 12/13.



### Details and comments

Removing the `const` expression allows the code to compile with gcc 12/13 using CUDA 12.4/12.5. I have not yet checked if the issue us specific to Grace Grace and Grace Hopper which is ARM. 


