### PR TITLE
Fix QubitVector::check_dimension to use only the data_size_ field

### DIFF
--- a/src/simulators/statevector/qubitvector.hpp
+++ b/src/simulators/statevector/qubitvector.hpp
@@ -730,10 +730,10 @@ void QubitVector<data_t>::check_vector(const cvector_t<data_t> &vec,
 
 template <typename data_t>
 void QubitVector<data_t>::check_dimension(const QubitVector &qv) const {
-  if (data_size_ != qv.size_) {
+  if (data_size_ != qv.data_size_) {
     std::string error = "QubitVector: vectors are different shape " +
                         std::to_string(data_size_) +
-                        " != " + std::to_string(qv.num_states_);
+                        " != " + std::to_string(qv.data_size_);
     throw std::runtime_error(error);
   }
 }

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -635,10 +635,10 @@ void QubitVectorThrust<data_t>::check_vector(const cvector_t<data_t> &vec,
 template <typename data_t>
 void QubitVectorThrust<data_t>::check_dimension(
     const QubitVectorThrust &qv) const {
-  if (data_size_ != qv.size_) {
+  if (data_size_ != qv.data_size_) {
     std::string error = "QubitVectorThrust: vectors are different shape " +
                         std::to_string(data_size_) +
-                        " != " + std::to_string(qv.num_states_);
+                        " != " + std::to_string(qv.data_size_);
     throw std::runtime_error(error);
   }
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes a bug where `QubitVector::check_dimension` attempted to access non-existing fields.

Fixes #2284 

### Details and comments
Originally, `QubitVector::check_dimension` was defined as
```cpp
template <class data_t>
void QubitVector<data_t>::check_dimension(const QubitVector &qv) const {
  if (size_ != qv.size_) {
    std::stringstream ss;
    ss << "QubitVector: vectors are different shape ";
    ss << size_ << " != " << qv.size_;
    throw std::runtime_error(ss.str());
  }
}
```

In 502ffcd01d9c515d47f72da7d4cefd95ce4bba4c this was changed to
```cpp
template <typename data_t>
void QubitVector<data_t>::check_dimension(const QubitVector &qv) const {
  if (data_size_ != qv.size_) {
    std::string error = "QubitVector: vectors are different shape " +
                         std::to_string(data_size_) + " != " +
                         std::to_string(qv.num_states_);
    throw std::runtime_error(error);
  }
}
```

Along with a change of the `size_` field to `data_size_`. It is unclear why `qv.size_` remained (maybe the idea was to use `qv.size()`?) nor what is the meaning of `qv.num_states_` (since no such field or similar getter was added). It seems to me that changing to `data_size_` retains the original meaning.

