### PR TITLE
Add rx, ry, rxx, ryy, rzz, rzx to stabilizer and extended stabilizer simulation

### DIFF
--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -219,6 +219,8 @@ BASIS_GATES = {
             "pauli",
             "ecr",
             "rz",
+            "rx",
+            "rzz",
             "store",
         ]
     ),
@@ -246,6 +248,8 @@ BASIS_GATES = {
             "pauli",
             "ecr",
             "rz",
+            "rx",
+            "rzz",
             "store",
         ]
     ),

--- a/qiskit_aer/backends/backend_utils.py
+++ b/qiskit_aer/backends/backend_utils.py
@@ -220,7 +220,11 @@ BASIS_GATES = {
             "ecr",
             "rz",
             "rx",
+            "ry",
             "rzz",
+            "rxx",
+            "ryy",
+            "rzx",
             "store",
         ]
     ),
@@ -249,7 +253,11 @@ BASIS_GATES = {
             "ecr",
             "rz",
             "rx",
+            "ry",
             "rzz",
+            "rxx",
+            "ryy",
+            "rzx",
             "store",
         ]
     ),

--- a/releasenotes/notes/stabilizer_rx_rzz-a1b2c3d4e5f6a7b8.yaml
+++ b/releasenotes/notes/stabilizer_rx_rzz-a1b2c3d4e5f6a7b8.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    Added support for ``rx`` and ``rzz`` gates to the ``stabilizer`` and
+    ``extended_stabilizer`` simulation methods when the gate angle is a
+    multiple of ``pi/2`` (i.e. a Clifford angle).
+    ``rx(k*pi/2)`` is decomposed as ``H RZ(k*pi/2) H``, and
+    ``rzz(k*pi/2)`` is decomposed as ``CX (I x RZ(k*pi/2)) CX``.
+    When ``method=automatic`` (the default), circuits containing only
+    Clifford-angle ``rx`` and ``rzz`` gates will automatically select
+    the ``stabilizer`` method.

--- a/releasenotes/notes/stabilizer_rx_rzz-a1b2c3d4e5f6a7b8.yaml
+++ b/releasenotes/notes/stabilizer_rx_rzz-a1b2c3d4e5f6a7b8.yaml
@@ -1,11 +1,18 @@
 ---
 upgrade:
   - |
-    Added support for ``rx`` and ``rzz`` gates to the ``stabilizer`` and
-    ``extended_stabilizer`` simulation methods when the gate angle is a
-    multiple of ``pi/2`` (i.e. a Clifford angle).
-    ``rx(k*pi/2)`` is decomposed as ``H RZ(k*pi/2) H``, and
-    ``rzz(k*pi/2)`` is decomposed as ``CX (I x RZ(k*pi/2)) CX``.
+    Added support for ``rx``, ``ry``, ``rzz``, ``rxx``, ``ryy``, and ``rzx``
+    gates to the ``stabilizer`` and ``extended_stabilizer`` simulation methods
+    when the gate angle is a multiple of ``pi/2`` (i.e. a Clifford angle).
+    The decompositions used are:
+
+    - ``rx(theta)`` = ``H RZ(theta) H``
+    - ``ry(theta)``: pi2=1 → ``X H``, pi2=2 → ``Y``, pi2=3 → ``H X``
+    - ``rzz(theta)`` = ``CX (I x RZ(theta)) CX``
+    - ``rxx(theta)`` = ``(H x H) RZZ(theta) (H x H)``
+    - ``ryy(theta)`` = ``(S x S)(H x H) RZZ(theta) (H x H)(Sdg x Sdg)``
+    - ``rzx(theta)`` = ``(I x H) RZZ(theta) (I x H)``
+
     When ``method=automatic`` (the default), circuits containing only
-    Clifford-angle ``rx`` and ``rzz`` gates will automatically select
-    the ``stabilizer`` method.
+    Clifford-angle rotation gates will automatically select the ``stabilizer``
+    method.

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -48,7 +48,7 @@ const Operations::OpSet StateOpSet(
     {"CX", "u0",  "u1",  "p",   "cx",    "cz",    "swap", "id",
      "x",  "y",   "z",   "h",   "s",     "sdg",   "sx",   "sxdg",
      "t",  "tdg", "ccx", "ccz", "delay", "pauli", "ecr",  "rz",
-     "rx", "ry",  "rzz", "rxx", "ryy",  "rzx"});
+     "rx", "ry",  "rzz", "rxx", "ryy",   "rzx"});
 
 using chpauli_t = CHSimulator::pauli_t;
 using chstate_t = CHSimulator::Runner;
