### PR TITLE
Switch from pybind11 enum_ to native_enum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
   "scikit-build>=0.11.0",
   "cmake!=3.17.1,!=3.17.0",
   "ninja",
-  "pybind11>2.6",
+  "pybind11>=3.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/qiskit_aer/backends/wrappers/aer_circuit_binding.hpp
+++ b/qiskit_aer/backends/wrappers/aer_circuit_binding.hpp
@@ -17,6 +17,7 @@
 
 #include "misc/warnings.hpp"
 DISABLE_WARNING_PUSH
+#include <pybind11/native_enum.h>
 #include <pybind11/pybind11.h>
 DISABLE_WARNING_POP
 #if defined(_MSC_VER)
@@ -41,12 +42,14 @@ using namespace AER;
 template <typename MODULE>
 void bind_aer_circuit(MODULE m) {
 
-  py::enum_<Operations::UnaryOp>(m, "AerUnaryOp", py::arithmetic())
+  py::native_enum<Operations::UnaryOp>(m, "AerUnaryOp", "enum.Enum",
+                                       "Internal Aer UnaryOp class")
       .value("BitNot", Operations::UnaryOp::BitNot)
       .value("LogicNot", Operations::UnaryOp::LogicNot)
-      .export_values();
+      .finalize();
 
-  py::enum_<Operations::BinaryOp>(m, "AerBinaryOp", py::arithmetic())
+  py::native_enum<Operations::BinaryOp>(m, "AerBinaryOp", "enum.Enum",
+                                        "Internal Aer BinaryOp class")
       .value("BitAnd", Operations::BinaryOp::BitAnd)
       .value("BitOr", Operations::BinaryOp::BitOr)
       .value("BitXor", Operations::BinaryOp::BitXor)
@@ -58,7 +61,7 @@ void bind_aer_circuit(MODULE m) {
       .value("LessEqual", Operations::BinaryOp::LessEqual)
       .value("Greater", Operations::BinaryOp::Greater)
       .value("GreaterEqual", Operations::BinaryOp::GreaterEqual)
-      .export_values();
+      .finalize();
 
   py::class_<Operations::ScalarType, std::shared_ptr<Operations::ScalarType>>
       aer_scalar_type(m, "AerScalarType");


### PR DESCRIPTION
The motivation for switching is that `enum_` triggers a bug in pybind11 when using gcc 14. In particular, this bug:

https://github.com/pybind/pybind11/issues/5565

which has already been patched in pybind11 but the patch has not yet been released. Code within pybind11 used for generating the special methods was triggering an ambiguous template instantiation.

Using `native_enum` requires pybind11 3.0 or higher so the build requirement was updated.

There are side effects to these changes but they should not affect the way these undocumented enums are used within the codebase (and a GitHub search reveals no external usage):

* The `arithmetic` tag was dropped since the current usage does not use Python mathematical operators on these classes. This change removes methods like `__xor__` from the Python classes.
* The `export_values` call was dropped. That promotes the enum members into the module namespace, but all current use references them as class members of the enum.
* The classes are standard Python `enum.Enum` instances rather than pybind11 classes following the same interface.