### PR TITLE
Fix pybind11 init template errors

### DIFF
--- a/qiskit_aer/backends/wrappers/aer_circuit_binding.hpp
+++ b/qiskit_aer/backends/wrappers/aer_circuit_binding.hpp
@@ -66,13 +66,12 @@ void bind_aer_circuit(MODULE m) {
   py::class_<Operations::Uint, Operations::ScalarType,
              std::shared_ptr<Operations::Uint>>
       aer_uint(m, "AerUint");
-  aer_uint.def(
-      py::init([](const uint_t width) { return new Operations::Uint(width); }));
+  aer_uint.def(py::init<uint_t>(), py::arg("width"));
 
   py::class_<Operations::Bool, Operations::ScalarType,
              std::shared_ptr<Operations::Bool>>
       aer_bool(m, "AerBool");
-  aer_bool.def(py::init([]() { return new Operations::Bool(); }));
+  aer_bool.def(py::init<>());
 
   py::class_<Operations::CExpr, std::shared_ptr<Operations::CExpr>> aer_expr(
       m, "AerExpr");
@@ -83,20 +82,16 @@ void bind_aer_circuit(MODULE m) {
   py::class_<Operations::CastExpr, Operations::CExpr,
              std::shared_ptr<Operations::CastExpr>>
       aer_cast_expr(m, "AerCast");
-  aer_cast_expr.def(
-      py::init([](const std::shared_ptr<Operations::ScalarType> type,
-                  const std::shared_ptr<Operations::CExpr> expr) {
-        return new Operations::CastExpr(type, expr);
-      }));
+  aer_cast_expr.def(py::init<const std::shared_ptr<Operations::ScalarType>,
+                             const std::shared_ptr<Operations::CExpr>>(),
+                    py::arg("type"), py::arg("expr"));
 
   py::class_<Operations::VarExpr, Operations::CExpr,
              std::shared_ptr<Operations::VarExpr>>
       aer_var_expr(m, "AerVar");
-  aer_var_expr.def(
-      py::init([](const std::shared_ptr<Operations::ScalarType> type,
-                  const std::vector<uint_t> cbit_idxs) {
-        return new Operations::VarExpr(type, cbit_idxs);
-      }));
+  aer_var_expr.def(py::init<const std::shared_ptr<Operations::ScalarType>,
+                            const std::vector<uint_t>>(),
+                   py::arg("type"), py::arg("cbit_idxs"));
 
   py::class_<Operations::ValueExpr, Operations::CExpr,
              std::shared_ptr<Operations::ValueExpr>>
@@ -105,34 +100,28 @@ void bind_aer_circuit(MODULE m) {
   py::class_<Operations::UintValue, Operations::ValueExpr,
              std::shared_ptr<Operations::UintValue>>
       aer_uint_expr(m, "AerUintValue");
-  aer_uint_expr.def(py::init([](const size_t width, const uint_t val) {
-    return new Operations::UintValue(width, val);
-  }));
+  aer_uint_expr.def(py::init<const size_t, const uint_t>(), py::arg("width"),
+                    py::arg("val"));
 
   py::class_<Operations::BoolValue, Operations::ValueExpr,
              std::shared_ptr<Operations::BoolValue>>
       aer_bool_expr(m, "AerBoolValue");
-  aer_bool_expr.def(
-      py::init([](const bool val) { return new Operations::BoolValue(val); }));
+  aer_bool_expr.def(py::init<const bool>(), py::arg("val"));
 
   py::class_<Operations::UnaryExpr, Operations::CExpr,
              std::shared_ptr<Operations::UnaryExpr>>
       aer_unary_expr(m, "AerUnaryExpr");
-  aer_unary_expr.def(
-      py::init([](const Operations::UnaryOp op,
-                  const std::shared_ptr<Operations::CExpr> expr) {
-        return new Operations::UnaryExpr(op, expr);
-      }));
+  aer_unary_expr.def(py::init<const Operations::UnaryOp,
+                              const std::shared_ptr<Operations::CExpr>>(),
+                     py::arg("op"), py::arg("expr"));
 
   py::class_<Operations::BinaryExpr, Operations::CExpr,
              std::shared_ptr<Operations::BinaryExpr>>
       aer_binary_expr(m, "AerBinaryExpr");
-  aer_binary_expr.def(
-      py::init([](const Operations::BinaryOp op,
-                  const std::shared_ptr<Operations::CExpr> left,
-                  const std::shared_ptr<Operations::CExpr> right) {
-        return new Operations::BinaryExpr(op, left, right);
-      }));
+  aer_binary_expr.def(py::init<const Operations::BinaryOp,
+                               const std::shared_ptr<Operations::CExpr>,
+                               const std::shared_ptr<Operations::CExpr>>(),
+                      py::arg("op"), py::arg("left"), py::arg("right"));
 
   py::class_<Circuit, std::shared_ptr<Circuit>> aer_circuit(m, "AerCircuit");
   aer_circuit.def(py::init());

--- a/releasenotes/notes/pybind11-lambda-init-29250f692da1ae92.yaml
+++ b/releasenotes/notes/pybind11-lambda-init-29250f692da1ae92.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The pybind11 Python bindings for several Aer classes implmented in C++ were
+    updated to use the classes' public constructors directly rather than
+    creating a new object through a lambda function. This change helps with
+    compiling Aer with gcc version 14 which, unlike prevous versions of gcc,
+    would fail when handling one of the lambda functions with a message about
+    encountering an "ambiguous template instatiation."

--- a/releasenotes/notes/pybind11-lambda-init-29250f692da1ae92.yaml
+++ b/releasenotes/notes/pybind11-lambda-init-29250f692da1ae92.yaml
@@ -1,9 +1,9 @@
 ---
 fixes:
   - |
-    The pybind11 Python bindings for several Aer classes implmented in C++ were
+    The pybind11 Python bindings for several Aer classes implemented in C++ were
     updated to use the classes' public constructors directly rather than
     creating a new object through a lambda function. This change helps with
     compiling Aer with gcc version 14 which, unlike prevous versions of gcc,
     would fail when handling one of the lambda functions with a message about
-    encountering an "ambiguous template instatiation."
+    encountering an "ambiguous template instantiation."


### PR DESCRIPTION
With newer compiler toolchains, the following error message is triggered during the build: "aer_circuit_binding.hpp:69:28: error: ambiguous template instantiation" for `aer_uint` and similar methods. The issue has to do with the lambda function used in the constructor becoming ambiguous to the compiler. All of the lambdas simply forward the call to public constructors and pybind11 supports binding to the constructors directly, so that change is made here.