### PR TITLE
Bind parameters before truncation

### DIFF
--- a/releasenotes/notes/fix_parameter_bind-bf49a0bfb3c3a4de.yaml
+++ b/releasenotes/notes/fix_parameter_bind-bf49a0bfb3c3a4de.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Calling `Circuit::set_params` after binding parameters, because `set_params`
+    changes order of operations that causes failure of parameter binding.
+    This fixes issue #2367

--- a/src/controllers/controller_execute.hpp
+++ b/src/controllers/controller_execute.hpp
@@ -87,9 +87,6 @@ Result controller_execute(std::vector<std::shared_ptr<Circuit>> &input_circs,
         circs.push_back(circ);
         template_circs.push_back(circ);
       } else {
-        // Get base circuit without truncation
-        circ->set_params(false);
-        circ->set_metadata(config, truncate);
         // Load different parameterizations of the initial circuit
         const auto &circ_params = param_table[i];
         const size_t num_params = circ_params[0].second.size();
@@ -134,14 +131,9 @@ Result controller_execute(std::vector<std::shared_ptr<Circuit>> &input_circs,
               op.params[param_pos + stride * j] = params.second[j];
           }
           // Run truncation.
-          // TODO: Truncation should be performed and parameters should be
-          // resolved after it. However, parameters are associated with indices
-          // of instructions, which can be changed in truncation. Therefore,
-          // current implementation performs truncation for each parameter set.
-          if (truncate) {
-            param_circ->set_params(true);
-            param_circ->set_metadata(config, true);
-          }
+          param_circ->set_params(truncate);
+          param_circ->set_metadata(config, truncate);
+
           circs.push_back(param_circ);
           for (size_t j = 0; j < num_params; j++)
             template_circs.push_back(circ);
@@ -178,15 +170,9 @@ Result controller_execute(std::vector<std::shared_ptr<Circuit>> &input_circs,
               }
             }
             // Run truncation.
-            // TODO: Truncation should be performed and parameters should be
-            // resolved after it. However, parameters are associated with
-            // indices of instructions, which can be changed in truncation.
-            // Therefore, current implementation performs truncation for each
-            // parameter set.
-            if (truncate) {
-              param_circ->set_params(true);
-              param_circ->set_metadata(config, true);
-            }
+            param_circ->set_params(truncate);
+            param_circ->set_metadata(config, truncate);
+
             circs.push_back(param_circ);
             template_circs.push_back(circ);
           }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is fix for issue #2367

### Details and comments

The ops between measures are remapped when `Circuit::set_params` is called.
So This fix binds parameters before calling `Circuit::set_params`


