### PR TITLE
[Test] fix classical expression test import from qiskit

### DIFF
--- a/test/terra/expression/test_classical_expressions.py
+++ b/test/terra/expression/test_classical_expressions.py
@@ -16,7 +16,7 @@ Tests for utility functions to create device noise model.
 
 from test.terra.common import QiskitAerTestCase
 
-from qiskit.providers.aer.backends.controller_wrappers import *
+from qiskit_aer.backends.controller_wrappers import *
 
 
 class TestClassicalExpressions(QiskitAerTestCase):


### PR DESCRIPTION
description: Replace imports from qiskit.providers.aer.backends with from qiskit_aer.backends
    to align with the project upgrade from Qiskit 1.x to Qiskit >=2.0.0, where the
    Aer provider has been moved to the separate qiskit-aer package.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
edit the import in the test/terra/expression/test_classical_expressions.py
from `from qiskit.providers.aer.backends` to `from qiskit_aer.backends`


### Details and comments
because qiskit version that qiskit-aer depends on update from 1.X to >= 2.0

