### PR TITLE
Adds unique name for upload-artifact jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: ${{ github.job }}-${{ matrix.os }}
+          name: aer-deploy-wheel-build-${{ matrix.os }}
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: ${{ github.job }}-${{ matrix.os }}
+          name: aer-deploy-build_wheels_aarch64-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-          name: publish-shared-wheels
+          name: aer-deploy-wheel-arm64-macos-${{ matrix.os }}
   sdist:
     name: Publish qiskit-aer sdist
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./dist/qiskit*
-          name: ${{ github.job }}-${{ matrix.os }}
+          name: aer-deploy-sdist-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-          name: ${{ github.job }}-${{ matrix.os }}
+          name: aer-deploy-gpu-build-cuda11-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-          name: ${{ github.job }}-${{ matrix.os }}
+          name: aer-deploy-gpu-build-cuda12-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -238,7 +238,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: ${{ github.job }}-${{ matrix.os }}
+          name: aer-deploy-build_wheels_s390x-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -275,7 +275,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: ${{ github.job }}-${{ matrix.os }}
+          name: aer-deploy-build_wheels_ppc64le-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -291,7 +291,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: deploy
-          name: publish-shared-wheels
+          pattern: 'aer-deploy-'
+          merge-multiple: true
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: aer-deploy-wheel-build-${{ matrix.os }}
+          name: aer-deploy-shared-wheel-build-${{ matrix.os }}
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: aer-deploy-build_wheels_aarch64-${{ matrix.os }}
+          name: aer-deploy-separate-build_wheels_aarch64-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -85,10 +85,10 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: arm64
         run: cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: aer-deploy-wheel-arm64-macos-${{ matrix.os }}
+          name: aer-deploy-shared-wheel-arm64-macos-${{ matrix.os }}
   sdist:
     name: Publish qiskit-aer sdist
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./dist/qiskit*
-          name: aer-deploy-sdist-${{ matrix.os }}
+          name: aer-deploy-separate-sdist-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -153,10 +153,10 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND: 'auditwheel repair --exclude libcudart.so.11.0 --exclude libcustatevec.so.1 --exclude libcutensornet.so.2 --exclude libcutensor.so.1 --exclude libcutensorMg.so.1 --exclude libcusolver.so.11 --exclude libcusolverMg.so.11 --exclude libcusparse.so.11 --exclude libcublas.so.11 --exclude libcublasLt.so.11 -w {dest_dir} {wheel}'
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: aer-deploy-gpu-build-cuda11-${{ matrix.os }}
+          name: aer-deploy-separate-gpu-build-cuda11-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -198,10 +198,10 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND: 'auditwheel repair --exclude libcudart.so.12 --exclude libcustatevec.so.1 --exclude libcutensornet.so.2 --exclude libcutensor.so.1 --exclude libcutensorMg.so.1 --exclude libcusolver.so.11 --exclude libcusolverMg.so.11 --exclude libcusolver.so.12 --exclude libcusolverMg.so.12 --exclude libcusparse.so.12 --exclude libcublas.so.12 --exclude libcublasLt.so.12 --exclude libnvJitLink.so.12 -w {dest_dir} {wheel}'
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: aer-deploy-gpu-build-cuda12-${{ matrix.os }}
+          name: aer-deploy-separate-gpu-build-cuda12-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -238,7 +238,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: aer-deploy-build_wheels_s390x-${{ matrix.os }}
+          name: aer-deploy-separate-build_wheels_s390x-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -275,7 +275,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: aer-deploy-build_wheels_ppc64le-${{ matrix.os }}
+          name: aer-deploy-separate-build_wheels_ppc64le-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -291,7 +291,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: deploy
-          pattern: 'aer-deploy-'
+          pattern: 'aer-deploy-shared-'
           merge-multiple: true
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: publish-shared-wheels
+          name: ${{ github.job }}-${{ matrix.os }}
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -60,6 +60,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: ${{ github.job }}-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -110,6 +111,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./dist/qiskit*
+          name: ${{ github.job }}-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -154,6 +156,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+          name: ${{ github.job }}-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -198,6 +201,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+          name: ${{ github.job }}-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -234,6 +238,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: ${{ github.job }}-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -270,6 +275,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: ${{ github.job }}-${{ matrix.os }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,12 +69,12 @@ jobs:
       - name: Setup tutorials job
         run: |
           set -e
+          sudo apt install -y graphviz pandoc libblas-dev liblapack-dev
           git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
           python -m pip install --upgrade pip wheel
           pip install -U -r requirements-dev.txt -c constraints.txt
           pip install -c constraints.txt git+https://github.com/Qiskit/qiskit
           pip install -c constraints.txt .
-          sudo apt install -y graphviz pandoc libblas-dev liblapack-dev
           pip check
         shell: bash
       - name: Run Tutorials

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,7 +74,7 @@ jobs:
           pip install -U -r requirements-dev.txt -c constraints.txt
           pip install -c constraints.txt git+https://github.com/Qiskit/qiskit
           pip install -c constraints.txt .
-          sudo apt install -y graphviz pandoc libopenblas-dev
+          sudo apt install -y graphviz pandoc libblas-dev liblapack-dev
           pip check
         shell: bash
       - name: Run Tutorials

--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           test_selection: backend
           repo_install_command: |
-            sudo apt-get install -y libblas-dev
+            sudo apt-get install -y libblas-dev liblapack-dev
             pip install scipy==1.13.1
             pip install conan
             pip uninstall -y qiskit qiskit-terra qiskit-aer

--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           test_selection: backend
           repo_install_command: |
+            sudo apt-get install -y libblas-dev
             pip install scipy==1.13.1
             pip install conan
             pip uninstall -y qiskit qiskit-terra qiskit-aer


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes an error in the github action for `deploy` preventing wheels from being uploaded.


### Details and comments
When using `actions/upload-artifact@v4` a unique name should be given for separate jobs, otherwise the name clash results in `Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`.

This PR adds a unique name to the action.

