### PR TITLE
Add workflow_dispatch trigger to Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 jobs:
   wheel-build:
     name: Build qiskit-aer wheels
@@ -62,6 +63,7 @@ jobs:
           path: ./wheelhouse/*.whl
           name: aer-deploy-separate-build_wheels_aarch64-${{ matrix.os }}
       - name: Publish package distributions to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse
@@ -117,6 +119,7 @@ jobs:
           path: ./dist/qiskit*
           name: aer-deploy-separate-sdist-${{ matrix.os }}
       - name: Publish package distributions to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
@@ -162,6 +165,7 @@ jobs:
           path: ./wheelhouse/*.whl
           name: aer-deploy-separate-gpu-build-cuda11-${{ matrix.os }}
       - name: Publish package distributions to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse
@@ -207,6 +211,7 @@ jobs:
           path: ./wheelhouse/*.whl
           name: aer-deploy-separate-gpu-build-cuda12-${{ matrix.os }}
       - name: Publish package distributions to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse
@@ -244,6 +249,7 @@ jobs:
           path: ./wheelhouse/*.whl
           name: aer-deploy-separate-build_wheels_s390x-${{ matrix.os }}
       - name: Publish package distributions to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse
@@ -281,6 +287,7 @@ jobs:
           path: ./wheelhouse/*.whl
           name: aer-deploy-separate-build_wheels_ppc64le-${{ matrix.os }}
       - name: Publish package distributions to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse
@@ -298,6 +305,7 @@ jobs:
           pattern: 'aer-deploy-shared-*'
           merge-multiple: true
       - name: Publish package distributions to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: deploy


### PR DESCRIPTION
Two small changes to `.github/workflows/deploy.yml`:

1. Adds `workflow_dispatch:` to the `on:` block, so the wheel / sdist / CUDA-11 / CUDA-12 build matrix can be run manually from the Actions UI against any branch — no tag required.
2. Guards every `pypa/gh-action-pypi-publish` step with `if: startsWith(github.ref, 'refs/tags/')`, so a manual branch dispatch cannot publish to PyPI even if the `release` environment's deployment protection rules would otherwise allow it.

The motivating use case is verifying CUDA wheel builds on a PR before release. Right now the CUDA-11 and CUDA-12 jobs only fire on tag push, so a regression in those code paths is invisible to ordinary PR CI. With this change a maintainer can pick a PR's tip in the Actions UI and confirm those builds still link cleanly. Wheels are uploaded as workflow artifacts before the (now no-op) publish step, so downloading them after the run is straightforward.

No effect on existing tag-triggered behavior.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude 4.7