### PR TITLE
Improve numerical robustness in noise transformation by assuming PSD for quad_form in CVXPY optimization

### DIFF
--- a/qiskit_aer/utils/noise_transformation.py
+++ b/qiskit_aer/utils/noise_transformation.py
@@ -416,7 +416,10 @@ def _transform_by_operator_list(
         constraints=[cvxpy.sum(x) <= 1, x >= 0, source_fids.T @ x <= target_fid],
     )
     # solve quadratic program
-    prob.solve()
+    # the matrix A in the quadratic program is a Gram matrix and therefore by construction PSD
+    # due to numerical noise small negative eigenvalues can occur causing a DCPError with prob.solve()
+    # as the PSD check might fail; assume_PSD=True tells cvxpy to not perform this check
+    prob.solve(assume_PSD=True)
     probabilities = x.value
     return probabilities
 

--- a/qiskit_aer/utils/noise_transformation.py
+++ b/qiskit_aer/utils/noise_transformation.py
@@ -412,14 +412,14 @@ def _transform_by_operator_list(
     # create quadratic program
     x = cvxpy.Variable(n)
     prob = cvxpy.Problem(
-        cvxpy.Minimize(cvxpy.quad_form(x, A) + b.T @ x),
+        # the matrix A in the quadratic program is a Gram matrix and therefore by construction PSD
+        # due to numerical noise small negative eigenvalues can occur causing a DCPError with prob.solve()
+        # as the PSD check might fail; assume_PSD=True tells cvxpy to not perform this check
+        cvxpy.Minimize(cvxpy.quad_form(x, A, assume_PSD=True) + b.T @ x),
         constraints=[cvxpy.sum(x) <= 1, x >= 0, source_fids.T @ x <= target_fid],
     )
     # solve quadratic program
-    # the matrix A in the quadratic program is a Gram matrix and therefore by construction PSD
-    # due to numerical noise small negative eigenvalues can occur causing a DCPError with prob.solve()
-    # as the PSD check might fail; assume_PSD=True tells cvxpy to not perform this check
-    prob.solve(assume_PSD=True)
+    prob.solve()
     probabilities = x.value
     return probabilities
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Skip explicit PSD check in CVXPY to improve numerical robustness


### Details and comments
In the method `_transform_by_operator_list()` inside the noise transformation utilities, the CVXPY optimization problem is solved by calling `prob.solve()` on a problem with a quadratic form `cvxpy.quad_form(x,A)`.  
Because the matrix involved is a Gram matrix by construction, it *should* be positive semidefinite (PSD). However, due to numerical noise, very small negative eigenvalues can appear, which can cause CVXPY’s default DCP check to fail. Using larger operator lists/basis sets might increase the numerical noise which is why this issue is often observed for more complex decompositions. Using `cvxpy.quad_form(x,A,assume_PSD = True)` circumvents this problem by skipping the DCP check of the solver.

Rationale:
- The matrix in the quadratic form is a Gram matrix and therefore PSD by definition, therefore the small negative eigenvalues and failed DCP checks are numerical artifacts
- skipping the DCP checks avoids unnecessary numerical failures without changing the actual problem

Notes:
- the existing tests already cover noise transformation behaviour in relevant scenarios which is why I did not introduce a new test
