### PR TITLE
Add explicit json conversions

### DIFF
--- a/qiskit_aer/backends/wrappers/aer_controller_binding.hpp
+++ b/qiskit_aer/backends/wrappers/aer_controller_binding.hpp
@@ -93,8 +93,11 @@ void bind_aer_controller(MODULE m) {
                           std::vector<std::shared_ptr<Circuit>> &circuits,
                           py::object noise_model, AER::Config &config) {
                  Noise::NoiseModel noise_model_native;
-                 if (noise_model)
-                   noise_model_native.load_from_json(noise_model);
+                 if (!noise_model.is_none()) {
+                   json_t noise_model_json;
+                   std::to_json(noise_model_json, noise_model);
+                   noise_model_native.load_from_json(noise_model_json);
+                 }
 
                  return self.execute(circuits, noise_model_native, config);
                });

--- a/releasenotes/notes/fix-json-conversion-ef0b31b95d055df8.yaml
+++ b/releasenotes/notes/fix-json-conversion-ef0b31b95d055df8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Incompatibility with ``nlohmann_json``, a C++ build-time dependency of Aer,
+    has been addressed, allowing compilation with ``nlohmann_json`` version
+    3.10.3 and higher. For details, see `#2418
+    <https://github.com/Qiskit/qiskit-aer/pull/2418>`__.

--- a/src/framework/pybind_json.hpp
+++ b/src/framework/pybind_json.hpp
@@ -213,7 +213,9 @@ json_t JSON::numpy_to_json(py::array_t<T, py::array::c_style> arr) {
 json_t JSON::iterable_to_json_list(const py::handle &obj) {
   json_t js = nl::json::array();
   for (py::handle value : obj) {
-    js.push_back(value);
+    json_t elem;
+    std::to_json(elem, value);
+    js.push_back(std::move(elem));
   }
   return js;
 }
@@ -235,8 +237,15 @@ void std::to_json(json_t &js, const py::handle &obj) {
   } else if (py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj)) {
     js = JSON::iterable_to_json_list(obj);
   } else if (py::isinstance<py::dict>(obj)) {
+
+    js = nl::json::object();
     for (auto item : py::cast<py::dict>(obj)) {
-      js[item.first.cast<nl::json::string_t>()] = item.second;
+      auto key = item.first.cast<nl::json::string_t>();
+
+      json_t val;
+      std::to_json(val, item.second);
+
+      js[key] = std::move(val);
     }
   } else if (py::isinstance<py::array_t<double>>(obj)) {
     js = JSON::numpy_to_json(

--- a/src/framework/pybind_json.hpp
+++ b/src/framework/pybind_json.hpp
@@ -237,7 +237,6 @@ void std::to_json(json_t &js, const py::handle &obj) {
   } else if (py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj)) {
     js = JSON::iterable_to_json_list(obj);
   } else if (py::isinstance<py::dict>(obj)) {
-
     js = nl::json::object();
     for (auto item : py::cast<py::dict>(obj)) {
       auto key = item.first.cast<nl::json::string_t>();


### PR DESCRIPTION
nlohmann_json 3.10.3 improved the detection of C++ iterables, so that more objects are correctly identified as iterable and passed through its iterable to array converter function. This change included detecting pybind11 py::handle objects pointing to Python dicts. The result of this change is that Python dicts are passed to functions accepting `json_t` objects the implicit conversion started treating them as iterables and producing JSON arrays of the dict keys rather than falling through to Aer's `std::to_json` converter and its `py::dict` case. So a noise model would be converted into a `["errors"]` array instead of an object with more nested data.

To address this issue, more explicit conversion of Python objects to JSON objects was inserted into the code. Where the noise model is passed in from Python in `execute`, an explicit `std:to_json` call was added. That alone was not enough because `std::to_json` itself was handling dicts without explicit conversion and so any nested dicts were falling into the same iterable-to-array implicit conversion problem. Explicit construction of the JSON object and conversion of the dict values with `std::json` were added to address the conversion issue recursively. Although no test failures flagged it as problematic, the `JSON::iterable_to_json_list` helper function was also updated to call `std::to_json` for completeness and to handle any untested cases where the noise model could contain a list of dicts. 

With these changes, Aer builds and passes all the tests with nlohmann_json 3.12.0.

Addresses the issues discussed in #1742