### PR TITLE
Attempt to Add ROCm Support to Qiskit Aer for AMD GPUs (issue #2113)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,3 +163,32 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
           name: artifact-${{ github.job }}
+  test-rocm:
+    runs-on: ubuntu-latest
+    needs: wheel-gpu-rocm  # Ensures the ROCm wheels are built before testing
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install ROCm Dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y rocm-dev rocm-libs rocblas rocm-llvm
+          echo "/opt/rocm/bin" >> $GITHUB_PATH
+
+      - name: Install Test Dependencies
+        run: |
+          pip install -r requirements-dev.txt pytest
+
+      - name: Install ROCm Build
+        run: |
+          pip install ./wheelhouse/qiskit_aer_gpu_rocm*.whl
+
+      - name: Run Unit Tests for ROCm
+        env:
+          AER_THRUST_BACKEND: ROCM
+        run: |
+          pytest -v tests --disable-warnings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,3 +120,46 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
           name: artifact-${{ github.job }}
+  wheel-gpu-rocm:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 30000
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.13'
+
+      - name: Install ROCm Dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y rocm-dev rocm-libs rocblas rocm-llvm
+          echo "/opt/rocm/bin" >> $GITHUB_PATH
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2.22.0
+
+      - name: Build ROCm wheels
+        env:
+          CIBW_BEFORE_ALL: "yum install -y openblas-devel"
+          CIBW_SKIP: "*-manylinux_i686 pp* cp36* cp37* cp38* cp39* cp310* cp311* *musllinux*"
+          CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu-rocm AER_THRUST_BACKEND=ROCM AER_ROCM_ARCH="gfx900 gfx906 gfx908 gfx90a gfx1030"
+          CIBW_REPAIR_WHEEL_COMMAND: 'auditwheel repair --exclude librocblas.so.0 --exclude librocm-runtime.so.1 -w {dest_dir} {wheel}'
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: artifact-${{ github.job }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,6 +206,62 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse
+  gpu-build-rocm:
+    name: Build qiskit-aer-gpu-rocm wheels
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+    runs-on: ${{ matrix.os }}
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 32000
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.13'
+
+      - name: Install ROCm Dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y rocm-dev rocm-libs rocblas rocm-llvm
+          echo "/opt/rocm/bin" >> $GITHUB_PATH
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2.22.0
+
+      - name: Build ROCm wheels
+        env:
+          CIBW_BEFORE_ALL: "yum install -y openblas-devel"
+          CIBW_SKIP: "*-manylinux_i686 pp* cp36* cp37* cp38* *musllinux*"
+          CIBW_TEST_SKIP: "*"
+          CIBW_ENVIRONMENT: QISKIT_AER_PACKAGE_NAME=qiskit-aer-gpu-rocm AER_THRUST_BACKEND=ROCM AER_ROCM_ARCH="gfx900 gfx906 gfx908 gfx90a gfx1030"
+          CIBW_REPAIR_WHEEL_COMMAND: 'auditwheel repair --exclude librocblas.so.0 --exclude librocm-runtime.so.1 -w {dest_dir} {wheel}'
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: aer-deploy-separate-gpu-build-rocm-${{ matrix.os }}
+
+      - name: Publish ROCm wheels to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse
   build_wheels_s390x:
     name: Build wheels on s390x
     runs-on: ${{ matrix.os }}

--- a/qiskit_aer/primitives/estimator.py
+++ b/qiskit_aer/primitives/estimator.py
@@ -371,8 +371,11 @@ class Estimator(BaseEstimator):
         circs = []
         for meas_circuit in meas_circuits:
             new_circ = circuit.copy()
+            # Track existing classical register names in new_circ
+            existing_creg_names = {creg.name for creg in new_circ.cregs}
             for creg in meas_circuit.cregs:
-                new_circ.add_register(creg)
+                if creg.name not in existing_creg_names: # Prevent duplicate registers
+                    new_circ.add_register(creg)
             new_circ.compose(meas_circuit, inplace=True)
             _update_metadata(new_circ, meas_circuit.metadata)
             circs.append(new_circ)

--- a/test/terra/backends/aer_simulator/test_rocm_backend.py
+++ b/test/terra/backends/aer_simulator/test_rocm_backend.py
@@ -1,0 +1,69 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+AerSimulator ROCm Integration Tests
+"""
+import os
+import pytest
+from qiskit import QuantumCircuit
+from qiskit_aer import AerSimulator
+from test.terra.backends.simulator_test_case import SimulatorTestCase, supported_methods
+
+
+class TestROCmBackend(SimulatorTestCase):
+    """AerSimulator tests for ROCm backend"""
+
+    @pytest.mark.skipif(
+        "AER_THRUST_BACKEND" not in os.environ or os.environ["AER_THRUST_BACKEND"] != "ROCM",
+        reason="Skipping ROCm-specific tests",
+    )
+    @supported_methods(["statevector"])
+    def test_rocm_backend_initialization(self, method, device):
+        """Test if Qiskit Aer initializes with ROCm backend."""
+        backend = self.backend(method=method, device=device)
+        self.assertEqual(backend.backend_name, "aer_simulator")
+
+    @pytest.mark.skipif(
+        "AER_THRUST_BACKEND" not in os.environ or os.environ["AER_THRUST_BACKEND"] != "ROCM",
+        reason="Skipping ROCm-specific tests",
+    )
+    @supported_methods(["statevector"])
+    def test_rocm_statevector(self, method, device):
+        """Test a simple circuit on the ROCm backend."""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+
+        backend = self.backend(method=method, device=device)
+        result = backend.run(qc).result()
+        statevector = result.get_statevector()
+
+        self.assertEqual(len(statevector), 2**2)
+
+    @pytest.mark.skipif(
+        "AER_THRUST_BACKEND" not in os.environ or os.environ["AER_THRUST_BACKEND"] != "ROCM",
+        reason="Skipping ROCm-specific tests",
+    )
+    @supported_methods(["statevector"])
+    def test_rocm_expectation_value(self, method, device):
+        """Test expectation value calculation on ROCm."""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+
+        backend = self.backend(method=method, device=device)
+        result = backend.run(qc).result()
+        statevector = result.get_statevector()
+
+        # Check probability of |00⟩ state (around 50% for H + CNOT)
+        prob_00 = abs(statevector[0]) ** 2
+        self.assertTrue(0.49 < prob_00 < 0.51)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I made changes to build.yml, deploy.yml and added tests for the ROCm backend.

The changes include:
- CI/CD updates to build and deploy ROCm-enabled wheels.
- Unit tests to validate ROCm functionality.
- New configurations to to CI.

This is a work-in-progress (WIP), my first time attempting to write workflows and I would highly appreciate any feedback and performance optimizations for ROCm.


### Details and comments
**Modified Files:**

- .github/workflows/build.yml → Adds wheel-gpu-rocm job for ROCm builds.
- .github/workflows/deploy.yml → For automatic deployment of ROCm wheels to PyPI.

**Changes:**

Adds a new job (wheel-gpu-rocm) that builds Qiskit Aer using AER_THRUST_BACKEND=ROCM.
Ensures that ROCm-enabled wheels are packaged and uploaded alongside CUDA and CPU builds.
Runs automated CI/CD testing for ROCm compatibility.

**Looking for feedback on:**

Whether the CI/CD workflow properly integrates with ROCm and any optimizations that can improve the build process. Additionally, I do not have an AMD card so I would appreciate if people could test this out on actual hardware.

