### PR TITLE
Update intersphinx mapping and others URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,7 @@ html_last_updated_fmt = '%Y/%m/%d'
 autoclass_content = 'both'
 intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
 }
 
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -7,7 +7,7 @@ Getting started
 Installation
 ============
 Qiskit Aer depends on the main Qiskit package which has its own
-`Qiskit Installation guide <https://docs.quantum.ibm.com/start/install>`__ detailing the
+`Qiskit Installation guide <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__ detailing the
 installation options for Qiskit and its supported environments/platforms. You should refer to
 that first. Then the information here can be followed which focuses on the additional installation
 specific to Qiskit Aer.
@@ -17,7 +17,7 @@ specific to Qiskit Aer.
 
     .. tab-item:: Start locally
 
-      The simplest way to get started is to follow the installation guide for Qiskit `here <https://docs.quantum.ibm.com/start/install>`__
+      The simplest way to get started is to follow the installation guide for Qiskit `here <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__
 
       In your virtual environment where you installed Qiskit, add ``qiskit-aer``, e.g.:
 
@@ -54,7 +54,7 @@ specific to Qiskit Aer.
       the latest version of the Qiskit Aer code more efficiently.
 
       Since Qiskit Aer depends on Qiskit, and its latest changes may require new or changed
-      features of Qiskit, you should first follow Qiskit's `"Install from source"` instructions `here <https://docs.quantum.ibm.com/start/install-qiskit-source>`__
+      features of Qiskit, you should first follow Qiskit's `"Install from source"` instructions `here <https://quantum.cloud.ibm.com/docs/guides/install-qiskit-source>`__
 
       .. raw:: html
 

--- a/qiskit_aer/primitives/__init__.py
+++ b/qiskit_aer/primitives/__init__.py
@@ -18,7 +18,7 @@ Primitives (:mod:`qiskit_aer.primitives`)
 .. currentmodule:: qiskit_aer.primitives
 
 This module is Aer implementation of primitives.
-See the docs https://docs.quantum.ibm.com/api/qiskit/primitives for general descriptions.
+See the docs https://quantum.cloud.ibm.com/docs/api/qiskit/primitives for general descriptions.
 
 
 Classes

--- a/releasenotes/notes/0.14/support_backend_v2-9eeb4690199b01d1.yaml
+++ b/releasenotes/notes/0.14/support_backend_v2-9eeb4690199b01d1.yaml
@@ -4,4 +4,4 @@ features:
     Update Aer Backend to BackendV2. Refer to `#1681<https://github.com/Qiskit/qiskit-aer/issues/1681>`. 
     BackendV2 is differs from BackendV1 in the following points: backend.name() changes to backend.name string attribute, 
     the configuration attribute no longer exists, and the options attribute is added. For more information about BackendV2 is
-    `here<https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.BackendV2>`.
+    `here<https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.providers.BackendV2>`.


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.