### PR TITLE
Fix for https://github.com/Qiskit/qiskit-aer/issues/2286

### DIFF
--- a/releasenotes/notes/mps-sim-has-global-bond-dim-and-truncation-threshold-47dacf39fdee5c28.yaml
+++ b/releasenotes/notes/mps-sim-has-global-bond-dim-and-truncation-threshold-47dacf39fdee5c28.yaml
@@ -1,0 +1,8 @@
+---
+prelude: >
+    MPS simulator had global bond dimension and singular values truncation threshold
+fixes:
+  - |
+    Each MPS simulator has now its own settings for the bond dimension and singular values
+    truncation threshold. Refer to `#2286 <https://github.com/Qiskit/qiskit-aer/issues/2286>`
+    for more information.

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -324,14 +324,14 @@ size_t State::required_memory_mb(uint_t num_qubits,
 
 void State::set_config(const Config &config) {
   // Set threshold for truncating Schmidt coefficients
-  MPS_Tensor::set_truncation_threshold(
+  qreg_.set_truncation_threshold(
       config.matrix_product_state_truncation_threshold);
 
   if (config.matrix_product_state_max_bond_dimension.has_value())
-    MPS_Tensor::set_max_bond_dimension(
+    qreg_.set_max_bond_dimension(
         config.matrix_product_state_max_bond_dimension.value());
   else
-    MPS_Tensor::set_max_bond_dimension(UINT64_MAX);
+    qreg_.set_max_bond_dimension(UINT64_MAX);
 
   // Set threshold for truncating snapshots
   MPS::set_json_chop_threshold(config.chop_threshold);
@@ -363,9 +363,9 @@ void State::set_config(const Config &config) {
 }
 
 void State::add_metadata(ExperimentResult &result) const {
-  result.metadata.add(MPS_Tensor::get_truncation_threshold(),
+  result.metadata.add(qreg_.get_truncation_threshold(),
                       "matrix_product_state_truncation_threshold");
-  result.metadata.add(MPS_Tensor::get_max_bond_dimension(),
+  result.metadata.add(qreg_.get_max_bond_dimension(),
                       "matrix_product_state_max_bond_dimension");
   result.metadata.add(MPS::get_sample_measure_alg(),
                       "matrix_product_state_sample_measure_algorithm");

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -663,8 +663,9 @@ void MPS::common_apply_2_qubit_gate(
 
   MPS_Tensor left_gamma, right_gamma;
   rvector_t lambda;
-  double discarded_value = MPS_Tensor::Decompose(temp, left_gamma, lambda,
-                                                 right_gamma, MPS::mps_lapack_);
+  double discarded_value = MPS_Tensor::Decompose(
+      temp, left_gamma, lambda, right_gamma, MPS::mps_lapack_,
+      max_bond_dimension_, truncation_threshold_);
 
   if (discarded_value > json_chop_threshold_)
     MPS::print_to_log("discarded_value=", discarded_value, ", ");
@@ -1804,8 +1805,8 @@ void MPS::initialize_from_matrix(uint_t num_qubits, const cmatrix_t &mat) {
     S.clear();
     S.resize(std::min(reshaped_matrix.GetRows(), reshaped_matrix.GetColumns()));
     csvd_wrapper(reshaped_matrix, U, S, V, MPS::mps_lapack_);
-    reduce_zeros(U, S, V, MPS_Tensor::get_max_bond_dimension(),
-                 MPS_Tensor::get_truncation_threshold(), MPS::mps_lapack_);
+    reduce_zeros(U, S, V, get_max_bond_dimension(), get_truncation_threshold(),
+                 MPS::mps_lapack_);
 
     // step 3 - update q_reg_ with new gamma and new lambda
     //          increment number of qubits in the MPS structure

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -292,6 +292,13 @@ public:
                                             reg_t &index_vec,
                                             const reg_t &qubits) const;
 
+  void set_max_bond_dimension(uint_t max_bond_dimension) {
+    max_bond_dimension_ = max_bond_dimension;
+  }
+  void set_truncation_threshold(double truncation_threshold) {
+    truncation_threshold_ = truncation_threshold;
+  }
+
   static void set_omp_threads(uint_t threads) {
     if (threads > 0)
       omp_threads_ = threads;
@@ -321,6 +328,9 @@ public:
   }
 
   static void set_mps_lapack_svd(bool mps_lapack) { mps_lapack_ = mps_lapack; }
+
+  uint_t get_max_bond_dimension() const { return max_bond_dimension_; }
+  double get_truncation_threshold() const { return truncation_threshold_; }
 
   static uint_t get_omp_threads() { return omp_threads_; }
   static uint_t get_omp_threshold() { return omp_threshold_; }
@@ -557,6 +567,9 @@ private:
   //-----------------------------------------------------------------------
   // Config settings
   //-----------------------------------------------------------------------
+  uint_t max_bond_dimension_ = UINT64_MAX;
+  double truncation_threshold_ = 1e-16;
+
   static uint_t omp_threads_; // Disable multithreading by default
   static uint_t
       omp_threshold_; // Qubit threshold for multithreading when enabled


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

MPS simulator had global bond dimension and singular values truncation threshold

### Details and comments

Moved the settings from `MPS_Tensor` into the internal `State`, but now without the `static` specifier. For details, see: https://github.com/Qiskit/qiskit-aer/issues/2286
 
