### PR TITLE
Fix for https://github.com/Qiskit/qiskit-aer/issues/2291

### DIFF
--- a/releasenotes/notes/aggregate_operations-crash-c262132ba430972d.yaml
+++ b/releasenotes/notes/aggregate_operations-crash-c262132ba430972d.yaml
@@ -1,0 +1,9 @@
+---
+prelude: >
+    DiagonalFusion::aggregate_operations could crash in some circumstances
+fixes:
+  - |
+    Sometimes `DiagonalFuson::get_next_deagonal_end` had an invalid `from`
+    parameter. Now it has a check to return -1 in such a case. For more
+    details refer to: `#2291 <https://github.com/Qiskit/qiskit-aer/issues/2291>`
+

--- a/src/transpile/fusion.hpp
+++ b/src/transpile/fusion.hpp
@@ -579,6 +579,9 @@ int DiagonalFusion::get_next_diagonal_end(
     const oplist_t &ops, const int from, const int end,
     std::set<uint_t> &fusing_qubits) const {
 
+  if (ops.size() <= from)
+    return -1;
+
   if (is_diagonal_op(ops[from])) {
     for (const auto qubit : ops[from].qubits)
       fusing_qubits.insert(qubit);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`DiagonalFusion::aggregate_operations` could crash in some circumstances

### Details and comments

Sometimes it could get an invalid `from` parameter. Now it's modified to check it and return -1 if it's not valid.
See https://github.com/Qiskit/qiskit-aer/issues/2291 for more information.



