### PR TITLE
Fix multi-controlled gates in name mapping

### DIFF
--- a/qiskit_aer/backends/name_mapping.py
+++ b/qiskit_aer/backends/name_mapping.py
@@ -20,19 +20,19 @@ from qiskit.circuit.store import Store
 from qiskit.circuit.library import (
     U2Gate,
     RGate,
-    CYGate,
-    CZGate,
-    CSXGate,
-    CU3Gate,
-    CSwapGate,
+    YGate,
+    ZGate,
+    SXGate,
+    U3Gate,
+    SwapGate,
     PauliGate,
     DiagonalGate,
     UnitaryGate,
     MCPhaseGate,
     MCXGate,
-    CRXGate,
-    CRYGate,
-    CRZGate,
+    RXGate,
+    RYGate,
+    RZGate,
     MCU1Gate,
     MCXGrayCode,
     Initialize,
@@ -88,7 +88,7 @@ class MCSXGate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CSXGate(),
+            base_gate=SXGate(),
         )
 
 
@@ -103,7 +103,7 @@ class MCYGate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CYGate(),
+            base_gate=YGate(),
         )
 
 
@@ -118,7 +118,7 @@ class MCZGate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CZGate(),
+            base_gate=ZGate(),
         )
 
 
@@ -133,7 +133,7 @@ class MCRXGate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CRXGate(theta),
+            base_gate=RXGate(theta),
         )
 
 
@@ -148,7 +148,7 @@ class MCRYGate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CRYGate(theta),
+            base_gate=RYGate(theta),
         )
 
 
@@ -163,7 +163,7 @@ class MCRZGate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CRZGate(theta),
+            base_gate=RZGate(theta),
         )
 
 
@@ -208,7 +208,7 @@ class MCU3Gate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CU3Gate(theta, phi, lam),
+            base_gate=U3Gate(theta, phi, lam),
         )
 
 
@@ -223,7 +223,7 @@ class MCUGate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CU3Gate(theta, phi, lam),
+            base_gate=U3Gate(theta, phi, lam),
         )
 
 
@@ -238,7 +238,7 @@ class MCSwapGate(ControlledGate):
             None,
             num_ctrl_qubits,
             ctrl_state=ctrl_state,
-            base_gate=CSwapGate(),
+            base_gate=SwapGate(),
         )
 
 


### PR DESCRIPTION
### Summary

`MCSXGate`, `MCYGate`, `MCZGate`, `MCRXGate`, `MCRYGate`, `MCRZGate`, `MCU3Gate`, `MCUGate`, and `MCSwapGate` can not be instantiated due to a mismatch in the number of qubits with the base gate:
```
CircuitError: 'The number of control qubits must be in `[1, num_qubits - base_gate.num_qubits]`.'
```

### Details and comments

I came across this issue while writing a unit test for Qiskit/qiskit#13952.

Commit https://github.com/doichanj/qiskit-aer/commit/4587384b63e894a60dc57fbd790b189c6be2d709 (pull #1995) changed the base gates of these gates from non-controlled gates into singly controlled gates, which means there is one qubit too much in the base gate.

An alternative solution would be to reduce `num_ctrl_qubits` by one when calling `ControlledGate.__init__()`, but then the multi-controlled gates can only be created for two or more control qubits and one would need to extract the last qubit from the control state to pass it to the base gate.