### PR TITLE
Fix nlohmann_json >= 3.11 incompatibility breaking noise simulation

### DIFF
--- a/releasenotes/notes/fix_nlohmann_json_3_11_compat-e2e1f6251eb7bcbc.yaml
+++ b/releasenotes/notes/fix_nlohmann_json_3_11_compat-e2e1f6251eb7bcbc.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed an incompatibility with nlohmann_json >= 3.11 that caused noisy
+    simulation to fail with ``ValueError: Invalid noise_params JSON: not an
+    object.`` when aer was built from source against a system-provided
+    nlohmann_json 3.11.x (the version shipped in current-generation Linux
+    distributions). The Python-to-JSON conversion now uses
+    ``nlohmann::adl_serializer`` specializations, which is the documented
+    extension point and is stable across nlohmann_json releases.

--- a/src/framework/pybind_basics.hpp
+++ b/src/framework/pybind_basics.hpp
@@ -108,7 +108,7 @@ py::object to_python(T &&obj) {
 template <>
 py::object to_python(json_t &&obj) {
   py::object pydata;
-  from_json(obj, pydata);
+  JSON::py_from_json(obj, pydata);
   return pydata;
 }
 

--- a/src/framework/pybind_json.hpp
+++ b/src/framework/pybind_json.hpp
@@ -55,24 +55,57 @@ using json_t = nlohmann::json;
 // Nlohman JSON <--> Python Conversion
 //------------------------------------------------------------------------------
 
-namespace std {
+namespace JSON {
 
 /**
  * Convert a python object to a json.
  * @param js a json_t object to contain converted type.
- * @param o is a python object to convert.
+ * @param obj is a python object to convert.
  */
-void to_json(json_t &js, const py::handle &o);
+void py_to_json(json_t &js, const py::handle &obj);
 
 /**
- * Create a python object from a json
- * @param js a json_t object
- * @param o is a reference to an existing (empty) python object
+ * Create a python object from a json.
+ * @param js a json_t object.
+ * @param o is a reference to a python object to populate.
  */
-void from_json(const json_t &js, py::object &o);
+void py_from_json(const json_t &js, py::object &o);
 
-} // end namespace std.
+} // end namespace JSON.
 
+namespace nlohmann {
+
+/**
+ * adl_serializer specialization for pybind11::handle.
+ *
+ * Provides version-stable Python -> JSON conversion through nlohmann's
+ * documented extension point. Avoids relying on free-function ADL of
+ * to_json, which became non-discoverable starting with nlohmann_json 3.11.
+ */
+template <>
+struct adl_serializer<pybind11::handle> {
+  static void to_json(nlohmann::json &js, const pybind11::handle &obj) {
+    JSON::py_to_json(js, obj);
+  }
+};
+
+/**
+ * adl_serializer specialization for pybind11::object.
+ *
+ * Delegates to_json to the handle version (object derives from handle), and
+ * provides JSON -> Python conversion.
+ */
+template <>
+struct adl_serializer<pybind11::object> {
+  static void to_json(nlohmann::json &js, const pybind11::object &obj) {
+    JSON::py_to_json(js, obj);
+  }
+  static void from_json(const nlohmann::json &js, pybind11::object &o) {
+    JSON::py_from_json(js, o);
+  }
+};
+
+} // end namespace nlohmann.
 //------------------------------------------------------------------------------
 // Python->JSON Conversion
 //------------------------------------------------------------------------------
@@ -218,7 +251,7 @@ json_t JSON::iterable_to_json_list(const py::handle &obj) {
   return js;
 }
 
-void std::to_json(json_t &js, const py::handle &obj) {
+void JSON::py_to_json(json_t &js, const py::handle &obj) {
   static py::object PyNoiseModel =
       py::module::import("qiskit_aer.noise.noise_model").attr("NoiseModel");
   static py::object PyCircuitHeader =
@@ -236,7 +269,9 @@ void std::to_json(json_t &js, const py::handle &obj) {
     js = JSON::iterable_to_json_list(obj);
   } else if (py::isinstance<py::dict>(obj)) {
     for (auto item : py::cast<py::dict>(obj)) {
-      js[item.first.cast<nl::json::string_t>()] = item.second;
+      json_t tmp;
+      JSON::py_to_json(tmp, item.second);
+      js[item.first.cast<nl::json::string_t>()] = std::move(tmp);
     }
   } else if (py::isinstance<py::array_t<double>>(obj)) {
     js = JSON::numpy_to_json(
@@ -247,9 +282,9 @@ void std::to_json(json_t &js, const py::handle &obj) {
   } else if (obj.is_none()) {
     return;
   } else if (py::isinstance(obj, PyNoiseModel)) {
-    std::to_json(js, obj.attr("to_dict")());
+    JSON::py_to_json(js, obj.attr("to_dict")());
   } else if (py::isinstance(obj, PyCircuitHeader)) {
-    std::to_json(js, obj.attr("to_dict")());
+    JSON::py_to_json(js, obj.attr("to_dict")());
   } else {
     auto type_str = std::string(py::str(obj.get_type()));
     if (type_str == "<class \'complex\'>" ||
@@ -278,7 +313,7 @@ void std::to_json(json_t &js, const py::handle &obj) {
   }
 }
 
-void std::from_json(const json_t &js, py::object &o) {
+void JSON::py_from_json(const json_t &js, py::object &o) {
   if (js.is_boolean()) {
     o = py::bool_(js.get<nl::json::boolean_t>());
   } else if (js.is_number()) {
@@ -295,7 +330,7 @@ void std::from_json(const json_t &js, py::object &o) {
     std::vector<py::object> obj(js.size());
     for (size_t i = 0; i < js.size(); i++) {
       py::object tmp;
-      from_json(js[i], tmp);
+      JSON::py_from_json(js[i], tmp);
       obj[i] = tmp;
     }
     o = py::cast(obj);
@@ -303,7 +338,7 @@ void std::from_json(const json_t &js, py::object &o) {
     py::dict obj;
     for (json_t::const_iterator it = js.cbegin(); it != js.cend(); ++it) {
       py::object tmp;
-      from_json(it.value(), tmp);
+      JSON::py_from_json(it.value(), tmp);
       obj[py::str(it.key())] = tmp;
     }
     o = std::move(obj);
@@ -314,7 +349,6 @@ void std::from_json(const json_t &js, py::object &o) {
                              js.dump());
   }
 }
-
 //------------------------------------------------------------------------------
 
 #endif

--- a/src/framework/python_parser.hpp
+++ b/src/framework/python_parser.hpp
@@ -70,7 +70,7 @@ struct Parser<py::handle> {
 
   static void convert_to_json(json_t &var, const py::handle &po) {
     if (py::hasattr(po, "to_dict")) {
-      std::to_json(var, po.attr("to_dict")());
+      JSON::py_to_json(var, po.attr("to_dict")());
     } else if (py::isinstance<py::list>(po)) {
       var = nl::json::array();
       for (auto item : po) {
@@ -79,7 +79,7 @@ struct Parser<py::handle> {
         var.push_back(item_js);
       }
     } else {
-      std::to_json(var, po);
+        JSON::py_to_json(var, po);
     }
   }
 

--- a/src/framework/python_parser.hpp
+++ b/src/framework/python_parser.hpp
@@ -79,7 +79,7 @@ struct Parser<py::handle> {
         var.push_back(item_js);
       }
     } else {
-        JSON::py_to_json(var, po);
+      JSON::py_to_json(var, po);
     }
   }
 

--- a/src/framework/results/pybind_result.hpp
+++ b/src/framework/results/pybind_result.hpp
@@ -15,8 +15,8 @@
 #ifndef _aer_framework_result_pybind_result_hpp_
 #define _aer_framework_result_pybind_result_hpp_
 
-#include "framework/results/data/pybind_data.hpp"
 #include "framework/pybind_json.hpp"
+#include "framework/results/data/pybind_data.hpp"
 #include "framework/results/data/pybind_metadata.hpp"
 #include "framework/results/result.hpp"
 

--- a/src/framework/results/pybind_result.hpp
+++ b/src/framework/results/pybind_result.hpp
@@ -16,6 +16,7 @@
 #define _aer_framework_result_pybind_result_hpp_
 
 #include "framework/results/data/pybind_data.hpp"
+#include "framework/pybind_json.hpp"
 #include "framework/results/data/pybind_metadata.hpp"
 #include "framework/results/result.hpp"
 
@@ -66,7 +67,7 @@ py::object AerToPy::to_python(AER::ExperimentResult &&result) {
 
   if (result.header.empty() == false) {
     py::object tmp;
-    from_json(result.header, tmp);
+    JSON::py_from_json(result.header, tmp);
     pyexperiment["header"] = std::move(tmp);
   }
   return std::move(pyexperiment);
@@ -91,7 +92,7 @@ py::object AerToPy::to_python(AER::Result &&result) {
   //   bc these are assumed to be small relative to the ExperimentResults
   if (result.header.empty() == false) {
     py::object tmp;
-    from_json(result.header, tmp);
+    JSON::py_from_json(result.header, tmp);
     pyresult["header"] = std::move(tmp);
   }
   pyresult["success"] = (result.status == AER::Result::Status::completed);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2421. aer's pybind11 → nlohmann::json conversion in
`src/framework/pybind_json.hpp` defined `to_json`/`from_json` overloads
in the `std::` namespace. This worked under nlohmann_json ≤ 3.10's
permissive ADL but breaks under 3.11+, which is now the default
system-package version on Ubuntu 24, Fedora 40, etc. All noisy
simulation fails with `ValueError: Invalid noise_params JSON: not an object.`

This PR moves the conversion into `nlohmann::adl_serializer<T>`
specializations — nlohmann's documented, version-stable extension
point — so the build works correctly against all nlohmann_json
versions.


### Details and comments

**Root cause:** [keep the paragraph from the current body about ADL
tightening and the failure mode]

**Fix:** [keep the bullet list of changes]

**Verification:**
- Minimal noise repro (`depolarizing_error` on 2-qubit GHZ) now
  returns correct counts; previously raised the JSON error.
- Test suite on plain `main` + this fix, CPU-only build:
  - Noise test module: 97/97 pass
  - Full suite: 3038 pass, 132 skipped, 0 fail
- On a separate Blackwell + CUDA 13.2 build (per #2415): 216 of 221
  previously-failing noise tests now pass under parallel execution;
  the remaining are unrelated tensor_network GPU concurrency flakes
  that pass in serial mode.

### Checklist

- [x] I have added the tests to cover my changes (existing noise test
      module passes; no new tests needed since the fix restores
      previously-broken functionality).
- [x] I have updated the documentation accordingly (release note added
      under `releasenotes/notes/`).
- [x] I have read the CONTRIBUTING document.
- 