### PR TITLE
support save_amplitudes_sq in extended_stabilizer method

### DIFF
--- a/qiskit_aer/backends/aer_simulator.py
+++ b/qiskit_aer/backends/aer_simulator.py
@@ -609,6 +609,7 @@ class AerSimulator(AerBackend):
                 "qerror_loc",
                 "roerror",
                 "save_statevector",
+                "save_amplitudes_sq",
                 "reset",
                 "delay",
             ]

--- a/qiskit_aer/library/instructions_table.csv
+++ b/qiskit_aer/library/instructions_table.csv
@@ -1,6 +1,6 @@
 ﻿Instruction,Automatic,Statevector,Density Matrix,MPS,Stabilizer,Ext. Stabilizer,Unitary,SuperOp
 :class:`SaveAmplitudes`,✔,✔,✘,✔,✘,✘,✘,✘
-:class:`SaveAmplitudesSquared`,✔,✔,✔,✔,✔,✘,✘,✘
+:class:`SaveAmplitudesSquared`,✔,✔,✔,✔,✔,✔,✘,✘
 :class:`SaveClifford`,✔,✘,✘,✘,✔,✘,✘,✘
 :class:`SaveDensityMatrix`,✔,✔,✔,✔,✘,✘,✘,✘
 :class:`SaveExpectationValue`,✔,✔,✔,✔,✔,✘,✘,✘

--- a/releasenotes/notes/extended-stabilizer-save-amplitudes-0a85ef5d368f58c2.yaml
+++ b/releasenotes/notes/extended-stabilizer-save-amplitudes-0a85ef5d368f58c2.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Enabled `save_amplitudes_sq` for the extended_stabilizer simulation
+    method. This allows computing the probability of a particular outcome
+    without resorting to computing the value for all outcomes, as was
+    the case for `save_statevector` (which does not scale beyond
+    a handful of qubits).
+
+    For example by adding
+    `circuit.save_amplitudes_squared([0], label="p0")` to the circuit,
+    the probability of the all-zero outcome bitstring is saved in the
+    result object under the "p0" label.

--- a/src/simulators/extended_stabilizer/ch_runner.hpp
+++ b/src/simulators/extended_stabilizer/ch_runner.hpp
@@ -155,10 +155,8 @@ public:
   complex_t amplitude(uint_t x_measure);
   AER::Vector<complex_t> statevector();
   // Return the probability of an outcome bitstring.
-  double get_probability(uint_t outcome,
-                         uint_t default_samples,
-                         uint_t repetitions,
-                         AER::RngEngine &rng);
+  double get_probability(uint_t outcome, uint_t default_samples,
+                         uint_t repetitions, AER::RngEngine &rng);
 };
 
 //=========================================================================
@@ -658,19 +656,17 @@ complex_t Runner::amplitude(uint_t x_measure) {
   return {real_part, imag_part};
 }
 
