### PR TITLE
Fix Python 3.14 wheel builds for aarch64/s390x/ppc64le and config cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
           CIBW_BEFORE_BUILD: | # conan<2.0.0 on arm64 (turns to be 1.66.0) complains about not supporting Clang 17
             python -m pip install "conan<2.0.0"
             conan config init --force
-            sed -i '' 's/"16.0"/"16.0", "17.0"/' ~/.conan/settings.yml
+            sed -i '' 's/"16.0"/"16.0", "17.0", "18.0", "19.0", "20.0", "21.0"/' ~/.conan/settings.yml
         run: cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
         env:
-          CIBW_BEFORE_ALL_LINUX: "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo && yum install -y https://dl.fedoraproject.org/pub/archive/epel/7/aarch64/Packages/e/epel-release-7-12.noarch.rpm && yum install -y openblas-devel"
           CIBW_ARCHS_LINUX: aarch64
           CIBW_TEST_SKIP: "cp*"
       - uses: actions/upload-artifact@v4
@@ -243,7 +242,6 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: s390x
           CIBW_TEST_SKIP: "cp*"
-          CIBW_BEFORE_ALL: "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo && yum install -y https://dl.fedoraproject.org/pub/epel/8/Everything/s390x/Packages/e/epel-release-8-21.el8.noarch.rpm && yum install -y openblas-devel"
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
@@ -277,9 +275,8 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v3.2.1
         env:
-          CIBW_BEFORE_ALL: "sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo && yum install -y https://dl.fedoraproject.org/pub/archive/epel/7/ppc64le/Packages/e/epel-release-7-14.noarch.rpm && yum install -y openblas-devel"
           CIBW_ARCHS_LINUX: ppc64le
           CIBW_TEST_SKIP: "cp*"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,7 +232,7 @@ jobs:
           set -e
           python -m pip install 'conan<2.0.0'
           conan config init --force
-          sed -i '' 's/"16.0"/"16.0", "17.0"/' ~/.conan/settings.yml
+          sed -i '' 's/"16.0"/"16.0", "17.0", "18.0", "19.0", "20.0", "21.0"/' ~/.conan/settings.yml
 
       - name: Install Aer and dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ before-all = "dnf install -y openblas-devel"
 before-build = [
     "python -m pip install 'conan<2.0.0'",
     "conan config init --force",
-    "sed -i '' 's/\"16.0\"/\"16.0\", \"17.0\"/' ~/.conan/settings.yml",
+    "sed -i '' 's/\"16.0\"/\"16.0\", \"17.0\", \"18.0\", \"19.0\", \"20.0\", \"21.0\"/' ~/.conan/settings.yml",
 ]
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+manylinux-s390x-image = "manylinux_2_28"
+manylinux-ppc64le-image = "manylinux_2_28"
 skip = "pp* *musllinux* *i686* *win32* cp38-* cp39-* cp3??t-*"
 test-command = "python {project}/tools/verify_wheels.py"
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a
@@ -39,4 +42,4 @@ environment = { CMAKE_GENERATOR = "Visual Studio 17 2022"}
 
 [tool.black]
 line-length = 100
-target-version = ['py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314']

--- a/qiskit_aer/__init__.py
+++ b/qiskit_aer/__init__.py
@@ -52,8 +52,6 @@ Exceptions
 """
 
 import platform
-import sys
-import warnings
 
 
 # https://github.com/Qiskit/qiskit-aer/issues/1
@@ -75,14 +73,6 @@ from qiskit_aer import quantum_info
 from qiskit_aer import noise
 from qiskit_aer import utils
 from qiskit_aer.version import __version__
-
-if sys.version_info < (3, 8):
-    warnings.warn(
-        "Using Aer with Python 3.7 is deprecated as of the 0.12.0 release. "
-        "Support for running Aer with Python 3.7 will be removed in a future "
-        "release",
-        DeprecationWarning,
-    )
 
 
 # Global instance to be used as the entry point for convenience.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ scikit-build>=0.11.0
 asv
 cvxpy<1.6.0
 pylint
-black[jupyter]~=24.1
+black[jupyter]~=25.1
 clang-format~=15.0.7
 Sphinx>=1.8.3
 jupyter-sphinx

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     author_email="qiskit@us.ibm.com",
     license="Apache 2.0",
     classifiers=classifiers,
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     install_requires=requirements,
     include_package_data=False,
     package_data={"qiskit_aer": ["VERSION.txt"], "qiskit_aer.library": ["*.csv"]},

--- a/test/terra/states/test_aer_statevector.py
+++ b/test/terra/states/test_aer_statevector.py
@@ -300,7 +300,7 @@ class TestAerStatevector(common.QiskitAerTestCase):
                 sv1 = sv1.data
             if not isinstance(sv2, np.ndarray):
                 sv2 = sv2.data
-            return np.isclose(np.cross(sv1, sv2), 0)
+            return np.isclose(sv1[0] * sv2[1] - sv1[1] * sv2[0], 0)
 
         circuit = QuantumCircuit(1)
         circuit.h(0)


### PR DESCRIPTION
## Summary
- Use manylinux_2_28 for aarch64/s390x/ppc64le builds (Python 3.14 requires glibc 2.28+, which manylinux2014 cannot provide), fixing #2419
- Remove CentOS 7/EPEL 7 `CIBW_BEFORE_ALL` overrides from deploy jobs, inheriting `dnf install -y openblas-devel` from pyproject.toml
- Bump ppc64le cibuildwheel from v2.19.2 to v3.2.1
- Extend conan apple-clang version hack through 21.0 (macOS-latest now ships clang 21)
- Bump black to 25.x (supports `py314` target-version)
- Update `python_requires` from `>=3.7` to `>=3.10` to match actual support
- Remove dead Python <3.8 deprecation warning and unused imports
- Fix `test_kraus` numpy 2.x incompatibility (`np.cross` no longer accepts 2D vectors)

## Test plan
- [x] CI builds wheels for Python 3.14 on all architectures (Linux x86_64, aarch64, macOS, Windows)
- [x] Tests pass on Linux/macOS/Windows with Python 3.14
- [x] All workflows green on fork: https://github.com/VestigeJ/qiskit-aer/pull/1

Closes #2419

🤖 Generated with [Claude Code](https://claude.com/claude-code)