### PR TITLE
Typo Fix: User warning now correctly formats the operation name into the message

### DIFF
--- a/qiskit_aer/noise/passes/relaxation_noise_pass.py
+++ b/qiskit_aer/noise/passes/relaxation_noise_pass.py
@@ -107,7 +107,7 @@ class RelaxationNoisePass(LocalNoisePass):
 
         if duration is None:
             warnings.warn(
-                r"Instruction duration not found for {op.name}. RelaxationNoisePass ignores "
+                f"Instruction duration not found for {op.name}. RelaxationNoisePass ignores "
                 "instructions without duration. "
                 "To avoid this warning, provide the corresponding duration information via `target`.",
                 UserWarning,


### PR DESCRIPTION
### Summary
This PR fixes the typo 'r' to 'f' so that the operation name will be formatted into the user warning when no instruction duration is found. Before this change, the user warning would literally include "{op.name}", which is obviously an unintended effect.

### Details and comments
I think this issue went unnoticed for some time, but because of my own academic research, I ran into this user warning typo.

