### PR TITLE
Fix Windows CI by pinning to windows-2022 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-15-intel", "ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["macos-15-intel", "ubuntu-latest", "windows-2022", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -283,7 +283,7 @@ jobs:
         uses: microsoft/setup-msbuild@v2
       - name: Build Aer Windows
         env:
-          CMAKE_GENERATOR: "Visual Studio 18 2025"
+          CMAKE_GENERATOR: "Visual Studio 18 2026"
         run: |
           set -e
           pip install build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -250,7 +250,7 @@ jobs:
           stestr run --slowest
         shell: bash
   tests_windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     name: Windows Python ${{ matrix.python-version }}
     needs: ["lint", "sdist"]
     timeout-minutes: 60
@@ -283,7 +283,7 @@ jobs:
         uses: microsoft/setup-msbuild@v2
       - name: Build Aer Windows
         env:
-          CMAKE_GENERATOR: "Visual Studio 18 2026"
+          CMAKE_GENERATOR: "Visual Studio 17 2022"
         run: |
           set -e
           pip install build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -282,8 +282,6 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
       - name: Build Aer Windows
-        env:
-          CMAKE_GENERATOR: "Visual Studio 17 2022"
         run: |
           set -e
           pip install build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -282,6 +282,8 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
       - name: Build Aer Windows
+        env:
+          CMAKE_GENERATOR: "Visual Studio 18 2025"
         run: |
           set -e
           pip install build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ before-build = [
 ]
 
 [tool.cibuildwheel.windows]
-environment = { CMAKE_GENERATOR = "Visual Studio 18 2026"}
+environment = { CMAKE_GENERATOR = "Visual Studio 17 2022"}
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ before-build = [
 ]
 
 [tool.cibuildwheel.windows]
-environment = { CMAKE_GENERATOR = "Visual Studio 18 2025"}
+environment = { CMAKE_GENERATOR = "Visual Studio 18 2026"}
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ before-build = [
 ]
 
 [tool.cibuildwheel.windows]
-environment = { CMAKE_GENERATOR = "Visual Studio 17 2022"}
+environment = { CMAKE_GENERATOR = "Visual Studio 18 2025"}
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes CI on windows by forcing the the image `windows-2022` instead of `windows-latest` where the build system has access to older MSVS versions and tooling. See the commit history of this branch for some things that were tried and didn't work. However, this PR is a stop-gap: this project needs a build system overhaul as it depends on on some EOL tools.

### Details and comments

Claude 4.7 helped me find the problem.