-double Runner::get_probability(uint_t outcome,
-                               uint_t default_samples,
-                               uint_t repetitions,
-                               AER::RngEngine &rng) {
+double Runner::get_probability(uint_t outcome, uint_t default_samples,
+                               uint_t repetitions, AER::RngEngine &rng) {
 
-    uint_t n_samples = std::llrint(0.5 * std::pow(n_qubits_, 2));
-    if (n_samples < default_samples) {
-        n_samples = default_samples;
-    }
-    double norm = norm_estimation(n_samples, repetitions, rng);
-    complex_t amp = amplitude(outcome);
-    double prob = (amp.real() * amp.real() + amp.imag() * amp.imag()) / norm;
-    return prob;
+  uint_t n_samples = std::llrint(0.5 * std::pow(n_qubits_, 2));
+  if (n_samples < default_samples) {
+    n_samples = default_samples;
+  }
+  double norm = norm_estimation(n_samples, repetitions, rng);
+  complex_t amp = amplitude(outcome);
+  double prob = (amp.real() * amp.real() + amp.imag() * amp.imag()) / norm;
+  return prob;
 }
 
 AER::Vector<complex_t> Runner::statevector() {

--- a/src/simulators/extended_stabilizer/ch_runner.hpp
+++ b/src/simulators/extended_stabilizer/ch_runner.hpp
@@ -154,6 +154,11 @@ public:
   // Utilities for the state-vector snapshot.
   complex_t amplitude(uint_t x_measure);
   AER::Vector<complex_t> statevector();
+  // Return the probability of an outcome bitstring.
+  double get_probability(uint_t outcome,
+                         uint_t default_samples,
+                         uint_t repetitions,
+                         AER::RngEngine &rng);
 };
 
 //=========================================================================
@@ -651,6 +656,21 @@ complex_t Runner::amplitude(uint_t x_measure) {
     imag_part += amplitude.imag();
   }
   return {real_part, imag_part};
+}
+
+double Runner::get_probability(uint_t outcome,
+                               uint_t default_samples,
+                               uint_t repetitions,
+                               AER::RngEngine &rng) {
+
+    uint_t n_samples = std::llrint(0.5 * std::pow(n_qubits_, 2));
+    if (n_samples < default_samples) {
+        n_samples = default_samples;
+    }
+    double norm = norm_estimation(n_samples, repetitions, rng);
+    complex_t amp = amplitude(outcome);
+    double prob = (amp.real() * amp.real() + amp.imag() * amp.imag()) / norm;
+    return prob;
 }
 
 AER::Vector<complex_t> Runner::statevector() {

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -142,8 +142,7 @@ protected:
 
   // Compute and save amplitudes squared for some outcomes
   void apply_save_amplitudes_sq(const Operations::Op &op,
-                                ExperimentResult &result,
-                                RngEngine &rng);
+                                ExperimentResult &result, RngEngine &rng);
 
   // Compute and save the expval for the current simulator state
   void apply_save_expval(const Operations::Op &op, ExperimentResult &result,
@@ -805,10 +804,9 @@ void State::apply_save_amplitudes_sq(const Operations::Op &op,
   rvector_t amps_sq(op.int_params.size(),
                     1.0); // Must be initialized in 1 for helper func
   for (size_t i = 0; i < op.int_params.size(); i++) {
-    amps_sq[i] = BaseState::qreg_.get_probability(op.int_params[i],
-                                                  norm_estimation_samples_,
-                                                  norm_estimation_repetitions_,
-                                                  rng);
+    amps_sq[i] = BaseState::qreg_.get_probability(
+        op.int_params[i], norm_estimation_samples_,
+        norm_estimation_repetitions_, rng);
   }
   result.save_data_average(creg(), op.string_params[0], std::move(amps_sq),
                            op.type, op.save_type);

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -42,6 +42,7 @@ const Operations::OpSet StateOpSet(
         Operations::OpType::bfunc,
         Operations::OpType::qerror_loc,
         Operations::OpType::save_statevec,
+        Operations::OpType::save_amps_sq,
     }, // Operations::OpType::save_expval, Operations::OpType::save_expval_var},
     // Gates
     {"CX", "u0",  "u1",  "p",   "cx",    "cz",    "swap", "id",
@@ -138,6 +139,11 @@ protected:
   // Compute and save the statevector for the current simulator state
   void apply_save_statevector(const Operations::Op &op,
                               ExperimentResult &result);
+
+  // Compute and save amplitudes squared for some outcomes
+  void apply_save_amplitudes_sq(const Operations::Op &op,
+                                ExperimentResult &result,
+                                RngEngine &rng);
 
   // Compute and save the expval for the current simulator state
   void apply_save_expval(const Operations::Op &op, ExperimentResult &result,
@@ -334,6 +340,7 @@ bool State::check_measurement_opt(InputIterator first,
     if (op->type == Operations::OpType::measure ||
         op->type == Operations::OpType::bfunc ||
         op->type == Operations::OpType::save_statevec ||
+        op->type == Operations::OpType::save_amps_sq ||
         op->type == Operations::OpType::save_expval) {
       return false;
     }
@@ -419,6 +426,9 @@ void State::apply_ops(InputIterator first, InputIterator last,
             break;
           case Operations::OpType::save_statevec:
             apply_save_statevector(op, result);
+            break;
+          case Operations::OpType::save_amps_sq:
+            apply_save_amplitudes_sq(op, result, rng);
             break;
           // Disabled until can fix bug in expval
           // case Operations::OpType::save_expval:
@@ -544,6 +554,9 @@ void State::apply_stabilizer_circuit(InputIterator first, InputIterator last,
         break;
       case Operations::OpType::save_statevec:
         apply_save_statevector(op, result);
+        break;
+      case Operations::OpType::save_amps_sq:
+        apply_save_amplitudes_sq(op, result, rng);
         break;
       case Operations::OpType::save_expval:
       case Operations::OpType::save_expval_var:
@@ -779,6 +792,25 @@ void State::apply_save_statevector(const Operations::Op &op,
     statevec *= BaseState::global_phase_;
   }
   result.save_data_pershot(creg(), op.string_params[0], std::move(statevec),
+                           op.type, op.save_type);
+}
+
+void State::apply_save_amplitudes_sq(const Operations::Op &op,
+                                     ExperimentResult &result, RngEngine &rng) {
+  if (op.int_params.empty()) {
+    throw std::invalid_argument(
+        "Invalid save_amplitudes_sq instructions (empty params).");
+  }
+  uint_t num_qubits = op.qubits.size();
+  rvector_t amps_sq(op.int_params.size(),
+                    1.0); // Must be initialized in 1 for helper func
+  for (size_t i = 0; i < op.int_params.size(); i++) {
+    amps_sq[i] = BaseState::qreg_.get_probability(op.int_params[i],
+                                                  norm_estimation_samples_,
+                                                  norm_estimation_repetitions_,
+                                                  rng);
+  }
+  result.save_data_average(creg(), op.string_params[0], std::move(amps_sq),
                            op.type, op.save_type);
 }
 

--- a/test/terra/backends/aer_simulator/test_save_amplitudes.py
+++ b/test/terra/backends/aer_simulator/test_save_amplitudes.py
@@ -69,7 +69,14 @@ class TestSaveAmplitudes(SimulatorTestCase):
         self._test_save_amplitudes(QFT(3), params, False, method=method, device=device)
 
     @supported_methods(
-        ["automatic", "statevector", "matrix_product_state", "density_matrix", "tensor_network"],
+        [
+            "automatic",
+            "statevector",
+            "matrix_product_state",
+            "density_matrix",
+            "tensor_network",
+            "extended_stabilizer",
+        ],
         AMPLITUDES,
     )
     def test_save_amplitudes_squared(self, method, device, params):
@@ -80,6 +87,7 @@ class TestSaveAmplitudes(SimulatorTestCase):
         [
             "automatic",
             "stabilizer",
+            "extended_stabilizer",
             "statevector",
             "matrix_product_state",
             "density_matrix",
@@ -110,7 +118,7 @@ class TestSaveAmplitudes(SimulatorTestCase):
             max_parallel_threads=1,
         )
 
-    @supported_methods(["statevector", "density_matrix"], AMPLITUDES)
+    @supported_methods(["statevector", "density_matrix", "extended_stabilizer"], AMPLITUDES)
     def test_save_amplitudes_squared_cache_blocking(self, method, device, params):
         """Test save_amplitudes_squared instruction"""
         self._test_save_amplitudes(

--- a/test/terra/backends/aer_simulator/test_save_amplitudes.py
+++ b/test/terra/backends/aer_simulator/test_save_amplitudes.py
@@ -75,7 +75,6 @@ class TestSaveAmplitudes(SimulatorTestCase):
             "matrix_product_state",
             "density_matrix",
             "tensor_network",
-            "extended_stabilizer",
         ],
         AMPLITUDES,
     )
@@ -87,7 +86,6 @@ class TestSaveAmplitudes(SimulatorTestCase):
         [
             "automatic",
             "stabilizer",
-            "extended_stabilizer",
             "statevector",
             "matrix_product_state",
             "density_matrix",
@@ -118,7 +116,7 @@ class TestSaveAmplitudes(SimulatorTestCase):
             max_parallel_threads=1,
         )
 
-    @supported_methods(["statevector", "density_matrix", "extended_stabilizer"], AMPLITUDES)
+    @supported_methods(["statevector", "density_matrix"], AMPLITUDES)
     def test_save_amplitudes_squared_cache_blocking(self, method, device, params):
         """Test save_amplitudes_squared instruction"""
         self._test_save_amplitudes(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Support for saving the amplitudes_squared of a particular outcome in the extended_stabilizer simulation method.
For example to get the probability of measuring all zero:
`circuit.save_amplitudes_squared([0], label="p0")`

### Details and comments

Previously this was only doable by saving the entire statevector (via `circuit.save_statevector(label='sv')`) which is not scalable.


Here is an example script. 
```py
from qiskit import QuantumCircuit
from qiskit_aer import AerSimulator

shots = 100

circuit = QuantumCircuit(1, 1)
circuit.h(0)
circuit.t(0)
circuit.h(0)
circuit.save_statevector(label="sv")
circuit.save_amplitudes_squared([0], label="p0")
circuit.measure(0, 0)
simulator = AerSimulator(method='extended_stabilizer')
res = simulator.run(circuit,
                    shots=shots,
                    extended_stabilizer_sampling_method="metropolis",
                    extended_stabilizer_approximation_error=0.03,
                    extended_stabilizer_metropolis_mixing_time=5000,
                    extended_stabilizer_norm_estimation_samples=100,
                    extended_stabilizer_norm_estimation_repetitions=6
                    ).result()
p0_from_statevector = res.data(0)['sv'].probabilities()[0]
p0_from_amplitudes_squared = res.data(0)['p0'][0]

print(f'computed p0 = {p0_from_statevector} (expensive) vs. {p0_from_amplitudes_squared} (cheap)')
```
