### PR TITLE
Add temporal drift options to SamplerV2 to simulate non-Markovian hardware dynamics

### DIFF
--- a/qiskit_aer/primitives/sampler_v2.py
+++ b/qiskit_aer/primitives/sampler_v2.py
@@ -16,6 +16,7 @@ Sampler V2 class.
 
 from __future__ import annotations
 
+import copy
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -108,6 +109,7 @@ class SamplerV2(BaseSamplerV2):
         self._options = Options(**options) if options else Options()
         if isinstance(self._options.temporal_drift, dict):
             self._options.temporal_drift = TemporalDriftOptions(**self._options.temporal_drift)
+        self._validate_options()
         self._backend = AerSimulator(**self.options.backend_options)
         self._rng = np.random.default_rng(seed)
 
@@ -135,6 +137,13 @@ class SamplerV2(BaseSamplerV2):
     def options(self) -> Options:
         """Return the options"""
         return self._options
+
+    def _validate_options(self):
+        temporal_drift = self._options.temporal_drift
+        if temporal_drift.sigma < 0:
+            raise ValueError("temporal_drift.sigma must be non-negative")
+        if temporal_drift.window_size is not None and temporal_drift.window_size <= 0:
+            raise ValueError("temporal_drift.window_size must be a positive integer")
 
     def run(
         self, pubs: Iterable[SamplerPubLike], *, shots: int | None = None
@@ -226,14 +235,18 @@ class SamplerV2(BaseSamplerV2):
         if baseline_noise_model is None:
             return None, factor
 
-        perturbed_dict = baseline_noise_model.to_dict(serializable=True)
-        for error in perturbed_dict.get("errors", []):
-            probabilities = error.get("probabilities")
-            if probabilities is None:
-                continue
-            if error.get("type") == "qerror":
-                error["probabilities"] = _perturb_cptp_probabilities(probabilities, factor)
-        return NoiseModel.from_dict(perturbed_dict), factor
+        perturbed_noise_model = copy.deepcopy(baseline_noise_model)
+
+        for name, error in perturbed_noise_model._default_quantum_errors.items():
+            perturbed_noise_model._default_quantum_errors[name] = _perturb_quantum_error(error, factor)
+
+        for name, errors in perturbed_noise_model._local_quantum_errors.items():
+            for qubits, error in errors.items():
+                perturbed_noise_model._local_quantum_errors[name][qubits] = _perturb_quantum_error(
+                    error, factor
+                )
+
+        return perturbed_noise_model, factor
 
     def _stitch_pub_results(
         self, chunk_results: list[SamplerPubResult], total_shots: int
@@ -251,6 +264,7 @@ class SamplerV2(BaseSamplerV2):
         metadata["simulator_metadata"] = [
             result.metadata.get("simulator_metadata", {}) for result in chunk_results
         ]
+        metadata["chunk_shots"] = [result.metadata.get("shots") for result in chunk_results]
         return SamplerPubResult(
             DataBin(**stitched_data, shape=first_result.data.shape),
             metadata=metadata,
@@ -378,3 +392,9 @@ def _perturb_cptp_probabilities(probabilities: list[float], factor: float) -> li
     perturbed[error_indices] = scaled_error_probs
     perturbed[identity_index] = 1.0 - error_mass
     return perturbed.tolist()
+
+
+def _perturb_quantum_error(error, factor: float):
+    """Return a perturbed copy of a quantum error with CPTP-preserving probabilities."""
+    probabilities = _perturb_cptp_probabilities(list(error.probabilities), factor)
+    return error.__class__(zip(error.circuits, probabilities))

--- a/qiskit_aer/primitives/sampler_v2.py
+++ b/qiskit_aer/primitives/sampler_v2.py
@@ -41,6 +41,18 @@ from qiskit.primitives.primitive_job import PrimitiveJob
 from qiskit.result import Result
 
 from qiskit_aer import AerSimulator
+from qiskit_aer.noise.noise_model import NoiseModel
+
+
+@dataclass
+class TemporalDriftOptions:
+    """Options controlling temporal drift for non-stationary noise simulation."""
+
+    sigma: float = 0.0
+    """Lognormal sigma controlling temporal drift intensity."""
+
+    window_size: int | None = None
+    """Number of shots per chunk when temporal drift is enabled."""
 
 
 @dataclass
@@ -52,6 +64,9 @@ class Options:
 
     run_options: dict = field(default_factory=dict)
     """run_options: Options passed to run."""
+
+    temporal_drift: TemporalDriftOptions = field(default_factory=TemporalDriftOptions)
+    """temporal_drift: Options for non-Markovian temporal noise drift."""
 
 
 class SamplerV2(BaseSamplerV2):
@@ -91,7 +106,10 @@ class SamplerV2(BaseSamplerV2):
         self._seed = seed
 
         self._options = Options(**options) if options else Options()
+        if isinstance(self._options.temporal_drift, dict):
+            self._options.temporal_drift = TemporalDriftOptions(**self._options.temporal_drift)
         self._backend = AerSimulator(**self.options.backend_options)
+        self._rng = np.random.default_rng(seed)
 
     @classmethod
     def from_backend(cls, backend, **options):
@@ -139,6 +157,9 @@ class SamplerV2(BaseSamplerV2):
                 )
 
     def _run(self, pubs: list[SamplerPub]) -> PrimitiveResult[SamplerPubResult]:
+        if self._temporal_drift_active():
+            return self._run_with_temporal_drift(pubs)
+
         pub_dict = defaultdict(list)
         # consolidate pubs with the same number of shots
         for i, pub in enumerate(pubs):
@@ -152,6 +173,88 @@ class SamplerV2(BaseSamplerV2):
             for i, pub_result in zip(lst, pub_results):
                 results[i] = pub_result
         return PrimitiveResult(results, metadata={"version": 2})
+
+    def _run_with_temporal_drift(self, pubs: list[SamplerPub]) -> PrimitiveResult[SamplerPubResult]:
+        results = [None] * len(pubs)
+        for index, pub in enumerate(pubs):
+            results[index] = self._run_drifted_pub(pub)
+        return PrimitiveResult(results, metadata={"version": 2})
+
+    def _run_drifted_pub(self, pub: SamplerPub) -> SamplerPubResult:
+        total_shots = pub.shots
+        chunk_results = []
+        drift_trajectory = []
+        original_noise_model = getattr(self._backend.options, "noise_model", None)
+
+        for chunk_shots in self._chunk_shots(total_shots):
+            perturbed_noise_model, factor = self._perturb_noise_model(original_noise_model)
+            drift_trajectory.append(factor)
+            try:
+                self._backend.set_options(noise_model=perturbed_noise_model)
+                chunk_results.extend(self._run_pubs([pub], chunk_shots))
+            finally:
+                self._backend.set_options(noise_model=original_noise_model)
+
+        stitched = self._stitch_pub_results(chunk_results, total_shots)
+        stitched.metadata["temporal_drift_trajectory"] = drift_trajectory
+        stitched.metadata["temporal_drift"] = {
+            "sigma": self.options.temporal_drift.sigma,
+            "window_size": self.options.temporal_drift.window_size,
+        }
+        return stitched
+
+    def _temporal_drift_active(self) -> bool:
+        temporal_drift = self.options.temporal_drift
+        return temporal_drift.sigma > 0 and temporal_drift.window_size is not None
+
+    def _chunk_shots(self, total_shots: int) -> list[int]:
+        window_size = self.options.temporal_drift.window_size
+        if window_size is None or window_size <= 0:
+            return [total_shots]
+        chunk_sizes = []
+        remaining = total_shots
+        while remaining > 0:
+            chunk = min(window_size, remaining)
+            chunk_sizes.append(chunk)
+            remaining -= chunk
+        return chunk_sizes
+
+    def _perturb_noise_model(
+        self, baseline_noise_model: NoiseModel | None
+    ) -> tuple[NoiseModel | None, float]:
+        factor = float(self._rng.lognormal(mean=0.0, sigma=self.options.temporal_drift.sigma))
+        if baseline_noise_model is None:
+            return None, factor
+
+        perturbed_dict = baseline_noise_model.to_dict(serializable=True)
+        for error in perturbed_dict.get("errors", []):
+            probabilities = error.get("probabilities")
+            if probabilities is None:
+                continue
+            if error.get("type") == "qerror":
+                error["probabilities"] = _perturb_cptp_probabilities(probabilities, factor)
+        return NoiseModel.from_dict(perturbed_dict), factor
+
+    def _stitch_pub_results(
+        self, chunk_results: list[SamplerPubResult], total_shots: int
+    ) -> SamplerPubResult:
+        first_result = chunk_results[0]
+        field_names = [name for name in vars(first_result.data) if name != "shape"]
+        stitched_data = {}
+        for name in field_names:
+            bitarrays = [getattr(result.data, name) for result in chunk_results]
+            stitched_array = np.concatenate([bitarray.array for bitarray in bitarrays], axis=-2)
+            stitched_data[name] = BitArray(stitched_array, bitarrays[0].num_bits)
+
+        metadata = dict(first_result.metadata)
+        metadata["shots"] = total_shots
+        metadata["simulator_metadata"] = [
+            result.metadata.get("simulator_metadata", {}) for result in chunk_results
+        ]
+        return SamplerPubResult(
+            DataBin(**stitched_data, shape=first_result.data.shape),
+            metadata=metadata,
+        )
 
     def _run_pubs(self, pubs: list[SamplerPub], shots: int) -> list[SamplerPubResult]:
         """Compute results for pubs that all require the same value of ``shots``."""
@@ -254,3 +357,24 @@ def _prepare_memory(result: Result) -> list[list[str]]:
             # no measure in a circuit
             lst.append(["0x0"] * exp.shots)
     return lst
+
+
+def _perturb_cptp_probabilities(probabilities: list[float], factor: float) -> list[float]:
+    """Perturb only non-identity probability mass and reconstruct the identity branch."""
+    probs = np.asarray(probabilities, dtype=float)
+    if probs.size == 0:
+        return []
+
+    identity_index = int(np.argmax(probs))
+    error_indices = [index for index in range(probs.size) if index != identity_index]
+    error_probs = probs[error_indices]
+    scaled_error_probs = np.clip(error_probs * factor, 0.0, None)
+    error_mass = float(np.sum(scaled_error_probs))
+    if error_mass > 0.999:
+        scaled_error_probs *= 0.999 / error_mass
+        error_mass = 0.999
+
+    perturbed = np.zeros_like(probs)
+    perturbed[error_indices] = scaled_error_probs
+    perturbed[identity_index] = 1.0 - error_mass
+    return perturbed.tolist()

--- a/test/terra/primitives/test_sampler_v2.py
+++ b/test/terra/primitives/test_sampler_v2.py
@@ -30,6 +30,8 @@ from qiskit.providers import JobStatus
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from qiskit_aer import AerSimulator
+from qiskit_aer.noise import NoiseModel
+from qiskit_aer.noise.errors.standard_errors import depolarizing_error
 from qiskit_aer.primitives import SamplerV2
 
 
@@ -714,6 +716,46 @@ class TestSamplerV2(QiskitAerTestCase):
         with self.subTest("set int"):
             sampler = SamplerV2(seed=self._seed)
             self.assertEqual(sampler.seed, self._seed)
+
+    def test_temporal_drift_chunking_and_metadata(self):
+        """Test SamplerV2 temporal drift chunking and trajectory metadata."""
+        qc = QuantumCircuit(1)
+        qc.measure_all()
+
+        noise_model = NoiseModel()
+        noise_model.add_all_qubit_quantum_error(depolarizing_error(0.05, 1), ["id"])
+
+        sampler = SamplerV2(
+            default_shots=9,
+            seed=self._seed,
+            options={
+                "backend_options": {"method": "density_matrix", "noise_model": noise_model},
+                "temporal_drift": {"sigma": 0.2, "window_size": 4},
+            },
+        )
+
+        result = sampler.run([qc], shots=9).result()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].data.meas.num_shots, 9)
+        self.assertEqual(sum(result[0].data.meas.get_counts().values()), 9)
+        self.assertIn("temporal_drift_trajectory", result[0].metadata)
+        self.assertEqual(len(result[0].metadata["temporal_drift_trajectory"]), 3)
+        self.assertEqual(result[0].metadata["temporal_drift"], {"sigma": 0.2, "window_size": 4})
+        self.assertIsInstance(result[0].metadata["simulator_metadata"], list)
+        self.assertEqual(len(result[0].metadata["simulator_metadata"]), 3)
+
+    def test_temporal_drift_disabled_uses_standard_metadata_shape(self):
+        """Test that default SamplerV2 behavior is unchanged when drift is disabled."""
+        qc = QuantumCircuit(1)
+        qc.measure_all()
+        sampler = SamplerV2(default_shots=10, seed=self._seed)
+
+        result = sampler.run([qc], shots=10).result()
+
+        self.assertEqual(result[0].metadata["shots"], 10)
+        self.assertIsInstance(result[0].metadata["simulator_metadata"], dict)
+        self.assertNotIn("temporal_drift_trajectory", result[0].metadata)
 
 
 if __name__ == "__main__":

