### PR TITLE
fixes #2042

### DIFF
--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -371,8 +371,11 @@ class Estimator(BaseEstimator):
         circs = []
         for meas_circuit in meas_circuits:
             new_circ = circuit.copy()
+            # Track existing classical register names in new_circ
+            existing_creg_names = {creg.name for creg in new_circ.cregs}
             for creg in meas_circuit.cregs:
-                new_circ.add_register(creg)
+                if creg.name not in existing_creg_names: # Prevent duplicate registers
+                    new_circ.add_register(creg)
             new_circ.compose(meas_circuit, inplace=True)
             _update_metadata(new_circ, meas_circuit.metadata)
             circs.append(new_circ)


### PR DESCRIPTION
Greetings,

This is my first issue.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed issue #2042 by adding a check for estimator adding duplicate classical registers in _combine_circs.


### Details and comments

I added a check to _combinecircs in qiskit_aer > primitives > estimator.py to prevent a clash of register names for estimator which happens if the same name is used e.g. 'c'.

