### PR TITLE
Add Python3.13 support and remove Python 3.8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,15 @@ jobs:
         os: ["macos-13", "ubuntu-latest", "windows-2019"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python Python '3.10'
+      - name: Set up Python Python '3.13'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
         if: runner.os == 'Windows'
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.17.0
+        run: python -m pip install -U cibuildwheel==2.22.0
       - name: Build Wheels
         env:
           AER_CMAKE_OPENMP_BUILD: 1
@@ -39,13 +39,13 @@ jobs:
         os: ["macos-latest"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python Python 3.10
+      - name: Set up Python Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
           architecture: arm64
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.17.0
+        run: python -m pip install -U cibuildwheel==2.22.0
       - name: Build Wheels
         env:
           CIBW_ARCHS_MACOS: arm64
@@ -70,10 +70,10 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.22.0
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL: "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo && yum install -y yum-utils wget && wget -q https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda-repo-rhel7-11-8-local-11.8.0_520.61.05-1.x86_64.rpm && rpm -i cuda-repo-rhel7-11-8-local-11.8.0_520.61.05-1.x86_64.rpm && yum clean all && yum -y install cuda && yum -y install openblas-devel && yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo && yum clean all"
@@ -103,10 +103,10 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.22.0
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL: "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo && yum install -y yum-utils wget && wget -q https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda-repo-rhel8-12-5-local-12.5.1_555.42.06-1.x86_64.rpm && rpm -i cuda-repo-rhel8-12-5-local-12.5.1_555.42.06-1.x86_64.rpm && yum clean all && yum -y install cuda-toolkit-12-5 && yum -y install openblas-devel && yum clean all"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.22.0
       - name: Build wheels
         env:
           AER_CMAKE_OPENMP_BUILD: 1
@@ -74,13 +74,13 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python Python '3.10'
+      - name: Set up Python Python '3.13'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
           architecture: arm64
       - name: Install deps
-        run: python -m pip install -U cibuildwheel==2.17.0
+        run: python -m pip install -U cibuildwheel==2.22.0
       - name: Build Wheels
         env:
           CIBW_ARCHS_MACOS: arm64
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Install Deps
         run: pip install -U scikit-build wheel
       - name: Build Artifacts
@@ -139,15 +139,15 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2
+          python -m pip install cibuildwheel==2.22.0
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL: "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo && yum install -y yum-utils wget && wget -q https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda-repo-rhel7-11-8-local-11.8.0_520.61.05-1.x86_64.rpm && rpm -i cuda-repo-rhel7-11-8-local-11.8.0_520.61.05-1.x86_64.rpm && yum clean all && yum -y install cuda && yum -y install openblas-devel && yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo && yum clean all"
           CIBW_BEFORE_BUILD : "pip install nvidia-cuda-runtime-cu11 nvidia-cublas-cu11 nvidia-cusolver-cu11 nvidia-cusparse-cu11 'cuquantum-cu11<24.11.0'"
-          CIBW_SKIP: "*-manylinux_i686 pp* cp36* cp37* *musllinux*"
+          CIBW_SKIP: "*-manylinux_i686 pp* cp36* cp37* cp38* *musllinux*"
           CIBW_TEST_SKIP: "*"
           CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu-cu11 QISKIT_AER_CUDA_MAJOR=11 CMAKE_VERBOSE_MAKEFILE=true AER_THRUST_BACKEND=CUDA CUDACXX=/usr/local/cuda/bin/nvcc AER_CUDA_ARCH="7.0 7.2 7.5 8.0 8.6 8.7" AER_PYTHON_CUDA_ROOT=/opt/_internal AER_CIBUILD=true
           CIBW_REPAIR_WHEEL_COMMAND: 'auditwheel repair --exclude libcudart.so.11.0 --exclude libcustatevec.so.1 --exclude libcutensornet.so.2 --exclude libcutensor.so.1 --exclude libcutensorMg.so.1 --exclude libcusolver.so.11 --exclude libcusolverMg.so.11 --exclude libcusparse.so.11 --exclude libcublas.so.11 --exclude libcublasLt.so.11 -w {dest_dir} {wheel}'
@@ -187,12 +187,12 @@ jobs:
           python-version: '3.10'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2
+          python -m pip install cibuildwheel==2.22.0
       - name: Build wheels
         env:
           CIBW_BEFORE_ALL: "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo && yum install -y yum-utils wget && wget -q https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda-repo-rhel8-12-5-local-12.5.1_555.42.06-1.x86_64.rpm && rpm -i cuda-repo-rhel8-12-5-local-12.5.1_555.42.06-1.x86_64.rpm && yum clean all && yum -y install cuda-toolkit-12-5 && yum -y install openblas-devel && yum clean all"
           CIBW_BEFORE_BUILD : "pip install nvidia-cuda-runtime-cu12 nvidia-nvjitlink-cu12 nvidia-cublas-cu12 nvidia-cusolver-cu12 nvidia-cusparse-cu12 'cuquantum-cu12<24.11.0"
-          CIBW_SKIP: "*-manylinux_i686 pp* cp36* cp37* *musllinux*"
+          CIBW_SKIP: "*-manylinux_i686 pp* cp36* cp37* cp38* *musllinux*"
           CIBW_TEST_SKIP: "*"
           CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu QISKIT_AER_CUDA_MAJOR=12 CMAKE_VERBOSE_MAKEFILE=true AER_THRUST_BACKEND=CUDA CUDACXX=/usr/local/cuda/bin/nvcc AER_CUDA_ARCH="7.0 7.2 7.5 8.0 8.6 8.7 9.0" AER_PYTHON_CUDA_ROOT=/opt/_internal AER_CIBUILD=true
           CIBW_REPAIR_WHEEL_COMMAND: 'auditwheel repair --exclude libcudart.so.12 --exclude libcustatevec.so.1 --exclude libcutensornet.so.2 --exclude libcutensor.so.1 --exclude libcutensorMg.so.1 --exclude libcusolver.so.11 --exclude libcusolverMg.so.11 --exclude libcusolver.so.12 --exclude libcusolverMg.so.12 --exclude libcusparse.so.12 --exclude libcublas.so.12 --exclude libcublasLt.so.12 --exclude libnvJitLink.so.12 -w {dest_dir} {wheel}'
@@ -258,7 +258,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     needs: ["lint"]
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", '3.11', "3.12.0"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         platform: [
           { os: "ubuntu-latest", python-architecture: "x64" },
         ]
@@ -93,7 +93,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12.0"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         qiskit-extra: [""]
         include:
           - python-version: "3.10"
@@ -198,7 +198,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", '3.11', "3.12.0"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       AER_THRUST_BACKEND: OMP
       QISKIT_TEST_CAPTURE_STREAMS: 1
@@ -243,7 +243,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12.0"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       AER_THRUST_BACKEND: OMP
       QISKIT_TEST_CAPTURE_STREAMS: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-skip = "pp* cp36* cp37* *musllinux* cp38-macosx_arm64"
+skip = "pp* cp36* cp37* cp38* *musllinux*"
 test-skip = "cp3*-win32 cp3*-manylinux_i686"
 test-command = "python {project}/tools/verify_wheels.py"
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a
@@ -28,9 +28,9 @@ before-all = "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -
 environment = { CMAKE_GENERATOR = "Visual Studio 16 2019"}
 
 [[tool.cibuildwheel.overrides]]
-select = "cp3{8,9,10,11,12}-manylinux_i686"
+select = "cp3{9,10,11,12,13}-manylinux_i686"
 before-all = "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo && yum install -y wget && bash {project}/tools/install_openblas_i686.sh && bash {project}/tools/install_rust.sh"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']

--- a/releasenotes/notes/add_support_for_python_313-a92b1656dcc23576.yaml
+++ b/releasenotes/notes/add_support_for_python_313-a92b1656dcc23576.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added support for running qiskit-aer with Python 3.13
+deprecations:
+  - |
+    Python 3.8 is no longer supported as it is not supported in qiskit 1.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ cmake!=3.17.1,!=3.17.0
 conan<2.0.0
 scikit-build>=0.11.0
 asv
-cvxpy<1.5.0
+cvxpy<1.6.0
 pylint
 black[jupyter]~=24.1
 clang-format~=15.0.7


### PR DESCRIPTION
### Summary
This PR adds Python 3.13 support for building wheels and removes Python 3.8 which was dropped by qiskit version 1.3.

### Details and comments
The version of cibuildwheel was updated to the latest 2.22 to ensure support for Python 3.13.