@@ -359,8 +359,8 @@ bool State::validate_parameters(const std::vector<Operations::Op> &ops) const {
     if (ops[i].type == OpType::gate) {
       // check parameter of rotation gates: only k * pi/2 angles are Clifford
       const auto &name = ops[i].name;
-      if (name == "rz" || name == "rx" || name == "ry" ||
-          name == "rzz" || name == "rxx" || name == "ryy" || name == "rzx") {
+      if (name == "rz" || name == "rx" || name == "ry" || name == "rzz" ||
+          name == "rxx" || name == "ryy" || name == "rzx") {
         double pi2 = std::real(ops[i].params[0]) * 2.0 / M_PI;
         double pi2_int = (double)std::round(pi2);
 

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -47,7 +47,8 @@ const Operations::OpSet StateOpSet(
     // Gates
     {"CX", "u0",  "u1",  "p",   "cx",    "cz",    "swap", "id",
      "x",  "y",   "z",   "h",   "s",     "sdg",   "sx",   "sxdg",
-     "t",  "tdg", "ccx", "ccz", "delay", "pauli", "ecr",  "rz", "rx", "rzz"});
+     "t",  "tdg", "ccx", "ccz", "delay", "pauli", "ecr",  "rz",
+     "rx", "ry",  "rzz", "rxx", "ryy",  "rzx"});
 
 using chpauli_t = CHSimulator::pauli_t;
 using chstate_t = CHSimulator::Runner;
@@ -221,6 +222,7 @@ const stringmap_t<Gates> State::gateset_({
     {"tdg", Gates::tdg},   // Conjguate-transpose of T gate
     {"rz", Gates::rz},     // RZ gate (only support k * pi/2 cases)
     {"rx", Gates::rx},     // RX gate (only support k * pi/2 cases)
+    {"ry", Gates::ry},     // RY gate (only support k * pi/2 cases)
     // Waltz Gates
     {"u0", Gates::u0}, // idle gate in multiples of X90
     {"u1", Gates::u1}, // zero-X90 pulse waltz gate
@@ -232,6 +234,9 @@ const stringmap_t<Gates> State::gateset_({
     {"swap", Gates::swap}, // SWAP gate
     {"ecr", Gates::ecr},   // ECR Gate
     {"rzz", Gates::rzz},   // RZZ gate (only support k * pi/2 cases)
+    {"rxx", Gates::rxx},   // RXX gate (only support k * pi/2 cases)
+    {"ryy", Gates::ryy},   // RYY gate (only support k * pi/2 cases)
+    {"rzx", Gates::rzx},   // RZX gate (only support k * pi/2 cases)
     // Three-qubit gates
     {"ccx", Gates::ccx}, // Controlled-CX gate (Toffoli)
     {"ccz", Gates::ccz}, // Constrolled-CZ gate (H3 Toff H3)
@@ -354,7 +359,8 @@ bool State::validate_parameters(const std::vector<Operations::Op> &ops) const {
     if (ops[i].type == OpType::gate) {
       // check parameter of rotation gates: only k * pi/2 angles are Clifford
       const auto &name = ops[i].name;
-      if (name == "rz" || name == "rx" || name == "rzz") {
+      if (name == "rz" || name == "rx" || name == "ry" ||
+          name == "rzz" || name == "rxx" || name == "ryy" || name == "rzx") {
         double pi2 = std::real(ops[i].params[0]) * 2.0 / M_PI;
         double pi2_int = (double)std::round(pi2);
 
@@ -771,6 +777,19 @@ void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank) {
       BaseState::qreg_.apply_h(op.qubits[0], rank);
     }
     break;
+  case Gates::ry:
+    // RY Clifford action: pi2=1 is X*H, pi2=2 is Y, pi2=3 is H*X
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 == 1) {
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+      BaseState::qreg_.apply_x(op.qubits[0], rank);
+    } else if (pi2 == 2) {
+      BaseState::qreg_.apply_y(op.qubits[0], rank);
+    } else if (pi2 == 3) {
+      BaseState::qreg_.apply_x(op.qubits[0], rank);
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+    }
+    break;
   case Gates::rzz:
     // RZZ(theta) = CX (I x RZ(theta)) CX
     pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
@@ -789,6 +808,70 @@ void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank) {
       BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
       BaseState::qreg_.apply_sdag(op.qubits[1], rank);
       BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+    }
+    break;
+  case Gates::rxx:
+    // RXX(theta) = (H x H) RZZ(theta) (H x H)
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 != 0) {
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+      BaseState::qreg_.apply_h(op.qubits[1], rank);
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      if (pi2 == 1) {
+        BaseState::qreg_.apply_s(op.qubits[1], rank);
+      } else if (pi2 == 2) {
+        BaseState::qreg_.apply_z(op.qubits[1], rank);
+      } else {
+        BaseState::qreg_.apply_sdag(op.qubits[1], rank);
+      }
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+      BaseState::qreg_.apply_h(op.qubits[1], rank);
+    }
+    break;
+  case Gates::ryy:
+    // RYY(theta) = (S x S)(H x H) RZZ(theta) (H x H)(Sdg x Sdg)
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 != 0) {
+      // Sdg on both qubits
+      BaseState::qreg_.apply_sdag(op.qubits[0], rank);
+      BaseState::qreg_.apply_sdag(op.qubits[1], rank);
+      // H on both qubits
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+      BaseState::qreg_.apply_h(op.qubits[1], rank);
+      // RZZ inner
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      if (pi2 == 1) {
+        BaseState::qreg_.apply_s(op.qubits[1], rank);
+      } else if (pi2 == 2) {
+        BaseState::qreg_.apply_z(op.qubits[1], rank);
+      } else {
+        BaseState::qreg_.apply_sdag(op.qubits[1], rank);
+      }
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      // H on both qubits
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+      BaseState::qreg_.apply_h(op.qubits[1], rank);
+      // S on both qubits
+      BaseState::qreg_.apply_s(op.qubits[0], rank);
+      BaseState::qreg_.apply_s(op.qubits[1], rank);
+    }
+    break;
+  case Gates::rzx:
+    // RZX(theta) = (I x H) RZZ(theta) (I x H)
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 != 0) {
+      BaseState::qreg_.apply_h(op.qubits[1], rank);
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      if (pi2 == 1) {
+        BaseState::qreg_.apply_s(op.qubits[1], rank);
+      } else if (pi2 == 2) {
+        BaseState::qreg_.apply_z(op.qubits[1], rank);
+      } else {
+        BaseState::qreg_.apply_sdag(op.qubits[1], rank);
+      }
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      BaseState::qreg_.apply_h(op.qubits[1], rank);
     }
     break;
   default: // u0 or Identity

--- a/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
+++ b/src/simulators/extended_stabilizer/extended_stabilizer_state.hpp
@@ -47,7 +47,7 @@ const Operations::OpSet StateOpSet(
     // Gates
     {"CX", "u0",  "u1",  "p",   "cx",    "cz",    "swap", "id",
      "x",  "y",   "z",   "h",   "s",     "sdg",   "sx",   "sxdg",
-     "t",  "tdg", "ccx", "ccz", "delay", "pauli", "ecr",  "rz"});
+     "t",  "tdg", "ccx", "ccz", "delay", "pauli", "ecr",  "rz", "rx", "rzz"});
 
 using chpauli_t = CHSimulator::pauli_t;
 using chstate_t = CHSimulator::Runner;
@@ -220,6 +220,7 @@ const stringmap_t<Gates> State::gateset_({
     {"t", Gates::t},       // T-gate (sqrt(S))
     {"tdg", Gates::tdg},   // Conjguate-transpose of T gate
     {"rz", Gates::rz},     // RZ gate (only support k * pi/2 cases)
+    {"rx", Gates::rx},     // RX gate (only support k * pi/2 cases)
     // Waltz Gates
     {"u0", Gates::u0}, // idle gate in multiples of X90
     {"u1", Gates::u1}, // zero-X90 pulse waltz gate
@@ -230,6 +231,7 @@ const stringmap_t<Gates> State::gateset_({
     {"cz", Gates::cz},     // Controlled-Z gate
     {"swap", Gates::swap}, // SWAP gate
     {"ecr", Gates::ecr},   // ECR Gate
+    {"rzz", Gates::rzz},   // RZZ gate (only support k * pi/2 cases)
     // Three-qubit gates
     {"ccx", Gates::ccx}, // Controlled-CX gate (Toffoli)
     {"ccz", Gates::ccz}, // Constrolled-CZ gate (H3 Toff H3)
@@ -350,8 +352,9 @@ bool State::check_measurement_opt(InputIterator first,
 bool State::validate_parameters(const std::vector<Operations::Op> &ops) const {
   for (uint_t i = 0; i < ops.size(); i++) {
     if (ops[i].type == OpType::gate) {
-      // check parameter of RZ gates
-      if (ops[i].name == "rz") {
+      // check parameter of rotation gates: only k * pi/2 angles are Clifford
+      const auto &name = ops[i].name;
+      if (name == "rz" || name == "rx" || name == "rzz") {
         double pi2 = std::real(ops[i].params[0]) * 2.0 / M_PI;
         double pi2_int = (double)std::round(pi2);
 
@@ -748,6 +751,44 @@ void State::apply_gate(const Operations::Op &op, RngEngine &rng, uint_t rank) {
     } else if (pi2 == 3) {
       // Sdg
       BaseState::qreg_.apply_sdag(op.qubits[0], rank);
+    }
+    break;
+  case Gates::rx:
+    // RX(theta) = H RZ(theta) H
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 == 1) {
+      // H S H = SX
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+      BaseState::qreg_.apply_s(op.qubits[0], rank);
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+    } else if (pi2 == 2) {
+      // H Z H = X
+      BaseState::qreg_.apply_x(op.qubits[0], rank);
+    } else if (pi2 == 3) {
+      // H Sdg H = SXdg
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+      BaseState::qreg_.apply_sdag(op.qubits[0], rank);
+      BaseState::qreg_.apply_h(op.qubits[0], rank);
+    }
+    break;
+  case Gates::rzz:
+    // RZZ(theta) = CX (I x RZ(theta)) CX
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 == 1) {
+      // CX (I x S) CX
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      BaseState::qreg_.apply_s(op.qubits[1], rank);
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+    } else if (pi2 == 2) {
+      // CX (I x Z) CX
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      BaseState::qreg_.apply_z(op.qubits[1], rank);
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+    } else if (pi2 == 3) {
+      // CX (I x Sdg) CX
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
+      BaseState::qreg_.apply_sdag(op.qubits[1], rank);
+      BaseState::qreg_.apply_cx(op.qubits[0], op.qubits[1], rank);
     }
     break;
   default: // u0 or Identity

--- a/src/simulators/extended_stabilizer/gates.hpp
+++ b/src/simulators/extended_stabilizer/gates.hpp
@@ -61,6 +61,8 @@ enum class Gates {
   pauli,
   ecr,
   rz,
+  rx,
+  rzz,
 };
 
 enum class Gatetypes { pauli, clifford, non_clifford };
@@ -83,12 +85,14 @@ const AER::stringmap_t<Gatetypes> gate_types_ = {
     {"u1", Gatetypes::non_clifford},  // zero-X90 pulse waltz gate
     {"p", Gatetypes::non_clifford},   // zero-X90 pulse waltz gate
     {"rz", Gatetypes::clifford},      // RZ gate (only support k * pi/2 cases)
+    {"rx", Gatetypes::clifford},      // RX gate (only support k * pi/2 cases)
     // Two-qubit gates
     {"CX", Gatetypes::clifford},   // Controlled-X gate (CNOT)
     {"cx", Gatetypes::clifford},   // Controlled-X gate (CNOT)
     {"cz", Gatetypes::clifford},   // Controlled-Z gate
     {"swap", Gatetypes::clifford}, // SWAP gate
     {"ecr", Gatetypes::clifford},  // ECR Gate
+    {"rzz", Gatetypes::clifford},  // RZZ gate (only support k * pi/2 cases)
     // Three-qubit gates
     {"ccx", Gatetypes::non_clifford}, // Controlled-CX gate (Toffoli)
     {"ccz", Gatetypes::non_clifford}, // Controlled-CZ gate (H3 Toff H3)

--- a/src/simulators/extended_stabilizer/gates.hpp
+++ b/src/simulators/extended_stabilizer/gates.hpp
@@ -62,7 +62,11 @@ enum class Gates {
   ecr,
   rz,
   rx,
+  ry,
   rzz,
+  rxx,
+  ryy,
+  rzx,
 };
 
 enum class Gatetypes { pauli, clifford, non_clifford };
@@ -86,6 +90,7 @@ const AER::stringmap_t<Gatetypes> gate_types_ = {
     {"p", Gatetypes::non_clifford},   // zero-X90 pulse waltz gate
     {"rz", Gatetypes::clifford},      // RZ gate (only support k * pi/2 cases)
     {"rx", Gatetypes::clifford},      // RX gate (only support k * pi/2 cases)
+    {"ry", Gatetypes::clifford},      // RY gate (only support k * pi/2 cases)
     // Two-qubit gates
     {"CX", Gatetypes::clifford},   // Controlled-X gate (CNOT)
     {"cx", Gatetypes::clifford},   // Controlled-X gate (CNOT)
@@ -93,6 +98,9 @@ const AER::stringmap_t<Gatetypes> gate_types_ = {
     {"swap", Gatetypes::clifford}, // SWAP gate
     {"ecr", Gatetypes::clifford},  // ECR Gate
     {"rzz", Gatetypes::clifford},  // RZZ gate (only support k * pi/2 cases)
+    {"rxx", Gatetypes::clifford},  // RXX gate (only support k * pi/2 cases)
+    {"ryy", Gatetypes::clifford},  // RYY gate (only support k * pi/2 cases)
+    {"rzx", Gatetypes::clifford},  // RZX gate (only support k * pi/2 cases)
     // Three-qubit gates
     {"ccx", Gatetypes::non_clifford}, // Controlled-CX gate (Toffoli)
     {"ccz", Gatetypes::non_clifford}, // Controlled-CZ gate (H3 Toff H3)

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -42,7 +42,7 @@ const Operations::OpSet StateOpSet(
      OpType::store},
     // Gates
     {"CX", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s", "sdg", "sx",
-     "sxdg", "delay", "pauli", "ecr", "rz"});
+     "sxdg", "delay", "pauli", "ecr", "rz", "rx", "rzz"});
 // clang-format on
 
 enum class Gates {
@@ -61,7 +61,9 @@ enum class Gates {
   swap,
   pauli,
   ecr,
-  rz
+  rz,
+  rx,
+  rzz
 };
 
 //============================================================================
@@ -205,6 +207,7 @@ const stringmap_t<Gates> State::gateset_({
     {"sx", Gates::sx},     // Sqrt X gate.
     {"sxdg", Gates::sxdg}, // Inverse Sqrt X gate.
     {"rz", Gates::rz},     // RZ gate (only support k * pi/2 cases)
+    {"rx", Gates::rx},     // RX gate (only support k * pi/2 cases)
     // Two-qubit gates
     {"CX", Gates::cx},       // Controlled-X gate (CNOT)
     {"cx", Gates::cx},       // Controlled-X gate (CNOT),
@@ -213,6 +216,7 @@ const stringmap_t<Gates> State::gateset_({
     {"swap", Gates::swap},   // SWAP gate
     {"pauli", Gates::pauli}, // Pauli gate
     {"ecr", Gates::ecr},     // ECR gate
+    {"rzz", Gates::rzz},     // RZZ gate (only support k * pi/2 cases)
 });
 
 //============================================================================
@@ -257,8 +261,9 @@ void State::set_config(const Config &config) {
 bool State::validate_parameters(const std::vector<Operations::Op> &ops) const {
   for (uint_t i = 0; i < ops.size(); i++) {
     if (ops[i].type == OpType::gate) {
-      // check parameter of RZ gates
-      if (ops[i].name == "rz") {
+      // check parameter of rotation gates: only k * pi/2 angles are Clifford
+      const auto &name = ops[i].name;
+      if (name == "rz" || name == "rx" || name == "rzz") {
         double pi2 = std::real(ops[i].params[0]) * 2.0 / M_PI;
         double pi2_int = (double)std::round(pi2);
 
@@ -408,6 +413,46 @@ void State::apply_gate(const Operations::Op &op) {
       // Sdg
       BaseState::qreg_.append_z(op.qubits[0]);
       BaseState::qreg_.append_s(op.qubits[0]);
+    }
+    break;
+  case Gates::rx:
+    // RX(theta) = H RZ(theta) H
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 == 1) {
+      // H S H = SX
+      BaseState::qreg_.append_h(op.qubits[0]);
+      BaseState::qreg_.append_s(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[0]);
+    } else if (pi2 == 2) {
+      // H Z H = X
+      BaseState::qreg_.append_x(op.qubits[0]);
+    } else if (pi2 == 3) {
+      // H Sdg H = SXdg
+      BaseState::qreg_.append_h(op.qubits[0]);
+      BaseState::qreg_.append_z(op.qubits[0]);
+      BaseState::qreg_.append_s(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[0]);
+    }
+    break;
+  case Gates::rzz:
+    // RZZ(theta) = CX (I x RZ(theta)) CX
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 == 1) {
+      // CX (I x S) CX
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      BaseState::qreg_.append_s(op.qubits[1]);
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+    } else if (pi2 == 2) {
+      // CX (I x Z) CX
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      BaseState::qreg_.append_z(op.qubits[1]);
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+    } else if (pi2 == 3) {
+      // CX (I x Sdg) CX
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      BaseState::qreg_.append_z(op.qubits[1]);
+      BaseState::qreg_.append_s(op.qubits[1]);
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
     }
     break;
   default:

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -42,7 +42,7 @@ const Operations::OpSet StateOpSet(
      OpType::store},
     // Gates
     {"CX", "cx", "cy", "cz", "swap", "id", "x", "y", "z", "h", "s", "sdg", "sx",
-     "sxdg", "delay", "pauli", "ecr", "rz", "rx", "rzz"});
+     "sxdg", "delay", "pauli", "ecr", "rz", "rx", "ry", "rzz", "rxx", "ryy", "rzx"});
 // clang-format on
 
 enum class Gates {
@@ -63,7 +63,11 @@ enum class Gates {
   ecr,
   rz,
   rx,
-  rzz
+  ry,
+  rzz,
+  rxx,
+  ryy,
+  rzx
 };
 
 //============================================================================
@@ -208,6 +212,7 @@ const stringmap_t<Gates> State::gateset_({
     {"sxdg", Gates::sxdg}, // Inverse Sqrt X gate.
     {"rz", Gates::rz},     // RZ gate (only support k * pi/2 cases)
     {"rx", Gates::rx},     // RX gate (only support k * pi/2 cases)
+    {"ry", Gates::ry},     // RY gate (only support k * pi/2 cases)
     // Two-qubit gates
     {"CX", Gates::cx},       // Controlled-X gate (CNOT)
     {"cx", Gates::cx},       // Controlled-X gate (CNOT),
@@ -217,6 +222,9 @@ const stringmap_t<Gates> State::gateset_({
     {"pauli", Gates::pauli}, // Pauli gate
     {"ecr", Gates::ecr},     // ECR gate
     {"rzz", Gates::rzz},     // RZZ gate (only support k * pi/2 cases)
+    {"rxx", Gates::rxx},     // RXX gate (only support k * pi/2 cases)
+    {"ryy", Gates::ryy},     // RYY gate (only support k * pi/2 cases)
+    {"rzx", Gates::rzx},     // RZX gate (only support k * pi/2 cases)
 });
 
 //============================================================================
@@ -263,7 +271,8 @@ bool State::validate_parameters(const std::vector<Operations::Op> &ops) const {
     if (ops[i].type == OpType::gate) {
       // check parameter of rotation gates: only k * pi/2 angles are Clifford
       const auto &name = ops[i].name;
-      if (name == "rz" || name == "rx" || name == "rzz") {
+      if (name == "rz" || name == "rx" || name == "ry" ||
+          name == "rzz" || name == "rxx" || name == "ryy" || name == "rzx") {
         double pi2 = std::real(ops[i].params[0]) * 2.0 / M_PI;
         double pi2_int = (double)std::round(pi2);
 
@@ -434,6 +443,19 @@ void State::apply_gate(const Operations::Op &op) {
       BaseState::qreg_.append_h(op.qubits[0]);
     }
     break;
+  case Gates::ry:
+    // RY Clifford action: pi2=1 is X*H, pi2=2 is Y, pi2=3 is H*X
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 == 1) {
+      BaseState::qreg_.append_h(op.qubits[0]);
+      BaseState::qreg_.append_x(op.qubits[0]);
+    } else if (pi2 == 2) {
+      BaseState::qreg_.append_y(op.qubits[0]);
+    } else if (pi2 == 3) {
+      BaseState::qreg_.append_x(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[0]);
+    }
+    break;
   case Gates::rzz:
     // RZZ(theta) = CX (I x RZ(theta)) CX
     pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
@@ -453,6 +475,75 @@ void State::apply_gate(const Operations::Op &op) {
       BaseState::qreg_.append_z(op.qubits[1]);
       BaseState::qreg_.append_s(op.qubits[1]);
       BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+    }
+    break;
+  case Gates::rxx:
+    // RXX(theta) = (H x H) RZZ(theta) (H x H)
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 != 0) {
+      BaseState::qreg_.append_h(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[1]);
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      if (pi2 == 1) {
+        BaseState::qreg_.append_s(op.qubits[1]);
+      } else if (pi2 == 2) {
+        BaseState::qreg_.append_z(op.qubits[1]);
+      } else {
+        BaseState::qreg_.append_z(op.qubits[1]);
+        BaseState::qreg_.append_s(op.qubits[1]);
+      }
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      BaseState::qreg_.append_h(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[1]);
+    }
+    break;
+  case Gates::ryy:
+    // RYY(theta) = (S x S)(H x H) RZZ(theta) (H x H)(Sdg x Sdg)
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 != 0) {
+      // Sdg on both qubits
+      BaseState::qreg_.append_z(op.qubits[0]);
+      BaseState::qreg_.append_s(op.qubits[0]);
+      BaseState::qreg_.append_z(op.qubits[1]);
+      BaseState::qreg_.append_s(op.qubits[1]);
+      // H on both qubits
+      BaseState::qreg_.append_h(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[1]);
+      // RZZ inner
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      if (pi2 == 1) {
+        BaseState::qreg_.append_s(op.qubits[1]);
+      } else if (pi2 == 2) {
+        BaseState::qreg_.append_z(op.qubits[1]);
+      } else {
+        BaseState::qreg_.append_z(op.qubits[1]);
+        BaseState::qreg_.append_s(op.qubits[1]);
+      }
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      // H on both qubits
+      BaseState::qreg_.append_h(op.qubits[0]);
+      BaseState::qreg_.append_h(op.qubits[1]);
+      // S on both qubits
+      BaseState::qreg_.append_s(op.qubits[0]);
+      BaseState::qreg_.append_s(op.qubits[1]);
+    }
+    break;
+  case Gates::rzx:
+    // RZX(theta) = (I x H) RZZ(theta) (I x H)
+    pi2 = (int_t)std::round(std::real(op.params[0]) * 2.0 / M_PI) & 3;
+    if (pi2 != 0) {
+      BaseState::qreg_.append_h(op.qubits[1]);
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      if (pi2 == 1) {
+        BaseState::qreg_.append_s(op.qubits[1]);
+      } else if (pi2 == 2) {
+        BaseState::qreg_.append_z(op.qubits[1]);
+      } else {
+        BaseState::qreg_.append_z(op.qubits[1]);
+        BaseState::qreg_.append_s(op.qubits[1]);
+      }
+      BaseState::qreg_.append_cx(op.qubits[0], op.qubits[1]);
+      BaseState::qreg_.append_h(op.qubits[1]);
     }
     break;
   default:

--- a/src/simulators/stabilizer/stabilizer_state.hpp
+++ b/src/simulators/stabilizer/stabilizer_state.hpp
@@ -271,8 +271,8 @@ bool State::validate_parameters(const std::vector<Operations::Op> &ops) const {
     if (ops[i].type == OpType::gate) {
       // check parameter of rotation gates: only k * pi/2 angles are Clifford
       const auto &name = ops[i].name;
-      if (name == "rz" || name == "rx" || name == "ry" ||
-          name == "rzz" || name == "rxx" || name == "ryy" || name == "rzx") {
+      if (name == "rz" || name == "rx" || name == "ry" || name == "rzz" ||
+          name == "rxx" || name == "ryy" || name == "rzx") {
         double pi2 = std::real(ops[i].params[0]) * 2.0 / M_PI;
         double pi2_int = (double)std::round(pi2);
 

--- a/test/terra/backends/aer_simulator/test_rotation.py
+++ b/test/terra/backends/aer_simulator/test_rotation.py
@@ -35,6 +35,26 @@ SUPPORTED_METHODS_RZ = [
     "extended_stabilizer",
 ]
 
+SUPPORTED_METHODS_RX_CLIFFORD = [
+    "automatic",
+    "stabilizer",
+    "statevector",
+    "density_matrix",
+    "matrix_product_state",
+    "tensor_network",
+    "extended_stabilizer",
+]
+
+SUPPORTED_METHODS_RZZ_CLIFFORD = [
+    "automatic",
+    "stabilizer",
+    "statevector",
+    "density_matrix",
+    "matrix_product_state",
+    "tensor_network",
+    "extended_stabilizer",
+]
+
 
 @ddt
 class TestRotation(SimulatorTestCase):
@@ -56,6 +76,21 @@ class TestRotation(SimulatorTestCase):
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)
 
+    @supported_methods(SUPPORTED_METHODS_RX_CLIFFORD)
+    def test_rx_gate_clifford(self, method, device):
+        """Test rx-gate at Clifford angles (k * pi/2) including stabilizer methods.
+
+        Uses sign-sensitive circuits (RX -> Sdg -> H) that yield different
+        deterministic outcomes for +pi/2 vs -pi/2, catching sign errors.
+        """
+        backend = self.backend(method=method, device=device, seed_simulator=self.SEED)
+        shots = 1000
+        circuits = ref_rotation.rx_gate_clifford_circuits(final_measure=True)
+        targets = ref_rotation.rx_gate_clifford_counts(shots)
+        result = backend.run(circuits, shots=shots).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+
     # ---------------------------------------------------------------------
     # Test rz-gate
     # ---------------------------------------------------------------------
@@ -66,6 +101,20 @@ class TestRotation(SimulatorTestCase):
         shots = 1000
         circuits = ref_rotation.rz_gate_circuits_deterministic(final_measure=True)
         targets = ref_rotation.rz_gate_counts_deterministic(shots)
+        result = backend.run(circuits, shots=shots).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+
+    # ---------------------------------------------------------------------
+    # Test rzz-gate (Clifford angles)
+    # ---------------------------------------------------------------------
+    @supported_methods(SUPPORTED_METHODS_RZZ_CLIFFORD)
+    def test_rzz_gate_clifford(self, method, device):
+        """Test rzz-gate at Clifford angles (k * pi/2)"""
+        backend = self.backend(method=method, device=device, seed_simulator=self.SEED)
+        shots = 1000
+        circuits = ref_rotation.rzz_gate_clifford_circuits(final_measure=True)
+        targets = ref_rotation.rzz_gate_clifford_counts(shots)
         result = backend.run(circuits, shots=shots).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)

--- a/test/terra/backends/aer_simulator/test_rotation.py
+++ b/test/terra/backends/aer_simulator/test_rotation.py
@@ -55,6 +55,46 @@ SUPPORTED_METHODS_RZZ_CLIFFORD = [
     "extended_stabilizer",
 ]
 
+SUPPORTED_METHODS_RY_CLIFFORD = [
+    "automatic",
+    "stabilizer",
+    "statevector",
+    "density_matrix",
+    "matrix_product_state",
+    "tensor_network",
+    "extended_stabilizer",
+]
+
+SUPPORTED_METHODS_RXX_CLIFFORD = [
+    "automatic",
+    "stabilizer",
+    "statevector",
+    "density_matrix",
+    "matrix_product_state",
+    "tensor_network",
+    "extended_stabilizer",
+]
+
+SUPPORTED_METHODS_RYY_CLIFFORD = [
+    "automatic",
+    "stabilizer",
+    "statevector",
+    "density_matrix",
+    "matrix_product_state",
+    "tensor_network",
+    "extended_stabilizer",
+]
+
+SUPPORTED_METHODS_RZX_CLIFFORD = [
+    "automatic",
+    "stabilizer",
+    "statevector",
+    "density_matrix",
+    "matrix_product_state",
+    "tensor_network",
+    "extended_stabilizer",
+]
+
 
 @ddt
 class TestRotation(SimulatorTestCase):
@@ -129,6 +169,75 @@ class TestRotation(SimulatorTestCase):
         shots = 1000
         circuits = ref_rotation.ry_gate_circuits_deterministic(final_measure=True)
         targets = ref_rotation.ry_gate_counts_deterministic(shots)
+        result = backend.run(circuits, shots=shots).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+
+    @supported_methods(SUPPORTED_METHODS_RY_CLIFFORD)
+    def test_ry_gate_clifford(self, method, device):
+        """Test ry-gate at Clifford angles (k * pi/2) including stabilizer methods.
+
+        Uses sign-sensitive circuits (RY -> H) that yield different
+        deterministic outcomes for +pi/2 vs 3*pi/2, catching sign errors.
+        """
+        backend = self.backend(method=method, device=device, seed_simulator=self.SEED)
+        shots = 1000
+        circuits = ref_rotation.ry_gate_clifford_circuits(final_measure=True)
+        targets = ref_rotation.ry_gate_clifford_counts(shots)
+        result = backend.run(circuits, shots=shots).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+
+    # ---------------------------------------------------------------------
+    # Test rxx-gate (Clifford angles)
+    # ---------------------------------------------------------------------
+    @supported_methods(SUPPORTED_METHODS_RXX_CLIFFORD)
+    def test_rxx_gate_clifford(self, method, device):
+        """Test rxx-gate at Clifford angles (k * pi/2) including stabilizer methods.
+
+        Uses sign-sensitive circuits (RXX -> S0 -> CX -> H0) that yield different
+        deterministic outcomes for +pi/2 vs 3*pi/2, catching sign errors.
+        """
+        backend = self.backend(method=method, device=device, seed_simulator=self.SEED)
+        shots = 1000
+        circuits = ref_rotation.rxx_gate_clifford_circuits(final_measure=True)
+        targets = ref_rotation.rxx_gate_clifford_counts(shots)
+        result = backend.run(circuits, shots=shots).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+
+    # ---------------------------------------------------------------------
+    # Test ryy-gate (Clifford angles)
+    # ---------------------------------------------------------------------
+    @supported_methods(SUPPORTED_METHODS_RYY_CLIFFORD)
+    def test_ryy_gate_clifford(self, method, device):
+        """Test ryy-gate at Clifford angles (k * pi/2) including stabilizer methods.
+
+        Uses sign-sensitive circuits (RYY -> S0 -> CX -> H0) that yield different
+        deterministic outcomes for +pi/2 vs 3*pi/2, catching sign errors.
+        """
+        backend = self.backend(method=method, device=device, seed_simulator=self.SEED)
+        shots = 1000
+        circuits = ref_rotation.ryy_gate_clifford_circuits(final_measure=True)
+        targets = ref_rotation.ryy_gate_clifford_counts(shots)
+        result = backend.run(circuits, shots=shots).result()
+        self.assertSuccess(result)
+        self.compare_counts(result, circuits, targets, delta=0.05 * shots)
+
+    # ---------------------------------------------------------------------
+    # Test rzx-gate (Clifford angles)
+    # ---------------------------------------------------------------------
+    @supported_methods(SUPPORTED_METHODS_RZX_CLIFFORD)
+    def test_rzx_gate_clifford(self, method, device):
+        """Test rzx-gate at Clifford angles (k * pi/2) including stabilizer methods.
+
+        Uses sign-sensitive circuits (RZX -> Sdg1 -> H1) that yield different
+        deterministic outcomes for +pi/2 vs 3*pi/2, catching sign errors.
+        """
+        backend = self.backend(method=method, device=device, seed_simulator=self.SEED)
+        shots = 1000
+        circuits = ref_rotation.rzx_gate_clifford_circuits(final_measure=True)
+        targets = ref_rotation.rzx_gate_clifford_counts(shots)
         result = backend.run(circuits, shots=shots).result()
         self.assertSuccess(result)
         self.compare_counts(result, circuits, targets, delta=0.05 * shots)

--- a/test/terra/reference/ref_rotation.py
+++ b/test/terra/reference/ref_rotation.py
@@ -416,3 +416,304 @@ def rzz_gate_clifford_counts(shots, hex_counts=True):
         targets.append({"01": shots})    # 3*pi/2: qubit0=1 -> "01"
         targets.append({"00": shots})    # 4*pi/2 = I: |00>
     return targets
+
+
+# ==========================================================================
+# RY-gate (Clifford angles, sign-distinguishing)
+# ==========================================================================
+
+
+def ry_gate_clifford_circuits(final_measure=True):
+    """RY-gate test circuits at Clifford angles (k * pi/2) with sign-sensitive outcomes.
+
+    RY(pi/2)|0> = |+>; applying H after maps |+> -> |0> and |-> -> |1>,
+    distinguishing +pi/2 from 3*pi/2.
+    """
+    circuits = []
+    qr = QuantumRegister(1)
+    if final_measure:
+        cr = ClassicalRegister(1)
+        regs = (qr, cr)
+    else:
+        regs = (qr,)
+
+    # RY(pi/2)|0> = |+>; H|+> = |0>
+    circuit = QuantumCircuit(*regs)
+    circuit.ry(np.pi / 2, qr)
+    circuit.h(qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RY(pi) = Y (up to phase): |0> -> i|1>; direct measure -> |1>
+    circuit = QuantumCircuit(*regs)
+    circuit.ry(np.pi, qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RY(3*pi/2)|0> = |->; H|-> = |1>
+    circuit = QuantumCircuit(*regs)
+    circuit.ry(3 * np.pi / 2, qr)
+    circuit.h(qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RY(4*pi/2) = I: |0> -> |0>
+    circuit = QuantumCircuit(*regs)
+    circuit.ry(4 * np.pi / 2, qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
+def ry_gate_clifford_counts(shots, hex_counts=True):
+    """RY-gate Clifford circuits reference counts."""
+    targets = []
+    if hex_counts:
+        targets.append({"0x0": shots})   # pi/2:   |0>
+        targets.append({"0x1": shots})   # pi:     |1>
+        targets.append({"0x1": shots})   # 3*pi/2: |1>
+        targets.append({"0x0": shots})   # 4*pi/2 = I: |0>
+    else:
+        targets.append({"0": shots})   # pi/2:   |0>
+        targets.append({"1": shots})   # pi:     |1>
+        targets.append({"1": shots})   # 3*pi/2: |1>
+        targets.append({"0": shots})   # 4*pi/2 = I: |0>
+    return targets
+
+
+# ==========================================================================
+# RXX-gate (Clifford angles, sign-distinguishing)
+# ==========================================================================
+
+
+def rxx_gate_clifford_circuits(final_measure=True):
+    """RXX-gate test circuits at Clifford angles (k * pi/2) with sign-sensitive outcomes.
+
+    RXX(theta)|00> = cos(theta/2)|00> - i*sin(theta/2)|11>.
+    The readout circuit S0 -> CX01 -> H0 maps the pi/2 state to |00>
+    and the 3*pi/2 state to |10> (hex 0x1), distinguishing the two.
+    """
+    circuits = []
+    qr = QuantumRegister(2)
+    if final_measure:
+        cr = ClassicalRegister(2)
+        regs = (qr, cr)
+    else:
+        regs = (qr,)
+
+    # RXX(pi/2)|00> = (|00> - i|11>)/sqrt(2); S0 CX01 H0 -> |00>
+    circuit = QuantumCircuit(*regs)
+    circuit.rxx(np.pi / 2, qr[0], qr[1])
+    circuit.s(qr[0])
+    circuit.cx(qr[0], qr[1])
+    circuit.h(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RXX(pi)|00> = -i|11>; direct measure -> |11>
+    circuit = QuantumCircuit(*regs)
+    circuit.rxx(np.pi, qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RXX(3*pi/2)|00> = (-|00> - i|11>)/sqrt(2); S0 CX01 H0 -> qubit0=1 -> 0x1
+    circuit = QuantumCircuit(*regs)
+    circuit.rxx(3 * np.pi / 2, qr[0], qr[1])
+    circuit.s(qr[0])
+    circuit.cx(qr[0], qr[1])
+    circuit.h(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RXX(4*pi/2) = I: |00> -> |00>
+    circuit = QuantumCircuit(*regs)
+    circuit.rxx(4 * np.pi / 2, qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
+def rxx_gate_clifford_counts(shots, hex_counts=True):
+    """RXX-gate Clifford circuits reference counts."""
+    targets = []
+    if hex_counts:
+        targets.append({"0x0": shots})   # pi/2:   |00>
+        targets.append({"0x3": shots})   # pi:     |11>
+        targets.append({"0x1": shots})   # 3*pi/2: qubit0=1, qubit1=0 -> 0x1
+        targets.append({"0x0": shots})   # 4*pi/2 = I: |00>
+    else:
+        targets.append({"00": shots})    # pi/2:   |00>
+        targets.append({"11": shots})    # pi:     |11>
+        targets.append({"01": shots})    # 3*pi/2: qubit0=1 -> "01"
+        targets.append({"00": shots})    # 4*pi/2 = I: |00>
+    return targets
+
+
+# ==========================================================================
+# RYY-gate (Clifford angles, sign-distinguishing)
+# ==========================================================================
+
+
+def ryy_gate_clifford_circuits(final_measure=True):
+    """RYY-gate test circuits at Clifford angles (k * pi/2) with sign-sensitive outcomes.
+
+    RYY(theta)|00> = cos(theta/2)|00> + i*sin(theta/2)|11>.
+    Uses the same S0 -> CX01 -> H0 readout as RXX, but the +i sign gives
+    opposite outcomes for pi/2 vs 3*pi/2.
+    """
+    circuits = []
+    qr = QuantumRegister(2)
+    if final_measure:
+        cr = ClassicalRegister(2)
+        regs = (qr, cr)
+    else:
+        regs = (qr,)
+
+    # RYY(pi/2)|00> = (|00> + i|11>)/sqrt(2); S0 CX01 H0 -> qubit0=1 -> 0x1
+    circuit = QuantumCircuit(*regs)
+    circuit.ryy(np.pi / 2, qr[0], qr[1])
+    circuit.s(qr[0])
+    circuit.cx(qr[0], qr[1])
+    circuit.h(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RYY(pi)|00> = i|11>; direct measure -> |11>
+    circuit = QuantumCircuit(*regs)
+    circuit.ryy(np.pi, qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RYY(3*pi/2)|00> = (-|00> + i|11>)/sqrt(2); S0 CX01 H0 -> |00>
+    circuit = QuantumCircuit(*regs)
+    circuit.ryy(3 * np.pi / 2, qr[0], qr[1])
+    circuit.s(qr[0])
+    circuit.cx(qr[0], qr[1])
+    circuit.h(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RYY(4*pi/2) = I: |00> -> |00>
+    circuit = QuantumCircuit(*regs)
+    circuit.ryy(4 * np.pi / 2, qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
+def ryy_gate_clifford_counts(shots, hex_counts=True):
+    """RYY-gate Clifford circuits reference counts."""
+    targets = []
+    if hex_counts:
+        targets.append({"0x1": shots})   # pi/2:   qubit0=1, qubit1=0 -> 0x1
+        targets.append({"0x3": shots})   # pi:     |11>
+        targets.append({"0x0": shots})   # 3*pi/2: |00>
+        targets.append({"0x0": shots})   # 4*pi/2 = I: |00>
+    else:
+        targets.append({"01": shots})    # pi/2:   qubit0=1 -> "01"
+        targets.append({"11": shots})    # pi:     |11>
+        targets.append({"00": shots})    # 3*pi/2: |00>
+        targets.append({"00": shots})    # 4*pi/2 = I: |00>
+    return targets
+
+
+# ==========================================================================
+# RZX-gate (Clifford angles, sign-distinguishing)
+# ==========================================================================
+
+
+def rzx_gate_clifford_circuits(final_measure=True):
+    """RZX-gate test circuits at Clifford angles (k * pi/2) with sign-sensitive outcomes.
+
+    RZX(theta)|00> = cos(theta/2)|00> - i*sin(theta/2)|01>.
+    For pi/2 and 3*pi/2, applies Sdg1 -> H1 to convert the Y-axis eigenstate
+    of qubit1 to a deterministic Z-basis outcome.
+    """
+    circuits = []
+    qr = QuantumRegister(2)
+    if final_measure:
+        cr = ClassicalRegister(2)
+        regs = (qr, cr)
+    else:
+        regs = (qr,)
+
+    # RZX(pi/2)|00> = (|00> - i|01>)/sqrt(2); Sdg1 H1 -> qubit1=1 -> 0x2
+    circuit = QuantumCircuit(*regs)
+    circuit.rzx(np.pi / 2, qr[0], qr[1])
+    circuit.sdg(qr[1])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RZX(pi)|00> = -i|01>; direct measure -> qubit1=1 -> 0x2
+    circuit = QuantumCircuit(*regs)
+    circuit.rzx(np.pi, qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RZX(3*pi/2)|00> = (-|00> - i|01>)/sqrt(2); Sdg1 H1 -> |00>
+    circuit = QuantumCircuit(*regs)
+    circuit.rzx(3 * np.pi / 2, qr[0], qr[1])
+    circuit.sdg(qr[1])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RZX(4*pi/2) = I: |00> -> |00>
+    circuit = QuantumCircuit(*regs)
+    circuit.rzx(4 * np.pi / 2, qr[0], qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
+def rzx_gate_clifford_counts(shots, hex_counts=True):
+    """RZX-gate Clifford circuits reference counts."""
+    targets = []
+    if hex_counts:
+        targets.append({"0x2": shots})   # pi/2:   qubit1=1 -> 0x2
+        targets.append({"0x2": shots})   # pi:     qubit1=1 -> 0x2
+        targets.append({"0x0": shots})   # 3*pi/2: |00>
+        targets.append({"0x0": shots})   # 4*pi/2 = I: |00>
+    else:
+        targets.append({"10": shots})    # pi/2:   qubit1=1 -> "10"
+        targets.append({"10": shots})    # pi:     qubit1=1 -> "10"
+        targets.append({"00": shots})    # 3*pi/2: |00>
+        targets.append({"00": shots})    # 4*pi/2 = I: |00>
+    return targets

--- a/test/terra/reference/ref_rotation.py
+++ b/test/terra/reference/ref_rotation.py
@@ -254,3 +254,165 @@ def ry_gate_counts_deterministic(shots, hex_counts=True):
         # 4*pi/2
         targets.append({"0": shots})
     return targets
+
+
+# ==========================================================================
+# RX-gate (Clifford angles, sign-distinguishing)
+# ==========================================================================
+
+
+def rx_gate_clifford_circuits(final_measure=True):
+    """RX-gate test circuits at Clifford angles (k * pi/2) with sign-sensitive outcomes.
+
+    The circuit for pi/2 and 3*pi/2 applies RX then Sdg then H, which maps the
+    Y-axis eigenstates to deterministic Z-basis outcomes and distinguishes +pi/2
+    from -pi/2 (both would otherwise give 50/50 counts when measuring directly).
+    """
+    circuits = []
+    qr = QuantumRegister(1)
+    if final_measure:
+        cr = ClassicalRegister(1)
+        regs = (qr, cr)
+    else:
+        regs = (qr,)
+
+    # RX(pi/2)|0> = |-y> = (|0>-i|1>)/sqrt(2); Sdg H |-y> = |1>
+    circuit = QuantumCircuit(*regs)
+    circuit.rx(np.pi / 2, qr)
+    circuit.sdg(qr)
+    circuit.h(qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RX(pi) = X: |0> -> |1>
+    circuit = QuantumCircuit(*regs)
+    circuit.rx(np.pi, qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RX(3*pi/2)|0> = |+y> = (|0>+i|1>)/sqrt(2); Sdg H |+y> = |0>
+    circuit = QuantumCircuit(*regs)
+    circuit.rx(3 * np.pi / 2, qr)
+    circuit.sdg(qr)
+    circuit.h(qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RX(4*pi/2) = I: |0> -> |0>
+    circuit = QuantumCircuit(*regs)
+    circuit.rx(4 * np.pi / 2, qr)
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
+def rx_gate_clifford_counts(shots, hex_counts=True):
+    """RX-gate Clifford circuits reference counts."""
+    targets = []
+    if hex_counts:
+        targets.append({"0x1": shots})   # pi/2: |1>
+        targets.append({"0x1": shots})   # pi:   |1>
+        targets.append({"0x0": shots})   # 3*pi/2: |0>
+        targets.append({"0x0": shots})   # 4*pi/2 = I: |0>
+    else:
+        targets.append({"1": shots})   # pi/2: |1>
+        targets.append({"1": shots})   # pi:   |1>
+        targets.append({"0": shots})   # 3*pi/2: |0>
+        targets.append({"0": shots})   # 4*pi/2 = I: |0>
+    return targets
+
+
+# ==========================================================================
+# RZZ-gate (Clifford angles, sign-distinguishing)
+# ==========================================================================
+
+
+def rzz_gate_clifford_circuits(final_measure=True):
+    """RZZ-gate test circuits at Clifford angles (k * pi/2) with sign-sensitive outcomes.
+
+    For pi/2 and 3*pi/2 cases the circuit H0 -> RZZ -> Sdg0 -> H0 is used.
+    Starting from |00>, H0 prepares |+0>. After RZZ(theta) the state is
+    e^{-i*theta/2}(|00> + e^{i*theta}|10>)/sqrt(2). Sdg0 then H0 maps qubit 0
+    to |0> for theta=pi/2 and |1> for theta=3*pi/2, distinguishing the two cases.
+    For pi and 2*pi the H0 H1 -> RZZ -> H0 H1 sandwich is used.
+    """
+    circuits = []
+    qr = QuantumRegister(2)
+    if final_measure:
+        cr = ClassicalRegister(2)
+        regs = (qr, cr)
+    else:
+        regs = (qr,)
+
+    # RZZ(pi/2): qubit0 -> |0>
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[0])
+    circuit.rzz(np.pi / 2, qr[0], qr[1])
+    circuit.sdg(qr[0])
+    circuit.h(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RZZ(pi): H H -> RZZ(pi) -> H H maps |00> to |11>
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[0])
+    circuit.h(qr[1])
+    circuit.rzz(np.pi, qr[0], qr[1])
+    circuit.h(qr[0])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RZZ(3*pi/2): qubit0 -> |1>
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[0])
+    circuit.rzz(3 * np.pi / 2, qr[0], qr[1])
+    circuit.sdg(qr[0])
+    circuit.h(qr[0])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    # RZZ(4*pi/2) = I: H H -> I -> H H maps |00> to |00>
+    circuit = QuantumCircuit(*regs)
+    circuit.h(qr[0])
+    circuit.h(qr[1])
+    circuit.rzz(4 * np.pi / 2, qr[0], qr[1])
+    circuit.h(qr[0])
+    circuit.h(qr[1])
+    if final_measure:
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
+    circuits.append(circuit)
+
+    return circuits
+
+
+def rzz_gate_clifford_counts(shots, hex_counts=True):
+    """RZZ-gate Clifford circuits reference counts."""
+    targets = []
+    if hex_counts:
+        targets.append({"0x0": shots})   # pi/2: qubit0=0, qubit1=0 -> |00>
+        targets.append({"0x3": shots})   # pi:   |11>
+        targets.append({"0x1": shots})   # 3*pi/2: qubit0=1, qubit1=0 -> |01>
+        targets.append({"0x0": shots})   # 4*pi/2 = I: |00>
+    else:
+        targets.append({"00": shots})    # pi/2: |00>
+        targets.append({"11": shots})    # pi:   |11>
+        targets.append({"01": shots})    # 3*pi/2: qubit0=1 -> "01"
+        targets.append({"00": shots})    # 4*pi/2 = I: |00>
+    return targets

--- a/test/terra/reference/ref_rotation.py
+++ b/test/terra/reference/ref_rotation.py
@@ -319,15 +319,15 @@ def rx_gate_clifford_counts(shots, hex_counts=True):
     """RX-gate Clifford circuits reference counts."""
     targets = []
     if hex_counts:
-        targets.append({"0x1": shots})   # pi/2: |1>
-        targets.append({"0x1": shots})   # pi:   |1>
-        targets.append({"0x0": shots})   # 3*pi/2: |0>
-        targets.append({"0x0": shots})   # 4*pi/2 = I: |0>
+        targets.append({"0x1": shots})  # pi/2: |1>
+        targets.append({"0x1": shots})  # pi:   |1>
+        targets.append({"0x0": shots})  # 3*pi/2: |0>
+        targets.append({"0x0": shots})  # 4*pi/2 = I: |0>
     else:
-        targets.append({"1": shots})   # pi/2: |1>
-        targets.append({"1": shots})   # pi:   |1>
-        targets.append({"0": shots})   # 3*pi/2: |0>
-        targets.append({"0": shots})   # 4*pi/2 = I: |0>
+        targets.append({"1": shots})  # pi/2: |1>
+        targets.append({"1": shots})  # pi:   |1>
+        targets.append({"0": shots})  # 3*pi/2: |0>
+        targets.append({"0": shots})  # 4*pi/2 = I: |0>
     return targets
 
 
@@ -406,15 +406,15 @@ def rzz_gate_clifford_counts(shots, hex_counts=True):
     """RZZ-gate Clifford circuits reference counts."""
     targets = []
     if hex_counts:
-        targets.append({"0x0": shots})   # pi/2: qubit0=0, qubit1=0 -> |00>
-        targets.append({"0x3": shots})   # pi:   |11>
-        targets.append({"0x1": shots})   # 3*pi/2: qubit0=1, qubit1=0 -> |01>
-        targets.append({"0x0": shots})   # 4*pi/2 = I: |00>
+        targets.append({"0x0": shots})  # pi/2: qubit0=0, qubit1=0 -> |00>
+        targets.append({"0x3": shots})  # pi:   |11>
+        targets.append({"0x1": shots})  # 3*pi/2: qubit0=1, qubit1=0 -> |01>
+        targets.append({"0x0": shots})  # 4*pi/2 = I: |00>
     else:
-        targets.append({"00": shots})    # pi/2: |00>
-        targets.append({"11": shots})    # pi:   |11>
-        targets.append({"01": shots})    # 3*pi/2: qubit0=1 -> "01"
-        targets.append({"00": shots})    # 4*pi/2 = I: |00>
+        targets.append({"00": shots})  # pi/2: |00>
+        targets.append({"11": shots})  # pi:   |11>
+        targets.append({"01": shots})  # 3*pi/2: qubit0=1 -> "01"
+        targets.append({"00": shots})  # 4*pi/2 = I: |00>
     return targets
 
 
@@ -478,15 +478,15 @@ def ry_gate_clifford_counts(shots, hex_counts=True):
     """RY-gate Clifford circuits reference counts."""
     targets = []
     if hex_counts:
-        targets.append({"0x0": shots})   # pi/2:   |0>
-        targets.append({"0x1": shots})   # pi:     |1>
-        targets.append({"0x1": shots})   # 3*pi/2: |1>
-        targets.append({"0x0": shots})   # 4*pi/2 = I: |0>
+        targets.append({"0x0": shots})  # pi/2:   |0>
+        targets.append({"0x1": shots})  # pi:     |1>
+        targets.append({"0x1": shots})  # 3*pi/2: |1>
+        targets.append({"0x0": shots})  # 4*pi/2 = I: |0>
     else:
-        targets.append({"0": shots})   # pi/2:   |0>
-        targets.append({"1": shots})   # pi:     |1>
-        targets.append({"1": shots})   # 3*pi/2: |1>
-        targets.append({"0": shots})   # 4*pi/2 = I: |0>
+        targets.append({"0": shots})  # pi/2:   |0>
+        targets.append({"1": shots})  # pi:     |1>
+        targets.append({"1": shots})  # 3*pi/2: |1>
+        targets.append({"0": shots})  # 4*pi/2 = I: |0>
     return targets
 
 
@@ -555,15 +555,15 @@ def rxx_gate_clifford_counts(shots, hex_counts=True):
     """RXX-gate Clifford circuits reference counts."""
     targets = []
     if hex_counts:
-        targets.append({"0x0": shots})   # pi/2:   |00>
-        targets.append({"0x3": shots})   # pi:     |11>
-        targets.append({"0x1": shots})   # 3*pi/2: qubit0=1, qubit1=0 -> 0x1
-        targets.append({"0x0": shots})   # 4*pi/2 = I: |00>
+        targets.append({"0x0": shots})  # pi/2:   |00>
+        targets.append({"0x3": shots})  # pi:     |11>
+        targets.append({"0x1": shots})  # 3*pi/2: qubit0=1, qubit1=0 -> 0x1
+        targets.append({"0x0": shots})  # 4*pi/2 = I: |00>
     else:
-        targets.append({"00": shots})    # pi/2:   |00>
-        targets.append({"11": shots})    # pi:     |11>
-        targets.append({"01": shots})    # 3*pi/2: qubit0=1 -> "01"
-        targets.append({"00": shots})    # 4*pi/2 = I: |00>
+        targets.append({"00": shots})  # pi/2:   |00>
+        targets.append({"11": shots})  # pi:     |11>
+        targets.append({"01": shots})  # 3*pi/2: qubit0=1 -> "01"
+        targets.append({"00": shots})  # 4*pi/2 = I: |00>
     return targets
 
 
@@ -632,15 +632,15 @@ def ryy_gate_clifford_counts(shots, hex_counts=True):
     """RYY-gate Clifford circuits reference counts."""
     targets = []
     if hex_counts:
-        targets.append({"0x1": shots})   # pi/2:   qubit0=1, qubit1=0 -> 0x1
-        targets.append({"0x3": shots})   # pi:     |11>
-        targets.append({"0x0": shots})   # 3*pi/2: |00>
-        targets.append({"0x0": shots})   # 4*pi/2 = I: |00>
+        targets.append({"0x1": shots})  # pi/2:   qubit0=1, qubit1=0 -> 0x1
+        targets.append({"0x3": shots})  # pi:     |11>
+        targets.append({"0x0": shots})  # 3*pi/2: |00>
+        targets.append({"0x0": shots})  # 4*pi/2 = I: |00>
     else:
-        targets.append({"01": shots})    # pi/2:   qubit0=1 -> "01"
-        targets.append({"11": shots})    # pi:     |11>
-        targets.append({"00": shots})    # 3*pi/2: |00>
-        targets.append({"00": shots})    # 4*pi/2 = I: |00>
+        targets.append({"01": shots})  # pi/2:   qubit0=1 -> "01"
+        targets.append({"11": shots})  # pi:     |11>
+        targets.append({"00": shots})  # 3*pi/2: |00>
+        targets.append({"00": shots})  # 4*pi/2 = I: |00>
     return targets
 
 
@@ -707,13 +707,13 @@ def rzx_gate_clifford_counts(shots, hex_counts=True):
     """RZX-gate Clifford circuits reference counts."""
     targets = []
     if hex_counts:
-        targets.append({"0x2": shots})   # pi/2:   qubit1=1 -> 0x2
-        targets.append({"0x2": shots})   # pi:     qubit1=1 -> 0x2
-        targets.append({"0x0": shots})   # 3*pi/2: |00>
-        targets.append({"0x0": shots})   # 4*pi/2 = I: |00>
+        targets.append({"0x2": shots})  # pi/2:   qubit1=1 -> 0x2
+        targets.append({"0x2": shots})  # pi:     qubit1=1 -> 0x2
+        targets.append({"0x0": shots})  # 3*pi/2: |00>
+        targets.append({"0x0": shots})  # 4*pi/2 = I: |00>
     else:
-        targets.append({"10": shots})    # pi/2:   qubit1=1 -> "10"
-        targets.append({"10": shots})    # pi:     qubit1=1 -> "10"
-        targets.append({"00": shots})    # 3*pi/2: |00>
-        targets.append({"00": shots})    # 4*pi/2 = I: |00>
+        targets.append({"10": shots})  # pi/2:   qubit1=1 -> "10"
+        targets.append({"10": shots})  # pi:     qubit1=1 -> "10"
+        targets.append({"00": shots})  # 3*pi/2: |00>
+        targets.append({"00": shots})  # 4*pi/2 = I: |00>
     return targets


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently, these two simulation methods allow `rz` gates at the four angles where it is a Clifford operation.
This PR follows this pattern to add support for the other single-parameter Pauli rotation gates in these two 
simulation methods. 

### Details and comments

Help from Claude Opus 4.6
