### PR TITLE
Make mergify consistent with branch protection rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,10 @@
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: automerge
     merge_method: squash
+    batch_size: 1
 
 pull_request_rules:
   - name: automatic merge on CI success and review


### PR DESCRIPTION
Mergify will not run on a branch that is not up to date with the main branch if the branch protection rule requiring branches be up to date with the main branch is in place, unless mergify is configured to run merges serially, one at a time. Here the mergify configuration is modified to try to meet this condition.