--- a/test/terra/primitives/test_sampler_v2.py
+++ b/test/terra/primitives/test_sampler_v2.py
@@ -33,6 +33,7 @@ from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel
 from qiskit_aer.noise.errors.standard_errors import depolarizing_error
 from qiskit_aer.primitives import SamplerV2
+from qiskit_aer.primitives.sampler_v2 import _perturb_cptp_probabilities
 
 
 class TestSamplerV2(QiskitAerTestCase):
@@ -720,6 +721,7 @@ class TestSamplerV2(QiskitAerTestCase):
     def test_temporal_drift_chunking_and_metadata(self):
         """Test SamplerV2 temporal drift chunking and trajectory metadata."""
         qc = QuantumCircuit(1)
+        qc.id(0)
         qc.measure_all()
 
         noise_model = NoiseModel()
@@ -744,6 +746,7 @@ class TestSamplerV2(QiskitAerTestCase):
         self.assertEqual(result[0].metadata["temporal_drift"], {"sigma": 0.2, "window_size": 4})
         self.assertIsInstance(result[0].metadata["simulator_metadata"], list)
         self.assertEqual(len(result[0].metadata["simulator_metadata"]), 3)
+        self.assertEqual(result[0].metadata["chunk_shots"], [4, 4, 1])
 
     def test_temporal_drift_disabled_uses_standard_metadata_shape(self):
         """Test that default SamplerV2 behavior is unchanged when drift is disabled."""
