### PR TITLE
Add branch naming clarification in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,9 @@ The release automation processes will be triggered by the new tag and will perfo
 the following steps:
 
 1.  Create a stable branch for the new minor version from the release tag
-    on the `main` branch
+    on the `main` branch. The stable branch **must** follow the `stable/X.Y`
+    format. Otherwise, the documentation `[source]` links in the API docs will get
+    broken. 
 2.  Build and upload binary wheels to pypi
 3.  Create a GitHub release page with a generated changelog
 4.  Generate a PR on the meta-repository to bump the Aer version and


### PR DESCRIPTION
# Summary

The branch naming convention should be followed to avoid braking the documentation. This PR adds a clarification about that.

# Details
During the release process of 0.17, the stable branch was created with an out-of-convention name: `version-17-1` That broke the `[source]`  link in the documentation:

<img width="621" height="669" alt="image (62)" src="https://github.com/user-attachments/assets/59d3aee9-9357-4cc8-a63c-18898cae9b84" />

This link points to https://github.com/Qiskit/qiskit-aer/blob/stable/0.17/qiskit_aer/aerprovider.py#L26-L119 but the source code was in <code>github.com/Qiskit/qiskit-aer/blob/<b>version-17-1</b>/qiskit_aer/aerprovider.py#L26-L119`</code>