### PR TITLE
Adjust QuantumError.to_dict() to handle lack of Instruction.condition

### DIFF
--- a/qiskit_aer/library/control_flow_instructions/jump.py
+++ b/qiskit_aer/library/control_flow_instructions/jump.py
@@ -29,6 +29,7 @@ class AerJump(Instruction):
     def __init__(self, jump_to, num_qubits, num_clbits=0):
         super().__init__("jump", num_qubits, num_clbits, [jump_to])
         self.condition_expr = None
+        self.condition = None
 
     def set_conditional(self, cond):
         """Set condition to perform this jump instruction.
@@ -42,5 +43,5 @@ class AerJump(Instruction):
         if isinstance(cond, Expr):
             self.condition_expr = cond
         else:
-            self.c_if(*cond)
+            self.condition = cond
         return self

--- a/qiskit_aer/noise/errors/quantum_error.py
+++ b/qiskit_aer/noise/errors/quantum_error.py
@@ -319,8 +319,9 @@ class QuantumError(BaseQuantumError, TolerancesMixin):
                     inst_dict["params"] = inst.operation.params
                 if inst.operation.label:
                     inst_dict["label"] = inst.operation.label
-                if inst.operation.condition:
-                    inst_dict["condition"] = inst.operation.condition
+                condition = getattr(inst.operation, "condition", None)
+                if condition:
+                    inst_dict["condition"] = condition
                 circ_inst.append(inst_dict)
             instructions.append(circ_inst)
         # Construct error dict


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit 2.0 the Instruction.condition attribute will be removed following it's deprecation in 1.3.0. This attribute has been superseded by the IfElseOp which covers the use case but offers more functionality. The removal is pending in Qiskit/qiskit#13506 and the use of qiskit-aer in Qiskit's tests is blocking progress on that PR. This commit makes the usage of .condition optional to maintain compatibility with Qiskit<2.0 but also work in >=2.0 with the attribute removed.

### Details and comments