@@ -756,6 +759,18 @@ class TestSamplerV2(QiskitAerTestCase):
         self.assertEqual(result[0].metadata["shots"], 10)
         self.assertIsInstance(result[0].metadata["simulator_metadata"], dict)
         self.assertNotIn("temporal_drift_trajectory", result[0].metadata)
+
+    def test_temporal_drift_probability_perturbation_preserves_cptp(self):
+        """Temporal drift rescales only error mass and keeps total probability normalized."""
+        probabilities = [0.97, 0.02, 0.01]
+
+        perturbed = _perturb_cptp_probabilities(probabilities, 2.5)
+
+        self.assertAlmostEqual(sum(perturbed), 1.0)
+        self.assertGreaterEqual(perturbed[0], 0.0)
+        self.assertLessEqual(sum(perturbed[1:]), 0.999)
+        self.assertGreater(perturbed[1], probabilities[1])
+        self.assertGreater(perturbed[2], probabilities[2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Currently, `AerSimulator` utilizes perfectly stationary, Markovian noise models. While excellent for baseline testing, this creates a well-known "reality gap" in Quantum Error Mitigation (QEM) research. Standard QEM techniques often perform flawlessly on stationary simulators but struggle on deep circuits on real hardware due to drifting noise. Conversely, emerging techniques that exploit temporal noise inhomogeneity (such as trajectory-level stochastic filtering) often fail on standard simulators but succeed on physical QPUs. 

This PR natively extends `SamplerV2` to allow researchers to simulate non-Markovian temporal drift (e.g., thermal fluctuations, TLS defect activations) without requiring a custom backend, closing the gap between simulation and real hardware dynamics.

### Details and comments

This PR introduces a frictionless, native way to stress-test error mitigation protocols against dynamic, non-stationary noise environments:

* **Native Options:** Adds `options.temporal_drift.sigma` (default `0.0`) and `options.temporal_drift.window_size` (default `None`) to `SamplerV2`. Existing code defaults to the standard fast path.
* **Execution Chunking:** When drift is active, execution is automatically chunked into temporal windows.
* **CPTP-Compliant Perturbation:** Applies a lognormal perturbation to the non-identity branches of the `NoiseModel` per chunk. It strictly maintains CPTP validity by capping error probabilities at `0.999` and recalculating the identity branch as `1.0 - sum(scaled_errors)`.
* **Chronological Stitching:** Stitches the chunked `BitArray` results back together chronologically.
* **Trajectory Metadata:** Appends the `temporal_drift_trajectory` array to the `PrimitiveResult.metadata` so researchers can exactly correlate estimator drift with the simulated environment's temporal landscape.